### PR TITLE
feat(git): add sub-issue model, label taxonomy, and CI log retrieval (#24)

### DIFF
--- a/.claude/skills/gobbi-git/SKILL.md
+++ b/.claude/skills/gobbi-git/SKILL.md
@@ -115,4 +115,4 @@ This skill loads at session start as a core skill. Prerequisites run during sess
 
 | Document | Covers |
 |----------|--------|
-| [conventions.md](conventions.md) | Branch naming, commit messages, PR template, issue format, worktree directory naming |
+| [conventions.md](conventions.md) | Branch naming, commit messages, PR template, issue format, sub-issues, labels, worktree directory naming |

--- a/.claude/skills/gobbi-git/conventions.md
+++ b/.claude/skills/gobbi-git/conventions.md
@@ -78,11 +78,11 @@ Issues are the contract between ideation and execution. They can be created by t
 
 When a feature decomposes into three or more independent tasks that each produce their own commit or PR, sub-issues can track them under a parent issue. The parent issue captures the overall feature; each sub-issue is scoped to one deliverable.
 
-The orchestrator creates the parent issue from ideation output, then creates sub-issues during planning — one per task. Sub-issues follow the same naming conventions as regular issues, and the branch for each sub-issue uses the sub-issue number in its name (for example, `feat/{sub-issue-number}-{description}`). The parent issue closes when all sub-issues are resolved.
+The orchestrator creates the parent issue from ideation output, then creates sub-issues during planning — one per task. Sub-issues follow the same naming conventions as regular issues, and the branch for each sub-issue uses the sub-issue number in its name (for example, `feat/{sub-issue-number}-{description}`). The orchestrator closes the parent issue manually after confirming all sub-issues are resolved — GitHub does not close parent issues automatically.
 
 This is guidance for multi-task features, not a mandate. Simple tasks continue to use a single issue. Use sub-issues when the decomposition is clear, the tasks are genuinely independent, and tracking progress per task would be meaningful.
 
-The `gh issue` CLI does not have native sub-issue support. Sub-issue relationships are managed through the GitHub API directly via `gh api`.
+The `gh issue` CLI does not have native sub-issue support. Sub-issue relationships use GitHub's parent-child issue model: the orchestrator creates a child issue and links it to the parent, establishing a tracked relationship. The parent's sub-issue list can then be queried to check how many sub-issues are open versus resolved, which is how the orchestrator determines when all tasks are complete. This querying and linking is done through the GitHub API directly.
 
 ---
 
@@ -92,9 +92,11 @@ Labels organize issues along two independent axes: type and status.
 
 **Type labels** mirror the branch prefix taxonomy: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`, `perf`. Apply the matching type label when creating an issue. Type labels are always recommended — they connect the issue to the kind of work it tracks and make filtering straightforward.
 
-**Status labels** reflect where work stands in the lifecycle: `in-progress` (worktree created, delegation started) and `ready-for-review` (PR created). Status labels are optional — apply them when the project uses a label system or when the user has enabled status tracking. Not every project benefits from this level of overhead.
+**Status labels** reflect where work stands in the lifecycle: `in-progress` (worktree created, delegation started) and `ready-for-review` (PR created). Status labels are removed when the issue closes at merge — they track lifecycle state, so they naturally clear when the lifecycle ends. Status labels are optional — apply them when the project uses a label system or when the user has enabled status tracking. Not every project benefits from this level of overhead.
 
 The orchestrator applies labels; subagents never touch them. This is consistent with the role boundary that reserves all issue and PR management for the orchestrator.
+
+GitHub does not auto-create labels. On a fresh repository, the orchestrator must create any needed labels before applying them. Creating a label that already exists has no effect, so the orchestrator can safely attempt creation on first use without checking whether the label already exists.
 
 ---
 


### PR DESCRIPTION
## Summary

Implements 3 proposals from Session 7 github plugin review (comparing gobbi-git against the GitHub MCP server tool surface):

- **Sub-issue model** — guidance for hierarchical issue tracking when features decompose into 3+ independent tasks. Parent issue + sub-issues, each with own branch/worktree/PR. Framed as guidance, not mandate.
- **Label taxonomy** — two-tier model: type labels (always recommended, mirror branch prefixes) and status labels (optional, lifecycle tracking). Orchestrator-only per existing role boundaries.
- **CI failure log retrieval** — expanded CI failure recovery to include diagnostic sequence (list runs, view failed logs) before fix-commit-push. Includes external CI fallback.

## Files changed

- `.claude/skills/gobbi-git/conventions.md` — added Sub-issues and Labels sections (89 → 113 lines)
- `.claude/skills/gobbi-git/SKILL.md` — updated issue principle, expanded CI failure block (118 → 118 lines)

## Verification

- [x] Both files under 200 lines (113, 118)
- [x] Zero code blocks (gobbi-claude anti-pattern)
- [x] Sub-issues section reads as guidance, not mandate
- [x] Labels clearly marks status tier as optional
- [x] CI log retrieval matches existing failure mode prose style

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)