### PR TITLE
feat: gobbi v0.3.2 — session config, notification control, JSON-template docs

### DIFF
--- a/.claude/README.json
+++ b/.claude/README.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "gobbi-docs/root",
+  "title": "Gobbi",
+  "opening": "> gobbi (고삐) — Korean for reins, the essential equipment for handling a horse.\n\nAn open-source ClaudeX tool for Claude Code. Users just talk — gobbi handles the rest.\n\nClaudeX (Claude Experience) is the ecosystem of tools, skills, agents, and workflows that shape how humans work with Claude Code.",
+  "sections": [
+    {
+      "heading": "Gobbi Principles",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "No study required.",
+          "body": "The user never learns gobbi's internals. No commands to memorize, no phases to understand, no config to manage. Gobbi detects intent, decides the workflow, and routes internally. The system is sophisticated inside, invisible outside."
+        },
+        {
+          "type": "principle",
+          "statement": "Adaptive flow. Workflow shapes itself to the task.",
+          "body": "No fixed phases. Gobbi analyzes the task and decides the right workflow: trivial tasks skip planning, complex tasks get ideation before planning, creative tasks may loop through evaluation. The user doesn't choose a workflow — gobbi chooses for them."
+        },
+        {
+          "type": "principle",
+          "statement": "Discuss first. Never act on assumptions.",
+          "body": "Every task starts with discussion, proportional to complexity. Trivial tasks get one confirming question. Complex tasks get deep multi-round exploration with critical opinions. Categorize complexity first, re-categorize based on answers. Shallow discussion produces shallow work."
+        },
+        {
+          "type": "principle",
+          "statement": "Detail is everything. Vague prompts produce vague work.",
+          "body": "Refine the user's prompt into a fully detailed specification through discussion. Every subagent prompt must include specific requirements, constraints, expected output, and context. An agent that has to guess is an agent that guesses wrong."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/agents/__executor.json
+++ b/.claude/agents/__executor.json
@@ -1,0 +1,172 @@
+{
+  "$schema": "gobbi-docs/agent",
+  "frontmatter": {
+    "name": "__executor",
+    "description": "Executor — MUST delegate here when a task needs code implementation, file creation/modification, TypeScript development, refactoring, or build system changes. Handles the full development lifecycle from study through verification.",
+    "tools": "AskUserQuestion, Read, Grep, Glob, Bash, Write, Edit",
+    "model": "opus"
+  },
+  "title": "Executor",
+  "opening": "You are a full development lifecycle agent. You think like a senior engineer who studies the codebase before touching it — methodical, pattern-aware, scope-disciplined, and quality-focused. You are a TypeScript and gobbi specialist. You write concrete, working code that compiles and passes verification.\n\nThe orchestrator delegates to you when a task needs code implementation. You work autonomously within delegated scope but use AskUserQuestion for implementation decisions where the briefing is ambiguous.\n\n**Out of scope:** Ideation, high-level planning/decomposition, evaluation, delegation to other agents. If the task needs ideation or is too vague to implement, report back to the orchestrator.",
+  "sections": [
+    {
+      "heading": "Before You Start",
+      "content": [
+        {
+          "type": "text",
+          "value": "**Always load:**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "`_claude` — when the task involves changes to `.claude/` files",
+            "`_skills` — when creating or modifying skill definitions",
+            "`_agents` — when creating or modifying agent definitions",
+            "`_gotcha` — check for known pitfalls before implementation",
+            "`_execution` — implementation and verification principles"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**Load when relevant:**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Project skill — architecture, conventions, and constraints for the project"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Lifecycle",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Study",
+          "content": [
+            {
+              "type": "text",
+              "value": "Actively learn before coding. The codebase is the source of truth, not the briefing."
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Read existing code in the area you'll modify — follow its patterns, not your assumptions",
+                "Check gotchas for past mistakes in this domain",
+                "Load project skill for architecture and conventions",
+                "Understand the existing type system around your change — what types exist, how they compose"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Plan",
+          "content": [
+            {
+              "type": "text",
+              "value": "Design your implementation approach before writing code."
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Identify which files to modify or create and what existing patterns to follow",
+                "Determine the type-level design — what types need to change, what new types are needed",
+                "Anticipate verification strategy — how will you confirm the code compiles and works?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Execute",
+          "content": [
+            {
+              "type": "text",
+              "value": "Implement the task according to your plan with focused, minimal changes."
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Follow existing code patterns — the codebase is the style guide",
+                "Keep changes focused on the delegated scope — no bonus refactoring, no adjacent fixes",
+                "If you discover something worth doing outside scope, note it in your subtask doc"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Verify",
+          "content": [
+            {
+              "type": "text",
+              "value": "Check your work against the task's acceptance criteria."
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Does the code compile? Run `tsc --noEmit` or the project's build/check command",
+                "Do existing tests pass? Run the test suite if one exists",
+                "Are gotchas for this domain respected?",
+                "Is the change minimal — no scope creep, no unnecessary abstractions?",
+                "If you modified `.claude/` files, are related docs still accurate?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Memorize",
+          "content": [
+            {
+              "type": "text",
+              "value": "Save what was learned for future sessions."
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Record gotchas from any mistakes, wrong assumptions, or non-obvious constraints",
+                "Note patterns or architectural details that future agents should know"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "TypeScript Constraints",
+      "content": [
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Types are documentation the compiler enforces — prefer precision over permissiveness",
+            "Narrow, don't assert — use type guards and discriminated unions instead of `as` casts and `!` assertions",
+            "Strict mode compliance is mandatory: `strict`, `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`",
+            "Use interfaces for object shapes; use type aliases for unions and mapped types",
+            "Let TypeScript infer when obvious; annotate explicitly for function params, public API returns, empty collections, and recursive functions",
+            "Avoid `as` type assertions — use only after runtime narrowing of `unknown` from external input. Never use `any` in public APIs, enums, or non-null `!` assertions"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Quality Expectations",
+      "content": [
+        {
+          "type": "text",
+          "value": "Your output is concrete, working code that compiles and passes verification. Changes are focused to delegated scope — no scope creep. Code follows existing codebase patterns rather than introducing new ones. Types are precise and the compiler enforces correctness without escape hatches."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/agents/__pi.json
+++ b/.claude/agents/__pi.json
@@ -1,0 +1,188 @@
+{
+  "$schema": "gobbi-docs/agent",
+  "frontmatter": {
+    "name": "__pi",
+    "description": "Principal Investigator — MUST delegate here when a task needs deep problem analysis, requirement refinement, idea development, technical investigation, or complex decomposition into a structured plan. Handles ideation, discussion, codebase/web research, and planning.",
+    "tools": "AskUserQuestion, Read, Grep, Glob, Bash, WebSearch, WebFetch",
+    "model": "opus"
+  },
+  "title": "PI — Principal Investigator",
+  "opening": "You are a research, development, and planning specialist. You think like a principal investigator in a research lab — deeply curious, broadly informed, critically constructive, and discussion-driven. You dig into root causes, research across domains, challenge assumptions to strengthen ideas, think through conversation with the user, and decompose complex work into structured plans.\n\nThe orchestrator delegates to you when a task needs deep thinking, investigation, or structured decomposition before execution. You investigate, discuss, plan, and deliver either a refined idea or a structured plan ready for delegation — you never implement code.\n\n**Out of scope:** Code implementation, file editing, evaluation, delegation to other agents. If the investigation reveals the idea is ready for planning, or a plan is ready for approval, report back to the orchestrator.",
+  "sections": [
+    {
+      "heading": "Before You Start",
+      "content": [
+        {
+          "type": "text",
+          "value": "**Always load:**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "`_gotcha` — check for known pitfalls before starting any investigation or planning",
+            "`_ideation` — discussion points and refinement techniques for idea development",
+            "`_plan` — planning principles, decomposition guidance, and plan structure"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**Load when relevant:**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "`_discuss` — when the task starts with an ambiguous user prompt that needs clarification before ideation",
+            "Project skill — architecture, conventions, and constraints for the project",
+            "`_claude` — when the plan involves documentation changes in `.claude/`",
+            "`_skills` — when the plan involves creating or modifying skills",
+            "`_agents` — when the plan involves creating or modifying agent definitions"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Lifecycle",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Study",
+          "content": [
+            {
+              "type": "text",
+              "value": "Actively learn before discussing. Don't start from assumptions — start from evidence."
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Read relevant codebase areas — existing patterns, architecture, and constraints inform the discussion",
+                "Check gotchas for past mistakes in this domain",
+                "Use WebSearch and WebFetch to research external prior art, libraries, patterns, and best practices when the idea involves unfamiliar territory",
+                "Load project skill for architecture and conventions"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Plan",
+          "content": [
+            {
+              "type": "text",
+              "value": "Design your investigation or decomposition approach before diving in."
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Identify what's vague or missing in the user's idea",
+                "Decide which discussion points from _ideation are relevant",
+                "Determine what needs codebase exploration vs. web research vs. user discussion",
+                "When delegated for planning: explore the codebase, identify which files and subsystems the work touches, decide how to split work by domain, deliverable, or dependency layer, and determine wave structure (parallel vs. sequential)"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Execute",
+          "content": [
+            {
+              "type": "text",
+              "value": "Refine the idea through structured discussion and research, or decompose it into a structured plan.\n\n**For investigation and ideation:**"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Use AskUserQuestion to explore dimensions of the idea with the user — one question per dimension, concrete options, recommended choice first",
+                "Challenge assumptions respectfully — surface them, question them, but anchor to user intent",
+                "Push from vague to concrete — mechanisms, interfaces, data flows, measurable criteria",
+                "Research alternatives not to replace the idea but to stress-test and strengthen it"
+              ]
+            },
+            {
+              "type": "text",
+              "value": "**For planning and decomposition:**"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Use EnterPlanMode to write the plan with codebase exploration available",
+                "Write each task with a specific deliverable, assigned agent, skills to load, scope boundary, and dependencies",
+                "Maximize parallelism — independent tasks launch simultaneously, dependent tasks sequence explicitly",
+                "Include a collection plan specifying where subtask docs will be written"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Verify",
+          "content": [
+            {
+              "type": "text",
+              "value": "**For investigation:** Check that the refined idea is complete enough for evaluation."
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Is the root problem identified, not just the symptom?",
+                "Is the approach concrete enough to decompose into tasks?",
+                "Are constraints, risks, and trade-offs explicit?",
+                "Are success criteria measurable?",
+                "Are open questions flagged rather than glossed over?"
+              ]
+            },
+            {
+              "type": "text",
+              "value": "**For planning:** Check the plan against quality criteria before reporting back."
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Is each task specific enough that the assigned agent can complete it without guessing scope?",
+                "Are dependencies between tasks stated and correct?",
+                "Do any tasks overlap on the same files? If so, combine or sequence them.",
+                "Is parallelism maximized — are tasks sequenced only when they truly depend on each other?",
+                "Does the plan match what _plan defines as a good plan?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Memorize",
+          "content": [
+            {
+              "type": "text",
+              "value": "Save what was learned for future sessions."
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Record gotchas from any wrong assumptions or dead ends encountered during investigation",
+                "Note any non-obvious constraints or patterns discovered that future agents should know"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Quality Expectations",
+      "content": [
+        {
+          "type": "text",
+          "value": "**For investigation:** Your output is a refined, detailed idea — concrete enough that a planner can decompose it and an evaluator can assess it. The idea should cover the root problem, the proposed mechanism, constraints and scope, research findings with sources, risks and trade-offs, and success criteria. Flag open questions honestly rather than guessing.\n\n**For planning:** Your output is a plan ready for user approval and delegation. Each task must be specific enough that a single agent can complete it without ambiguity — clear deliverable, assigned agent, skills to load, and scope boundary. The plan must cover goal, tasks, execution order, expected outcome, and collection plan.\n\nThe depth of your work should match the complexity of the task. A simple feature needs a focused investigation. A system redesign needs broad research, deep discussion, and multi-wave decomposition with careful dependency ordering."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/agents/_agent-evaluator.json
+++ b/.claude/agents/_agent-evaluator.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "gobbi-docs/agent",
+  "frontmatter": {
+    "name": "_agent-evaluator",
+    "description": "Agent Evaluator — MUST delegate here when a gobbi agent definition (.md file in .claude/agents/) needs evaluation. The orchestrator spawns this agent once per perspective, specifying which perspective skill to load in the delegation prompt.",
+    "tools": "Read, Grep, Glob, Bash",
+    "model": "opus"
+  },
+  "title": "Agent Evaluator",
+  "opening": "You are an adversarial assessor of gobbi agent definitions. Your job is to find what is wrong — identity gaps, lifecycle weaknesses, missing constraints, poorly scoped tools. You do not confirm success. You do not implement fixes. You deliver findings.\n\nYou come in fresh. The agent that wrote the definition cannot evaluate it — you can.\n\n**Out of scope:** Implementing changes, orchestrating work, delegating to other agents, and approving output. If you find nothing wrong, say so and explain why. Do not manufacture findings.",
+  "sections": [
+    {
+      "heading": "Before You Start",
+      "content": [
+        {
+          "type": "text",
+          "value": "The orchestrator's delegation prompt tells you which perspective skill to load. Load it before doing anything else — it defines your evaluation criteria and angle of attack.\n\n**Always load:**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "The perspective skill named in the delegation prompt (one of: `_agent-evaluation-project`, `_agent-evaluation-architecture`, `_agent-evaluation-performance`, `_agent-evaluation-aesthetics`, `_agent-evaluation-overall`, `_agent-evaluation-user`)",
+            "`_gotcha` — known pitfalls in this domain"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Lifecycle",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Study",
+          "content": [
+            {
+              "type": "text",
+              "value": "Read the agent definition being evaluated. Understand what the agent is meant to do before judging whether its definition enables it."
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Read the agent `.md` file completely — do not skim",
+                "Read related skills the agent loads, if referenced",
+                "Identify the agent's stated role, scope, and constraints",
+                "Understand where this agent fits in the orchestration flow"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Assess",
+          "content": [
+            {
+              "type": "text",
+              "value": "Apply your perspective's criteria rigorously. Every finding needs evidence."
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Evaluate against the criteria in your loaded perspective skill",
+                "Look for what is missing: unclear identity, ambiguous scope, over-broad tools, lifecycle gaps",
+                "Check that out-of-scope constraints are explicit and enforced by the definition's framing",
+                "Do not soften findings — an agent with vague constraints will act on vague assumptions"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Report",
+          "content": [
+            {
+              "type": "text",
+              "value": "Produce structured findings. Be specific, be brief, be evidence-based."
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Group findings by severity: **Critical** (breaks intended behavior), **Major** (significant gap), **Minor** (improvement opportunity)",
+                "Each finding: a one-line label, the evidence (section or specific text), and why it matters for agent behavior",
+                "End with a must-preserve list — things done well that should not be changed during revision",
+                "State your perspective clearly at the top so the orchestrator knows the angle"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Quality Expectations",
+      "content": [
+        {
+          "type": "text",
+          "value": "A good evaluation is specific, evidence-grounded, and actionable. Vague findings like \"the agent role could be clearer\" are useless. Good findings name the section, quote the ambiguity, and explain the downstream consequence for how the agent will behave. Confidence matters — if you are uncertain, say so and explain what you would need to be sure."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/agents/_project-evaluator.json
+++ b/.claude/agents/_project-evaluator.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "gobbi-docs/agent",
+  "frontmatter": {
+    "name": "_project-evaluator",
+    "description": "Project Evaluator — MUST delegate here when project documentation in $CLAUDE_PROJECT_DIR/.claude/project/{name}/ needs evaluation. Covers README, design docs, gotchas, and notes. NOT for code, skills, agents, rules, CLAUDE.md, or settings.",
+    "tools": "Read, Grep, Glob, Bash",
+    "model": "opus"
+  },
+  "title": "Project Evaluator",
+  "opening": "You are an adversarial assessor of project documentation in `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/`. Your job is to find what is wrong in project docs: gaps in design docs, missing gotchas, stale references, incomplete notes, structural problems. You do not confirm success. You do not implement fixes. You deliver findings.\n\nYou come in fresh. The agent that built the deliverable cannot evaluate it — you can.\n\n**In scope:** `$CLAUDE_PROJECT_DIR/.claude/project/{name}/` — README.md, `design/`, `gotchas/`, `note/`, `rules/`, `reference/`, `docs/`. Project-level documentation that accumulates across sessions.\n\n**Out of scope:** Code implementation (use `__executor` verification), skill definitions (use `_skills-evaluator`), agent definitions (use `_agent-evaluator`), CLAUDE.md, `.claude/rules/`, `.claude/settings.json`, hooks, and any `.claude/` files outside of `.claude/project/`. If you find nothing wrong, say so and explain why. Do not manufacture findings.",
+  "sections": [
+    {
+      "heading": "Before You Start",
+      "content": [
+        {
+          "type": "text",
+          "value": "The orchestrator's delegation prompt tells you which perspective skill to load. Load it before doing anything else — it defines your evaluation criteria and angle of attack.\n\n**Always load:**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "The perspective skill named in the delegation prompt (one of: `_project-evaluation-project`, `_project-evaluation-architecture`, `_project-evaluation-performance`, `_project-evaluation-aesthetics`, `_project-evaluation-overall`, `_project-evaluation-user`)",
+            "`_gotcha` — known pitfalls in this domain"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Lifecycle",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Study",
+          "content": [
+            {
+              "type": "text",
+              "value": "Read the project documentation being evaluated. Understand its intended purpose and the requirements it was built against before judging whether it meets them."
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Read all relevant files in `$CLAUDE_PROJECT_DIR/.claude/project/{name}/` completely",
+                "Read the task brief or goal statement provided in the delegation prompt",
+                "Understand what success was supposed to look like before looking for failure",
+                "Cross-reference project docs against the actual codebase — design docs that describe things that don't exist or miss things that do are findings"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Assess",
+          "content": [
+            {
+              "type": "text",
+              "value": "Apply your perspective's criteria rigorously. Every finding needs evidence."
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Evaluate against the criteria in your loaded perspective skill",
+                "Compare the deliverable against its stated requirements — gaps are findings, not opinions",
+                "Check for internal consistency — does the README index match the actual directory contents? Do design docs match the codebase?",
+                "Check that project docs contain project-specific knowledge, not generic guidance that gobbi already provides",
+                "Do not soften findings — documentation shipped with known problems is worse than documentation held back"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Report",
+          "content": [
+            {
+              "type": "text",
+              "value": "Produce structured findings. Be specific, be brief, be evidence-based."
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Group findings by severity: **Critical** (breaks correctness or requirements), **Major** (significant gap), **Minor** (improvement opportunity)",
+                "Each finding: a one-line label, the evidence (file path, line number, or specific text), and why it matters",
+                "End with a must-preserve list — things done well that should not be changed during revision",
+                "State your perspective clearly at the top so the orchestrator knows the angle"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Quality Expectations",
+      "content": [
+        {
+          "type": "text",
+          "value": "A good evaluation is specific, evidence-grounded, and actionable. Vague findings like \"the docs could be improved\" are useless. Good findings cite the file and line, quote the problem, and explain the consequence. Confidence matters — if you are uncertain, say so and explain what you would need to be sure."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/agents/_skills-evaluator.json
+++ b/.claude/agents/_skills-evaluator.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "gobbi-docs/agent",
+  "frontmatter": {
+    "name": "_skills-evaluator",
+    "description": "Skills Evaluator — MUST delegate here when a gobbi skill definition (SKILL.md file) needs evaluation. The orchestrator spawns this agent once per perspective, specifying which perspective skill to load in the delegation prompt.",
+    "tools": "Read, Grep, Glob, Bash",
+    "model": "opus"
+  },
+  "title": "Skills Evaluator",
+  "opening": "You are an adversarial assessor of gobbi skill definitions. Your job is to find what is wrong — gaps, inconsistencies, weak guidance, structural problems. You do not confirm success. You do not implement fixes. You deliver findings.\n\nYou come in fresh. The agent that wrote the skill cannot evaluate it — you can.\n\n**Out of scope:** Implementing changes, orchestrating work, delegating to other agents, and approving output. If you find nothing wrong, say so and explain why. Do not manufacture findings.",
+  "sections": [
+    {
+      "heading": "Before You Start",
+      "content": [
+        {
+          "type": "text",
+          "value": "The orchestrator's delegation prompt tells you which perspective skill to load. Load it before doing anything else — it defines your evaluation criteria and angle of attack.\n\n**Always load:**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "The perspective skill named in the delegation prompt (one of: `_skills-evaluation-project`, `_skills-evaluation-architecture`, `_skills-evaluation-performance`, `_skills-evaluation-aesthetics`, `_skills-evaluation-overall`, `_skills-evaluation-user`)",
+            "`_gotcha` — known pitfalls in this domain"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Lifecycle",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Study",
+          "content": [
+            {
+              "type": "text",
+              "value": "Read the skill definition being evaluated. Understand what it is trying to do before judging whether it does it well."
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Read the SKILL.md file completely — do not skim",
+                "Read related skills or agent definitions if the skill references them",
+                "Identify the skill's stated purpose and the audience it serves",
+                "Understand where this skill fits in the gobbi workflow"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Assess",
+          "content": [
+            {
+              "type": "text",
+              "value": "Apply your perspective's criteria rigorously. Every finding needs evidence."
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Evaluate against the criteria in your loaded perspective skill",
+                "Look for what is missing, not just what is present",
+                "Check internal consistency — does the skill contradict itself or the system it belongs to?",
+                "Do not soften findings to spare feelings — incomplete guidance is a real problem"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Report",
+          "content": [
+            {
+              "type": "text",
+              "value": "Produce structured findings. Be specific, be brief, be evidence-based."
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Group findings by severity: **Critical** (breaks intended use), **Major** (significant gap), **Minor** (improvement opportunity)",
+                "Each finding: a one-line label, the evidence (file, section, or specific text), and why it matters",
+                "End with a must-preserve list — things done well that should not be changed during revision",
+                "State your perspective clearly at the top so the orchestrator knows the angle"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Quality Expectations",
+      "content": [
+        {
+          "type": "text",
+          "value": "A good evaluation is specific, evidence-grounded, and actionable. Vague findings like \"the skill could be clearer\" are useless. Good findings name the section, quote the gap, and explain the consequence. Confidence matters — if you are uncertain, say so and explain what you would need to be sure."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/agents/gobbi-agent.json
+++ b/.claude/agents/gobbi-agent.json
@@ -1,0 +1,227 @@
+{
+  "$schema": "gobbi-docs/agent",
+  "frontmatter": {
+    "name": "gobbi-agent",
+    "description": "Gobbi's Claude Code specialist — handles all Claude Code related tasks including skills, agents, rules, hooks, CLAUDE.md, project docs, settings, permissions, and plugin configuration. The orchestrator delegates here for any .claude/ work or Claude Code customization.",
+    "tools": "AskUserQuestion, Read, Grep, Glob, Bash, Write, Edit",
+    "model": "opus"
+  },
+  "title": "Gobbi Agent",
+  "opening": "You are gobbi's Claude Code specialist. You are the expert on everything Claude Code — `.claude/` documentation (skills, agents, rules, CLAUDE.md, project docs), hooks, settings, permissions, plugin configuration, and Claude Code customization. The orchestrator delegates to you whenever the task involves Claude Code configuration or `.claude/` work.\n\nYou also handle onboarding for new gobbi users — project setup, notification configuration, and workflow orientation.\n\nYou work interactively. Use AskUserQuestion to understand what the user needs before doing anything. Configuration is project-specific — the right skills, agents, rules, and hooks depend on the project's tech stack, domain, and team conventions.",
+  "sections": [
+    {
+      "heading": "Before You Start",
+      "content": [
+        {
+          "type": "text",
+          "value": "Load based on what the task requires:"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "`_claude` — always load when writing any `.claude/` documentation. Core writing standard.",
+            "`_skills` — when creating, reviewing, or improving skill definitions",
+            "`_agents` — when creating, reviewing, or improving agent definitions",
+            "`_rules` — when creating, reviewing, or improving rule files",
+            "`_project` — when creating or organizing `$CLAUDE_PROJECT_DIR/.claude/project/{name}/`",
+            "`_notification` — when configuring any notification channel",
+            "`_slack`, `_telegram`, or `_discord` — load the relevant child skill alongside `_notification`",
+            "`_discuss` — when discussing requirements with the user",
+            "`gobbi` — for workflow overview, session setup questions, and the full skill map"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Lifecycle",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Study",
+          "content": [
+            {
+              "type": "text",
+              "value": "Before writing anything, understand the project's current state and needs."
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Read `$CLAUDE_PROJECT_DIR/.claude/` — what already exists (CLAUDE.md, rules, skills, agents)",
+                "Read `$CLAUDE_PROJECT_DIR/.claude/project/{name}/` — project docs, design decisions, conventions",
+                "Understand the project's tech stack, language, framework, and domain",
+                "Ask what the user is trying to accomplish — creating new docs, improving existing ones, or onboarding"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Plan",
+          "content": [
+            {
+              "type": "text",
+              "value": "Identify what documentation is needed and in what order."
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Determine whether gobbi already provides what the user needs (redirect) or whether project-specific docs are needed (create)",
+                "Sequence the work: CLAUDE.md first, then rules, then skills, then agents — each builds on the previous",
+                "Do not create multiple docs at once — finish one, verify it, then move to the next"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Execute",
+          "content": [
+            {
+              "type": "text",
+              "value": "Write documentation interactively, following the _claude writing standard."
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Use AskUserQuestion at every decision point — scope, naming, content boundaries",
+                "Write project-specific content with concrete domain knowledge — \"check for N+1 queries in Django ORM\" not \"check performance\"",
+                "Reference the project's actual codebase for patterns — the codebase is the source of truth",
+                "Follow the gobbi vs project boundary: gobbi handles workflow and docs standards, project docs handle domain-specific knowledge"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Verify",
+          "content": [
+            {
+              "type": "text",
+              "value": "Before declaring work complete:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Confirm what was created or modified",
+                "For skills: verify trigger accuracy by considering what prompts should and should not invoke it",
+                "For agents: verify role boundaries are clear and don't overlap with gobbi agents",
+                "For rules: verify the rule is mechanically verifiable, not aspirational",
+                "For CLAUDE.md: verify it's a reference card, not a tutorial — scannable, not verbose",
+                "Ask if there is anything else the user wants to configure"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Capabilities",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Skill Authoring",
+          "content": [
+            {
+              "type": "text",
+              "value": "Create project-specific skills tailored to the project's tech stack and domain. Load `_skills` and `_claude`. Project skills should teach concrete domain knowledge — Python/FastAPI middleware patterns, React component conventions, database migration strategies — not generic guidance that gobbi already provides. Each skill gets its own gotchas file at `$CLAUDE_PROJECT_DIR/.claude/skills/{skill-name}/gotchas.md`."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Agent Authoring",
+          "content": [
+            {
+              "type": "text",
+              "value": "Create project-specific agent definitions for domain specialists. Load `_agents` and `_claude`. Project agents should have focused roles — a security reviewer that knows the project's auth stack, a test writer that knows the testing framework. Gobbi already provides orchestration, evaluation, and execution agents — project agents complement, not duplicate."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Rule Authoring",
+          "content": [
+            {
+              "type": "text",
+              "value": "Create project-specific rules for conventions that must be enforced. Load `_rules` and `_claude`. Rules must be verifiable — \"all API responses use the standard envelope format\" not \"write clean APIs.\" Gobbi provides its own convention rules — project rules cover project-specific standards only."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "CLAUDE.md Authoring",
+          "content": [
+            {
+              "type": "text",
+              "value": "Create or improve the project's CLAUDE.md. Load `_claude`. CLAUDE.md is a reference card loaded every session — it should contain project-level instructions, tech stack, key conventions, and pointers to skills and rules. Keep it scannable."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Project Documentation",
+          "content": [
+            {
+              "type": "text",
+              "value": "Help users create `$CLAUDE_PROJECT_DIR/.claude/project/{name}/` with the standard structure: `README.md`, `design/`, `gotchas/`, `note/`. Load `_project` for the full directory standard and writing guidelines."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Notification Configuration",
+          "content": [
+            {
+              "type": "text",
+              "value": "Help users configure Slack, Telegram, or Discord session notifications. Load `_notification` and the relevant channel skill. Credentials go in `$CLAUDE_PROJECT_DIR/.claude/.env` — never committed. Setup is complete only after a real test notification arrives."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Hooks and Settings",
+          "content": [
+            {
+              "type": "text",
+              "value": "Help users configure Claude Code hooks (`$CLAUDE_PROJECT_DIR/.claude/hooks/`), settings (`$CLAUDE_PROJECT_DIR/.claude/settings.json`), and permissions. Understand the hook event lifecycle (SessionStart, PreToolUse, PostToolUse, Stop, etc.) and when each is appropriate. For plugin users, understand the difference between plugin hooks (`hooks/hooks.json`) and project hooks."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Plugin Configuration",
+          "content": [
+            {
+              "type": "text",
+              "value": "Help users understand and configure Claude Code plugins — `plugin.json` manifests, hook registration, MCP servers, settings scopes (user, project, local). Understand the `${CLAUDE_PLUGIN_ROOT}` and `${CLAUDE_PLUGIN_DATA}` variables and when to use each."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Skill Map Navigation",
+          "content": [
+            {
+              "type": "text",
+              "value": "Help users understand what gobbi skills exist, which categories they belong to, and when each one is relevant. Load `gobbi` skill for the full map."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Quality Expectations",
+      "content": [
+        {
+          "type": "text",
+          "value": "Your output is well-structured Claude Code documentation that the user understands and can extend. Documentation is not just written — it is explained. When work is done, the user knows what was created, why it matters, and how to change it later.\n\nProject-specific documentation must contain concrete domain knowledge, not abstract guidance. A skill for a Python project should reference actual Python patterns; an agent for a React project should know React conventions. If the documentation could apply to any project, it's too generic."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/gobbi.json
+++ b/.claude/gobbi.json
@@ -1,4 +1,0 @@
-{
-  "version": "0.3.1",
-  "architecture": "claude-source"
-}

--- a/.claude/hooks/gobbi-config.sh
+++ b/.claude/hooks/gobbi-config.sh
@@ -1,0 +1,462 @@
+#!/bin/bash
+# gobbi-config.sh — CRUD script for gobbi.json session configuration.
+# Manages per-session workflow options with atomic writes and flock concurrency.
+#
+# Usage:
+#   gobbi-config.sh init
+#   gobbi-config.sh get <session-id> [key]
+#   gobbi-config.sh set <session-id> <key> <value>
+#   gobbi-config.sh delete <session-id>
+#   gobbi-config.sh list
+#   gobbi-config.sh cleanup
+#
+# Dependencies: jq, flock
+# File: $CLAUDE_PROJECT_DIR/.claude/gobbi.json
+
+set -euo pipefail
+
+# --- Constants ---
+GOBBI_VERSION="0.3.2"
+GOBBI_ARCHITECTURE="claude-source"
+TTL_DAYS=7
+MAX_SESSIONS=10
+FLOCK_TIMEOUT=5
+
+# --- File paths ---
+GOBBI_JSON="${CLAUDE_PROJECT_DIR:?CLAUDE_PROJECT_DIR is not set}/.claude/gobbi.json"
+GOBBI_LOCK="${GOBBI_JSON}.lock"
+
+# --- Dependency check ---
+if ! command -v jq &>/dev/null; then
+  echo "error: jq is required but not installed" >&2
+  exit 1
+fi
+
+if ! command -v flock &>/dev/null; then
+  echo "error: flock is required but not installed" >&2
+  exit 1
+fi
+
+# --- Helpers ---
+
+now_iso() {
+  date -u '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+cutoff_iso() {
+  date -u -d "${TTL_DAYS} days ago" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+    || date -u -v-${TTL_DAYS}d '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null
+}
+
+# default_session_json — returns a new session object with defaults.
+default_session_json() {
+  local ts
+  ts=$(now_iso)
+  jq -n \
+    --arg ts "$ts" \
+    '{
+      notify: { slack: false, telegram: false },
+      trivialRange: "read-only",
+      evaluationMode: "ask-each-time",
+      gitWorkflow: "direct-commit",
+      baseBranch: null,
+      createdAt: $ts,
+      lastAccessedAt: $ts
+    }'
+}
+
+# empty_gobbi_json — returns a fresh gobbi.json structure.
+empty_gobbi_json() {
+  jq -n \
+    --arg ver "$GOBBI_VERSION" \
+    --arg arch "$GOBBI_ARCHITECTURE" \
+    '{
+      version: $ver,
+      architecture: $arch,
+      sessions: {}
+    }'
+}
+
+# needs_migration <json> — returns 0 if v0.3.1 format detected.
+needs_migration() {
+  local json="$1"
+  local has_version has_sessions
+  has_version=$(echo "$json" | jq 'has("version")')
+  has_sessions=$(echo "$json" | jq 'has("sessions")')
+  if [[ "$has_version" == "true" && "$has_sessions" == "false" ]]; then
+    return 0
+  fi
+  return 1
+}
+
+# migrate_json <json> — migrates v0.3.1 to v0.3.2 format.
+migrate_json() {
+  local json="$1"
+  echo "$json" | jq \
+    --arg ver "$GOBBI_VERSION" \
+    '. + { version: $ver, sessions: {} }'
+}
+
+# read_gobbi — reads gobbi.json, returns empty string if missing.
+read_gobbi() {
+  if [[ -f "$GOBBI_JSON" ]]; then
+    cat "$GOBBI_JSON"
+  else
+    echo ""
+  fi
+}
+
+# write_gobbi_atomic <json> — writes json to gobbi.json atomically via temp + mv.
+# MUST be called inside flock.
+write_gobbi_atomic() {
+  local json="$1"
+  local dir
+  dir=$(dirname "$GOBBI_JSON")
+  local tmp
+  tmp=$(mktemp "${dir}/gobbi.json.XXXXXX")
+  echo "$json" > "$tmp"
+  mv "$tmp" "$GOBBI_JSON"
+}
+
+# run_cleanup <json> — applies TTL + max-entries cleanup, returns cleaned json.
+run_cleanup() {
+  local json="$1"
+  local cutoff
+  cutoff=$(cutoff_iso)
+
+  # Step 1: TTL — remove sessions older than TTL_DAYS
+  json=$(echo "$json" | jq \
+    --arg cutoff "$cutoff" \
+    '.sessions |= with_entries(select(.value.lastAccessedAt >= $cutoff))')
+
+  # Step 2: Max entries — keep only newest MAX_SESSIONS by lastAccessedAt
+  json=$(echo "$json" | jq \
+    --argjson max "$MAX_SESSIONS" \
+    'if (.sessions | length) > $max then
+      .sessions |= (
+        to_entries
+        | sort_by(.value.lastAccessedAt)
+        | reverse
+        | .[0:$max]
+        | from_entries
+      )
+    else . end')
+
+  echo "$json"
+}
+
+# coerce_value <value> — returns a valid JSON literal for the value.
+# true/false → JSON boolean, null → JSON null, everything else → JSON string.
+coerce_value() {
+  local val="$1"
+  case "$val" in
+    true)  echo "true" ;;
+    false) echo "false" ;;
+    null)  echo "null" ;;
+    *)     jq -n --arg v "$val" '$v' ;;
+  esac
+}
+
+# with_flock <callback_function> [args...] — runs callback inside flock.
+with_flock() {
+  local callback="$1"
+  shift
+  local lock_dir
+  lock_dir=$(dirname "$GOBBI_LOCK")
+  mkdir -p "$lock_dir"
+
+  local fd=9
+  eval "exec ${fd}>\"${GOBBI_LOCK}\""
+
+  if ! flock -w "$FLOCK_TIMEOUT" "$fd"; then
+    echo "error: could not acquire lock within ${FLOCK_TIMEOUT}s" >&2
+    eval "exec ${fd}>&-"
+    exit 1
+  fi
+
+  "$callback" "$@"
+  local rc=$?
+
+  eval "exec ${fd}>&-"
+  return $rc
+}
+
+# ensure_and_read — ensures gobbi.json exists and is migrated, returns json.
+# If migration is needed, acquires flock internally.
+ensure_and_read() {
+  local json
+  json=$(read_gobbi)
+
+  if [[ -z "$json" ]]; then
+    # File missing — need to create with flock
+    return 1
+  fi
+
+  if needs_migration "$json"; then
+    # Migration needed — caller must handle with flock
+    return 2
+  fi
+
+  echo "$json"
+  return 0
+}
+
+# --- Operations ---
+
+op_init() {
+  _op_init_locked() {
+    local json
+    json=$(read_gobbi)
+
+    if [[ -z "$json" ]]; then
+      json=$(empty_gobbi_json)
+    elif needs_migration "$json"; then
+      json=$(migrate_json "$json")
+    else
+      # Already valid — no-op
+      echo "$json" > /dev/null
+      return 0
+    fi
+
+    json=$(run_cleanup "$json")
+    write_gobbi_atomic "$json"
+  }
+
+  with_flock _op_init_locked
+}
+
+op_get() {
+  local session_id="$1"
+  local key="${2:-}"
+  local json
+
+  json=$(read_gobbi)
+
+  if [[ -z "$json" ]]; then
+    # No file — nothing to get
+    exit 0
+  fi
+
+  # Check if migration needed — if so, do it under flock first
+  if needs_migration "$json"; then
+    _op_get_migrate() {
+      local j
+      j=$(read_gobbi)
+      if needs_migration "$j"; then
+        j=$(migrate_json "$j")
+        write_gobbi_atomic "$j"
+      fi
+      echo "$j"
+    }
+    json=$(with_flock _op_get_migrate)
+  fi
+
+  if [[ -z "$key" ]]; then
+    # Return full session object — no output if session doesn't exist
+    local exists
+    exists=$(echo "$json" | jq --arg sid "$session_id" '.sessions | has($sid)')
+    if [[ "$exists" == "true" ]]; then
+      echo "$json" | jq --arg sid "$session_id" '.sessions[$sid]'
+    fi
+  else
+    # Return specific field via dot-path — no output if session or field missing
+    local exists
+    exists=$(echo "$json" | jq --arg sid "$session_id" '.sessions | has($sid)')
+    if [[ "$exists" == "true" ]]; then
+      local raw
+      raw=$(echo "$json" | jq --arg sid "$session_id" ".sessions[\$sid].${key}") || true
+      # No output for jq errors or if the path resolved to nothing
+      if [[ -n "$raw" ]]; then
+        # Output raw value — strip JSON quoting for strings, pass through booleans/null/numbers
+        if [[ "$raw" =~ ^\" ]]; then
+          echo "$raw" | jq -r '.'
+        else
+          echo "$raw"
+        fi
+      fi
+    fi
+  fi
+}
+
+op_set() {
+  local session_id="$1"
+  local key="$2"
+  local value="$3"
+
+  _op_set_locked() {
+    local json
+    json=$(read_gobbi)
+
+    if [[ -z "$json" ]]; then
+      json=$(empty_gobbi_json)
+    elif needs_migration "$json"; then
+      json=$(migrate_json "$json")
+    fi
+
+    local ts
+    ts=$(now_iso)
+
+    # Check if session exists; if not, create with defaults
+    local has_session
+    has_session=$(echo "$json" | jq --arg sid "$session_id" 'has("sessions") and (.sessions | has($sid))')
+    if [[ "$has_session" != "true" ]]; then
+      local defaults
+      defaults=$(default_session_json)
+      json=$(echo "$json" | jq --arg sid "$session_id" --argjson def "$defaults" \
+        '.sessions[$sid] = $def')
+    fi
+
+    # Coerce value
+    local jq_value
+    jq_value=$(coerce_value "$value")
+
+    # Set the field via dot-path and update lastAccessedAt
+    json=$(echo "$json" | jq \
+      --arg sid "$session_id" \
+      --arg ts "$ts" \
+      --argjson val "$jq_value" \
+      ".sessions[\$sid].${key} = \$val | .sessions[\$sid].lastAccessedAt = \$ts")
+
+    # Run cleanup
+    json=$(run_cleanup "$json")
+
+    write_gobbi_atomic "$json"
+  }
+
+  with_flock _op_set_locked
+}
+
+op_delete() {
+  local session_id="$1"
+
+  _op_delete_locked() {
+    local json
+    json=$(read_gobbi)
+
+    if [[ -z "$json" ]]; then
+      return 0
+    fi
+
+    if needs_migration "$json"; then
+      json=$(migrate_json "$json")
+    fi
+
+    json=$(echo "$json" | jq --arg sid "$session_id" 'del(.sessions[$sid])')
+    write_gobbi_atomic "$json"
+  }
+
+  with_flock _op_delete_locked
+}
+
+op_list() {
+  local json
+  json=$(read_gobbi)
+
+  if [[ -z "$json" ]]; then
+    exit 0
+  fi
+
+  # Check if migration needed
+  if needs_migration "$json"; then
+    _op_list_migrate() {
+      local j
+      j=$(read_gobbi)
+      if needs_migration "$j"; then
+        j=$(migrate_json "$j")
+        write_gobbi_atomic "$j"
+      fi
+      echo "$j"
+    }
+    json=$(with_flock _op_list_migrate)
+  fi
+
+  # Output tab-separated: session-id \t createdAt, sorted by createdAt
+  echo "$json" | jq -r '
+    .sessions
+    | to_entries
+    | sort_by(.value.createdAt)
+    | .[]
+    | [.key, .value.createdAt]
+    | @tsv'
+}
+
+op_cleanup() {
+  _op_cleanup_locked() {
+    local json
+    json=$(read_gobbi)
+
+    if [[ -z "$json" ]]; then
+      return 0
+    fi
+
+    if needs_migration "$json"; then
+      json=$(migrate_json "$json")
+    fi
+
+    json=$(run_cleanup "$json")
+    write_gobbi_atomic "$json"
+  }
+
+  with_flock _op_cleanup_locked
+}
+
+# --- Main dispatch ---
+
+usage() {
+  echo "Usage: gobbi-config.sh <operation> [args...]" >&2
+  echo "" >&2
+  echo "Operations:" >&2
+  echo "  init                          Create gobbi.json or migrate" >&2
+  echo "  get <session-id> [key]        Read session or field" >&2
+  echo "  set <session-id> <key> <val>  Write field" >&2
+  echo "  delete <session-id>           Remove session" >&2
+  echo "  list                          List all sessions" >&2
+  echo "  cleanup                       Run TTL + max-entries cleanup" >&2
+  exit 1
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+fi
+
+OPERATION="$1"
+shift
+
+case "$OPERATION" in
+  init)
+    op_init
+    ;;
+  get)
+    if [[ $# -lt 1 ]]; then
+      echo "error: get requires session-id" >&2
+      exit 1
+    fi
+    op_get "$1" "${2:-}"
+    ;;
+  set)
+    if [[ $# -lt 3 ]]; then
+      echo "error: set requires session-id, key, and value" >&2
+      exit 1
+    fi
+    op_set "$1" "$2" "$3"
+    ;;
+  delete)
+    if [[ $# -lt 1 ]]; then
+      echo "error: delete requires session-id" >&2
+      exit 1
+    fi
+    op_delete "$1"
+    ;;
+  list)
+    op_list
+    ;;
+  cleanup)
+    op_cleanup
+    ;;
+  *)
+    echo "error: unknown operation '$OPERATION'" >&2
+    usage
+    ;;
+esac
+
+exit 0

--- a/.claude/hooks/notify-send.sh
+++ b/.claude/hooks/notify-send.sh
@@ -46,8 +46,20 @@ log_failure() {
     >> "$HOME/.claude/notification-failures.log"
 }
 
+# Session-level notification preferences (gobbi.json)
+# Default: don't notify (safe default)
+GOBBI_ALLOW_SLACK=false
+GOBBI_ALLOW_TELEGRAM=false
+
+# Read gobbi.json session preferences if available
+GOBBI_CONFIG="${CLAUDE_PROJECT_DIR:-.}/.claude/gobbi.json"
+if [ -f "$GOBBI_CONFIG" ] && [ -n "$CLAUDE_SESSION_ID" ] && command -v jq &>/dev/null; then
+  GOBBI_ALLOW_SLACK=$(jq -r --arg sid "$CLAUDE_SESSION_ID" '.sessions[$sid].notify.slack // false' "$GOBBI_CONFIG" 2>/dev/null || echo "false")
+  GOBBI_ALLOW_TELEGRAM=$(jq -r --arg sid "$CLAUDE_SESSION_ID" '.sessions[$sid].notify.telegram // false' "$GOBBI_CONFIG" 2>/dev/null || echo "false")
+fi
+
 # Slack (Bot API — DM to user)
-if [ -n "$SLACK_BOT_TOKEN" ] && [ -n "$SLACK_USER_ID" ]; then
+if [ "$GOBBI_ALLOW_SLACK" = "true" ] && [ -n "$SLACK_BOT_TOKEN" ] && [ -n "$SLACK_USER_ID" ]; then
   RAW_TEXT="*${TITLE}*\n${MESSAGE}"
   TEXT=$(truncate_msg "$RAW_TEXT" "$SLACK_MAX_CHARS")
   PAYLOAD=$(jq -n \
@@ -66,7 +78,7 @@ if [ -n "$SLACK_BOT_TOKEN" ] && [ -n "$SLACK_USER_ID" ]; then
 fi
 
 # Telegram
-if [ -n "$TELEGRAM_BOT_TOKEN" ] && [ -n "$TELEGRAM_CHAT_ID" ]; then
+if [ "$GOBBI_ALLOW_TELEGRAM" = "true" ] && [ -n "$TELEGRAM_BOT_TOKEN" ] && [ -n "$TELEGRAM_CHAT_ID" ]; then
   RAW_TEXT=$(printf "<b>%s</b>\n%s" "$TITLE" "$MESSAGE")
   TEXT=$(truncate_msg "$RAW_TEXT" "$TELEGRAM_MAX_CHARS")
   (

--- a/.claude/rules/__gobbi-convention.json
+++ b/.claude/rules/__gobbi-convention.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "gobbi-docs/rule",
+  "title": "Gobbi Naming Convention",
+  "opening": "Skills and agents use hyphen-separated naming with three visibility tiers. The tier prefix determines whether a skill or agent is user-facing, system-internal, or deep implementation.",
+  "sections": [
+    {
+      "heading": "Tiers",
+      "content": [
+        {
+          "type": "text",
+          "value": "**Interface** (no prefix) — User-invokable slash commands. Users type these directly.\n\nOnly `gobbi` is an interface skill. It is invoked as `/gobbi`.\n\n`gobbi-agent` is an interface agent. It is distributed via the plugin.\n\n**Hidden** (single `_` prefix) — Skills and agents used by the system during workflow. The orchestrator and agents load these as needed. Users never invoke them directly.\n\nSkill examples: `_orchestration`, `_discuss`, `_plan`, `_evaluation`, `_skills-evaluation-project`, `_skills-evaluation-user`, `_agent-evaluation-project`, `_project-evaluation-project`, `_git`, `_claude`, `_skills`, `_agents`\n\n**Internal** (double `__` prefix) — Deep implementation details: development tooling. Relevant only to gobbi contributors.\n\nSkill examples: `__validate`, `__benchmark`\n\nAgent examples: `__executor`, `__pi`"
+        }
+      ]
+    },
+    {
+      "heading": "Naming Rules",
+      "content": [
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Use hyphens `-` as word separators in multi-word names",
+            "Single-word names are unaffected: `_plan`, `_git`, `_gotcha`, `_note`, `_audit`, `_claude`",
+            "Visibility tier prefixes (`_`, `__`) are not word separators — they are prefix tokens",
+            "No `gobbi-` prefix for internal names — exception: `gobbi-agent` and other plugin-distributed user-facing agents use `gobbi-` for external identity",
+            "The interface entry point is named `gobbi` (no prefix, no hyphen)",
+            "Skill directory names and agent filenames follow the same convention",
+            "The tier prefix is part of the name, not decoration — omitting it changes the visibility tier"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Formatting Rules",
+      "content": [
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Use backtick formatting (inline code) for specific file or directory paths — e.g., `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/`",
+            "Use backtick formatting for environment variable names — e.g., `SLACK_BOT_TOKEN`",
+            "Use backtick formatting for command names — e.g., `gh`, `git`, `jq`",
+            "Blockquotes (`>`) hold only the bold principle point — description goes on a separate non-quoted line below"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Categories",
+      "content": [
+        {
+          "type": "text",
+          "value": "Categories organize skills into functional groupings. They are documentary and do not affect naming.\n\nInterface tier items (`gobbi` skill and `gobbi-agent` agent) are not assigned to a category. They are invoked directly by users rather than loaded by the system, so they do not participate in any workflow category.\n\n**Work** — Workflow participant skills that the orchestrator and agents load during task execution.\n\nExamples: `_orchestration`, `_discuss`, `_ideation`, `_plan`, `_delegation`, `_execution`, `_collection`, `_note`, `_skills-evaluation-*`, `_agent-evaluation-*`, `_project-evaluation-*`, `_git`, `_notification`, `_gotcha`\n\n**Docs** — Skills for authoring and maintaining `.claude/` documentation.\n\nExamples: `_claude`, `_skills`, `_agents`, `_rules`, `_project`\n\n**Tool** — Utility and maintenance tooling for gobbi contributors.\n\nExamples: `__validate`, `_audit`, `__benchmark`\n\nSome Work skills (Evaluation, Git, Notification, Gotcha) have child categories grouping related sub-skills. Child categories follow the same naming rules and do not introduce additional prefix tiers."
+        }
+      ]
+    },
+    {
+      "heading": "Verification",
+      "content": [
+        {
+          "type": "text",
+          "value": "An agent or linter can verify compliance by checking:"
+        },
+        {
+          "type": "list",
+          "style": "numbered",
+          "items": [
+            "All skill directory names under `.claude/skills/` match `^gobbi$|^_[a-z]|^__[a-z]`",
+            "All agent filenames under `.claude/agents/` match `^gobbi-[a-z]|^_[a-z]|^__[a-z]`",
+            "After stripping the leading `_` or `__` prefix, no remaining underscores — underscores in the body of a name indicate a violation",
+            "Hyphens are the word separator for all multi-word names"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/__benchmark/SKILL.json
+++ b/.claude/skills/__benchmark/SKILL.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "__benchmark",
+    "description": "Skill benchmarking methodology — evaluate how well a skill performs against realistic scenarios. Use when measuring skill quality, comparing before/after changes, or tracking skill reliability over time.",
+    "allowed-tools": "Read, Grep, Glob, Bash, Agent, AskUserQuestion"
+  },
+  "title": "Gobbi Benchmark Skill",
+  "opening": "Methodology for measuring how well skills perform. Benchmarks test a skill against realistic scenarios with structured scoring rubrics, then track results over time to detect improvement or regression.",
+  "navigation": {
+    "Benchmark scenarios": "`benchmarks/` subdirectory",
+    "Trigger testing scripts": "`scripts/` subdirectory"
+  },
+  "sections": [
+    {
+      "heading": "Core Principles",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Benchmarks measure trends, not exact scores.",
+          "body": "LLM output is non-deterministic. The same skill with the same input will produce different outputs across runs. A single benchmark run tells you very little. Multiple runs reveal a distribution, and comparing distributions before and after a skill change reveals whether the change helped, hurt, or had no measurable effect. Treat individual scores as samples, not verdicts."
+        },
+        {
+          "type": "principle",
+          "statement": "Each benchmark run is expensive. Use them intentionally.",
+          "body": "A single scenario run involves at minimum two agent calls — one to execute the skill against the test input, one to evaluate the output against the rubric. Variance measurement multiplies this by the number of runs. Delta tracking doubles it again (before and after). This is not something to run on every change or in automated CI. V1 is manual-trigger only: the orchestrator runs benchmarks on explicit request, for specific scenarios, with a clear reason."
+        },
+        {
+          "type": "principle",
+          "statement": "Scenarios are the unit of measurement. One scenario tests one skill behavior.",
+          "body": "Each scenario is a self-contained test case: a defined input, expected behavior criteria, a scoring rubric, and a pass threshold. Scenarios are narrow — they test specific capabilities of a skill, not the skill as a whole. A skill's overall quality is the aggregate pattern across its scenarios."
+        },
+        {
+          "type": "principle",
+          "statement": "Evaluation drives scoring. The evaluator agent scores, not the executor.",
+          "body": "The agent under test never scores itself. The orchestrator spawns the executor with the skill loaded and the test input, captures the output, then spawns a separate evaluator agent with the rubric to score independently. This mirrors _evaluation's separation principle — the entity that creates must never evaluate its own output."
+        }
+      ]
+    },
+    {
+      "heading": "Scenario Anatomy",
+      "content": [
+        {
+          "type": "text",
+          "value": "Benchmark scenarios live in the `benchmarks/` subdirectory, named `scenario-NN-{skill}-{description}.md`. Each scenario defines five elements:\n\n**Context** — Background information about the simulated situation. What project is being worked on, what state is the codebase in, what has happened before this interaction. Enough to make the test realistic, not so much that it overwhelms the executor.\n\n**Input** — The exact prompt or task the executor agent receives. This is the stimulus being tested. For discussion skills, this might be a deliberately vague user request. For execution skills, this might be a task with missing constraints.\n\n**Expected behavior** — What the skill should cause the agent to do. Not a single correct output (LLM output varies), but observable behaviors and qualities the output should exhibit. Expressed as criteria the evaluator checks against.\n\n**Scoring rubric** — Structured criteria with a 0-10 scale per criterion. Each criterion targets one dimension of the expected behavior. The evaluator agent scores each criterion independently with a brief justification. Criteria should be specific enough that different evaluators would reach similar scores for the same output.\n\n**Pass threshold** — The minimum acceptable performance. Typically expressed as an average score across all criteria. A scenario passes when the average meets or exceeds this threshold.\n\nRead existing scenarios in `benchmarks/` for the concrete format. The first scenario establishes the structural pattern."
+        }
+      ]
+    },
+    {
+      "heading": "Execution Model",
+      "content": [
+        {
+          "type": "text",
+          "value": "Benchmarking is an agent-orchestrated workflow, not a script. The orchestrator manages the full cycle."
+        },
+        {
+          "type": "subsection",
+          "heading": "Single Run",
+          "content": [
+            {
+              "type": "text",
+              "value": "The orchestrator reads a scenario file, spawns an executor agent with the target skill loaded and the scenario's context and input, captures the executor's output, then spawns an evaluator agent with the scenario's rubric and the executor's output. The evaluator scores each criterion and returns a structured result."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Variance Measurement",
+          "content": [
+            {
+              "type": "text",
+              "value": "Run the same scenario multiple times (typically 3-5 runs) to observe output consistency. The orchestrator collects all scores across runs and reports the mean and spread for each criterion. High variance on a criterion means the skill's guidance for that behavior is not reliable — the agent sometimes follows it, sometimes does not. Low variance with high scores means the skill reliably produces the desired behavior."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Delta Tracking",
+          "content": [
+            {
+              "type": "text",
+              "value": "Run the same scenarios before and after modifying a skill. Compare the score distributions to determine whether the change improved, regressed, or had no measurable effect on each criterion. Delta tracking is the primary use case for benchmarks — it answers \"did this skill change actually help?\""
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Honest Limitations",
+      "content": [
+        {
+          "type": "text",
+          "value": "**Cost is real.** Each scenario run costs at minimum two agent calls. Variance measurement with 5 runs costs 10 calls per scenario. Delta tracking with variance costs 20 calls per scenario. A skill with 5 scenarios measured for delta with variance costs 100 agent calls. Budget accordingly and run only the scenarios relevant to the change being measured.\n\n**Scores are noisy.** LLM non-determinism means scores will vary between runs even with no skill changes. Small score differences (1-2 points) between before and after may be noise, not signal. Only trust clear trends supported by multiple runs.\n\n**Evaluator subjectivity.** The evaluator agent interpreting the rubric introduces its own variance. Different evaluator runs may score the same output differently. Well-written rubric criteria reduce this variance but cannot eliminate it.\n\n**Scenarios are not coverage.** Having benchmark scenarios does not mean a skill is well-tested. Scenarios test what you thought to test. Skills can fail in ways no scenario anticipated. Benchmarks complement qualitative judgment — they do not replace it."
+        }
+      ]
+    },
+    {
+      "heading": "Relationship to Skill Verification",
+      "content": [
+        {
+          "type": "text",
+          "value": "__benchmark and _skills verification (see `_skills/verification.md`) serve different purposes:"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "**Benchmark** measures specific skill behaviors quantitatively — numeric scores, variance, delta tracking. Use benchmarks to answer \"did this change improve the skill's performance on this specific behavior?\"",
+            "**Verification** assesses holistic skill quality with specialized agents (grader, analyzer, comparator) — trigger accuracy, output quality, blind A/B comparison. Use verification to answer \"is this skill well-written and effective overall?\""
+          ]
+        },
+        {
+          "type": "text",
+          "value": "Benchmark scenarios complement verification agents. Run verification for broad quality assessment. Run benchmarks for targeted measurement of specific behaviors you're actively changing."
+        }
+      ]
+    },
+    {
+      "heading": "Trigger Testing Script",
+      "content": [
+        {
+          "type": "text",
+          "value": "The `scripts/trigger-test.py` script answers a narrow question: does this skill's description reliably identify the prompts it should load for, and reliably exclude the ones it should not?\n\n**Two tracks, two questions.** Script-based trigger testing and agent-based verification are complementary but distinct. The script tests one thing cheaply and repeatably: does the description match the right prompts? Agent-based verification (`_skills-evaluator`) tests something harder and more expensive: does the skill produce good outcomes when loaded? Trigger accuracy is a prerequisite for outcome quality — if the skill never loads for the right prompts, it can never help — but a skill can trigger correctly and still produce poor output. Use the script for the narrow question, the agent for the holistic one.\n\n**Why Python and the anthropic package.** The __validate scripts are bash-only. This script departs from that pattern deliberately. Trigger testing is a classification problem: given this description, does this prompt warrant loading? That question requires LLM judgment. Grep patterns and heuristics cannot approximate semantic relevance. The dependency cost (Python, `pip install anthropic`, an API key) is the price of getting a meaningful signal rather than a fast but meaningless one.\n\n**Usage.** Prepare a prompts file with one line per prompt, prefixed `+` for prompts that should trigger and `-` for those that should not. Run `trigger-test.py` from `__benchmark/scripts/` with two arguments: the path to the SKILL.md under test and the path to a prompts file.\n\nUse `--verbose` to see per-prompt results. The script reports true positives, false positives, true negatives, false negatives, precision, recall, and F1 score. A strong description should produce high precision (few false triggers) and high recall (few missed triggers). When F1 is low, revise the description to be more specific or broader, depending on which direction the score leans.\n\n**Overlap analysis (--roster).** For targeted investigation of description overlap — when you suspect a skill's description is too broad and may co-trigger with other skills — pass `--roster <skills-dir>`. The script scans the directory for `*/SKILL.md` files and tests each positive prompt against every other skill's description. Overlap findings print as informational warnings after the main results and do not affect the exit code or test outcome. This is not routine testing: cost scales with roster size (positive_prompts × roster_skills additional API calls). Use it deliberately, when overlap is a specific concern."
+        }
+      ]
+    },
+    {
+      "heading": "Constraints",
+      "content": [
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Benchmark execution is manual-trigger only — no automated CI, no pre-commit hooks",
+            "The executor agent under test never scores itself — always a separate evaluator agent",
+            "Each scenario tests one skill — cross-skill interaction benchmarks are out of scope for V1",
+            "Scenarios are flat in `benchmarks/` — one level of nesting, consistent with the `scripts/` precedent in _note",
+            "Benchmark results are ephemeral in V1 — tracked in notes or discussion, not in a persistent store",
+            "Do not benchmark all skills — benchmark the skills you are actively improving, for the behaviors you are actively changing"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/__benchmark/benchmarks/scenario-01-gobbi-discuss-vague-prompt.json
+++ b/.claude/skills/__benchmark/benchmarks/scenario-01-gobbi-discuss-vague-prompt.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "gobbi-docs/child",
+  "parent": "__benchmark",
+  "title": "Scenario 01: _discuss — Vague Prompt Handling",
+  "opening": "Tests whether an agent loaded with _discuss correctly handles a deliberately vague user request by pushing for specificity rather than accepting the request at face value.",
+  "sections": [
+    {
+      "heading": "Context",
+      "content": [
+        {
+          "type": "text",
+          "value": "The user is working on an existing web application with a React frontend and Node.js backend. The application has been in production for several months. The agent has been loaded with _discuss and is in discussion mode. No other context about the application's current problems, performance metrics, or priorities has been provided."
+        }
+      ]
+    },
+    {
+      "heading": "Input",
+      "content": [
+        {
+          "type": "text",
+          "value": "> \"Make the app better.\"\n\nThe agent should treat this as a user message delivered via AskUserQuestion interaction. No follow-up context is provided unless the evaluator is also assessing multi-turn behavior, in which case the evaluator provides deliberately vague follow-up answers like \"you know, just... better\" or \"faster and stuff\" to test whether the agent continues pushing for precision."
+        }
+      ]
+    },
+    {
+      "heading": "Expected Behavior",
+      "content": [
+        {
+          "type": "text",
+          "value": "The agent using _discuss should:"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "**Refuse to accept the vague requirement.** The agent must not start planning or executing based on \"make the app better.\" It must recognize this as insufficiently specific and enter discussion mode."
+          ]
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "**Ask clarifying questions that target specific dimensions.** Questions should address distinct dimensions from _discuss's discussion framework — problem, scope, deliverable, priority, constraints, verification. Each question should narrow one dimension, not ask broad compound questions."
+          ]
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "**Challenge the implicit assumptions.** The prompt assumes the app needs improvement but does not specify what is wrong. The agent should surface this: what is the actual problem? What triggered this request? What happens if nothing changes?"
+          ]
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "**Offer concrete options with a recommendation.** Rather than asking open-ended \"what do you mean by better?\", the agent should propose specific interpretations — performance optimization, UX improvements, code quality, feature additions — and recommend which to investigate first based on typical high-impact areas. The recommendation should have reasoning."
+          ]
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "**Push for measurable specificity.** \"Better\" is not measurable. The agent should push toward specific metrics, targets, or observable outcomes. Which endpoint is slow? What is the current response time? What target response time would constitute \"better\"?"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Scoring Rubric",
+      "content": [
+        {
+          "type": "text",
+          "value": "Each criterion scored 0-10 by the evaluator agent."
+        },
+        {
+          "type": "subsection",
+          "heading": "Clarification Quality (0-10)",
+          "content": [
+            {
+              "type": "text",
+              "value": "Did the agent ask specific, dimension-targeted questions rather than broad open-ended ones?"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**0-2:** Agent accepted the vague prompt or asked only \"what do you mean?\" without structure",
+                "**3-5:** Agent asked some questions but they were broad, compound, or missed key dimensions",
+                "**6-8:** Agent asked specific questions covering multiple dimensions, each narrowing one thing",
+                "**9-10:** Agent asked precise, well-ordered questions across problem, scope, priority, and verification dimensions — each question made the specification more concrete"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Assumption Challenging (0-10)",
+          "content": [
+            {
+              "type": "text",
+              "value": "Did the agent surface and question the implicit assumptions in \"make the app better\"?"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**0-2:** Agent treated the request as self-evidently valid and moved to execution planning",
+                "**3-5:** Agent acknowledged vagueness but did not probe the underlying assumptions (why \"better\"? is there actually a problem? what triggered this?)",
+                "**6-8:** Agent surfaced the key assumption that improvement is needed and questioned what the actual trigger or problem is",
+                "**9-10:** Agent identified multiple implicit assumptions (that the app is insufficient, that improvement is the right framing, that the user knows what \"better\" means) and challenged each constructively"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Recommendation Strength (0-10)",
+          "content": [
+            {
+              "type": "text",
+              "value": "Did the agent lead with a recommendation rather than just presenting options?"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**0-2:** Agent asked what the user wants without offering any direction",
+                "**3-5:** Agent listed options but without clear recommendation or reasoning",
+                "**6-8:** Agent presented options with a clear recommended option and explained why",
+                "**9-10:** Agent led with a strong, reasoned recommendation, explained the trade-offs of alternatives, and made it easy for the user to either accept or choose differently"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Specificity Push (0-10)",
+          "content": [
+            {
+              "type": "text",
+              "value": "Did the agent reject vague answers and push for precision?"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**0-2:** Agent accepted \"better\" or similar vague terms as sufficient specification",
+                "**3-5:** Agent asked for more detail but accepted moderately vague answers without further probing",
+                "**6-8:** Agent pushed for specific metrics, targets, or observable outcomes at least once",
+                "**9-10:** Agent consistently pushed vague responses toward measurable specificity — named concrete metrics, asked for current vs target values, refused to proceed until the specification was actionable"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Pass Threshold",
+      "content": [
+        {
+          "type": "text",
+          "value": "Average score across all four criteria must be **7 or higher** to pass.\n\nA score of 7+ indicates the agent reliably follows _discuss principles when confronted with vague input. Scores below 7 indicate the skill's guidance is insufficient to prevent the agent from accepting or inadequately challenging vague requirements."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/__benchmark/benchmarks/scenario-02-skills-skill-creation.json
+++ b/.claude/skills/__benchmark/benchmarks/scenario-02-skills-skill-creation.json
@@ -1,0 +1,161 @@
+{
+  "$schema": "gobbi-docs/child",
+  "parent": "__benchmark",
+  "title": "Scenario 02: _skills — Skill Creation from a Vague Prompt",
+  "opening": "Tests whether an agent loaded with _skills correctly handles a moderately vague skill creation request by discussing before writing, applying description craft principles, and producing a well-structured skill file.",
+  "sections": [
+    {
+      "heading": "Context",
+      "content": [
+        {
+          "type": "text",
+          "value": "The user is working in a project that already has several gobbi skills installed. The agent has been loaded with _skills and _discuss. No existing Slack notification skill exists in the project. The agent is asked to create a new skill. No prior context about trigger scenarios, integration points, or scope has been provided."
+        }
+      ]
+    },
+    {
+      "heading": "Input",
+      "content": [
+        {
+          "type": "text",
+          "value": "> \"Create a skill for managing Slack notifications.\"\n\nThe agent should treat this as a task instruction. The prompt has a clear domain (Slack notifications) but is vague on scope: it does not specify whether the skill covers sending, receiving, or routing notifications; which trigger scenarios should load the skill; whether an existing notification system already handles some of this; or what other installed skills might overlap."
+        }
+      ]
+    },
+    {
+      "heading": "Expected Behavior",
+      "content": [
+        {
+          "type": "text",
+          "value": "The agent using _skills should:"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "**Discuss before writing.** Recognize that the prompt is insufficiently specified to produce a well-targeted skill. Enter discussion mode before drafting anything. Ask about domain ownership, trigger scenarios, scope boundaries, and overlap with existing skills."
+          ]
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "**Apply description craft.** When drafting the SKILL.md description, demonstrate awareness of the loading model: the description is what an LLM uses to decide whether to load the skill. Frame the description around intent and trigger scenarios rather than listing the skill's contents. Calibrate precision and recall — specific enough to avoid misfiring on general Slack questions, broad enough to catch all notification management tasks."
+          ]
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "**Follow content writing principles.** Produce content that explains the why behind each guideline, not just what to do. Avoid constraint overload. Generalize beyond the immediate context so the skill remains useful as the notification system evolves."
+          ]
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "**Produce correct structure.** Valid SKILL.md with proper frontmatter (name, description, allowed-tools fields), under 200 lines, flat documentation structure (no subdirectories), core principles placed in the first ~50 lines after frontmatter."
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Scoring Rubric",
+      "content": [
+        {
+          "type": "text",
+          "value": "Each criterion scored 0-10 by the evaluator agent."
+        },
+        {
+          "type": "subsection",
+          "heading": "Discussion Quality (0-10)",
+          "content": [
+            {
+              "type": "text",
+              "value": "Did the agent discuss before writing? Did it ask about the right dimensions — domain ownership, trigger scenarios, scope, and overlap with existing skills? Did it challenge the vague prompt rather than accepting it?"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**0-2:** Jumped straight to writing the skill without any discussion",
+                "**3-5:** Asked some questions but missed key dimensions (e.g., asked about API credentials but not trigger scenarios or overlap)",
+                "**6-8:** Asked about multiple dimensions, challenged assumptions, waited for answers before drafting",
+                "**9-10:** Thorough discussion covering domain ownership, trigger scenarios, scope boundaries, overlap with existing skills, and what verification would look like — each question narrowed a specific unknown"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Description Quality (0-10)",
+          "content": [
+            {
+              "type": "text",
+              "value": "Is the description intent-focused? Does it specify when to load the skill rather than what the skill contains? Is it precise enough to avoid misfiring on unrelated Slack questions while broad enough to catch all legitimate notification management tasks?"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**0-2:** Generic description that describes the file's contents (\"This skill covers Slack notification settings and preferences\") — would misfire on many prompts or fail to trigger for legitimate use cases",
+                "**3-5:** Partially intent-focused but still describes features rather than trigger scenarios; precision or recall is off",
+                "**6-8:** Intent-focused with clear trigger language, reasonable precision/recall balance; reads as \"load me when...\" rather than \"I contain...\"",
+                "**9-10:** Sharp, distinctive description that reliably triggers for notification management tasks, stands out from adjacent skills (general Slack usage, alerting infrastructure), and would not trigger for unrelated prompts"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Content Principles (0-10)",
+          "content": [
+            {
+              "type": "text",
+              "value": "Does the content teach mental models rather than enumerate procedures? Does it explain the why behind each guideline? Does it avoid constraint overload and remain useful beyond the immediate use case?"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**0-2:** Step-by-step procedures, configuration recipes, or code examples dominate the content",
+                "**3-5:** Mix of principles and procedures; some guidelines lack reasoning; constraint list is long without prioritization",
+                "**6-8:** Principles-based content that explains reasoning; most constraints carry a rationale; content is reasonably generalizable",
+                "**9-10:** Every guideline explains why it exists; mental models are explicit; constraint count is low and each constraint is load-bearing; content would remain applicable as the notification system evolves"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Structure Correctness (0-10)",
+          "content": [
+            {
+              "type": "text",
+              "value": "Valid SKILL.md with proper frontmatter? Within the 200-line budget? Flat documentation (no subdirectory references for a first-version skill)? Core principles in the first ~50 lines?"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**0-2:** Missing frontmatter, major structural issues, or no SKILL.md produced at all",
+                "**3-5:** Frontmatter present but fields are incorrect, missing, or malformed; significantly over line budget",
+                "**6-8:** Correct frontmatter with all required fields, within line budget, correct flat structure",
+                "**9-10:** Perfect structure — all frontmatter fields correct, core principles within first 50 lines, constraints section present, within budget with room to spare"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Pass Threshold",
+      "content": [
+        {
+          "type": "text",
+          "value": "Average score across all four criteria must be **7 or higher** to pass.\n\nA score of 7+ indicates the agent reliably applies _skills principles when creating a skill from a moderately vague prompt. Scores below 7 indicate the skill's guidance is insufficient to prevent the agent from skipping discussion, producing poorly targeted descriptions, or delivering structurally incorrect output."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/__validate/SKILL.json
+++ b/.claude/skills/__validate/SKILL.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "__validate",
+    "description": "Validate gobbi agent definitions, skill files, and gotcha entries for structural correctness. Use after creating or modifying agents, skills, or gotchas.",
+    "allowed-tools": "Read, Bash, Glob"
+  },
+  "title": "Validate",
+  "opening": "Validation catches structural problems before they cause runtime failures or agent confusion. A malformed agent definition silently degrades the orchestrator's routing. A skill with anti-patterns teaches agents to mimic instead of think. A gotcha with missing sections fails to prevent repeated mistakes.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Validate structure, not content. Structure is machine-checkable; content quality requires judgment.",
+          "body": "These tools check that files follow the structural contracts their consumers depend on — frontmatter fields, naming conventions, section markers, line budgets. They do not assess whether the content is well-written, accurate, or useful. Content quality is the evaluator's job."
+        },
+        {
+          "type": "principle",
+          "statement": "Validate after creation and after modification. Not before, not continuously.",
+          "body": "Run validation when you finish creating or modifying an agent, skill, or gotcha file. Validation is a verification step in the execution lifecycle, not a gate before writing."
+        },
+        {
+          "type": "principle",
+          "statement": "False positives erode trust. Prefer missing a violation over flagging correct content.",
+          "body": "A validation tool that cries wolf gets ignored. Each check should have a clear structural signal. When a heuristic is uncertain, warn instead of fail."
+        }
+      ]
+    },
+    {
+      "heading": "Tools",
+      "content": [
+        {
+          "type": "text",
+          "value": "Validation scripts live in `scripts/` and are invoked directly with bash. Each takes a file path as its only argument, reports results to stdout/stderr, and exits 0 on pass or 1 on failure."
+        },
+        {
+          "type": "table",
+          "headers": [
+            "Script",
+            "Validates",
+            "Use when"
+          ],
+          "rows": [
+            [
+              "`validate-agent.sh`",
+              "Agent definition `.md` files",
+              "After creating or modifying an agent in `agents/`"
+            ],
+            [
+              "`validate-skill.sh`",
+              "Skill `SKILL.md` files",
+              "After creating or modifying a skill's SKILL.md"
+            ],
+            [
+              "`lint-skill.sh`",
+              "Any `.md` skill file for anti-patterns",
+              "After writing any `.claude/` documentation"
+            ],
+            [
+              "`validate-gotcha.sh`",
+              "Gotcha `.md` files",
+              "After recording a new gotcha entry"
+            ]
+          ]
+        },
+        {
+          "type": "text",
+          "value": "Run from the repository root or provide absolute paths. Scripts are self-contained with no external dependencies beyond standard bash utilities."
+        }
+      ]
+    },
+    {
+      "heading": "What Each Tool Checks",
+      "content": [
+        {
+          "type": "text",
+          "value": "**validate-agent.sh** verifies the structural contract that the orchestrator depends on: YAML frontmatter with required fields, name format conventions, trigger language in the description, valid model values, and sufficient system prompt content.\n\n**validate-skill.sh** verifies the structural contract that skill loading depends on: YAML frontmatter with required fields, line budget compliance, and navigation structure when child documents exist.\n\n**lint-skill.sh** detects _claude anti-patterns that cause agents to mimic instead of think: code examples, BAD/GOOD comparison blocks, step-by-step recipes, and interface definitions. Uses heuristics to distinguish illustrative directory trees (acceptable) from code examples (not acceptable).\n\n**validate-gotcha.sh** verifies the entry structure that makes gotchas useful: required sections (title, priority, what happened, user feedback, correct approach) and valid priority values."
+        }
+      ]
+    },
+    {
+      "heading": "Constraints",
+      "content": [
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Scripts are tools, not documentation — they check structure, not content quality",
+            "Exit codes are the API: 0 means pass, 1 means failure, warnings go to stderr",
+            "Heuristic checks (like code block detection) warn rather than fail when uncertain",
+            "Scripts must not modify files — read-only validation only"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/__validate/SKILL.json
+++ b/.claude/skills/__validate/SKILL.json
@@ -2,7 +2,7 @@
   "$schema": "gobbi-docs/skill",
   "frontmatter": {
     "name": "__validate",
-    "description": "Validate gobbi agent definitions, skill files, and gotcha entries for structural correctness. Use after creating or modifying agents, skills, or gotchas.",
+    "description": "Validate gobbi agent definitions, skill files, gotcha entries, and JSON doc templates for structural correctness. Use after creating or modifying agents, skills, gotchas, or docs.",
     "allowed-tools": "Read, Bash, Glob"
   },
   "title": "Validate",
@@ -33,7 +33,11 @@
       "content": [
         {
           "type": "text",
-          "value": "Validation scripts live in `scripts/` and are invoked directly with bash. Each takes a file path as its only argument, reports results to stdout/stderr, and exits 0 on pass or 1 on failure."
+          "value": "Two categories of validation tools exist: bash scripts for Markdown-based files and the `gobbi docs validate` CLI command for JSON templates."
+        },
+        {
+          "type": "text",
+          "value": "**Bash scripts** live in `scripts/` and are invoked directly. Each takes a file path as its only argument, reports results to stdout/stderr, and exits 0 on pass or 1 on failure."
         },
         {
           "type": "table",
@@ -68,6 +72,29 @@
         {
           "type": "text",
           "value": "Run from the repository root or provide absolute paths. Scripts are self-contained with no external dependencies beyond standard bash utilities."
+        },
+        {
+          "type": "text",
+          "value": "**CLI command** for JSON-first doc templates (v0.3.2+):"
+        },
+        {
+          "type": "table",
+          "headers": [
+            "Command",
+            "Validates",
+            "Use when"
+          ],
+          "rows": [
+            [
+              "`gobbi docs validate <path>`",
+              "JSON doc templates against the gobbi-docs schema",
+              "After creating or modifying any `.json` template in `.claude/`"
+            ]
+          ]
+        },
+        {
+          "type": "text",
+          "value": "Can validate individual files or be run across all docs. Reports schema errors, missing required fields, invalid block types, and Markdown sync status."
         }
       ]
     },
@@ -76,7 +103,7 @@
       "content": [
         {
           "type": "text",
-          "value": "**validate-agent.sh** verifies the structural contract that the orchestrator depends on: YAML frontmatter with required fields, name format conventions, trigger language in the description, valid model values, and sufficient system prompt content.\n\n**validate-skill.sh** verifies the structural contract that skill loading depends on: YAML frontmatter with required fields, line budget compliance, and navigation structure when child documents exist.\n\n**lint-skill.sh** detects _claude anti-patterns that cause agents to mimic instead of think: code examples, BAD/GOOD comparison blocks, step-by-step recipes, and interface definitions. Uses heuristics to distinguish illustrative directory trees (acceptable) from code examples (not acceptable).\n\n**validate-gotcha.sh** verifies the entry structure that makes gotchas useful: required sections (title, priority, what happened, user feedback, correct approach) and valid priority values."
+          "value": "**validate-agent.sh** verifies the structural contract that the orchestrator depends on: YAML frontmatter with required fields, name format conventions, trigger language in the description, valid model values, and sufficient system prompt content.\n\n**validate-skill.sh** verifies the structural contract that skill loading depends on: YAML frontmatter with required fields, line budget compliance, and navigation structure when child documents exist.\n\n**lint-skill.sh** detects _claude anti-patterns that cause agents to mimic instead of think: code examples, BAD/GOOD comparison blocks, step-by-step recipes, and interface definitions. Uses heuristics to distinguish illustrative directory trees (acceptable) from code examples (not acceptable).\n\n**validate-gotcha.sh** verifies the entry structure that makes gotchas useful: required sections (title, priority, what happened, user feedback, correct approach) and valid priority values.\n\n**gobbi docs validate** validates JSON doc templates against the gobbi-docs schema. Checks that `$schema` is a recognized doc type, required fields exist per type (frontmatter for skills and agents, parent for child and gotcha types), content blocks have valid types with required sub-fields, and gotcha entries have complete body structures. When a corresponding `.md` file exists alongside the `.json`, compares the rendered output against it and reports sync status (in-sync, out-of-sync, or no `.md` file found)."
         }
       ]
     },

--- a/.claude/skills/__validate/SKILL.md
+++ b/.claude/skills/__validate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: __validate
-description: Validate gobbi agent definitions, skill files, and gotcha entries for structural correctness. Use after creating or modifying agents, skills, or gotchas.
+description: Validate gobbi agent definitions, skill files, gotcha entries, and JSON doc templates for structural correctness. Use after creating or modifying agents, skills, gotchas, or docs.
 allowed-tools: Read, Bash, Glob
 ---
 
@@ -28,7 +28,9 @@ A validation tool that cries wolf gets ignored. Each check should have a clear s
 
 ## Tools
 
-Validation scripts live in `scripts/` and are invoked directly with bash. Each takes a file path as its only argument, reports results to stdout/stderr, and exits 0 on pass or 1 on failure.
+Two categories of validation tools exist: bash scripts for Markdown-based files and the `gobbi docs validate` CLI command for JSON templates.
+
+**Bash scripts** live in `scripts/` and are invoked directly. Each takes a file path as its only argument, reports results to stdout/stderr, and exits 0 on pass or 1 on failure.
 
 | Script | Validates | Use when |
 |--------|-----------|----------|
@@ -38,6 +40,14 @@ Validation scripts live in `scripts/` and are invoked directly with bash. Each t
 | `validate-gotcha.sh` | Gotcha `.md` files | After recording a new gotcha entry |
 
 Run from the repository root or provide absolute paths. Scripts are self-contained with no external dependencies beyond standard bash utilities.
+
+**CLI command** for JSON-first doc templates (v0.3.2+):
+
+| Command | Validates | Use when |
+|---------|-----------|----------|
+| `gobbi docs validate <path>` | JSON doc templates against the gobbi-docs schema | After creating or modifying any `.json` template in `.claude/` |
+
+Can validate individual files or be run across all docs. Reports schema errors, missing required fields, invalid block types, and Markdown sync status.
 
 ---
 
@@ -50,6 +60,8 @@ Run from the repository root or provide absolute paths. Scripts are self-contain
 **lint-skill.sh** detects _claude anti-patterns that cause agents to mimic instead of think: code examples, BAD/GOOD comparison blocks, step-by-step recipes, and interface definitions. Uses heuristics to distinguish illustrative directory trees (acceptable) from code examples (not acceptable).
 
 **validate-gotcha.sh** verifies the entry structure that makes gotchas useful: required sections (title, priority, what happened, user feedback, correct approach) and valid priority values.
+
+**gobbi docs validate** validates JSON doc templates against the gobbi-docs schema. Checks that `$schema` is a recognized doc type, required fields exist per type (frontmatter for skills and agents, parent for child and gotcha types), content blocks have valid types with required sub-fields, and gotcha entries have complete body structures. When a corresponding `.md` file exists alongside the `.json`, compares the rendered output against it and reports sync status (in-sync, out-of-sync, or no `.md` file found).
 
 ---
 

--- a/.claude/skills/_agent-evaluation-aesthetics/SKILL.json
+++ b/.claude/skills/_agent-evaluation-aesthetics/SKILL.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_agent-evaluation-aesthetics",
+    "description": "Aesthetics perspective for evaluating gobbi agent definitions — assesses naming consistency, writing quality, readability, and whether a new contributor could understand the agent's role from reading the definition.",
+    "allowed-tools": "Read, Grep, Glob, Bash"
+  },
+  "title": "Agent Evaluation — Aesthetics Perspective",
+  "opening": "You evaluate gobbi agent definitions from an aesthetics perspective. Your job is to find problems — not confirm success.\n\nThe aesthetics perspective asks: is this definition well-written? Is the naming consistent with gobbi's conventions? Is the writing precise enough that a new contributor reading it would immediately understand this agent's role, stance, and boundaries?",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "An agent definition that is hard to read produces agents that are hard to understand and maintain.",
+          "body": "Aesthetic problems are not cosmetic. Poor naming creates confusion about routing. Vague writing leaves agents without clear behavioral guidance. Filler content trains agents to skim — and when agents skim, they miss the parts that matter."
+        },
+        {
+          "type": "principle",
+          "statement": "Clarity is testable. Ask: would a new contributor understand this agent's role in under two minutes?",
+          "body": "This is the primary readability criterion. If the answer is no, the definition has an aesthetics problem regardless of how structurally sound it is."
+        }
+      ]
+    },
+    {
+      "heading": "What to Examine",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Naming Convention Compliance",
+          "content": [
+            {
+              "type": "text",
+              "value": "The `name` frontmatter field and the agent's filename must follow gobbi's naming convention. For hidden agents, the convention requires a `__` prefix, hyphen word separators, and no underscores in the body of the name. Load `.claude/rules/__gobbi-convention.md` to verify naming against the authoritative rule.\n\nCommon violations: underscores used as word separators in the body; missing or incorrect tier prefix; name that doesn't match the filename; multi-word name using camelCase instead of hyphens."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Opening Clarity",
+          "content": [
+            {
+              "type": "text",
+              "value": "The first paragraph establishes the agent's identity. Read it from the perspective of a contributor encountering this agent for the first time. Within two or three sentences, it should be clear: what this agent is, what kind of thinking it brings, and when it receives work.\n\nWatch for: openings that describe the role rather than embody it (\"This agent handles...\"); openings generic enough to describe any agent; openings that require reading further before the role is clear."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Writing Precision",
+          "content": [
+            {
+              "type": "text",
+              "value": "Precise writing uses specific language that closes off misinterpretation. Vague writing uses words that could mean many things and leaves the agent to fill gaps with assumptions.\n\nLook for: qualifiers that dilute precision (\"may\", \"often\", \"generally\" when the behavior is definite); abstract nouns where concrete verbs would be clearer; passive constructions that hide who does what. The test: can any sentence be read two meaningfully different ways? If yes, rewrite until the answer is no."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Filler and Redundancy",
+          "content": [
+            {
+              "type": "text",
+              "value": "Filler content is text that adds length without adding meaning. It appears as: restatements of what was just said; transitional sentences that don't carry information; principles restated in different words without adding nuance; sections that exist to match a structural template rather than to serve the reader.\n\nEach paragraph should have a clear reason to exist. If removing it would not cause a contributor or the agent to misunderstand something, it is filler."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Consistency with Gobbi Style",
+          "content": [
+            {
+              "type": "text",
+              "value": "Gobbi's documentation style has patterns that create coherence across the system. Blockquotes (`>`) hold the bold principle points — only one concept per blockquote, description following below. Headings are used for structural navigation, not emphasis. Lists are used when items are genuinely enumerable, not as a way to avoid prose.\n\nCheck: does the definition follow these patterns consistently? Inconsistency is not just aesthetic — it signals that the agent was written without reference to existing patterns, which often correlates with other problems."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Contributor Comprehensibility",
+          "content": [
+            {
+              "type": "text",
+              "value": "As a final check, read the definition as if you are a contributor who has never seen this agent before. After reading:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Can you state this agent's purpose in one sentence?",
+                "Can you identify the three most important things this agent must never do?",
+                "Would you know which skills to add if the agent's domain were extended?"
+              ]
+            },
+            {
+              "type": "text",
+              "value": "If any of these are unclear, the definition has a readability problem worth reporting."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Findings Format",
+      "content": [
+        {
+          "type": "text",
+          "value": "Each finding needs: the specific text or section with the problem, what is unclear or inconsistent about it, and a description of the improved version. Aesthetics findings should distinguish between problems that create genuine misunderstanding (high priority) and problems that are merely inelegant (lower priority)."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_agent-evaluation-architecture/SKILL.json
+++ b/.claude/skills/_agent-evaluation-architecture/SKILL.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_agent-evaluation-architecture",
+    "description": "Architecture perspective for evaluating gobbi agent definitions — assesses structural quality, lifecycle completeness, skill loading discipline, scope boundary sharpness, and abstraction level.",
+    "allowed-tools": "Read, Grep, Glob, Bash"
+  },
+  "title": "Agent Evaluation — Architecture Perspective",
+  "opening": "You evaluate gobbi agent definitions from an architecture perspective. Your job is to find problems — not confirm success.\n\nThe architecture perspective asks: is this agent well-structured? Does its definition give the agent the right mental model to act coherently? Are its boundaries clear, its context loading disciplined, and its lifecycle phases meaningful?",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Structure shapes behavior. A poorly structured definition produces an agent that guesses at its own role.",
+          "body": "An agent definition is not just documentation — it is the operating context the agent receives at runtime. Structural problems in the definition create behavioral problems at execution time."
+        },
+        {
+          "type": "principle",
+          "statement": "Lifecycle phases exist because sequencing matters. Each phase should be distinct and purposeful.",
+          "body": "The Study-Plan-Execute-Verify lifecycle is not decorative. Study builds context before acting. Plan designs before implementing. Execute stays in scope. Verify confirms criteria were met. When phases are collapsed, missing, or incoherent, agents skip steps that exist for good reasons."
+        }
+      ]
+    },
+    {
+      "heading": "What to Examine",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Lifecycle Completeness and Quality",
+          "content": [
+            {
+              "type": "text",
+              "value": "Does the agent definition include Study, Plan, Execute, Verify phases? Are they adapted to the agent's actual domain, or are they generic placeholders? Each phase should contain guidance that is specific to what this agent does — not recycled boilerplate.\n\nWatch for: missing phases entirely; phases that repeat the same guidance with different labels; Study sections that don't mention what to actually study; Verify sections that don't state domain-specific criteria.\n\nMemorize is optional but appropriate for agents that learn from their executions. If the agent operates in a domain where mistakes are non-obvious or patterns shift, a Memorize phase adds value."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "\"Before You Start\" Discipline",
+          "content": [
+            {
+              "type": "text",
+              "value": "The \"Before You Start\" section lists skills and context the agent loads. Evaluate it for both completeness and restraint. Skills should be loaded because the agent genuinely uses their guidance — not as a precaution. Equally, missing a critical skill means the agent operates without essential context.\n\nCommon structural problems: loading skills that belong in \"when relevant\" as always-load; loading broad skills when a narrow child would suffice; omitting the skill that covers the agent's core domain."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Scope Boundary Sharpness",
+          "content": [
+            {
+              "type": "text",
+              "value": "The \"Out of scope\" statement defines the agent's limits. Structurally, it should appear early in the definition (within the first ~20 lines) and state exclusions clearly and specifically. Vague exclusions like \"things outside my domain\" provide no architectural guidance.\n\nA well-structured out-of-scope section names adjacent agents or categories that handle the excluded work. This creates a complete routing picture — in-scope goes here, excluded work goes there."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Identity and Opening",
+          "content": [
+            {
+              "type": "text",
+              "value": "The opening paragraph establishes who the agent is. Architecturally, this sets the framing for everything that follows. An agent that cannot articulate its \"think like a...\" identity in a few sentences will not behave consistently.\n\nRead the opening: is it specific to this agent's role, or generic enough to describe any agent? Does it establish a clear cognitive stance — how this agent approaches problems?"
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Abstraction Level",
+          "content": [
+            {
+              "type": "text",
+              "value": "The definition should operate at the right level of abstraction. Too concrete: the definition becomes a task script that the agent follows rigidly, skipping steps when the scenario differs slightly. Too abstract: the definition provides no actionable guidance, and the agent must guess.\n\nThe test: would this definition guide the agent well for a typical scenario it will encounter, and still generalize appropriately for edge cases?"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Findings Format",
+      "content": [
+        {
+          "type": "text",
+          "value": "Each finding needs: what the structural problem is, which section of the agent definition it appears in, and what behavioral consequence it creates. Structural problems that produce inconsistent agent behavior at runtime should be ranked above problems that are merely imprecise."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_agent-evaluation-overall/SKILL.json
+++ b/.claude/skills/_agent-evaluation-overall/SKILL.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_agent-evaluation-overall",
+    "description": "Overall perspective for evaluating gobbi agent definitions — synthesizes cross-cutting gaps across project, architecture, performance, and aesthetics perspectives, identifies integration concerns with adjacent agents, and defines what must be preserved.",
+    "allowed-tools": "Read, Grep, Glob, Bash"
+  },
+  "title": "Agent Evaluation — Overall Perspective",
+  "opening": "You evaluate gobbi agent definitions from an overall perspective. Your job is to find problems — not confirm success.\n\nThe overall perspective is synthetic. Where the other four perspectives each examine one dimension in depth, you look for gaps that fall between dimensions, integration problems with adjacent agents, and cross-cutting issues that no single perspective captures fully.\n\nYou also carry one unique responsibility the other perspectives do not: identifying what must be preserved. Every agent definition has elements that work — naming them prevents fixes from accidentally breaking what is already good.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Cross-cutting gaps are the ones most likely to be missed. Each perspective sees its dimension clearly; none sees where dimensions interact.",
+          "body": "A definition can pass each perspective's evaluation individually and still fail when the perspectives are considered together. Purpose is clear (project), structure is sound (architecture), it is concise (performance), and it reads well (aesthetics) — yet the agent's role creates a gap in the system that only becomes visible when you look at all agents together."
+        },
+        {
+          "type": "principle",
+          "statement": "Preserve what works. Evaluation findings are inputs to improvement, not a mandate to rewrite.",
+          "body": "Identifying what must be preserved is not optional. Without it, improvements risk eliminating the elements that make the agent effective. The must-preserve list is part of your deliverable."
+        }
+      ]
+    },
+    {
+      "heading": "What to Examine",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Cross-Cutting Gaps",
+          "content": [
+            {
+              "type": "text",
+              "value": "These are problems that appear only when multiple dimensions are considered together:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "A clear purpose (project) but no lifecycle phase that corresponds to it (architecture) — the agent knows what it is but not how to work",
+                "Concise but incomplete (performance, architecture) — brevity that omits necessary guidance",
+                "Well-written but misrouted (aesthetics, project) — a readable description that sends work to the wrong agent",
+                "Structured lifecycle but wrong model (architecture, performance) — phases that require deep synthesis assigned to a fast-execution model"
+              ]
+            },
+            {
+              "type": "text",
+              "value": "Look for patterns that span the perspectives rather than repeating findings each perspective already captured."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Integration with Adjacent Agents",
+          "content": [
+            {
+              "type": "text",
+              "value": "Load `.claude/agents/` and read the definitions of agents that border this one. Integration problems appear at the boundaries:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Two agents whose descriptions overlap — the orchestrator faces an ambiguous routing decision",
+                "An agent whose \"Out of scope\" sends work to an agent that doesn't accept it — a routing gap",
+                "An agent that loads a skill which grants permissions its adjacent agents don't have, creating inconsistent capabilities at the boundary",
+                "A lifecycle phase that implicitly depends on state or output from another agent but doesn't state that dependency"
+              ]
+            },
+            {
+              "type": "text",
+              "value": "The integration question is: does this agent fit cleanly into the system of agents, or does its presence create friction at the seams?"
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Orchestrator Routing Confidence",
+          "content": [
+            {
+              "type": "text",
+              "value": "Stand in the orchestrator's position. Given a typical task that belongs to this agent's domain, would the orchestrator route it here confidently? Or would the orchestrator hesitate between this agent and another?\n\nRouting confidence requires: an unambiguous description, a distinct domain that doesn't overlap with neighbors, and an \"Out of scope\" that handles edge cases the description doesn't cover."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Systemic Risks",
+          "content": [
+            {
+              "type": "text",
+              "value": "Some problems in an agent definition create systemic risk — they can cascade beyond the agent's boundary. An agent with scope creep tendencies will modify files it shouldn't. An agent with overly broad tool grants will take actions outside its mandate. An agent with a vague \"Out of scope\" will absorb work that should go elsewhere, leaving gaps in the system.\n\nIdentify findings that create risk beyond this single agent's behavior."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Must Preserve",
+          "content": [
+            {
+              "type": "text",
+              "value": "Before reporting problems, document what must be preserved. For each element worth keeping:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Name the element (a specific phrase, a section, a design decision)",
+                "State why it works — what would be lost if it were changed"
+              ]
+            },
+            {
+              "type": "text",
+              "value": "Elements typically worth preserving: an identity framing that distinctly captures the agent's cognitive stance; an \"Out of scope\" statement that has clearly resolved a past boundary conflict; a Before You Start section that correctly balances always-load and conditional loading; quality expectations that are concrete and checkable."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Findings Format",
+      "content": [
+        {
+          "type": "text",
+          "value": "Report in two parts. First, the must-preserve list — elements that evaluators and implementors should protect during improvements. Second, findings — cross-cutting gaps, integration problems, and systemic risks, each with: what the issue is, which perspectives it spans, why it matters at the system level, and priority.\n\nSurface integration and systemic risk findings prominently. These are the issues most likely to propagate beyond the agent definition under review."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_agent-evaluation-performance/SKILL.json
+++ b/.claude/skills/_agent-evaluation-performance/SKILL.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_agent-evaluation-performance",
+    "description": "Performance perspective for evaluating gobbi agent definitions — assesses definition conciseness, skill loading efficiency, model appropriateness, and content duplication that wastes context.",
+    "allowed-tools": "Read, Grep, Glob, Bash"
+  },
+  "title": "Agent Evaluation — Performance Perspective",
+  "opening": "You evaluate gobbi agent definitions from a performance perspective. Your job is to find problems — not confirm success.\n\nThe performance perspective asks: is this definition doing its job efficiently? Does it load only what the agent needs? Is the model right for the work? Does it avoid duplicating content that already exists in skills the agent loads?",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "An agent definition is loaded into context at runtime. Every unnecessary line is context consumed before the agent does any work.",
+          "body": "Performance in agent definitions is not runtime speed — it is context efficiency. A bloated definition front-loads irrelevant content, pushes out working memory, and forces the agent to scan through noise to find signal."
+        },
+        {
+          "type": "principle",
+          "statement": "Skills exist so definitions don't have to repeat them. Duplication is a maintenance liability and a context tax.",
+          "body": "When an agent loads a skill, the skill's content is available. Restating that content in the agent definition produces two copies — the definition version drifts from the skill, and the agent spends context reading both."
+        }
+      ]
+    },
+    {
+      "heading": "What to Examine",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Definition Length and Density",
+          "content": [
+            {
+              "type": "text",
+              "value": "Evaluate the definition's length relative to its purpose. A definition for a narrowly scoped agent that handles simple delegated work should be shorter than a definition for a complex multi-domain agent. The question is not whether the file is long — it is whether every line earns its place.\n\nLook for: paragraphs that could be removed without losing any behavioral guidance; sections that repeat the same principle with different phrasing; lifecycle phases that describe the obvious rather than the domain-specific."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Skill Loading Efficiency",
+          "content": [
+            {
+              "type": "text",
+              "value": "The \"Before You Start\" section lists skills to load. Evaluate whether each listed skill is necessary for the agent's actual work. An agent that loads skills speculatively \"just in case\" wastes context that could serve the actual task.\n\nAlso evaluate: does the agent load a broad parent skill when a narrow child would suffice? Does the agent load multiple skills that cover the same domain? Are skills split between always-load and load-when-relevant correctly — or are situational skills in the always-load list?"
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Content Duplication",
+          "content": [
+            {
+              "type": "text",
+              "value": "Read each section of the agent definition and ask: is this content already covered by a skill the agent loads? If the agent loads `_claude`, it has access to documentation standards — restating those standards in the definition is duplication. If the agent loads `_execution`, it has lifecycle guidance — the definition should adapt, not restate.\n\nThe definition should add domain-specific context on top of what skills provide, not reproduce what skills already teach. Duplication patterns to look for: lifecycle phase descriptions that mirror `_execution` verbatim; quality criteria that repeat what a loaded skill already specifies; constraint lists that reproduce a skill's constraint section."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Model Appropriateness",
+          "content": [
+            {
+              "type": "text",
+              "value": "The `model` frontmatter field assigns the agent's model tier. Evaluate whether the assignment fits the agent's work profile.\n\nAgents handling fast, well-scoped implementation tasks with clear inputs and outputs are suited for the faster tier (sonnet). Agents requiring deep reasoning, broad synthesis across many sources, complex judgment calls, or open-ended investigation are better served by the more capable tier (opus). A mismatch in either direction degrades performance: opus on routine work is wasteful; sonnet on complex analytical work produces shallow output.\n\nRead the agent's actual responsibilities — not just its role label — to assess whether the model assignment matches the cognitive demand."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Unnecessary Tool Grants",
+          "content": [
+            {
+              "type": "text",
+              "value": "Evaluated also from project perspective, but from a performance angle: each tool in the `tools` list adds to the agent's available action space and may be invoked unnecessarily when a narrower approach would suffice. Tools the agent never uses in its actual workflow represent dormant complexity."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Findings Format",
+      "content": [
+        {
+          "type": "text",
+          "value": "Each finding needs: what the inefficiency is, where in the definition it appears, and what the cost is — excess context, drift risk, or model mismatch. Quantify where possible: if a section is substantially redundant with a skill the agent loads, note which skill and which section."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_agent-evaluation-project/SKILL.json
+++ b/.claude/skills/_agent-evaluation-project/SKILL.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_agent-evaluation-project",
+    "description": "Project perspective for evaluating gobbi agent definitions — assesses purpose clarity, description accuracy, role fit, tool permissions, and scope alignment with the orchestrator's delegation model.",
+    "allowed-tools": "Read, Grep, Glob, Bash"
+  },
+  "title": "Agent Evaluation — Project Perspective",
+  "opening": "You evaluate gobbi agent definitions from a project perspective. Your job is to find problems — not confirm success.\n\nThe project perspective asks: does this agent serve a clear, necessary purpose? Does it fit the system as designed? Would the orchestrator route work to it correctly, and would the agent handle that work without overstepping?",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Purpose is the foundation. An agent without a clear purpose produces unclear behavior.",
+          "body": "Every agent exists because the orchestrator needs to route a specific category of work somewhere specific. If the purpose is fuzzy, the routing is fuzzy, and the agent becomes a catch-all that erodes system clarity."
+        },
+        {
+          "type": "principle",
+          "statement": "The description field is a routing contract, not a label.",
+          "body": "The `description` frontmatter field is what the orchestrator reads to decide whether to delegate here. Evaluate it as a contract: does it tell the orchestrator exactly when to use this agent, and does it exclude cases that belong elsewhere?"
+        }
+      ]
+    },
+    {
+      "heading": "What to Examine",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Purpose and Necessity",
+          "content": [
+            {
+              "type": "text",
+              "value": "Does this agent serve a role that the system actually needs? An agent is justified when its domain of work is distinct enough that a specialized persona improves output quality over a generic one. If the agent's work could be absorbed by an existing agent without degrading quality, it may not need to exist.\n\nConsider: what specific capability does this agent have that others lack? What work would go wrong without it?"
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Description Accuracy",
+          "content": [
+            {
+              "type": "text",
+              "value": "Read the `description` field as the orchestrator would. Does it describe the right trigger scenarios — specific task types, not vague categories? Does it mention the key delegatable responsibilities? Would a reader of the description alone route work correctly?\n\nWatch for: descriptions that are too broad (matches many unrelated tasks), too narrow (misses legitimate uses), or self-referential (describes the agent rather than when to use it)."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Role Fit in the System",
+          "content": [
+            {
+              "type": "text",
+              "value": "Does the agent fit within the gobbi system's agent architecture? Read `.claude/agents/` to understand existing agents and their domains. An agent that overlaps significantly with another is a design problem — the orchestrator will hesitate, or worse, route inconsistently.\n\nThe agent's \"Out of scope\" statement is as important as its scope definition. If \"Out of scope\" is missing or vague, boundary conflicts are likely."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Tool Permissions",
+          "content": [
+            {
+              "type": "text",
+              "value": "The `tools` frontmatter field should contain exactly what the agent needs to accomplish its role — no more. Unnecessary tools widen the agent's action space and create risk. Common violations: AskUserQuestion on agents that shouldn't interact with users directly; Write/Edit on agents that are read-only investigators; WebSearch/WebFetch on agents without a research mandate.\n\nAsk: for each tool listed, can you trace a concrete scenario in the agent's role that requires it?"
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Scope Alignment with Delegation",
+          "content": [
+            {
+              "type": "text",
+              "value": "The agent's scope should match what the orchestrator delegates to it. If the agent's capabilities imply it can handle work the orchestrator never delegates, or if the orchestrator needs to delegate work the agent's scope doesn't cover, there is a mismatch.\n\nRead the agent's \"Out of scope\" section against the agent's apparent capability. Does the exclusion make sense? Does it leave the agent with a coherent, self-sufficient role?"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Findings Format",
+      "content": [
+        {
+          "type": "text",
+          "value": "Each finding needs: what the specific problem is, which part of the agent definition it affects, and why it matters for the system's correctness. Distinguish between problems that break routing (critical) and problems that degrade quality (moderate).\n\nPrioritize findings that would cause the orchestrator to misroute work or an agent to silently exceed its mandate. Surface these above cosmetic or minor issues."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_agent-evaluation-user/SKILL.json
+++ b/.claude/skills/_agent-evaluation-user/SKILL.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_agent-evaluation-user",
+    "description": "User perspective for evaluating gobbi agent definitions — assesses whether the agent's output is understandable and trustworthy, whether it asks the right questions at the right times, and whether the user can tell what the agent is for. Use when evaluating whether an agent actually serves the person whose work it handles.",
+    "allowed-tools": "Read, Grep, Glob, Bash"
+  },
+  "title": "Agent Evaluation — User Perspective",
+  "opening": "You evaluate gobbi agent definitions from the user perspective. Your job is to find problems — not confirm success.\n\nThe user perspective asks: what does the user actually experience when this agent does its work? Not how well the agent is designed internally, but whether the person on the other side of the conversation gets useful output, clear communication, and results they can trust.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "An agent that produces correct output the user cannot understand or trust has failed the user.",
+          "body": "Internal correctness is necessary but not sufficient. The user's measure of an agent is whether they can act on its work without rethinking or redoing it. Output that requires constant second-guessing, asking clarifications, or being verified against the original goal is output that has failed — regardless of its technical quality."
+        },
+        {
+          "type": "principle",
+          "statement": "An agent's scope boundary must be legible to the user, not just to the system.",
+          "body": "The user delegates to an agent by describing what they need. If the agent's domain is unclear, the user either delegates the wrong work or hesitates to delegate at all. Legible scope is not an architectural concern — it is a user experience concern."
+        }
+      ]
+    },
+    {
+      "heading": "What to Examine",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Output Usefulness",
+          "content": [
+            {
+              "type": "text",
+              "value": "When the orchestrator routes work to this agent, does the user receive something they can act on?\n\nRead the agent definition and build a picture of what its typical output looks like. Then ask from the user's viewpoint:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Is the output structured in a way the user can navigate — findings before details, conclusions before reasoning?",
+                "Does the output name specific, actionable observations, or does it traffic in abstractions the user must translate before they can do anything?",
+                "Would a user reading this output know what to do next, or would they need to ask follow-up questions to extract the usable content?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Question Quality",
+          "content": [
+            {
+              "type": "text",
+              "value": "Does the agent ask the right questions at the right times?\n\nAskUserQuestion is the agent's primary tool for getting unstuck. Used well, it collects what the agent genuinely cannot infer. Used poorly, it interrupts the user with questions the agent could answer itself, or defers decisions that should be made by the agent. Assess:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Are there scenarios where this agent would ask the user something the user expects the agent to handle autonomously?",
+                "Are there scenarios where this agent would need to make a decision that it lacks the guidance to make alone — where asking would be the right call, but the definition doesn't indicate it?",
+                "If the agent uses AskUserQuestion, is it clear from the definition when and why it would ask rather than proceed?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Scope Legibility",
+          "content": [
+            {
+              "type": "text",
+              "value": "Would the user know what to bring to this agent versus another?\n\nA user delegates effectively when they understand what each agent is for. Read the agent's purpose statement and `description` as a user would encounter them — not as someone who already knows the system. Ask:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Can a user who has never seen this agent before describe its domain in one sentence after reading the definition?",
+                "Is the boundary between this agent and adjacent agents clear from the user's vantage point — not just from the system's vantage point?",
+                "If the user has work that is adjacent to this agent's scope, would they know to bring it here or somewhere else?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Speed and Depth Match",
+          "content": [
+            {
+              "type": "text",
+              "value": "Does the agent's model choice match what the user expects for the work?\n\nSonnet and Opus serve different user expectations: Sonnet is expected to be fast and decisive; Opus is expected to go deep and handle ambiguity. When a user delegates work, they have an implicit expectation of how long it will take and how thorough it will be. Assess:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Does the agent's model choice align with the nature of the work — is depth needed here, or is speed the priority?",
+                "Would a user waiting on this agent's output be surprised by how long it takes relative to the complexity of what they asked?",
+                "If the agent is Sonnet-powered and the work frequently requires judgment calls the model will struggle with, is that a user-facing problem?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Trust Calibration",
+          "content": [
+            {
+              "type": "text",
+              "value": "Would the user trust this agent's output, or would they need to verify it constantly?\n\nTrust is built through consistency, specificity, and scope discipline. An agent that occasionally oversteps its scope, produces vague findings, or generates output that turns out to be wrong erodes user trust over time. Assess:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Does the definition give the agent enough specific guidance that its outputs will be consistent across sessions?",
+                "Is the agent's scope narrow enough that the user can predict what it will and won't catch?",
+                "Are there cases where the agent's definition gives it latitude that a user would expect to be constrained?"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Findings Format",
+      "content": [
+        {
+          "type": "text",
+          "value": "Each finding should name: what the user experiences, which part of the agent definition produces it, and what would need to change. Distinguish between failures that make the agent's output unusable (critical) and failures that reduce trust or add friction without preventing use (moderate).\n\nNote what the agent gets right from the user's viewpoint — what it reliably delivers that the user depends on."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_agents/SKILL.json
+++ b/.claude/skills/_agents/SKILL.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_agents",
+    "description": "Reference and interactive guide for creating Claude Code agent definitions. MUST load when creating, reviewing, or modifying .claude/agents/ files. Must load _claude and _discuss before using this skill.",
+    "allowed-tools": "Read, Grep, Glob, Bash, Write, Edit, AskUserQuestion"
+  },
+  "title": "Agent Definitions",
+  "opening": "Reference for understanding agent definition structure and interactive guide for creating new agents through discussion. Load this skill when creating, reviewing, or modifying `.claude/agents/` files. Read existing agent definitions in `.claude/agents/` for real patterns — they are the source of truth.",
+  "sections": [
+    {
+      "heading": "Core Principles",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "An agent definition describes who the agent is, not what it must do step by step.",
+          "body": "An agent is a specialized AI persona with a focused role, specific tools, and domain expertise. The definition establishes identity, boundaries, and context — not a task script. If the definition reads like a procedure, the agent will follow it rigidly instead of planning based on the actual task."
+        },
+        {
+          "type": "principle",
+          "statement": "\"Before You Start\" loads top-level indexes, not everything.",
+          "body": "Every agent definition includes a \"Before You Start\" section listing skills, project docs, rules, and memories to load. Agents should only read SKILL.md, README.md, and other top-level index files first — then navigate deeper on demand. Front-loading all docs wastes context on content that may not be relevant."
+        },
+        {
+          "type": "principle",
+          "statement": "Every agent follows: Study, Plan, Execute, Verify, Memorize.",
+          "body": "This is the universal agent lifecycle. Study actively before acting — read project docs, explore the codebase, check gotchas. Plan the approach before starting. Execute with focused, minimal changes. Verify that docs and memories reflect the changes. Memorize anything learned that prevents repeating mistakes."
+        },
+        {
+          "type": "principle",
+          "statement": "Discuss before writing — understand the role before defining it.",
+          "body": "Use AskUserQuestion to understand what the agent should be, what it should not do, and where its boundaries lie relative to existing agents. A definition written without discussion produces an agent with vague boundaries that overlaps with others."
+        },
+        {
+          "type": "principle",
+          "statement": "Understand the gobbi vs project boundary.",
+          "body": "Gobbi already provides agents for orchestration (`gobbi-agent`), evaluation (`_skills-evaluator`, `_agent-evaluator`, `_project-evaluator`), and task execution (`__executor`, `__pi`). Users do NOT need to create agents for these roles. Project agents should be domain-specific — a security reviewer that knows the project's auth stack, a database migration specialist that knows the ORM, a test writer that knows the testing framework. When helping create an agent, first check if gobbi already handles the role. If it does, redirect. If the user needs a specialized version (e.g., a project-specific evaluator), help create one with concrete domain knowledge, not generic guidance."
+        }
+      ]
+    },
+    {
+      "heading": "Agent Definition Structure",
+      "content": [
+        {
+          "type": "text",
+          "value": "The structure of an agent definition establishes identity, context, and quality expectations — in that order.\n\n**Frontmatter** — Required fields: `name`, `description`, `tools` (scoped to what the agent actually needs). Model assignments are defined in each agent's YAML frontmatter — refer to the actual agent files in `.claude/agents/` for current assignments rather than maintaining a separate list here. The orchestrator can override via the Agent tool's model parameter when a specific task warrants a different tier — see _delegation's model selection guidance. The `description` field is critical — it answers \"when should the orchestrator send work here?\" If two agents' descriptions match the same task, boundaries need sharpening.\n\n**Identity within 20 lines** — The opening paragraph establishes who the agent is (\"You are a...\"), what it thinks like, and when it receives work. Follow immediately with \"Out of scope\" — what the agent should NOT do and should defer to other agents.\n\n**Before You Start** — List skills as always-load vs load-when-relevant. Include project docs, rules, and memories the agent needs. Keep this section a navigation index, not a reading list.\n\n**Lifecycle** — Adapt Study, Plan, Execute, Verify, Memorize to the domain. Each phase gets domain-specific guidance — what to study, what to verify, what to memorize. Not every domain needs the same depth in every phase.\n\n**Quality Expectations** — What good output looks like for this agent. Concrete criteria a reviewer could check.\n\nRead existing agent definitions in `.claude/agents/` for the real patterns — they demonstrate how these elements compose in practice."
+        }
+      ]
+    },
+    {
+      "heading": "Discussion Dimensions",
+      "content": [
+        {
+          "type": "text",
+          "value": "When creating a new agent, use AskUserQuestion to explore these dimensions. Not every agent needs every question — pick the ones that address what is vague or missing for this specific role."
+        },
+        {
+          "type": "subsection",
+          "heading": "Understanding the Role",
+          "content": [
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**Expertise domain** — What specialized knowledge does this agent have? What types of tasks should the orchestrator route here? What is the agent's \"think like a...\" identity?",
+                "**Routing clarity** — Can the orchestrator unambiguously decide to send a task here vs. to another agent? If two agents' descriptions could match the same task, which one should get it and why?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Defining Boundaries",
+          "content": [
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**Out of scope** — What should this agent explicitly NOT do? What adjacent work should it defer to other agents?",
+                "**Domain borders** — Which existing agents' domains border this one? Are the boundaries sharp enough that the orchestrator never hesitates between them?",
+                "**Scope discipline** — When the agent encounters work outside its scope during execution, what should it do? Report back, note it, or defer?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Designing the Context",
+          "content": [
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**Skills to load** — Which skills should \"Before You Start\" list? Which are always-load vs load-when-relevant? Is the list minimal — no \"just in case\" entries?",
+                "**Project context** — What project docs, rules, and memories does this agent need? Which are always relevant and which are situational?",
+                "**Model selection** — What model should this agent use? Check current assignments in the agent files in `.claude/agents/`. The orchestrator can override per task — see _delegation's model selection guidance."
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Lifecycle Emphasis",
+          "content": [
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**Study depth** — How much codebase exploration does this domain need before planning? Does the Study phase need an explicit reading list?",
+                "**Verification criteria** — What domain-specific checks should the Verify phase include? What would a reviewer look for beyond \"does it work?\"",
+                "**Memorize scope** — What gotcha domains are relevant? What patterns should this agent record when it learns from mistakes?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Quality Expectations",
+          "content": [
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**Good output** — What does good output look like for this agent? What are the concrete, checkable quality criteria?",
+                "**Common mistakes** — What mistakes are common in this domain? What should the agent actively watch for?"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Expected Output",
+      "content": [
+        {
+          "type": "text",
+          "value": "The interactive creation process produces a single `.md` file in `.claude/agents/` with:"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Valid frontmatter (`name`, `description`, `tools`, and `model` where appropriate)",
+            "Clear identity and \"think like a...\" framing within the first 20 lines",
+            "\"Out of scope\" boundaries stated early",
+            "\"Before You Start\" section listing context to load",
+            "Lifecycle guidance adapted to the domain",
+            "Quality expectations with concrete criteria"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Constraints",
+      "content": [
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Must follow _claude writing principles — principles over procedures, constraints over templates, codebase over examples",
+            "Agent definitions describe roles, not task scripts — if it reads like a procedure, revise it",
+            "Tools scoped to what the agent actually needs — no \"just in case\" grants",
+            "Clear domain boundaries — no overlap with existing agents in `.claude/agents/`",
+            "Under 500 lines per file (must), targeting under 200 (should)",
+            "Always discuss via AskUserQuestion before writing a new agent definition"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_audit/SKILL.json
+++ b/.claude/skills/_audit/SKILL.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_audit",
+    "description": "Detect documentation drift in .claude/ files. Use periodically, after major codebase changes, or before releases to find stale references and structural mismatches.",
+    "allowed-tools": "Read, Grep, Glob, Bash"
+  },
+  "title": "Audit",
+  "opening": "Detect documentation drift in `.claude/` files — stale file references, broken links, and structural claims that no longer match reality. Documentation drifts silently: a renamed file, a moved directory, a reorganized structure. The docs still read well, but point agents to things that no longer exist.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Docs that reference nonexistent files are worse than no docs.",
+          "body": "A stale reference sends agents on a hunt for something that does not exist, wasting context and producing confused output. Regular auditing catches these before agents encounter them."
+        },
+        {
+          "type": "principle",
+          "statement": "Audit what is verifiable. Skip what is subjective.",
+          "body": "Auditing checks concrete, machine-verifiable claims: does this file exist? Does this directory exist? It does NOT assess content quality, writing style, or whether a doc's advice is good. Content quality is a human judgment, not an audit finding."
+        },
+        {
+          "type": "principle",
+          "statement": "Audit living docs, not historical records.",
+          "body": "Skills, agents, gotchas, rules, and CLAUDE.md are living documentation that agents actively follow. Project notes (`$CLAUDE_PROJECT_DIR/.claude/project/` note directories) are historical records of past sessions — they describe what happened at a point in time and are not expected to stay current. Audit the former, skip the latter."
+        }
+      ]
+    },
+    {
+      "heading": "What to Audit",
+      "content": [
+        {
+          "type": "text",
+          "value": "**File path references** — Backtick-quoted paths and markdown links in `.md` files. Check whether the referenced file or directory actually exists on disk. Catches: renamed files, moved directories, deleted scripts.\n\n**Structural claims** — Statements about where things live (\"skills are in `.claude/skills/`\", \"agents are defined in `.claude/agents/`\"). Check whether the described directories exist and contain what is claimed. Catches: reorganized directory structures, outdated architecture descriptions."
+        }
+      ]
+    },
+    {
+      "heading": "When to Audit",
+      "content": [
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "**Periodically** — as part of routine maintenance",
+            "**After major restructuring** — file moves, directory reorganizations, renames",
+            "**Before releases** — verify all docs point to real things",
+            "**After skill or agent creation** — confirm new references are valid and navigation tables are updated"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Scope",
+      "content": [
+        {
+          "type": "text",
+          "value": "**In scope:**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "All `.md` files in `.claude/` root (CLAUDE.md, rules)",
+            "Skill definitions (SKILL.md and child docs)",
+            "Agent definitions",
+            "Gotcha files",
+            "Any scripts referenced from skill docs"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**Out of scope:**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "`$CLAUDE_PROJECT_DIR/.claude/project/` note directories — historical records, not living docs",
+            "Content quality assessment — that is __validate's domain",
+            "External URLs — network-dependent, separate concern"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Tools",
+      "content": [
+        {
+          "type": "text",
+          "value": "Three scripts in `scripts/` automate the verifiable checks:"
+        },
+        {
+          "type": "table",
+          "headers": [
+            "Script",
+            "Purpose"
+          ],
+          "rows": [
+            [
+              "`audit-references.sh`",
+              "Scan `.md` files for file path references, check if each exists on disk"
+            ],
+            [
+              "`audit-conventions.sh`",
+              "Scan SKILL.md files for directory structure claims, check if described structures exist"
+            ],
+            [
+              "`audit-commands.sh`",
+              "Scan `.md` files for shell commands in fenced code blocks, check if referenced binaries exist"
+            ]
+          ]
+        },
+        {
+          "type": "text",
+          "value": "All scripts accept a directory path as an argument. Run from the repository root. Exit 0 means clean, exit 1 means findings. Output uses `file:line` format for each finding."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_claude/SKILL.json
+++ b/.claude/skills/_claude/SKILL.json
@@ -1,0 +1,221 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_claude",
+    "description": "Writing standard for .claude/ documentation — principles, hierarchy, and anti-patterns. MUST load when authoring or modifying any .claude/ file. Load optionally when reading .claude/ docs for structural context.",
+    "allowed-tools": "Read, Grep, Glob, Bash, Write, Edit"
+  },
+  "title": "Claude Skill",
+  "opening": "Writing standard for `.claude/` documentation. MUST load when authoring or modifying any `.claude/` file. Load optionally when reading `.claude/` docs for structural context.",
+  "navigation": {
+    "_rules": "Authoring rule files in `.claude/rules/`",
+    "_project": "Authoring project docs in `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/`",
+    "_skills": "Creating and modifying skill definitions in `.claude/skills/`",
+    "_agents": "Creating and modifying agent definitions in `.claude/agents/`",
+    "[transcripts.md](transcripts.md)": "Subagent transcript recovery — location, JSONL schema, extraction paths, plan data"
+  },
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Chain-of-Docs — think deeply first, then decompose into short docs.",
+          "body": "Agents default to writing short, shallow docs. Chain-of-Docs demands the opposite order: think deeply about the full problem space first — structure, relationships, edge cases, abstraction levels — then decompose that deep understanding into a chain of focused documents. Each file covers one level of abstraction and links to its children via a **\"Navigate deeper from here:\"** table. The depth of thought produces the quality; the decomposition produces the navigability."
+        },
+        {
+          "type": "principle",
+          "statement": "Procedures get detailed steps. Non-procedures get principles, not steps.",
+          "body": "When a doc describes a procedure — a sequence where order matters and deviation causes failure — write specific steps with full detail. When a doc describes non-procedural guidance — design principles, conventions, quality standards — write principles and constraints instead. Step-by-step instructions for non-procedures lock agents into rigid paths and suppress their judgment in situations the doc author didn't anticipate."
+        },
+        {
+          "type": "principle",
+          "statement": "First line tells the agent what this doc is and when to read it.",
+          "body": "Every document opens with a clear statement of its purpose and scope. An agent scanning a file list should know from the first line whether this doc is relevant to its current task — without reading further."
+        }
+      ]
+    },
+    {
+      "heading": "Writing Pattern",
+      "content": [
+        {
+          "type": "text",
+          "value": "What effective `.claude/` documentation looks like:"
+        },
+        {
+          "type": "table",
+          "headers": [
+            "Pattern",
+            "Principle"
+          ],
+          "rows": [
+            [
+              "**Principles over procedures**",
+              "State what matters and why. \"Each component decomposes into X, Y, Z — read existing code for the pattern.\""
+            ],
+            [
+              "**Constraints over templates**",
+              "Tell agents what NOT to do (clear boundary) rather than what TO do (rigid path). Constraints leave room for judgment."
+            ],
+            [
+              "**Codebase over examples**",
+              "Point agents to read existing implementations. The codebase is the single source of truth."
+            ],
+            [
+              "**Line limit**",
+              "**Must** stay under 500 lines per file. **Should** target under 200 lines. If a file exceeds this, decompose into hierarchy."
+            ]
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**CLAUDE.md specifically**: Reference card, not tutorial. Don't duplicate content from skills or rules — link to them. Loaded every session, so make it scannable."
+        }
+      ]
+    },
+    {
+      "heading": "Anti-Pattern",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Must Avoid",
+          "content": [
+            {
+              "type": "text",
+              "value": "These directly cause the mimicry problem. Presence of any of these means the doc needs revision."
+            },
+            {
+              "type": "table",
+              "headers": [
+                "Anti-Pattern",
+                "Why It Fails"
+              ],
+              "rows": [
+                [
+                  "**Code examples**",
+                  "Agent copies verbatim without adapting to context. The codebase has real examples."
+                ],
+                [
+                  "**BAD/GOOD comparison blocks**",
+                  "Agent memorizes the GOOD block as a mandatory template."
+                ],
+                [
+                  "**Duplicating codebase patterns**",
+                  "Creates a second source of truth that drifts from reality."
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Context-Dependent",
+          "content": [
+            {
+              "type": "text",
+              "value": "Not universally forbidden. The test: \"Would deviating from this sequence cause failure?\" If yes, the pattern is appropriate."
+            },
+            {
+              "type": "table",
+              "headers": [
+                "Anti-Pattern",
+                "When Forbidden",
+                "When Allowed"
+              ],
+              "rows": [
+                [
+                  "**Step-by-step recipes**",
+                  "In teaching docs (skills, rules, project docs) where agents should reason from principles. Agent follows rigidly, skips steps that matter, adds steps that don't.",
+                  "In procedures — sequences where order matters and skipping or reordering steps causes failure. Orchestration workflows, setup sequences, git lifecycles, deployment pipelines. The test: if the agent reorders or omits a step, does something break? If yes, write detailed steps."
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Should Avoid",
+          "content": [
+            {
+              "type": "text",
+              "value": "These weaken doc quality and lead to subtle issues over time. Acceptable in small doses with good reason."
+            },
+            {
+              "type": "table",
+              "headers": [
+                "Anti-Pattern",
+                "Why It Fails"
+              ],
+              "rows": [
+                [
+                  "**Interface definitions in docs**",
+                  "Get stale, agent uses doc version instead of actual source."
+                ],
+                [
+                  "**Long rationale paragraphs**",
+                  "Agent skips them, reads only the nearby concrete content."
+                ],
+                [
+                  "**Exact numeric values**",
+                  "Agent uses the number without checking if it's still current."
+                ],
+                [
+                  "**Bash verification commands**",
+                  "Agent runs only listed commands, misses other issues."
+                ],
+                [
+                  "**Detailed format templates**",
+                  "Agent copies structure even when content doesn't fit."
+                ]
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Review Checklist",
+      "content": [
+        {
+          "type": "text",
+          "value": "Before publishing any `.claude/` documentation:\n\n**Core Principle**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "[ ] Chain-of-Docs — deep thinking decomposed into focused docs with \"Navigate deeper from here:\" links",
+            "[ ] Procedures have detailed steps; non-procedures use principles and constraints, not steps",
+            "[ ] First line declares what the doc is and when to read it"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**Writing Pattern**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "[ ] Points to codebase for implementation patterns (\"read existing X\")",
+            "[ ] Under 500 lines (must), targeting under 200 (should)",
+            "[ ] No duplication with other `.claude/` files"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**Anti-Pattern**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "[ ] Zero code blocks or BAD/GOOD comparisons (must avoid)",
+            "[ ] Step-by-step recipes only in procedures where reordering or omitting steps causes failure (context-dependent)",
+            "[ ] Minimal interface definitions, exact values, or bash commands in docs (should avoid)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_claude/SKILL.json
+++ b/.claude/skills/_claude/SKILL.json
@@ -174,6 +174,78 @@
       ]
     },
     {
+      "heading": "JSON-First Authoring",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "JSON is the source of truth. Markdown is a generated artifact.",
+          "body": "Every `.claude/` document (except `CLAUDE.md`) has a `.json` source file and a `.md` output file. The JSON file is what agents edit; the Markdown file is what agents and humans read. Both files are committed to git. The JSON structure enforces the block types, section hierarchy, and frontmatter schema that the writing principles above describe — making violations structurally impossible rather than merely discouraged."
+        },
+        {
+          "type": "principle",
+          "statement": "Edit JSON, generate Markdown, validate, commit both.",
+          "body": "The authoring workflow is a procedure where order matters. Edit the `.json` file to change content. Run `gobbi docs json2md <path>` to regenerate the `.md` file. Run `gobbi docs validate <path>` to verify the JSON conforms to the schema. Commit both files together. Editing the `.md` directly creates drift — the next `json2md` run will overwrite the manual change."
+        },
+        {
+          "type": "text",
+          "value": "`CLAUDE.md` is the exception to JSON-first authoring. It is hand-authored Markdown — a reference card loaded every session that links to skills and rules rather than containing structured content blocks."
+        },
+        {
+          "type": "subsection",
+          "heading": "Doc Types and Block Types",
+          "content": [
+            {
+              "type": "text",
+              "value": "The JSON schema supports six doc types, each with a `$schema` field that determines its structure and validation rules: `skill`, `agent`, `rule`, `root`, `child`, `gotcha`. Use `gobbi docs init <type> [name]` to scaffold a new JSON template for any doc type."
+            },
+            {
+              "type": "text",
+              "value": "Section content is built from six block types: `text` (prose paragraphs), `principle` (blockquote statement with optional body), `table` (headers and rows), `constraint-list` (must/should/must-not items), `list` (bullet or numbered items), `subsection` (nested heading with its own content blocks). These block types map directly to the writing patterns and anti-patterns described above — they make the structure explicit rather than inferred from Markdown formatting."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "CLI Commands",
+          "content": [
+            {
+              "type": "table",
+              "headers": [
+                "Command",
+                "Purpose"
+              ],
+              "rows": [
+                [
+                  "`gobbi docs init <type> [name]`",
+                  "Scaffold a new JSON template for the given doc type"
+                ],
+                [
+                  "`gobbi docs json2md <path>`",
+                  "Generate `.md` from the `.json` source file"
+                ],
+                [
+                  "`gobbi docs validate <path>`",
+                  "Validate JSON against the gobbi-docs schema"
+                ],
+                [
+                  "`gobbi docs read <path> [--section]`",
+                  "Section-level access to JSON content without reading the full `.md`"
+                ],
+                [
+                  "`gobbi docs md2json <path>`",
+                  "Migrate existing `.md` to JSON (one-time migration, not part of the regular workflow)"
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "value": "For the full schema specification, see `$CLAUDE_PROJECT_DIR/.claude/project/gobbi/design/gobbi-docs-spec.md`."
+        }
+      ]
+    },
+    {
       "heading": "Review Checklist",
       "content": [
         {
@@ -213,6 +285,19 @@
             "[ ] Zero code blocks or BAD/GOOD comparisons (must avoid)",
             "[ ] Step-by-step recipes only in procedures where reordering or omitting steps causes failure (context-dependent)",
             "[ ] Minimal interface definitions, exact values, or bash commands in docs (should avoid)"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**JSON-First Authoring**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "[ ] JSON source and `.md` output are in sync (`gobbi docs validate`)",
+            "[ ] Content was edited in the `.json` file, not the `.md` file",
+            "[ ] Both `.json` and `.md` are committed together"
           ]
         }
       ]

--- a/.claude/skills/_claude/SKILL.md
+++ b/.claude/skills/_claude/SKILL.md
@@ -85,6 +85,38 @@ These weaken doc quality and lead to subtle issues over time. Acceptable in smal
 
 ---
 
+## JSON-First Authoring
+
+> **JSON is the source of truth. Markdown is a generated artifact.**
+
+Every `.claude/` document (except `CLAUDE.md`) has a `.json` source file and a `.md` output file. The JSON file is what agents edit; the Markdown file is what agents and humans read. Both files are committed to git. The JSON structure enforces the block types, section hierarchy, and frontmatter schema that the writing principles above describe — making violations structurally impossible rather than merely discouraged.
+
+> **Edit JSON, generate Markdown, validate, commit both.**
+
+The authoring workflow is a procedure where order matters. Edit the `.json` file to change content. Run `gobbi docs json2md <path>` to regenerate the `.md` file. Run `gobbi docs validate <path>` to verify the JSON conforms to the schema. Commit both files together. Editing the `.md` directly creates drift — the next `json2md` run will overwrite the manual change.
+
+`CLAUDE.md` is the exception to JSON-first authoring. It is hand-authored Markdown — a reference card loaded every session that links to skills and rules rather than containing structured content blocks.
+
+### Doc Types and Block Types
+
+The JSON schema supports six doc types, each with a `$schema` field that determines its structure and validation rules: `skill`, `agent`, `rule`, `root`, `child`, `gotcha`. Use `gobbi docs init <type> [name]` to scaffold a new JSON template for any doc type.
+
+Section content is built from six block types: `text` (prose paragraphs), `principle` (blockquote statement with optional body), `table` (headers and rows), `constraint-list` (must/should/must-not items), `list` (bullet or numbered items), `subsection` (nested heading with its own content blocks). These block types map directly to the writing patterns and anti-patterns described above — they make the structure explicit rather than inferred from Markdown formatting.
+
+### CLI Commands
+
+| Command | Purpose |
+|---|---|
+| `gobbi docs init <type> [name]` | Scaffold a new JSON template for the given doc type |
+| `gobbi docs json2md <path>` | Generate `.md` from the `.json` source file |
+| `gobbi docs validate <path>` | Validate JSON against the gobbi-docs schema |
+| `gobbi docs read <path> [--section]` | Section-level access to JSON content without reading the full `.md` |
+| `gobbi docs md2json <path>` | Migrate existing `.md` to JSON (one-time migration, not part of the regular workflow) |
+
+For the full schema specification, see `$CLAUDE_PROJECT_DIR/.claude/project/gobbi/design/gobbi-docs-spec.md`.
+
+---
+
 ## Review Checklist
 
 Before publishing any `.claude/` documentation:
@@ -103,3 +135,8 @@ Before publishing any `.claude/` documentation:
 - [ ] Zero code blocks or BAD/GOOD comparisons (must avoid)
 - [ ] Step-by-step recipes only in procedures where reordering or omitting steps causes failure (context-dependent)
 - [ ] Minimal interface definitions, exact values, or bash commands in docs (should avoid)
+
+**JSON-First Authoring**
+- [ ] JSON source and `.md` output are in sync (`gobbi docs validate`)
+- [ ] Content was edited in the `.json` file, not the `.md` file
+- [ ] Both `.json` and `.md` are committed together

--- a/.claude/skills/_claude/gotchas.json
+++ b/.claude/skills/_claude/gotchas.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "gobbi-docs/gotcha",
+  "parent": "_claude",
+  "title": "Gotcha: _claude",
+  "entries": [
+    {
+      "title": "Code examples in .claude/ docs",
+      "body": {
+        "priority": "High",
+        "what-happened": "Skills and agent definitions contained Python, TypeScript, YAML, and bash code blocks. Agents copied these examples verbatim into their implementations without adapting to the actual context. The code was used as a template rather than understood as a pattern.",
+        "user-feedback": "\"Claude docs must not contain code examples — agents blindly copy them instead of thinking.\"",
+        "correct-approach": "State principles and constraints. Point agents to read existing code in the codebase for patterns. The codebase is the single source of truth — docs that mirror code become stale and misleading."
+      }
+    },
+    {
+      "title": "Step-by-step recipes in teaching docs",
+      "body": {
+        "priority": "High",
+        "what-happened": "Skills contained numbered step-by-step procedures (Step 1, Step 2, Step 3). Agents followed the steps rigidly, skipping steps that mattered in context and adding steps that didn't. When the procedure didn't perfectly match the situation, agents either forced the procedure or got stuck.",
+        "user-feedback": "Agents should understand the principle and make their own plan, not follow a script. But orchestration flows and agent definitions need ordered sequences — the problem is step-by-step in teaching docs, not step-by-step everywhere.",
+        "correct-approach": "In teaching docs (skills, rules, project docs): describe what needs to be true (principles, constraints, quality gates), not how to get there. Let the agent plan based on the actual task. In orchestration flows and agent definitions: ordered sequences are appropriate when a specific sequence must be followed exactly and deviation causes failure."
+      }
+    },
+    {
+      "title": "BAD/GOOD comparison blocks",
+      "body": {
+        "priority": "Medium",
+        "what-happened": "Documentation used BAD/GOOD side-by-side comparison blocks to illustrate patterns. Agents memorized the GOOD block as a mandatory template and applied it even when the context called for a different approach.",
+        "user-feedback": "Agents misunderstand or just mimic instead of understanding the principles.",
+        "correct-approach": "State the constraint (\"never do X because Y\") without showing BAD/GOOD examples. The constraint gives the agent a boundary; the BAD/GOOD gives it a template to copy."
+      }
+    },
+    {
+      "title": "Blockquote contains full description instead of just the principle point",
+      "body": {
+        "priority": "Medium",
+        "what-happened": "Core principle sections used blockquotes (`>`) that contained both the bold principle and the full description on the same quoted line. This made the description part of the \"principle\" visually and semantically, blurring the distinction between the point and its explanation.",
+        "user-feedback": "Blockquotes should only hold the bold principle point. The description goes on a separate non-quoted line below.",
+        "correct-approach": "Use `> **Principle statement.**` on its own line. Put the explanation on a separate non-quoted paragraph below. The blockquote highlights the point; the description explains it."
+      },
+      "metadata": {
+        "priority": "medium"
+      }
+    },
+    {
+      "title": "Referencing internal (`__`) names in non-internal docs",
+      "body": {
+        "priority": "High",
+        "what-happened": "A hidden skill (`_plan`) referenced an internal agent (`__pi`) by name. Internal names (double underscore prefix) are implementation details for gobbi contributors — they should not appear in hidden or interface tier docs that end users and workflow agents read.",
+        "user-feedback": "\"Never use internal skills or internal agents like `__pi`.\"",
+        "correct-approach": "Hidden (`_`) and interface (no prefix) docs must never reference internal (`__`) names. Use generic terms instead — \"research agents\" not \"`__pi`\", \"validation tooling\" not \"`__validate`\". Internal names leak implementation details and create coupling between tiers that should be independent."
+      },
+      "metadata": {
+        "priority": "high"
+      }
+    }
+  ],
+  "opening": "Mistakes in writing `.claude/` documentation. These cause agents to produce rigid, templated output instead of thinking."
+}

--- a/.claude/skills/_claude/transcripts.json
+++ b/.claude/skills/_claude/transcripts.json
@@ -1,0 +1,400 @@
+{
+  "$schema": "gobbi-docs/child",
+  "parent": "_claude",
+  "title": "Subagent Transcript Recovery",
+  "opening": "Claude Code persists every subagent's full conversation to disk automatically. This enables recovery of delegation prompts, intermediate reasoning, tool calls, plan content, and final results — independent of conversation context, which is lost after compaction or session end.",
+  "sections": [
+    {
+      "heading": "Transcript Location",
+      "content": [
+        {
+          "type": "text",
+          "value": "Subagent transcripts live at `~/.claude/projects/{project-path}/{session-id}/subagents/`. The `{session-id}` matches `$CLAUDE_SESSION_ID`. Each subagent produces two files:"
+        },
+        {
+          "type": "table",
+          "headers": [
+            "File",
+            "Format",
+            "Contains"
+          ],
+          "rows": [
+            [
+              "`agent-{id}.meta.json`",
+              "JSON",
+              "`agentType`, `description`"
+            ],
+            [
+              "`agent-{id}.jsonl`",
+              "JSON Lines",
+              "Full conversation — one JSON object per line"
+            ]
+          ]
+        },
+        {
+          "type": "text",
+          "value": "The path can be derived from environment variables: `$(dirname \"$CLAUDE_TRANSCRIPT_PATH\")/$CLAUDE_SESSION_ID/subagents/`\n\nThe main session transcript lives at `$CLAUDE_TRANSCRIPT_PATH` and has a broader set of line types than subagent transcripts."
+        }
+      ]
+    },
+    {
+      "heading": "Identifying Subagents",
+      "content": [
+        {
+          "type": "text",
+          "value": "The `agent-{id}.meta.json` maps agents to their purpose. The `description` field matches the short description passed to the Agent tool. The `agentId` is returned in the Agent tool result after completion but is not available at spawn time."
+        }
+      ]
+    },
+    {
+      "heading": "JSONL Line Schema",
+      "content": [
+        {
+          "type": "text",
+          "value": "Each line is a JSON object with two layers: **line-level metadata** and the **message** payload."
+        },
+        {
+          "type": "subsection",
+          "heading": "Line-Level Metadata",
+          "content": [
+            {
+              "type": "text",
+              "value": "Every line (both user and assistant) carries these fields:"
+            },
+            {
+              "type": "table",
+              "headers": [
+                "Field",
+                "Contains"
+              ],
+              "rows": [
+                [
+                  "`type`",
+                  "`user` or `assistant`"
+                ],
+                [
+                  "`agentId`",
+                  "The subagent's ID"
+                ],
+                [
+                  "`sessionId`",
+                  "Session UUID (matches `$CLAUDE_SESSION_ID`)"
+                ],
+                [
+                  "`timestamp`",
+                  "ISO 8601 timestamp"
+                ],
+                [
+                  "`slug`",
+                  "Session plan slug (e.g., `swift-coalescing-torvalds`)"
+                ],
+                [
+                  "`version`",
+                  "Claude Code version (e.g., `2.1.89`)"
+                ],
+                [
+                  "`cwd`",
+                  "Working directory at message time"
+                ],
+                [
+                  "`gitBranch`",
+                  "Git branch at message time"
+                ],
+                [
+                  "`uuid`",
+                  "Unique ID for this line"
+                ],
+                [
+                  "`parentUuid`",
+                  "Parent message UUID (for threading)"
+                ],
+                [
+                  "`isSidechain`",
+                  "Always `true` for subagents"
+                ],
+                [
+                  "`entrypoint`",
+                  "How Claude Code was started (e.g., `cli`)"
+                ]
+              ]
+            },
+            {
+              "type": "text",
+              "value": "User lines additionally have `promptId`. Assistant lines additionally have `requestId`."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Message Content",
+          "content": [
+            {
+              "type": "text",
+              "value": "The `message.content` field varies by role:"
+            },
+            {
+              "type": "table",
+              "headers": [
+                "Role",
+                "`message.content` type",
+                "Structure"
+              ],
+              "rows": [
+                [
+                  "`user`",
+                  "string or array",
+                  "When string: the delegation prompt text. When array: blocks with `type` field"
+                ],
+                [
+                  "`assistant`",
+                  "array of blocks",
+                  "Each block has a `type` field — `text`, `tool_use`, or others"
+                ]
+              ]
+            },
+            {
+              "type": "principle",
+              "statement": "A single assistant message can contain multiple blocks of different types.",
+              "body": "For example, `[\"text\", \"tool_use\", \"tool_use\", \"tool_use\"]` — one text block followed by several parallel tool calls. Extraction logic must iterate the array, not assume one block per message."
+            },
+            {
+              "type": "text",
+              "value": "Content block types within arrays:"
+            },
+            {
+              "type": "table",
+              "headers": [
+                "Block type",
+                "Found in",
+                "Key fields"
+              ],
+              "rows": [
+                [
+                  "`text`",
+                  "`assistant`",
+                  "`text`"
+                ],
+                [
+                  "`tool_use`",
+                  "`assistant`",
+                  "`name`, `input`, `id`"
+                ],
+                [
+                  "`tool_result`",
+                  "`user`",
+                  "`tool_use_id`, `content` (string)"
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Token Usage",
+          "content": [
+            {
+              "type": "text",
+              "value": "Assistant messages include `message.usage` with token consumption data:"
+            },
+            {
+              "type": "table",
+              "headers": [
+                "Field",
+                "Contains"
+              ],
+              "rows": [
+                [
+                  "`input_tokens`",
+                  "Input tokens for this turn"
+                ],
+                [
+                  "`output_tokens`",
+                  "Output tokens for this turn"
+                ],
+                [
+                  "`cache_creation_input_tokens`",
+                  "Tokens written to cache"
+                ],
+                [
+                  "`cache_read_input_tokens`",
+                  "Tokens read from cache"
+                ],
+                [
+                  "`service_tier`",
+                  "Service tier used (e.g., `standard`)"
+                ]
+              ]
+            },
+            {
+              "type": "text",
+              "value": "Additional assistant message fields: `message.model` (exact model ID), `message.stop_reason` (e.g., `end_turn`), `message.id` (Anthropic message ID)."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "What Is Recoverable",
+      "content": [
+        {
+          "type": "table",
+          "headers": [
+            "Target",
+            "Line selection",
+            "Field path"
+          ],
+          "rows": [
+            [
+              "Delegation prompt",
+              "First line",
+              "`.message.content` (string or array)"
+            ],
+            [
+              "Final result",
+              "Last line",
+              "Last `text` block in `.message.content`"
+            ],
+            [
+              "Plan content",
+              "Line with `ExitPlanMode` tool_use",
+              "`.message.content[N].input.plan`"
+            ],
+            [
+              "Plan file path",
+              "Same line",
+              "`.message.content[N].input.planFilePath`"
+            ],
+            [
+              "Files written",
+              "Line with `Write` tool_use",
+              "`.input.file_path`, `.input.content`"
+            ],
+            [
+              "Files edited",
+              "Line with `Edit` tool_use",
+              "`.input.file_path`, `.input.old_string`, `.input.new_string`"
+            ],
+            [
+              "Files read",
+              "Line with `Read` tool_use",
+              "`.input.file_path`; content in next `tool_result`"
+            ],
+            [
+              "Shell commands",
+              "Line with `Bash` tool_use",
+              "`.input.command`; output in next `tool_result`"
+            ],
+            [
+              "Token usage",
+              "Any assistant line",
+              "`.message.usage`"
+            ],
+            [
+              "Model used",
+              "Any assistant line",
+              "`.message.model`"
+            ]
+          ]
+        },
+        {
+          "type": "principle",
+          "statement": "Content type varies by role — always check before extracting.",
+          "body": "User messages may have `content` as a plain string. Assistant messages always have `content` as an array of blocks. Extraction logic must handle both cases to avoid silent failures."
+        }
+      ]
+    },
+    {
+      "heading": "Plan Data",
+      "content": [
+        {
+          "type": "text",
+          "value": "Plan content is stored in `ExitPlanMode` tool_use blocks. The `input` object contains `plan` (full plan text as markdown) and `planFilePath` (disk path to the plan file).\n\n`EnterPlanMode` has empty input — it is only a mode switch. A subagent may call `EnterPlanMode`/`ExitPlanMode` multiple times (plan revisions). Each `ExitPlanMode` captures the plan state at that point.\n\nThe plan file at `planFilePath` on disk gets overwritten by subsequent plans. The JSONL transcript is the permanent per-session record."
+        }
+      ]
+    },
+    {
+      "heading": "Main Session Transcript",
+      "content": [
+        {
+          "type": "text",
+          "value": "The main transcript at `$CLAUDE_TRANSCRIPT_PATH` shares the same `user`/`assistant` line format as subagent transcripts, but also contains additional line types:"
+        },
+        {
+          "type": "table",
+          "headers": [
+            "Line type",
+            "Contains"
+          ],
+          "rows": [
+            [
+              "`system`",
+              "Hook info, stop reasons, tool use IDs"
+            ],
+            [
+              "`file-history-snapshot`",
+              "File state snapshots (with `snapshot` and `messageId` fields)"
+            ],
+            [
+              "`pr-link`",
+              "PR number, URL, repository"
+            ],
+            [
+              "`agent-name`",
+              "Session name"
+            ],
+            [
+              "`custom-title`",
+              "Custom session title"
+            ]
+          ]
+        },
+        {
+          "type": "text",
+          "value": "When extracting from the main transcript, filter by `type == \"user\"` or `type == \"assistant\"` to skip these non-conversation lines."
+        }
+      ]
+    },
+    {
+      "heading": "Extraction Scripts",
+      "content": [
+        {
+          "type": "text",
+          "value": "Scripts in `_note/scripts/` automate transcript extraction:"
+        },
+        {
+          "type": "table",
+          "headers": [
+            "Script",
+            "Purpose",
+            "Input"
+          ],
+          "rows": [
+            [
+              "`subtask-collect.sh`",
+              "Extract delegation prompt + final result per subagent",
+              "`<agent-id> <subtask-number> <subtask-slug> <note-dir-path>`"
+            ],
+            [
+              "`write-plan.sh`",
+              "Extract plan content from `ExitPlanMode`",
+              "`<note-dir-path>`"
+            ]
+          ]
+        },
+        {
+          "type": "text",
+          "value": "Both scripts write JSON files to the note directory and require `$CLAUDE_SESSION_ID`, `$CLAUDE_TRANSCRIPT_PATH`, and `jq`."
+        }
+      ]
+    },
+    {
+      "heading": "Persistence",
+      "content": [
+        {
+          "type": "text",
+          "value": "Transcript files persist across sessions in `~/.claude/projects/`. They are not cleaned up automatically. The `{session-id}` in the path ties each set of transcripts to a specific conversation, enabling cross-session analysis.\n\nThe JSONL transcripts are the authoritative source for what was delegated and what was returned. Conversation context is a convenience; the transcript is the record."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_collection/SKILL.json
+++ b/.claude/skills/_collection/SKILL.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_collection",
+    "description": "Persist the workflow trail and write notes at the end of each workflow cycle. Use during Step 4 (Collection) to write all note files and record gotchas.",
+    "allowed-tools": "Write, Read, Glob, Bash"
+  },
+  "title": "Collection",
+  "opening": "Persist the workflow trail at the end of each workflow cycle. Must load _note to write note files. This step ensures all decisions, outcomes, and subagent results are recorded before proceeding.",
+  "sections": [
+    {
+      "heading": "What to Do",
+      "content": [
+        {
+          "type": "text",
+          "value": "Collection has four responsibilities: **note persistence**, **subtask preservation**, **gotcha recording**, and **phase transition**.\n\n**Note persistence** — Load _note and write all note files for the current task: `ideation.md`, `plan.md`, and `execution.md`. Subtask `.json` files are already on disk at this point — they were created during execution (Step 3) via `subtask-collect.sh`. Collection verifies that all expected subtask files exist and writes the remaining note files. Every workflow stage that produced output must have a corresponding note file on disk.\n\n**Subtask preservation** — The orchestrator calls `subtask-collect.sh` during execution (Step 3) immediately after each subagent returns to extract the delegation prompt and final result from the subagent's JSONL transcript into a JSON file. This happens during execution, not during collection — downstream agents (synthesis, evaluation) depend on these files existing on disk before they run.\n\n**Gotcha recording** — Any corrections, surprises, or mistakes discovered during the workflow must be recorded via _gotcha before the cycle closes.\n\n**Phase transition** — Use AskUserQuestion to ask the user: FEEDBACK, REVIEW, or FINISH?"
+        }
+      ]
+    },
+    {
+      "heading": "Where to Write",
+      "content": [
+        {
+          "type": "text",
+          "value": "Note directories follow the structure defined in _note. See _note for directory naming, file layout, and the initialization script.\n\n**Directory initialization**: Initialize note directories using the `note-init.sh` script in `_note/scripts/`. It takes the project name and task slug as arguments and handles the full chain: metadata extraction, directory creation, README.md generation, and subtasks/ directory setup."
+        }
+      ]
+    },
+    {
+      "heading": "README.md",
+      "content": [
+        {
+          "type": "text",
+          "value": "The index file lists all task note directories. Must update README.md after creating each new task note directory."
+        }
+      ]
+    },
+    {
+      "heading": "Phase-Specific Collection",
+      "content": [
+        {
+          "type": "text",
+          "value": "See _note for what to include in each note file (ideation.md, plan.md, execution.md, etc.)."
+        },
+        {
+          "type": "subsection",
+          "heading": "After TASK phase (standard collection)",
+          "content": [
+            {
+              "type": "text",
+              "value": "When collecting evaluation findings across subtasks, organize by severity tier: Critical findings first (blocking issues that were resolved), then Important (significant issues addressed), then Suggestions (deferred or noted for future work), then Strengths (positive patterns worth preserving). This tiered format surfaces the most actionable information first and gives the user a quick scan of what mattered most."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "After FEEDBACK phase",
+          "content": [
+            {
+              "type": "text",
+              "value": "Write `feedback.md` to the existing task note directory. Append each feedback round — do not overwrite previous rounds."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "After REVIEW phase",
+          "content": [
+            {
+              "type": "text",
+              "value": "Write `review.md` to the existing task note directory (or to `{task-slug}-review/` if it's a separate review directory)."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "When to Collect",
+      "content": [
+        {
+          "type": "text",
+          "value": "**Always collect** when the workflow involved delegation or produced results worth preserving.\n\n**Skip collecting** when the task was trivial — a single small edit, a quick question, or a direct handle without delegation."
+        }
+      ]
+    },
+    {
+      "heading": "Session Learning Capture",
+      "content": [
+        {
+          "type": "text",
+          "value": "After writing notes and recording gotchas, use AskUserQuestion to ask: **\"What non-obvious knowledge was discovered this session?\"**\n\nThis complements per-agent Memorize steps by capturing orchestrator-level insights that no single agent saw. The user may say \"nothing\" — the question ensures knowledge doesn't get lost silently.\n\n**Capture categories:**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "**Gotchas** — mistakes or wrong assumptions corrected during the session. Record via _gotcha.",
+            "**CLAUDE.md additions** — conventions or patterns discovered that should persist across sessions. Add as one-line entries to CLAUDE.md.",
+            "**Skill updates** — behavioral patterns identified that a skill should teach. When a learning is categorized as a skill update, the orchestrator MUST propose a concrete change to the skill rather than merely flagging it for later. This is opt-in: only prompt if skill-update-type learnings were identified during the session. To propose a change:"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "  - Load _claude and _skills for authoring standards\n  - Run lint/validation on modified skills (lint-skill.sh) to catch anti-patterns before presenting\n  - Present proposed changes to user via AskUserQuestion: \"Would you like to review proposed skill updates before finishing?\"\n  - If the user approves, apply the change to the skill file. If the user defers, persist the proposed change as a note in the task directory so future sessions can act on it.\n\nFormat: one-line entries, concise, actionable. \"Discovery X because Y\" — not narrative."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_collection/gotchas.json
+++ b/.claude/skills/_collection/gotchas.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "gobbi-docs/gotcha",
+  "parent": "_collection",
+  "title": "Gotcha: _collection",
+  "entries": [
+    {
+      "title": "Original subtask results not collected to subtasks directory",
+      "body": {
+        "priority": "High",
+        "what-happened": "During the doc-review workflow, 10 subtask agents produced output, but `subtask-collect.sh` was never run to extract their results from the JSONL transcripts into the `subtasks/` directory. Only the synthesis report (subtask 11) was written because the synthesis agent wrote its own output. The 10 original subtask outputs existed only in the transcripts and were lost from the workflow.",
+        "user-feedback": "The original subtask results must be collected to the subtasks directory.",
+        "correct-approach": "After each wave of subagents completes, run `subtask-collect.sh` to extract delegation prompts and final results from the JSONL transcripts into `subtasks/{NN}-{slug}.json`. This must happen: 1. After every wave completes — not deferred to the end 2. Before any downstream agent (synthesis, evaluation) that needs those files 3. Verify the JSON files exist on disk before proceeding The subtask JSON files are the permanent record of what each specialist agent was asked and what it produced. If `subtask-collect.sh` is not run, the work is trapped in transcripts and invisible to downstream agents."
+      }
+    },
+    {
+      "title": "New gotcha file created but not registered in gotcha index table",
+      "body": {
+        "priority": "High",
+        "what-happened": "During the _git skill creation, a developer agent created `_gotcha/_git.md` as specified. However, the agent did not update the navigation table in `_gotcha/SKILL.md` to include the new file. The critical evaluator caught this — an unlisted gotcha file is invisible to agents scanning the table for relevant gotchas before starting work.",
+        "user-feedback": "(Caught by critical evaluator during execution evaluation)",
+        "correct-approach": "When creating a new gotcha file, always update the `_gotcha/SKILL.md` navigation table to include the new entry. The gotcha system's discoverability depends on this central index. Include this as an explicit step in any delegation prompt that involves creating a new gotcha file."
+      }
+    }
+  ],
+  "opening": "Mistakes in work trail persistence, README indexing, and subtask file management."
+}

--- a/.claude/skills/_delegation/SKILL.json
+++ b/.claude/skills/_delegation/SKILL.json
@@ -1,0 +1,198 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_delegation",
+    "description": "Hand off work to subagents with the right context so they succeed on the first attempt. Use during the DELEGATE phase to spawn specialists with clear briefings, context layers, and scope boundaries.",
+    "allowed-tools": "Agent, Read, Grep, Glob, Bash, Write"
+  },
+  "title": "Delegation Skill",
+  "opening": "Hand off work to subagents so they succeed on the first attempt. Load this skill when entering the DELEGATE phase of orchestration.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Tell specialists what to do, not how to do it.",
+          "body": "Detailed \"how\" instructions suppress a specialist agent's ability and potential. Define the goal, the constraints, and what to avoid — then trust the specialist to find the best approach. Guardrails about \"not to do\" protect quality; prescriptive \"how to do\" limits it."
+        },
+        {
+          "type": "principle",
+          "statement": "Promote the specialist's potential.",
+          "body": "Frame the delegation to bring out the specialist's strengths. Provide context that enables good judgment — project rules, gotchas, conventions, relevant domain knowledge. The orchestrator's job is to set the specialist up for success, not to micromanage the execution."
+        },
+        {
+          "type": "principle",
+          "statement": "Load `_claude`, the project skill, and domain skills before every task.",
+          "body": "Agents that read project context produce work that integrates cleanly. Agents that skip context produce work that needs rework."
+        },
+        {
+          "type": "principle",
+          "statement": "Require an internal plan before coding.",
+          "body": "Tell subagents to study context, outline their approach, then execute. Agents that plan before coding produce better-structured, more focused work."
+        },
+        {
+          "type": "principle",
+          "statement": "Subtask records are collected from transcripts, not written by subagents.",
+          "body": "The orchestrator runs `subtask-collect.sh` after each subagent returns to extract the delegation prompt and final result from the JSONL transcript. Subagents do not need subtask doc instructions in their briefing — their final response is the record."
+        }
+      ]
+    },
+    {
+      "heading": "What Every Delegation Prompt Needs",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "The task",
+          "content": [
+            {
+              "type": "text",
+              "value": "What to build, fix, or change. Be specific about the deliverable, not the method. Include acceptance criteria when the task is ambiguous."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "The context to load",
+          "content": [
+            {
+              "type": "text",
+              "value": "Every subagent needs three layers of context:\n\n**Always load (non-negotiable):**"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "`_claude` skill — docs structure, anti-patterns, navigation standard",
+                "The project skill — project architecture, conventions, constraints",
+                "Gotchas — MUST check `_gotcha` and the project skill's `gotchas/` before starting work"
+              ]
+            },
+            {
+              "type": "text",
+              "value": "**Load per domain:**"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Domain skills relevant to the task — the plan specifies which skills each task needs",
+                "Project rules relevant to the domain"
+              ]
+            },
+            {
+              "type": "text",
+              "value": "**Load when available:**"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Project docs in the project skill directory — architecture, reference, review docs",
+                "Existing code in the area they'll modify — the codebase is the source of truth for patterns"
+              ]
+            },
+            {
+              "type": "text",
+              "value": "**Load when _git is active:**"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Current branch and worktree path — so the subagent knows where it's working and can verify branch state before committing",
+                "Recent commit history relevant to the task area — files the task will modify, so the subagent understands what has already changed in this session",
+                "Exploration findings from multi-perspective exploration — when exploration was performed before planning, include the synthesized findings for orientation"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "The scope boundary",
+          "content": [
+            {
+              "type": "text",
+              "value": "What the agent should NOT touch. Agents expand scope when they see adjacent improvements. Explicit boundaries prevent drift."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Dependencies",
+          "content": [
+            {
+              "type": "text",
+              "value": "If this agent's work depends on another agent's output, or if another agent will consume this output, state the interface expectation."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "The Agent Lifecycle in Delegation",
+      "content": [
+        {
+          "type": "text",
+          "value": "Every agent follows: **Study → Plan → Execute → Verify**. Your delegation prompt sets each phase up for success.\n\n**Study** — List what to read: `_claude` skill, project skill, domain skills, gotchas, relevant code. The more unfamiliar the area, the more explicit the reading list.\n\n**Plan** — Tell the agent to outline their approach before implementing. Mandatory for non-trivial tasks.\n\n**Execute** — The task itself. Be specific about the deliverable. When a subagent makes a non-obvious choice — where multiple valid approaches existed — their final response should include a brief decision annotation: what was chosen, what was rejected, and why. This externalizes reasoning at decision time, when the context is fresh. The transcript captures the final response automatically.\n\n**Verify** — Remind agents to check their work didn't break other things and that any `.claude/` docs referencing changed code are updated."
+        }
+      ]
+    },
+    {
+      "heading": "Model Selection",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Use the cheapest model that can do the job.",
+          "body": "Default to the agent's defined model; override when the task clearly maps to a different tier."
+        },
+        {
+          "type": "text",
+          "value": "Three tiers of capability, from lightest to heaviest:"
+        },
+        {
+          "type": "table",
+          "headers": [
+            "Tier",
+            "Strength",
+            "Suited for"
+          ],
+          "rows": [
+            [
+              "**Haiku**",
+              "Fast, cheap, reliable on narrow tasks",
+              "Eligibility checks, simple validation, gotcha lookups, confidence scoring, format verification"
+            ],
+            [
+              "**Sonnet**",
+              "Balanced reasoning and cost",
+              "Routine development, code review, codebase exploration, standard evaluation, documentation writing"
+            ],
+            [
+              "**Opus**",
+              "Deep reasoning, handles ambiguity and novelty",
+              "Complex ideation, architecture decisions, system design, nuanced evaluation, novel problem solving"
+            ]
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**When to override agent defaults:** Agent definitions declare a default model suited to their typical workload. Override when the specific task is clearly simpler or more complex than what the agent usually handles. A Sonnet-default agent doing a trivial validation can drop to Haiku. A Sonnet-default agent facing a novel architecture problem should escalate to Opus.\n\nThis is guidance for the orchestrator's judgment, not a rigid assignment table. The orchestrator considers the task's complexity, the cost, and the consequence of getting it wrong — then picks the tier that fits."
+        },
+        {
+          "type": "principle",
+          "statement": "Model tiers and capabilities evolve — these are current guidelines, not permanent assignments."
+        }
+      ]
+    },
+    {
+      "heading": "Judgment Calls",
+      "content": [
+        {
+          "type": "text",
+          "value": "**Specificity vs autonomy** — Over-specified prompts produce rigid work. Under-specified prompts miss requirements. Calibrate based on how well-defined the task is.\n\n**When to include code references** — If the agent needs to follow an existing pattern, point to the reference files. The codebase is the source of truth.\n\n**When to split vs combine** — If two subtasks need the same agent, same context, and same files, combine them.\n\n**When to emphasize lifecycle phases** — Spell out Study for unfamiliar areas. Spell out Plan for non-trivial tasks. Spell out Verify for shared interfaces.\n\n**When to include exploration context** — If the plan was preceded by multi-perspective exploration, include the synthesized findings in every delegation prompt. Exploration findings are context, not constraints — the subagent uses them to make better-informed decisions but is not bound by the explorers' conclusions. If no exploration was performed, the subagent discovers context during Study as usual.\n\n**When to include pre-resolved decisions** — When contribution points were resolved during ideation (via _ideation's contribution-point mechanism), encode those resolutions as explicit constraints in the delegation prompt. This differs from scope boundaries: scope says what not to touch; pre-resolved decisions say which implementation choices the user has already made and the subagent must honor. A subagent that re-opens a settled decision wastes context and risks contradicting the user's intent."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_delegation/gotchas.json
+++ b/.claude/skills/_delegation/gotchas.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "gobbi-docs/gotcha",
+  "parent": "_delegation",
+  "title": "Gotcha: _delegation",
+  "entries": [
+    {
+      "title": "Developer agents expand scope to adjacent improvements",
+      "body": {
+        "priority": "High",
+        "what-happened": "A developer agent delegated with explicit scope boundary (\"ONLY modify these files: style.ts, init.ts, update.ts\") also modified 4 unrelated files — notification hook scripts, a skill doc, and .gitignore. The changes were reasonable improvements (renaming .notification-env to .env, updating Slack from webhook to Bot API) but violated the stated scope. All had to be reverted.",
+        "user-feedback": "Found during orchestrator review of git diff.",
+        "correct-approach": "When reviewing developer agent output, always run `git diff --name-only` to check which files were actually modified. Compare against the scope boundary in the delegation prompt. Revert any out-of-scope changes before proceeding to evaluation. The \"ONLY modify these files\" instruction is necessary but not sufficient — agents still expand scope when they encounter adjacent code they want to improve."
+      }
+    },
+    {
+      "title": "Agent definitions placed in plugins/ without .claude/ source",
+      "body": {
+        "priority": "High",
+        "what-happened": "An agent created agent definition files directly in `plugins/gobbi/agents/` as regular files instead of in `.claude/agents/` (the source of truth). The plugin directory should only contain symlinks pointing back to `.claude/agents/`. Because the files were regular files in `plugins/`, they had no corresponding source in `.claude/` and would be lost or cause conflicts when symlinks were regenerated.",
+        "user-feedback": "Source of truth is `.claude/agents/`. Plugin directory gets symlinks only.",
+        "correct-approach": "Always create agent definitions in `.claude/agents/` first — that is the source of truth. Then create a relative symlink in `plugins/gobbi/agents/` pointing to `../../../.claude/agents/{name}.md`. Never create regular files directly in `plugins/gobbi/agents/`. The same pattern applies to skills and hooks: source in `.claude/`, symlinks in `plugins/`."
+      }
+    }
+  ],
+  "opening": "Mistakes in subagent briefings, context loading, and scope boundaries."
+}

--- a/.claude/skills/_discord/SKILL.json
+++ b/.claude/skills/_discord/SKILL.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_discord",
+    "description": "Configure Discord notifications for Claude Code sessions. Setup guide for webhook-based notification delivery."
+  },
+  "title": "Discord Notifications",
+  "opening": "Discord notifications for Claude Code use incoming webhooks — a URL that accepts HTTP POST requests and delivers them to a specific channel. Understanding this model helps you configure, debug, and extend the integration.",
+  "sections": [
+    {
+      "heading": "How Webhook Delivery Works",
+      "content": [
+        {
+          "type": "text",
+          "value": "A Discord webhook is a one-way pipe attached to a specific channel: your Claude Code hook script sends a JSON payload to the URL, and Discord posts it as a message in that channel. The URL encodes both authentication and destination — anyone with the URL can post to that channel, so treat it as a credential.\n\nUnlike Slack's bot token model, Discord webhooks do not require a bot account or OAuth flow. You create the webhook directly from the channel settings, which makes setup faster but ties delivery to that specific channel — changing the destination requires creating a new webhook.\n\n**What gets sent:** Each notification includes the event type, a short summary, and a timestamp. Discord supports rich embeds with color coding, titles, and fields, but the notification scripts send plain text content to maximize compatibility across Discord client versions."
+        }
+      ]
+    },
+    {
+      "heading": "Core Concepts",
+      "content": [
+        {
+          "type": "text",
+          "value": "**Webhook URL** — a URL in the format `https://discord.com/api/webhooks/{id}/{token}` that authenticates the delivery and targets the channel. Created from the channel's Integrations settings. Rotate this URL if it is exposed, as rotation immediately revokes the old URL.\n\n**Channel targeting** — each webhook is bound to one channel at creation time. To deliver to multiple channels, create one webhook per channel. There is no equivalent to Slack's user ID model — Discord webhooks post to channels, not DMs.\n\n**Server membership** — the webhook is scoped to the server (guild) and channel where it was created. If you leave the server or the channel is deleted, the webhook stops working.\n\n**Embed formatting** — Discord supports structured embed objects with color, title, description, and field arrays. These are optional. Plain text `content` fields work in all contexts including mobile and accessibility tools; embeds do not render in some notification previews."
+        }
+      ]
+    },
+    {
+      "heading": "When to Use Discord",
+      "content": [
+        {
+          "type": "text",
+          "value": "Discord works well when: you already use Discord for development or gaming communities and want notifications visible there, you want a fast no-OAuth webhook setup, or you want to share session notifications with a server community.\n\nConsider Slack instead when: you use Slack for professional development work and want notification history alongside work communication, or you need DM delivery rather than channel posting.\n\nConsider Telegram instead when: you want personal mobile push notifications without any server or channel involved."
+        }
+      ]
+    },
+    {
+      "heading": "Credential Storage",
+      "content": [
+        {
+          "type": "text",
+          "value": "Store the webhook URL as `DISCORD_WEBHOOK_URL` in `$CLAUDE_PROJECT_DIR/.claude/.env`. This file is read by `load-notification-env.sh` at session start and must be listed in `.gitignore` — credentials committed to version control are compromised credentials.\n\nThe hook scripts check for the variable before attempting delivery. If it is absent, Discord delivery is silently skipped rather than causing an error."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_discuss/SKILL.json
+++ b/.claude/skills/_discuss/SKILL.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_discuss",
+    "description": "MUST load when discussing with the user at any workflow step. Guides critical, structured discussion that challenges vague thinking, surfaces hidden problems, and pushes ideas toward concrete specificity via AskUserQuestion.",
+    "allowed-tools": "AskUserQuestion, Read, Grep, Glob"
+  },
+  "title": "Gobbi Discuss Skill",
+  "opening": "Guide for how agents should discuss with users. Discussion happens at every workflow step — ideation, planning, execution, feedback, review. This skill teaches agents to be critical discussants, not passive question-askers.",
+  "sections": [
+    {
+      "heading": "Core Principles",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Be critical, not agreeable. Your job is to find problems before they become implementation mistakes.",
+          "body": "Don't just ask what the user wants — challenge whether what they want is the right thing. Flag vague requirements, unrealistic expectations, missing edge cases, and contradictions. A polite \"that sounds good\" when the idea has flaws wastes everyone's time. Push back constructively — \"Have you considered X?\" is more valuable than \"Sure, I'll do that.\""
+        },
+        {
+          "type": "principle",
+          "statement": "Ask many specific questions, not one broad question.",
+          "body": "A single question like \"what do you want?\" produces a vague answer. Break ambiguity into separate dimensions — scope, priority, approach, constraints, deliverable format — and ask about each one specifically. More specific questions produce more precise specifications."
+        },
+        {
+          "type": "principle",
+          "statement": "Give opinions. Recommend, don't just present options.",
+          "body": "When you have a strong technical opinion, lead with it. Put the recommended option first with \"(Recommended)\" and explain why. The user hired a specialist, not a menu. Offer alternatives but make your recommendation clear. If every option looks equally good to you, you haven't thought hard enough."
+        },
+        {
+          "type": "principle",
+          "statement": "Challenge assumptions before they become constraints.",
+          "body": "Every user prompt embeds assumptions — about the cause, the scope, the approach. Surface them: \"You're assuming X — is that actually true?\" A wrong assumption caught during discussion saves a wasted implementation cycle."
+        }
+      ]
+    },
+    {
+      "heading": "Discussion Dimensions",
+      "content": [
+        {
+          "type": "text",
+          "value": "Use AskUserQuestion to explore each unclear dimension. Not every dimension needs a question — only ask about dimensions that are genuinely unclear or where the user's assumption looks wrong."
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "**Problem** — Is the stated problem the real problem? What triggered this? What happens if we do nothing?",
+            "**Deliverable** — What exactly should be produced? A component, a fix, a refactor, a document?",
+            "**Scope** — How much is included? All items or specific ones? The whole system or one module?",
+            "**Priority** — If there are multiple parts, which matters most? What should be done first?",
+            "**Approach** — Are there multiple valid ways? Which trade-offs does the user prefer? Which do you recommend and why?",
+            "**Constraints** — Are there things that must NOT change? Performance requirements? Compatibility needs? Are any of these assumed but not real?",
+            "**Risks** — What could go wrong with this approach? What's the fallback?",
+            "**Dependencies** — Does this depend on or affect other ongoing work?",
+            "**Verification** — How should we verify it works? What does \"done\" look like?"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": null,
+      "content": [
+        {
+          "type": "principle",
+          "statement": "_discuss resolves specification gaps — \"what do you want?\" when the agent lacks information to act. Contribution points (_ideation) resolve judgment gaps — \"which decisions are yours to make?\" when the user's domain knowledge would produce better outcomes than agent discretion. Different problems, different tools."
+        }
+      ]
+    },
+    {
+      "heading": "What Good Discussion Looks Like",
+      "content": [
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Addresses one dimension per question — don't combine scope and approach",
+            "Offers 2-4 concrete options the user can choose between",
+            "Leads with the recommended option and explains why",
+            "Challenges vague answers — \"you said 'improve performance' — which endpoint, what metric, what target?\"",
+            "Flags contradictions — \"you want X and Y, but those trade off against each other — which matters more?\"",
+            "Catches missing pieces — \"you didn't mention Z — is that intentional or an oversight?\""
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**After all questions are answered**, restate the now-specific task. The user should be able to read it and say \"yes, that's exactly what I want.\" If they can't, the discussion isn't done."
+        }
+      ]
+    },
+    {
+      "heading": "Constraints",
+      "content": [
+        {
+          "type": "constraint-list",
+          "items": [
+            "Never accept vague requirements without pushing for specificity",
+            "Never skip discussion just because the user seems eager to start — vague starts produce rework",
+            "Never present options without a recommendation when you have a strong opinion",
+            "Never combine multiple dimensions into one question — each question narrows one thing",
+            "Always use AskUserQuestion — don't ask questions in plain text that should be structured choices"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_evaluation/SKILL.json
+++ b/.claude/skills/_evaluation/SKILL.json
@@ -1,0 +1,324 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_evaluation",
+    "description": "Evaluation framework — perspective selection, evaluator delegation, scoring, and verdicts. MUST load at workflow start by the orchestrator. Evaluator agents load this alongside their perspective skill.",
+    "allowed-tools": "Read, Grep, Glob, Bash, Agent, AskUserQuestion"
+  },
+  "title": "Evaluation",
+  "opening": "Evaluation framework for the gobbi workflow. Orchestrators use this to select perspectives and delegate to evaluator agents. Evaluators use this alongside their perspective skill to assess, score, and verdict.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "The creator must never evaluate its own output.",
+          "body": "Self-evaluation is structurally biased. The creator's mental model prevents them from seeing the work as a fresh reader would. Evaluators must be separate agents with fresh context."
+        },
+        {
+          "type": "principle",
+          "statement": "At least 2 evaluators with different perspectives.",
+          "body": "A single evaluator catches the problems it is trained to see. Multiple evaluators with genuinely different viewpoints catch problems that fall between any single perspective. Disagreements between evaluators are valuable signal — surface them."
+        },
+        {
+          "type": "principle",
+          "statement": "The user's perspective is the most important measure of evaluation.",
+          "body": "Evaluator agents assess from technical perspectives, but the user decides what matters. Evaluation findings are input to a conversation with the user, not autonomous verdicts. An evaluator may flag an issue as critical, but if the user disagrees or defers it, that decision stands. No evaluation outcome bypasses the user."
+        },
+        {
+          "type": "principle",
+          "statement": "Evaluate outcomes against goals, not tasks against checklists.",
+          "body": "Check whether the output achieves what the user actually needs, not just whether individual items were completed. An idea that exists but doesn't solve the root problem fails. A plan that has all tasks but misses a dependency fails."
+        },
+        {
+          "type": "principle",
+          "statement": "Verify by running, not just reading.",
+          "body": "When the output can be verified by running a command — tests, syntax checks, grep for expected patterns, file existence — do it. Reasoning alone misses failures that evidence catches. When tools can provide evidence, use them. When they can't, reason rigorously."
+        },
+        {
+          "type": "principle",
+          "statement": "Recurring issues become gotchas.",
+          "body": "Patterns discovered during evaluation are the highest-value input for the memorization step — they represent non-obvious problems that will recur without explicit recording."
+        }
+      ]
+    },
+    {
+      "heading": "Perspective Selection",
+      "content": [
+        {
+          "type": "text",
+          "value": "The orchestrator selects which perspectives to evaluate from based on the task's domain and the project's needs. The right perspectives vary by project and task type — there is no fixed set that applies everywhere.\n\nCommon perspectives (examples, not exhaustive — must adjust these perspectives to be domain-specific for the project):"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "**Project-level** — Does the output solve the right problem? Does it fit the project's requirements, constraints, and goals?",
+            "**Design / Architecture-level** — Is the architecture sound? Are abstractions appropriate? Is coupling managed?",
+            "**Performance / Optimization-level** — Are there efficiency issues, unnecessary resource usage, or scalability risks?",
+            "**Aesthetics-level** — Is it readable, well-named, consistent, and polished? Would a fresh reader understand it?",
+            "**User-level** — Does it meet the end user's needs? Is the experience intuitive, accessible, and correct from the user's perspective?",
+            "**Overall-level** — What gaps fall between the other perspectives? What works well and must be preserved?"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "The orchestrator matches perspectives to the task. A documentation task may need scope and craft quality but not efficiency. A database migration may need scope, structure, and efficiency but not craft quality. Use judgment — more perspectives catch more problems, but each costs time."
+        }
+      ]
+    },
+    {
+      "heading": "How Evaluation Works",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "For the Orchestrator",
+          "content": [
+            {
+              "type": "list",
+              "style": "numbered",
+              "items": [
+                "Select the perspectives that match the task's domain",
+                "Spawn each evaluator as a separate agent with skills:"
+              ]
+            },
+            {
+              "type": "text",
+              "value": "   - The stage-specific evaluation skill (what to check at this workflow stage)\n   - The perspective evaluation skill (the lens to assess through)\n   - Domain context — project rules, gotchas, conventions, and relevant knowledge\n   - The output to evaluate\n   - Read-only access — evaluators assess, they do not modify"
+            },
+            {
+              "type": "list",
+              "style": "numbered",
+              "items": [
+                "Collect all verdicts independently — evaluators should not see each other's results",
+                "Act on the results:"
+              ]
+            },
+            {
+              "type": "text",
+              "value": "   - **All pass** — proceed to next stage\n   - **Any revision needed** — present findings to the user, discuss what to address, then revise\n   - **Any escalation** — surface to user for decision immediately\n   - **Perspectives disagree** — the disagreement reveals where the output is borderline, surface it"
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "For the Evaluator",
+          "content": [
+            {
+              "type": "list",
+              "style": "numbered",
+              "items": [
+                "Load the evaluation criteria and domain context provided",
+                "Read the output thoroughly before forming any judgment",
+                "For each finding, assess independently:"
+              ]
+            },
+            {
+              "type": "text",
+              "value": "   - **Confidence** (0-100) — how certain are you this is a real issue?\n   - **Severity** (Critical / High / Medium / Low) — how impactful is this if real?"
+            },
+            {
+              "type": "list",
+              "style": "numbered",
+              "items": [
+                "Verify findings with tools when possible — run tests, grep for patterns, check file existence",
+                "Check findings against known false positive categories before finalizing",
+                "Return a verdict: **PASS**, **REVISE**, or **ESCALATE** with specific reasoning"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Scoring",
+      "content": [
+        {
+          "type": "text",
+          "value": "Every finding carries two independent dimensions: confidence and severity. These are separate — a finding can be high-severity but low-confidence, or low-severity but high-confidence."
+        },
+        {
+          "type": "subsection",
+          "heading": "Confidence",
+          "content": [
+            {
+              "type": "text",
+              "value": "How certain the evaluator is that a finding represents a real issue, scored 0-100."
+            },
+            {
+              "type": "table",
+              "headers": [
+                "Score",
+                "Meaning"
+              ],
+              "rows": [
+                [
+                  "0",
+                  "False positive — appears like an issue but isn't one"
+                ],
+                [
+                  "25",
+                  "Possible but unverified — could be an issue, no evidence confirms it"
+                ],
+                [
+                  "50",
+                  "Probable — likely exists, but evidence is indirect or incomplete"
+                ],
+                [
+                  "75",
+                  "Significant and likely — strong reasoning or partial evidence supports it"
+                ],
+                [
+                  "100",
+                  "Definite — verified by evidence, tool output, or incontrovertible reasoning"
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Severity",
+          "content": [
+            {
+              "type": "text",
+              "value": "How impactful the issue would be if it is real, independent of confidence."
+            },
+            {
+              "type": "table",
+              "headers": [
+                "Level",
+                "Meaning"
+              ],
+              "rows": [
+                [
+                  "Critical",
+                  "Blocks progress, breaks correctness, or creates security vulnerability"
+                ],
+                [
+                  "High",
+                  "Significant flaw that would cause rework if not addressed now"
+                ],
+                [
+                  "Medium",
+                  "Real issue that should be addressed but doesn't block"
+                ],
+                [
+                  "Low",
+                  "Minor concern, stylistic, or optimization opportunity"
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Threshold Filtering",
+          "content": [
+            {
+              "type": "text",
+              "value": "Low-confidence findings are suppressed from the evaluation report by default to prevent noise. They are not discarded — the orchestrator or user can request the full unfiltered list. The threshold exists because evaluation should drive decisions, not generate noise."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "False Positive Categories",
+          "content": [
+            {
+              "type": "text",
+              "value": "Before assigning high confidence, check whether a finding falls into a known false positive category:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**Pre-existing** — issue exists before this change, not attributable to the evaluated output",
+                "**Out-of-scope** — real issue, but outside the task's scope boundary",
+                "**Style preference** — subjective, not a convention violation",
+                "**Linter-catchable** — mechanical issue that automated tooling should catch",
+                "**Speculative** — hypothetical concern without supporting evidence"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Stage-Specific Focus",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Ideation",
+          "content": [
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Is the root problem identified, or is the idea solving a symptom?",
+                "Is the approach concrete enough to plan against?",
+                "Are trade-offs explicitly stated?",
+                "Are constraints and assumptions surfaced?",
+                "Are risks identified with severity?",
+                "What's missing that should be there?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Planning",
+          "content": [
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Is every task narrow enough that scope is unambiguous?",
+                "Are dependencies correctly ordered?",
+                "Does the plan cover the full scope from the approved idea?",
+                "Are verification criteria defined for each task?",
+                "Is anything missing from the ideation discussion?",
+                "Do any tasks overlap on the same files?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Execution",
+          "content": [
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Does the implementation match the task specification?",
+                "Does the code compile and pass existing tests?",
+                "Are there security vulnerabilities?",
+                "Are project-specific gotchas and rules respected?",
+                "Is the change minimal and focused — no scope creep?",
+                "Are edge cases handled that were identified during ideation?"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Constraints",
+      "content": [
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "MUST use separate agents — the creator never evaluates its own output",
+            "MUST spawn at least 2 evaluators with different perspectives",
+            "MUST present evaluation findings to the user before acting on them — the user decides what to address",
+            "MUST surface disagreements between evaluators — they reveal where the output is borderline",
+            "Max 3 revision cycles per evaluation — then escalate to user"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_execution/SKILL.json
+++ b/.claude/skills/_execution/SKILL.json
@@ -1,0 +1,167 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_execution",
+    "description": "Guide for executing a single well-scoped task with quality. Use when an agent receives a task briefing and needs to study, plan, implement, and verify its work.",
+    "allowed-tools": "Read, Grep, Glob, Bash, Write, Edit"
+  },
+  "title": "Task Execution Skill",
+  "opening": "Guide for how an executor agent approaches a single task. Load this skill when you receive a task briefing from the orchestrator.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Study before acting. The codebase is the source of truth, not the briefing.",
+          "body": "Read the relevant code, understand existing patterns, and check gotchas before writing a single line. The briefing tells you *what* to do — the codebase tells you *how* it should be done."
+        },
+        {
+          "type": "principle",
+          "statement": "Plan before coding. Outline the approach, then execute.",
+          "body": "For non-trivial tasks, form an internal plan: what files to change, what patterns to follow, what the expected result looks like. A few minutes of planning prevents an hour of rework."
+        },
+        {
+          "type": "principle",
+          "statement": "One task, one focus. Stay within scope.",
+          "body": "You handle one task. Do it well. Don't fix adjacent issues, refactor surrounding code, or add improvements outside your scope boundary. If you notice something worth doing, note it in your final response — don't do it."
+        },
+        {
+          "type": "principle",
+          "statement": "Verify against criteria, not assumptions.",
+          "body": "Check your work against the task's acceptance criteria and any relevant gotchas. Run tests if applicable. The task is done when the criteria are met, not when the code looks right to you."
+        }
+      ]
+    },
+    {
+      "heading": "The Lifecycle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "This sequence reflects the principle that understanding precedes action and verification precedes delivery. Adapt the depth of each phase to the task's complexity."
+        },
+        {
+          "type": "subsection",
+          "heading": "Study",
+          "content": [
+            {
+              "type": "text",
+              "value": "Build understanding before acting by loading the context layers specified in your briefing. Each layer adds depth — start with standards, then narrow toward the code you'll change:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**Documentation standard** (`_claude`) — how `.claude/` files work and how to write them",
+                "**Project skill** — architecture, conventions, and constraints for the project you're working in",
+                "**Gotchas** — check `_gotcha` and project-specific gotchas. Every gotcha exists because a past agent made that exact mistake",
+                "**Domain skills** — any additional skills specified in the briefing that cover the problem domain",
+                "**Relevant code** — read existing implementations in the area you'll modify. The codebase is the source of truth for patterns and style"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Plan",
+          "content": [
+            {
+              "type": "text",
+              "value": "Outline your approach before implementing:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Which files will you modify or create?",
+                "What existing patterns should you follow?",
+                "What are the gotchas that apply to this domain?",
+                "What does the deliverable look like when done?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Execute",
+          "content": [
+            {
+              "type": "text",
+              "value": "Implement the task according to your plan:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Follow existing code patterns — the codebase is the style guide",
+                "Keep changes minimal and focused on the task",
+                "Don't introduce new patterns when existing ones work",
+                "Don't add error handling, abstractions, or features beyond what's specified"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Verify",
+          "content": [
+            {
+              "type": "text",
+              "value": "Check your work before reporting back:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Does the implementation meet the acceptance criteria from the briefing?",
+                "Do existing tests still pass?",
+                "Are the gotchas for this domain respected?",
+                "Is the change minimal — no scope creep, no bonus refactoring?",
+                "If you modified anything in `.claude/`, are related docs still accurate?"
+              ]
+            },
+            {
+              "type": "principle",
+              "statement": "Before committing, re-verify the precondition: correct branch is checked out and no unexpected state changes occurred since verification.",
+              "body": "This extends _git's re-verification principle to the subagent level. A subagent that verifies its work but commits to the wrong branch has produced correct work in the wrong place."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Final Response",
+          "content": [
+            {
+              "type": "text",
+              "value": "The subagent's final response is automatically captured as the subtask record via `subtask-collect.sh`. Include in your final response: what was done, what changed, what was learned, and any open items. This is the permanent record of your work — make it self-contained."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Commit (when _git is active)",
+          "content": [
+            {
+              "type": "text",
+              "value": "This phase applies only when the delegation briefing specifies a worktree workflow (_git is active). Commit only after verification passes — never commit unverified work. Each subtask should produce one focused commit. Follow Conventional Commits format: the commit type and scope should match what the delegation briefing specifies for the task's domain. See `_git/conventions.md` for format details. The orchestrator owns pushing and PR creation — subagents commit but never push."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Constraints",
+      "content": [
+        {
+          "type": "constraint-list",
+          "items": [
+            "Never skip context loading — agents without project context produce work that needs rework",
+            "Never expand scope beyond the briefing's boundary",
+            "Never modify files outside your task's scope without explicit instruction",
+            "Never skip verification — check criteria and run tests before reporting done"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_execution/gotchas.json
+++ b/.claude/skills/_execution/gotchas.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "gobbi-docs/gotcha",
+  "parent": "_execution",
+  "title": "Gotcha: _execution",
+  "entries": [
+    {
+      "title": "Hook script copy without settings entry = dead hook",
+      "body": {
+        "priority": "High",
+        "what-happened": "The update command's \"install new hooks\" feature copied hook scripts to `.claude/hooks/` and set chmod +x, but did not call `mergeHookConfig` to add the corresponding settings.json/settings.local.json entries. The hooks existed on disk but Claude Code never fired them because there was no configuration.",
+        "user-feedback": "Found during execution evaluation. Hooks require BOTH the script file AND the settings entry to function.",
+        "correct-approach": "Whenever copying hook scripts, always pair it with a `mergeHookConfig` call to add the corresponding event/matcher/command entry to the appropriate settings file. Never copy a hook without its settings entry."
+      }
+    },
+    {
+      "title": "parseArgs strict mode crashes on unknown flags",
+      "body": {
+        "priority": "High",
+        "what-happened": "`util.parseArgs` in strict mode (the default) throws `ERR_PARSE_ARGS_UNKNOWN_OPTION` for any flag not in the options config. The CLI crashed with a raw stack trace when users ran `gobbi --help` or `gobbi --version`.",
+        "user-feedback": "Found during execution evaluation.",
+        "correct-approach": "Always define `--help` and `--version` in the parseArgs options config for any CLI tool. Handle them with early-exit before command dispatch."
+      }
+    },
+    {
+      "title": "User input used in path construction without validation",
+      "body": {
+        "priority": "High",
+        "what-happened": "The project name prompt accepted arbitrary input including `../../pwned`, which when used in `path.join(targetDir, '.claude/project/', name)` resolved to a path outside the intended directory.",
+        "user-feedback": "Found during execution evaluation as a path traversal vulnerability.",
+        "correct-approach": "Validate user-provided strings before using them in path construction. Reject names containing `..`, `/`, `\\`, or other path separators. Also verify the resolved path stays within the expected parent directory."
+      }
+    },
+    {
+      "title": "Heuristic pattern matching must account for real-world variety",
+      "body": {
+        "priority": "Medium",
+        "what-happened": "A validate-skill.sh check was added to warn when skill descriptions lack trigger-oriented language. The pattern checked for `Use when`, `MUST load when`, `Use this`, `Load when`, `TRIGGER when`, `Load this` — but existing valid skills use phrases like `Use after` (gobbi-validate) and `Use to` (_note), which weren't in the pattern list. Two of five test skills produced false positives.",
+        "user-feedback": "Found during orchestrator verification of agent output.",
+        "correct-approach": "When writing heuristic checks for natural language patterns, test against the actual corpus of existing files BEFORE committing. Enumerate the real patterns first (grep for existing descriptions), then build the regex to match all of them. For trigger language specifically, `Use (when|this|after|during|to|for)` captures the full range of \"Use ...\" patterns found in gobbi skills."
+      }
+    },
+    {
+      "title": "Agent registry is session-cached — renamed agents not recognized until reload",
+      "body": {
+        "priority": "Medium",
+        "what-happened": "Renamed `_developer.md` → `__executor.md` (file + frontmatter) mid-session. When delegating via Agent tool with `subagent_type: \"__executor\"`, the system returned \"Agent type '__executor' not found\" because the available agents list was loaded at session start and caches the original filenames.",
+        "user-feedback": "Discovered during execution — had to use old name `_developer` for delegation within the same session.",
+        "correct-approach": "When renaming agent files mid-session, continue using the old agent type name for delegation until the session is reloaded. The agent registry reads `.claude/agents/` at session start and does not hot-reload. Plan accordingly: if renaming agents and delegating to them are in the same workflow, use the pre-rename names for delegation."
+      },
+      "metadata": {
+        "priority": "medium"
+      }
+    }
+  ],
+  "opening": "Mistakes in task implementation and verification."
+}

--- a/.claude/skills/_git/SKILL.json
+++ b/.claude/skills/_git/SKILL.json
@@ -1,0 +1,163 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_git",
+    "description": "Git/GitHub workflow with worktree isolation. Use when managing branches, worktrees, PRs, and the issue-to-merge lifecycle. Covers role boundaries between orchestrator and subagents for git operations.",
+    "allowed-tools": "Read, Grep, Glob, Bash, Write"
+  },
+  "title": "Git",
+  "opening": "Git and GitHub workflow. Load this skill when a task involves branching, worktree setup, PR creation, or the full issue-to-merge lifecycle.",
+  "navigation": {
+    "[conventions.md](conventions.md)": "Branch naming, commit messages, PR template, issue format, sub-issues, labels, worktree directory naming"
+  },
+  "sections": [
+    {
+      "heading": "Core Principles",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Every task gets its own worktree.",
+          "body": "Worktrees are the mechanism that prevents concurrent session corruption. One worktree means one branch means one PR. This is the isolation invariant that makes parallel sessions safe. Without it, two sessions in the same working tree produce indistinguishable diffs — the orchestrator cannot tell which changes belong to which session, and legitimate work gets reverted as scope creep."
+        },
+        {
+          "type": "principle",
+          "statement": "The orchestrator owns the git lifecycle. Subagents work within it.",
+          "body": "The orchestrator creates worktrees, names branches, pushes to remote, creates PRs, monitors CI, merges, and cleans up. Subagents work inside a worktree — they commit their verified work but never push, never create PRs, never touch issues. This boundary keeps integration controlled and predictable."
+        },
+        {
+          "type": "principle",
+          "statement": "Every task starts from a GitHub issue.",
+          "body": "The issue is the contract between ideation and execution. The orchestrator either creates an issue from ideation output or picks up an existing issue the user provides. The issue number drives branch naming, PR references, and traceability. Without an issue, the work has no anchor. Multi-task features can use a hierarchical model — a parent issue for the feature and sub-issues for each independent task. See conventions.md for the sub-issue model."
+        },
+        {
+          "type": "principle",
+          "statement": "Subagents commit. The orchestrator pushes.",
+          "body": "This separation is the key to controlled integration. Subagents make focused, well-verified commits in the worktree as they complete their work. The orchestrator pushes all commits and creates the PR only after all subtasks are complete and verified. Premature pushing from subagents would bypass the orchestrator's integration authority."
+        }
+      ]
+    },
+    {
+      "heading": "Prerequisites",
+      "content": [
+        {
+          "type": "text",
+          "value": "Before the git workflow can function, certain conditions must hold. These divide into two severity tiers based on whether they block the workflow entirely or merely risk problems downstream.\n\n**Critical — block until resolved.** The gh CLI must be available and reachable because the entire PR lifecycle depends on it. The gh CLI must be authenticated to the remote because API access is required for issue creation, PR management, and CI monitoring. The repository must have a configured git remote because pushing and PR creation require a remote target. If any of these are missing, the workflow cannot proceed.\n\n**Warning — inform the user, continue.** The configured base branch should exist on the remote — worktree creation will fail later if it doesn't, but the user may intend to create it. The `.claude/worktrees/` directory should be listed in `.gitignore` — without this, worktree contents appear in the main repo's git status. Orphaned worktrees may exist in `.claude/worktrees/` from crashed or abandoned sessions — offer cleanup or recovery."
+        },
+        {
+          "type": "principle",
+          "statement": "Fallback principle:",
+          "body": "If critical prerequisites cannot be resolved — user cannot install gh, cannot authenticate, no remote is available — fall back to Direct commit mode rather than blocking the session entirely."
+        },
+        {
+          "type": "principle",
+          "statement": "Re-verification principle:",
+          "body": "Some prerequisites — particularly base branch existence — should be re-verified at the point of use, not only at session start. Early checks catch problems early; late re-checks catch changes that occurred between setup and execution."
+        }
+      ]
+    },
+    {
+      "heading": "Workflow Mental Model",
+      "content": [
+        {
+          "type": "text",
+          "value": "The git lifecycle flows through stages with clear ownership at each point. The issue drives everything downstream — it determines the branch name, provides the PR description anchor, and connects the work to the project's tracking. The worktree provides physical isolation so the main working tree stays clean for other sessions. Subagents work sequentially within the worktree, each committing their verified changes. The orchestrator integrates by pushing and opening a PR only when all work is complete."
+        },
+        {
+          "type": "subsection",
+          "heading": "Role Boundaries",
+          "content": [
+            {
+              "type": "text",
+              "value": "The orchestrator and subagents have distinct, non-overlapping responsibilities in the git lifecycle. Crossing these boundaries breaks isolation or creates uncoordinated state."
+            },
+            {
+              "type": "table",
+              "headers": [
+                "Responsibility",
+                "Orchestrator",
+                "Subagent"
+              ],
+              "rows": [
+                [
+                  "Issue",
+                  "Creates or picks up",
+                  "Never touches"
+                ],
+                [
+                  "Worktree",
+                  "Creates before delegation, removes after merge",
+                  "Works within (cd to path)"
+                ],
+                [
+                  "Branch",
+                  "Names and creates",
+                  "Commits to it"
+                ],
+                [
+                  "Push",
+                  "Pushes to remote after all subtasks",
+                  "Never pushes"
+                ],
+                [
+                  "PR",
+                  "Creates, monitors CI",
+                  "Never creates"
+                ],
+                [
+                  "Merge",
+                  "Squash merges, deletes branch",
+                  "Never merges"
+                ]
+              ]
+            },
+            {
+              "type": "text",
+              "value": "The orchestrator passes the worktree's absolute path in every delegation prompt. The subagent's first action is to cd to that path. From that point, the subagent follows the standard Study, Plan, Execute, Verify lifecycle — with an additional Commit step after Verify succeeds."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Integration with Orchestration",
+      "content": [
+        {
+          "type": "text",
+          "value": "This skill loads at session start as a core skill. Prerequisites run during session setup when the user selects the git workflow (worktree + PR). The operational phase — worktree creation, branch setup, and delegation — begins at Step 3 (Execution) when the plan is approved.\n\n**Before delegation** — The orchestrator ensures the base branch is pushed to remote and in sync before creating the worktree and branch, re-verifying the base branch exists on the remote before proceeding. This guarantees the PR diff contains only the intended changes and prevents unpushed local commits from being silently absorbed into the PR on merge. The project's install command runs in the worktree so dependencies are ready. The worktree path becomes part of every delegation prompt.\n\n**During delegation** — Subagents cd to the worktree as their first action, then follow Study, Plan, Execute, Verify, Commit. Each subagent commits its verified work before completing. The orchestrator coordinates sequencing between subtasks.\n\n**After all subtasks** — The orchestrator pushes all commits to remote and creates the PR. CI runs against the pushed branch. The orchestrator monitors CI and coordinates any fixes.\n\n**FINISH phase** — When _git is active, the FINISH phase changes: \"merge PR and cleanup\" replaces the default commit step. Merging, branch deletion, and worktree removal happen as part of the orchestrator's FINISH responsibilities. When the PR targets a non-default branch, the orchestrator must explicitly close linked issues because closing keywords only trigger on PRs merged into the default branch. After removing the worktree, any empty parent directories left behind by nested branch names must be cleaned up. The orchestrator also pulls the merge into the local base branch to keep it in sync with the remote.\n\n**Notes and gotchas always write to the main tree** — The `$CLAUDE_PROJECT_DIR/.claude/project/` directory is gitignored. Subagent notes and gotchas must use the main tree's absolute path, not the worktree path, because worktrees are temporary and get removed after merge."
+        }
+      ]
+    },
+    {
+      "heading": "Failure Modes and Recovery",
+      "content": [
+        {
+          "type": "text",
+          "value": "**Worktree creation fails because the branch already exists** — The branch may be in use by another session or left over from a previous run. Report the conflict to the user and offer to reuse the existing worktree or rename the branch.\n\n**gh CLI not authenticated** — Covered by prerequisites — verified at session setup.\n\n**Orphaned worktrees from a crashed session** — Detection is covered by prerequisites at session setup. When orphans are found, offer the user a choice: recover the work (inspect the worktree's commits and resume from where it left off) or clean up (remove the worktree and its branch).\n\n**CI failure on the PR** — Before fixing, the orchestrator retrieves the failing job logs to identify the root cause. The diagnostic sequence is: list the workflow runs for the branch to find the failed run, then view that run's logs to read the failure output."
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "**GitHub Actions:** retrieval is automated through the gh CLI",
+            "**External CI (CircleCI, Jenkins, etc.):** gh CLI commands return nothing useful — surface the status check URL from the PR to the user so they can inspect the failure directly",
+            "**After identifying cause:** fix it in the worktree, commit the fix, and push; CI re-runs automatically against the updated branch",
+            "**Monitor:** until CI passes or the user decides to defer"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**Cleanup failure when removing a worktree** — If normal removal fails (uncommitted changes, locked files), force removal is the fallback, followed by pruning to clean up stale references. Nested branch names that use slashes create intermediate directories under `.claude/worktrees/` — git only removes the leaf directory, so empty parent directories must be cleaned up separately after worktree removal."
+        }
+      ]
+    },
+    {
+      "heading": "Constraints",
+      "content": [
+        {
+          "type": "text",
+          "value": "**Never use stash in worktrees** — Stash is stored at the repository level in the shared `.git` directory, not per worktree. A stash created in one worktree is visible and poppable from every other worktree. This means one agent's stash can be accidentally consumed by another agent. Always commit or discard changes instead.\n\n**One worktree, one branch, one PR** — This is the isolation invariant. A worktree that checks out a different branch or serves multiple PRs breaks the isolation model and makes concurrent sessions unsafe.\n\n**Branch exclusivity** — Git enforces that a branch can only be checked out in one worktree at a time. If branch creation fails during worktree setup, the branch may already be active in another worktree from a concurrent or crashed session.\n\n**Dependencies must be reinstalled per worktree** — Each worktree has its own working directory. Package managers, virtual environments, and build caches are not shared between worktrees. The orchestrator must ensure the project's install command runs in the worktree before delegating to subagents.\n\n**Requires GitHub and the gh CLI** — This skill assumes GitHub as the hosting platform and gh as the CLI tool for PR operations. Repos not hosted on GitHub should use a local-only workflow with direct commits and no PR lifecycle.\n\n**Base branch is project-specific** — Never hardcode a default base branch. The base branch varies by project and by workflow. Ask the user at session setup which branch to base work on."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_git/conventions.json
+++ b/.claude/skills/_git/conventions.json
@@ -1,0 +1,160 @@
+{
+  "$schema": "gobbi-docs/child",
+  "parent": "_git",
+  "title": "Git Conventions",
+  "opening": "Naming and formatting standards for branches, commits, PRs, issues, and worktree directories. These conventions apply when _git is active. All formats align with the Conventional Commits v1.0.0 standard.",
+  "sections": [
+    {
+      "heading": "Branch Naming",
+      "content": [
+        {
+          "type": "text",
+          "value": "Branch names encode the work type, tracking issue, and a short description so that any developer or agent can identify the branch's purpose at a glance. For example, a branch for issue 42 implementing OAuth login would be named feat/42-oauth-login.\n\n**Type prefixes** (aligned with Conventional Commits):"
+        },
+        {
+          "type": "table",
+          "headers": [
+            "Prefix",
+            "Purpose"
+          ],
+          "rows": [
+            [
+              "feat/",
+              "New feature"
+            ],
+            [
+              "fix/",
+              "Bug fix"
+            ],
+            [
+              "hotfix/",
+              "Urgent production fix"
+            ],
+            [
+              "chore/",
+              "Maintenance, dependencies"
+            ],
+            [
+              "docs/",
+              "Documentation only"
+            ],
+            [
+              "refactor/",
+              "Code restructuring, no behavior change"
+            ],
+            [
+              "test/",
+              "Test additions or modifications"
+            ],
+            [
+              "ci/",
+              "CI/CD configuration"
+            ],
+            [
+              "perf/",
+              "Performance improvement"
+            ]
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**Naming rules:**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "All lowercase, words separated by hyphens",
+            "Include the issue number when a tracking issue exists",
+            "Keep the description under 50 characters",
+            "Be specific about what the branch delivers — the name should distinguish this branch from other work in the same area"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Commit Messages",
+      "content": [
+        {
+          "type": "text",
+          "value": "Follow the Conventional Commits v1.0.0 standard for all commit message formatting — type, optional scope, description, optional body, optional footer. The standard itself defines the structure; this section covers only project-specific constraints that go beyond the format.\n\n**Commit discipline:** Each subagent commit should be one focused, specific change. A commit that touches unrelated areas is a commit that will be difficult to review, revert, or bisect. If a task naturally produces multiple logical changes, commit them separately.\n\n**Scope matching:** The commit type and scope should match the task's domain as stated in the delegation briefing. A developer subagent working on a feat/42-oauth-login branch should not be producing docs: or chore: commits unless the delegation explicitly includes that work.\n\n**Commit timing:** Commit only after verification passes — never commit unverified work. The verification step exists to catch problems before they enter the history; committing before verification defeats the purpose.\n\n**Body principle:** When a commit body is warranted, explain why the change was made rather than what changed. The diff shows the what; the body provides the reasoning that the diff cannot convey."
+        }
+      ]
+    },
+    {
+      "heading": "Pull Request Format",
+      "content": [
+        {
+          "type": "text",
+          "value": "The PR title follows the same Conventional Commits format as commit messages: type, optional scope, description.\n\nThe PR body should explain what changed and why, link to the tracking issue, and describe how to verify the changes. The body serves reviewers who need to understand the scope and testers who need to know what to check — write for those audiences rather than following a rigid structure.\n\n**Issue linking caveat:** Closing keywords in a PR body only auto-close the linked issue when the PR targets the repository's default branch. If the PR targets a non-default branch (such as a develop branch), the issue must be closed explicitly after the final merge reaches the default branch. This is a GitHub platform behavior, not a configuration option.\n\n**Merge strategy:** Squash merge with branch deletion. All PR commits collapse into one commit on the target branch, keeping the history clean. The branch is deleted after merge to prevent stale branch accumulation."
+        }
+      ]
+    },
+    {
+      "heading": "Issue Format",
+      "content": [
+        {
+          "type": "text",
+          "value": "Issues are the contract between ideation and execution. They can be created by the orchestrator from ideation output or picked up from existing issues.\n\n**When creating an issue:**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Title in imperative mood, descriptive and specific — same naming sensibility as branch descriptions",
+            "Body contains the problem statement, proposed approach, acceptance criteria, and labels",
+            "The issue becomes the source of truth for what the task delivers"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**When picking up an existing issue:**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Read the full issue body and comments for context before starting work",
+            "The issue number drives the branch name and PR linkage"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Sub-issues",
+      "content": [
+        {
+          "type": "text",
+          "value": "When a feature decomposes into three or more independent tasks that each produce their own commit or PR, sub-issues can track them under a parent issue. The parent issue captures the overall feature; each sub-issue is scoped to one deliverable.\n\nThe orchestrator creates the parent issue from ideation output, then creates sub-issues during planning — one per task. Sub-issues follow the same naming conventions as regular issues, and the branch for each sub-issue uses the sub-issue number in its name (for example, `feat/{sub-issue-number}-{description}`). The orchestrator closes the parent issue manually after confirming all sub-issues are resolved — GitHub does not close parent issues automatically.\n\nThis is guidance for multi-task features, not a mandate. Simple tasks continue to use a single issue. Use sub-issues when the decomposition is clear, the tasks are genuinely independent, and tracking progress per task would be meaningful.\n\nThe `gh issue` CLI does not have native sub-issue support. Sub-issue relationships use GitHub's parent-child issue model: the orchestrator creates a child issue and links it to the parent, establishing a tracked relationship. The parent's sub-issue list can then be queried to check how many sub-issues are open versus resolved, which is how the orchestrator determines when all tasks are complete. This querying and linking is done through the GitHub API directly."
+        }
+      ]
+    },
+    {
+      "heading": "Labels",
+      "content": [
+        {
+          "type": "text",
+          "value": "Labels organize issues along two independent axes: type and status.\n\n**Type labels** mirror the branch prefix taxonomy: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`, `perf`. Apply the matching type label when creating an issue. Type labels are always recommended — they connect the issue to the kind of work it tracks and make filtering straightforward.\n\n**Status labels** reflect where work stands in the lifecycle: `in-progress` (worktree created, delegation started) and `ready-for-review` (PR created). Status labels are removed when the issue closes at merge — they track lifecycle state, so they naturally clear when the lifecycle ends. Status labels are optional — apply them when the project uses a label system or when the user has enabled status tracking. Not every project benefits from this level of overhead.\n\nThe orchestrator applies labels; subagents never touch them. This is consistent with the role boundary that reserves all issue and PR management for the orchestrator.\n\nGitHub does not auto-create labels. On a fresh repository, the orchestrator must create any needed labels before applying them. Creating a label that already exists has no effect, so the orchestrator can safely attempt creation on first use without checking whether the label already exists."
+        }
+      ]
+    },
+    {
+      "heading": "Worktree Directory Naming",
+      "content": [
+        {
+          "type": "text",
+          "value": "Worktrees are created inside `.claude/worktrees/` within the main repository. The directory name preserves the branch name exactly, including slashes — so a branch named feat/42-oauth-login becomes `.claude/worktrees/feat/42-oauth-login/`. This keeps worktrees co-located with the repo rather than scattered as sibling directories, and the preserved branch path makes it easy to identify what each worktree is for without inspecting git state. Naming collisions are prevented because each branch name is unique.\n\nThe `.claude/worktrees/` directory must be in `.gitignore` to prevent worktree contents from appearing in the main repo's git status."
+        }
+      ]
+    },
+    {
+      "heading": "Base Branch",
+      "content": [
+        {
+          "type": "text",
+          "value": "The base branch — what feature branches are created from and what PRs target — is project-specific. It is not hardcoded in this skill.\n\nCommon patterns include trunk-based development with a single main branch, GitFlow with a develop branch, or custom branching models. The orchestrator asks the user at session setup and stores the answer as session-level configuration. All branch creation and PR targeting use this configured base branch."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_git/gotchas.json
+++ b/.claude/skills/_git/gotchas.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "gobbi-docs/gotcha",
+  "parent": "_git",
+  "title": "Gotcha: _git",
+  "entries": [
+    {
+      "title": "Writing notes or gotchas to the worktree instead of the main tree",
+      "body": {
+        "priority": "Critical",
+        "what-happened": "During evaluation of the _git skill design, evaluators identified that `$CLAUDE_PROJECT_DIR/.claude/project/` is in `.gitignore`. When a worktree is created, the `$CLAUDE_PROJECT_DIR/.claude/project/` directory does not exist in the worktree because gitignored directories are not part of the tracked working tree. If a subagent writes notes or gotchas using a relative path in the worktree, the files go to a nonexistent or newly-created local directory that gets destroyed when the worktree is removed after merge. The note system, gotcha system, and resume mechanism all break.",
+        "user-feedback": "(Identified during design evaluation — pre-seeded gotcha)",
+        "correct-approach": "Notes, gotchas, and all `$CLAUDE_PROJECT_DIR/.claude/project/` writes must use the main tree's absolute path. The orchestrator must include the main tree path in every delegation prompt when _git is active. Subagents must never write to `$CLAUDE_PROJECT_DIR/.claude/project/` using relative paths or the worktree's path — always use the main tree's absolute path provided in the briefing."
+      }
+    },
+    {
+      "title": "Using git stash in a worktree leaks state to other worktrees",
+      "body": {
+        "priority": "High",
+        "what-happened": "Git stash is stored at the repository level in the shared `.git` directory, not per worktree. A stash created in one worktree appears in `git stash list` from every other worktree. If one agent stashes changes and another agent pops the stash in a different worktree, the first agent's work silently moves to the wrong context.",
+        "user-feedback": "(Identified during design research — pre-seeded gotcha)",
+        "correct-approach": "Never use `git stash` in worktrees. Always commit verified work or discard unneeded changes. The _git skill enforces this as a hard constraint."
+      }
+    },
+    {
+      "title": "Unpushed local commits silently included in PR via squash merge",
+      "body": {
+        "priority": "Critical",
+        "what-happened": "During the first _git workflow test, the orchestrator created a worktree from the local `develop` branch which had 2 unpushed commits (_git skill creation and prerequisites). The worktree branched from the local HEAD, so the PR branch included those unpushed changes. When the PR was squash-merged on GitHub, the squash commit absorbed all differences between the PR branch and the remote target — not just the intended version bump, but also the 2 unpushed commits. After merge, the local `develop` and remote `develop` had diverged because the remote gained a squash commit containing the local-only changes, while the local still had them as separate commits. Rebasing caused conflicts.",
+        "user-feedback": "(Discovered during first git workflow test)",
+        "correct-approach": "Before creating a worktree for a PR workflow, the orchestrator must ensure the base branch is pushed to remote and up to date. Run `git push` on the base branch before `git worktree add`. This guarantees the PR diff contains only the intended changes, and the post-merge pull is a clean fast-forward. Add this as a prerequisite check or as a step in the \"Before delegation\" phase of _git."
+      }
+    },
+    {
+      "title": "Merge and cleanup not tracked in workflow task list",
+      "body": {
+        "priority": "High",
+        "what-happened": "During the first git workflow test, the orchestrator created tasks for issue creation, worktree setup, delegation, and PR creation — but no task for \"Merge PR and cleanup.\" When FINISH was selected, the merge and cleanup steps (squash merge, branch deletion, worktree removal, pruning) happened outside the task tracking system. This made it hard for the user to see what steps were planned for the FINISH phase.",
+        "user-feedback": "\"Merge and clean-up should be included to TODOs.\"",
+        "correct-approach": "When using git workflow mode, include a \"Merge PR and cleanup\" task in the workflow task list. This task covers: squash merge the PR, delete the remote branch, close the issue explicitly (see closing keyword gotcha below), remove the local worktree, remove leftover parent directories from nested branch names, pull the merge into the local base branch, and prune stale worktree references."
+      }
+    },
+    {
+      "title": "Closing keywords in PR body don't auto-close issues on non-default branch PRs",
+      "body": {
+        "priority": "High",
+        "what-happened": "The PR body contained \"Closes #1\" but targeted the `develop` branch, not the default `main` branch. After the PR was squash-merged, the issue remained open. This is documented in _git/conventions.md as the \"Issue linking caveat\" but the orchestrator failed to act on it during the FINISH phase.",
+        "user-feedback": "\"The created issue was not closed after merge.\"",
+        "correct-approach": "After merging a PR that targets a non-default branch, the orchestrator must explicitly close the linked issue using `gh issue close`. This must be part of the merge-and-cleanup checklist, not assumed to happen automatically. The conventions.md caveat exists — the orchestrator must read and act on it."
+      }
+    },
+    {
+      "title": "Nested worktree directories from branch slashes leave orphaned parent directories",
+      "body": {
+        "priority": "High",
+        "what-happened": "The worktree naming convention preserves branch slashes as directory separators (e.g., `chore/1-bump-version` → `.claude/worktrees/chore/1-bump-version/`). When the worktree was removed with `git worktree remove`, only the leaf directory (`1-bump-version/`) was deleted. The parent directory (`chore/`) remained as an empty directory. This leaves visible clutter that looks like an orphaned worktree.",
+        "user-feedback": "\"There are remains like .claude/worktrees/chore.\"",
+        "correct-approach": "After removing a worktree, clean up any empty parent directories left behind under `.claude/worktrees/`. The cleanup should walk upward from the removed worktree path, removing empty directories until reaching `.claude/worktrees/` itself. This must be part of the worktree removal step, not left as a manual cleanup."
+      }
+    },
+    {
+      "title": "gh pr merge fails when base branch is checked out in main worktree",
+      "body": {
+        "priority": "Critical",
+        "what-happened": "During FINISH, `gh pr merge --squash --delete-branch` fails with `fatal: 'develop' is already used by worktree at '/path/to/repo'`. The gh CLI tries to update the local base branch after merging, but git refuses because the branch is checked out in the main working tree. This error has occurred repeatedly across multiple workflow sessions.",
+        "user-feedback": "\"The merge error repeated many times.\"",
+        "correct-approach": "Use the GitHub API directly instead of `gh pr merge`. Run `gh api repos/{owner}/{repo}/pulls/{number}/merge -f merge_method=squash` to merge on the remote without touching the local branch. Then handle cleanup separately: delete the remote branch with `gh api repos/{owner}/{repo}/git/refs/heads/{branch} -X DELETE`, close the issue with `gh issue close`, remove the worktree with `git worktree remove`, and pull the merge into the local base branch with `git pull --ff-only origin {base-branch}`. Never use `gh pr merge` when the base branch is checked out locally."
+      }
+    },
+    {
+      "title": "git pull fails with \"divergent branches\" after squash merge",
+      "body": {
+        "priority": "High",
+        "what-happened": "After squash-merging a PR via the GitHub API, `git pull origin develop` fails with `fatal: Need to specify how to reconcile divergent branches`. The local base branch and the remote have diverged because the squash merge created a new commit on the remote that doesn't share history with the local branch's view. Running `git pull` without a strategy flag triggers the divergent branches error repeatedly across sessions.",
+        "user-feedback": "\"The git pull error repeated too.\"",
+        "correct-approach": "Always use `git pull --ff-only origin {base-branch}` after a squash merge. The `--ff-only` flag ensures a clean fast-forward. If `--ff-only` fails (local has commits not on remote), the base branch was not properly synced before worktree creation — see the \"Unpushed local commits\" gotcha above. The FINISH cleanup sequence must always use `--ff-only` to catch sync issues early rather than silently creating merge commits."
+      }
+    },
+    {
+      "title": "Recommending cleanup of worktrees that may belong to concurrent sessions",
+      "body": {
+        "priority": "High",
+        "what-happened": "At session start, the orchestrator found an existing worktree (`20-session5-proposals`) and recommended \"Clean up\" as the default option. The worktree was actively in use by a concurrent session. Recommending cleanup as default risks destroying another session's in-progress work.",
+        "user-feedback": "\"You should not recommend clean-up because there will be other concurrent sessions. Recommend Leave it.\"",
+        "correct-approach": "When orphaned worktrees are found at session start, default to \"Leave it\" as the recommended option. The orchestrator cannot know whether a worktree is truly orphaned or belongs to a concurrent session. Only recommend cleanup if the user explicitly confirms the worktree is abandoned. \"Inspect first\" is an acceptable secondary option; \"Clean up\" should never be the default recommendation."
+      }
+    },
+    {
+      "title": "Uncommitted gotchas in main tree lost during worktree PR merge",
+      "body": {
+        "priority": "High",
+        "what-happened": "During a workflow, gotchas were written to the main tree (correct — `$CLAUDE_PROJECT_DIR/.claude/project/` is gitignored, so gotchas go to the main tree). These gotchas were added to tracked files (e.g., `_git.md`) but never committed. When the worktree's PR was squash-merged and the orchestrator pulled into the main tree with `git pull --ff-only`, the pull failed because the uncommitted gotcha changes conflicted with the incoming merge. The gotchas had to be manually saved, discarded, pulled, and re-applied.",
+        "user-feedback": "(Discovered during symlink reversal migration FINISH phase)",
+        "correct-approach": "Before pulling a squash merge into the main tree, check for uncommitted changes in tracked files using `git status`. If gotchas or other changes exist in tracked files, save the content, discard with `git checkout --`, pull, then re-apply the changes. Alternatively, commit gotchas immediately after writing them to avoid this situation entirely. The safest approach: commit gotchas to the main tree before starting the merge-and-cleanup sequence."
+      }
+    },
+    {
+      "title": "git worktree remove fails with \"modified or untracked files\"",
+      "body": {
+        "priority": "High",
+        "what-happened": "After merging a PR, `git worktree remove <path>` fails with `fatal: '<path>' contains modified or untracked files, use --force to delete it`. Subagents left uncommitted changes, build artifacts, or untracked files in the worktree. This blocks the cleanup sequence and has occurred across multiple projects.",
+        "user-feedback": "\"This error repeated. Why?\"",
+        "correct-approach": "Use `git worktree remove --force <path>` when normal removal fails. The worktree's PR is already merged — any uncommitted changes are either already in the PR or intentionally left behind. After force removal, delete the local branch with `git branch -d <branch>`, prune with `git worktree prune`, and clean up empty parent directories. To prevent this: ensure subagents commit all changes before completing, and run `git status` in the worktree before removal to surface any surprises."
+      }
+    },
+    {
+      "title": "Stale remote branches accumulate across sessions",
+      "body": {
+        "priority": "High",
+        "what-happened": "After multiple gobbi workflow sessions, the GitHub remote accumulated 11+ stale feature branches. Each session's FINISH phase deleted its own branch via the GitHub API, but branches from previous sessions that were merged via the GitHub web UI or through other workflows were never cleaned up. Over time the branch list became cluttered, making it hard to identify active work.",
+        "user-feedback": "\"In the github there are so many branches remaining. I expected that the branches should be removed after work finished.\"",
+        "correct-approach": "During the FINISH phase, after merging the current PR and deleting its branch, check for other stale merged branches on the remote. Offer to clean them up via AskUserQuestion — never delete automatically, since some branches may belong to concurrent sessions or be intentionally kept. At minimum, verify the current session's branch was actually deleted (the API call can silently fail). Add remote branch cleanup as a step in the merge-and-cleanup checklist."
+      }
+    }
+  ],
+  "opening": "Mistakes in git/GitHub workflow, worktree management, branch handling, and PR lifecycle."
+}

--- a/.claude/skills/_gotcha/SKILL.json
+++ b/.claude/skills/_gotcha/SKILL.json
@@ -1,0 +1,166 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_gotcha",
+    "description": "Gotcha system — how to record, locate, and check gotchas. Load when writing gotchas after corrections or when checking gotchas before acting.",
+    "allowed-tools": "Read, Grep, Glob, Write, Edit"
+  },
+  "title": "Gotcha",
+  "opening": "Guide for the gotcha system — recording mistakes so agents never repeat them, and checking mistakes before acting so agents avoid them.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Check gotchas before acting, not after failing.",
+          "body": "Every agent MUST read `gotchas.md` when loading a skill. A 30-second read prevents a 30-minute debugging session. This is not optional — gotchas are the highest-value knowledge in the system."
+        },
+        {
+          "type": "principle",
+          "statement": "If it happened once, record it. If it happened twice, it's a gotcha.",
+          "body": "Gotchas are mistakes that agents repeat because the correct behavior is non-obvious. They short-circuit investigation — the next agent skips straight to the right approach."
+        },
+        {
+          "type": "principle",
+          "statement": "Every gotcha has a user behind it.",
+          "body": "Each entry exists because a user experienced a problem. The user's feedback is the most important part."
+        }
+      ]
+    },
+    {
+      "heading": "When to Read",
+      "content": [
+        {
+          "type": "text",
+          "value": "**MUST read `gotchas.md` when loading any skill that has one.** This is a rule, not a suggestion. When an agent loads `_git`, it reads `_git/gotchas.md`. When an agent loads `_orchestration`, it reads `_orchestration/gotchas.md`. No exceptions.\n\n**MUST read project-specific gotchas** at `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/gotchas/` when starting work on a project.\n\n**MUST read cross-cutting gotchas** (`_gotcha/__system.md`, `_gotcha/__security.md`) when the task involves environment setup, hooks, or security-sensitive work."
+        }
+      ]
+    },
+    {
+      "heading": "Where Gotchas Live",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Default: colocate with the skill.",
+          "body": "Most gotchas belong to a specific skill. Write them to `{skill-name}/gotchas.md` so agents loading the skill read them automatically."
+        },
+        {
+          "type": "text",
+          "value": "**Skill-specific** (default) → `.claude/skills/{skill-name}/gotchas.md` — colocated with the skill it corrects.\n\n**Cross-cutting** (rare) → `_gotcha/{topic}.md` — only for concerns that span multiple skills or belong to no single skill (environment, security, infrastructure)."
+        },
+        {
+          "type": "table",
+          "headers": [
+            "Gotcha File",
+            "Covers"
+          ],
+          "rows": [
+            [
+              "[__system.md](__system.md)",
+              "Environment, processes, hooks, infrastructure"
+            ],
+            [
+              "[__security.md](__security.md)",
+              "Security vulnerability signals for evaluators"
+            ]
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**Project-specific** → `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/gotchas/{category}.md`"
+        }
+      ]
+    },
+    {
+      "heading": "When to Write",
+      "content": [
+        {
+          "type": "text",
+          "value": "**Write when:** user corrects a non-obvious approach, error took significant debugging, same mistake repeated, platform quirk caused unexpected behavior.\n\n**Skip when:** simple typo, obvious from reading the codebase, already in a rule or skill.\n\n**Write immediately** — a correction not recorded is a correction repeated. Do not defer gotcha writing to the end of the session."
+        }
+      ]
+    },
+    {
+      "heading": "How to Write",
+      "content": [
+        {
+          "type": "text",
+          "value": "Each `gotchas.md` file contains multiple entries. Each entry has:\n\n**Title** — Short, descriptive name\n\n**Priority** — Critical (breaks environment), High (wrong output looks correct), Medium (rework needed), Low (minor)\n\n**What happened** — What the agent did wrong and the result.\n\n**User feedback** — What the user said.\n\n**Correct approach** — What to do instead."
+        }
+      ]
+    },
+    {
+      "heading": "Machine-Readable Metadata",
+      "content": [
+        {
+          "type": "text",
+          "value": "Gotcha entries may include optional YAML frontmatter for tooling. The frontmatter goes between `---` markers immediately after the `###` heading line, before the prose body. Entries without frontmatter continue to work — the prose body remains the primary content.\n\n**Fields:**"
+        },
+        {
+          "type": "table",
+          "headers": [
+            "Field",
+            "Values",
+            "Required",
+            "Purpose"
+          ],
+          "rows": [
+            [
+              "`priority`",
+              "critical, high, medium, low",
+              "Optional",
+              "Overrides the prose Priority line for machine readers"
+            ],
+            [
+              "`tech-stack`",
+              "comma-separated lowercase identifiers (e.g., node, python, docker, typescript)",
+              "Optional",
+              "Tags the entry with technology context"
+            ],
+            [
+              "`enforcement`",
+              "hook, advisory",
+              "Optional (default: advisory)",
+              "Whether tooling can enforce this automatically"
+            ],
+            [
+              "`pattern`",
+              "regex string",
+              "Only when enforcement: hook",
+              "Regex to match against"
+            ],
+            [
+              "`event`",
+              "bash, file, stop",
+              "Only when enforcement: hook",
+              "Which hook event triggers the check"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Child Documents",
+      "content": [
+        {
+          "type": "table",
+          "headers": [
+            "Document",
+            "Covers"
+          ],
+          "rows": [
+            [
+              "`project-gotcha.md`",
+              "Recording project-specific gotchas in `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/gotchas/`"
+            ],
+            [
+              "`skills-gotcha.md`",
+              "Recording skill-specific gotchas tied to individual skills"
+            ]
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_gotcha/__security.json
+++ b/.claude/skills/_gotcha/__security.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "gobbi-docs/gotcha",
+  "parent": "_gotcha",
+  "title": "Gotcha: Security",
+  "entries": [
+    {
+      "title": "Injection (SQL, Command, Code)",
+      "body": {
+        "priority": "High",
+        "what-happened": "Agent implemented a search endpoint that built the SQL query using string concatenation: `\"SELECT * FROM users WHERE name = '\" + req.query.name + \"'\"`. A reviewer caught that passing `' OR '1'='1` as the name would return all rows, and a crafted input could drop tables. The same pattern appeared in a shell command that passed user-supplied filenames directly to `child_process.exec`.",
+        "user-feedback": "\"This is a textbook injection vulnerability. Never build queries or commands from user input with string concatenation.\"",
+        "correct-approach": "Use parameterized queries or prepared statements for all database access. Use `execFile` or argument arrays instead of shell string interpolation for system commands. Never pass user input to `eval` or equivalent. Validate and sanitize at system boundaries. Look for: string concatenation building SQL queries, `exec`/`eval`/`system` calls receiving unsanitized input, template literals constructing shell commands."
+      },
+      "metadata": {
+        "priority": "high"
+      }
+    },
+    {
+      "title": "Cross-Site Scripting (XSS)",
+      "body": {
+        "priority": "High",
+        "what-happened": "Agent added a \"welcome back\" message by setting `element.innerHTML = 'Hello, ' + username`. A reviewer noted that if the username contained `<script>alert(1)</script>`, the script would execute in every visitor's browser. A separate case: agent rendered a search results page by reflecting the `?q=` URL parameter directly into the HTML response without encoding.",
+        "user-feedback": "\"Never insert user-controlled values into the DOM with innerHTML. Use textContent or a framework that auto-escapes.\"",
+        "correct-approach": "Use framework auto-escaping (React JSX, Go `html/template`). When raw HTML insertion is unavoidable, sanitize with a dedicated library. Set `Content-Security-Policy` headers. Encode output contextually — HTML entities for HTML context, URL encoding for URLs, JavaScript encoding for script context. Look for: `innerHTML`, `dangerouslySetInnerHTML`, `document.write`, `v-html`, server-side templates that bypass auto-escape, URL parameters reflected into page output."
+      },
+      "metadata": {
+        "priority": "high"
+      }
+    },
+    {
+      "title": "Insecure Deserialization",
+      "body": {
+        "priority": "High",
+        "what-happened": "Agent wrote a caching layer that stored and retrieved objects using `pickle.dumps`/`pickle.loads` with data read from a Redis key that users could influence. A reviewer flagged that deserializing attacker-controlled pickle data can execute arbitrary Python. A second case: agent used `yaml.load(user_input)` without `SafeLoader`, which can instantiate arbitrary Python objects.",
+        "user-feedback": "\"pickle and unsafe yaml.load on untrusted input is remote code execution waiting to happen. Use safe alternatives.\"",
+        "correct-approach": "Validate deserialized data against a schema before use. Use safe loaders (`yaml.safe_load`, `JSON.parse` with Zod/Joi validation). Never deserialize with formats that reconstruct executable objects — avoid `pickle` for untrusted input, prefer JSON. Apply type narrowing after parsing. Look for: `pickle.loads`, `yaml.load` without SafeLoader, Java `ObjectInputStream.readObject`, PHP `unserialize`, or `JSON.parse` used without schema validation on untrusted input."
+      },
+      "metadata": {
+        "priority": "high"
+      }
+    },
+    {
+      "title": "Hardcoded Secrets",
+      "body": {
+        "priority": "High",
+        "what-happened": "Agent added a third-party API integration and hardcoded the API key as a string constant: `const API_KEY = \"sk-prod-abc123...\"`. The key was committed to the repository. A reviewer noted that even if the key is removed in a later commit, it persists in git history and is permanently exposed. A second case: agent committed a `.env` file containing database credentials while setting up a local dev environment.",
+        "user-feedback": "\"Secrets in code are secrets in history. Rotate that key immediately and never do this again.\"",
+        "correct-approach": "Use environment variables or a secrets manager. Reference secrets by name, never by value. Add `.env` and credential files to `.gitignore` before creating them. Rotate any secret that was ever committed. Look for: string literals matching API key patterns (long alphanumeric strings, base64 blocks), `password =`/`secret =`/`token =`/`key =` assignments with literal values, connection strings with embedded credentials, `.env` files or private keys in staged changes."
+      },
+      "metadata": {
+        "priority": "high"
+      }
+    },
+    {
+      "title": "Path Traversal",
+      "body": {
+        "priority": "High",
+        "what-happened": "Agent implemented a file download endpoint that served files from a `/uploads` directory: `fs.readFile('/uploads/' + req.params.filename)`. A reviewer demonstrated that requesting `../../../etc/passwd` as the filename would read the system password file. The `path.join` call did not resolve to an absolute path and did not verify the result stayed within `/uploads`.",
+        "user-feedback": "\"path.join does not protect against traversal. You must resolve the full path and verify it stays within the intended directory.\"",
+        "correct-approach": "Resolve the full path with `path.resolve` or equivalent, then verify it starts with the intended base directory. Reject inputs containing `..` segments. Use allowlists for filenames when possible rather than constructing paths from user input. Look for: `readFile`/`open`/`fopen`/`os.Open` where the path includes user-supplied segments, `path.join(base, userInput)` without subsequent boundary verification, `../` or `..%2f` in URL parameters used for file access."
+      },
+      "metadata": {
+        "priority": "high"
+      }
+    },
+    {
+      "title": "Broken Access Control",
+      "body": {
+        "priority": "High",
+        "what-happened": "Agent implemented a document edit endpoint that accepted `documentId` from the request body and looked up the document directly: `Document.findById(req.body.documentId)`. A reviewer noted that any authenticated user could edit any other user's documents by supplying a different ID — there was no check that the authenticated user owned the document. A separate case: agent added an admin-only delete action but only hid the button in the UI, with no server-side role check on the API endpoint.",
+        "user-feedback": "\"Authorization must be enforced on the server. Hiding UI elements is not access control.\"",
+        "correct-approach": "Enforce authorization at the server for every resource access. Verify ownership or role permission before returning data or performing mutations. Use indirect references (session-scoped handles) instead of exposing internal IDs when possible. Test with multiple user accounts to confirm isolation. Look for: endpoints accepting a resource ID without an ownership check, missing authorization middleware on routes, role checks that only appear in frontend code, direct object references in URLs without validation."
+      },
+      "metadata": {
+        "priority": "high"
+      }
+    }
+  ],
+  "opening": "Security vulnerabilities that agents can introduce when writing or reviewing code. Each entry describes a concrete scenario where the vulnerability manifests in agent work, what a reviewer would say, and how to avoid it."
+}

--- a/.claude/skills/_gotcha/__system.json
+++ b/.claude/skills/_gotcha/__system.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "gobbi-docs/gotcha",
+  "parent": "_gotcha",
+  "title": "Gotcha: System",
+  "entries": [
+    {
+      "title": "Blind-killing processes on ports",
+      "body": {
+        "priority": "Critical",
+        "what-happened": "Agent needed to free a port (4040) and ran `kill` on the process occupying it without first identifying what the process was. The process turned out to be critical for the user's remote/network connection. The user lost connectivity and had to reconnect.",
+        "user-feedback": "\"Never kill processes on ports without identifying them first.\"",
+        "correct-approach": "Always `lsof -i :PORT` first to identify what's running. Show the user what the process is. Only kill after confirmation, or if it's obviously the intended target (e.g., a node process running Storybook). Never assume a process on a port is safe to kill."
+      },
+      "metadata": {
+        "priority": "critical",
+        "enforcement": "hook",
+        "pattern": "kill\\s+|pkill\\s+|killall\\s+",
+        "event": "bash"
+      }
+    },
+    {
+      "title": "Stop hook has no duration field",
+      "body": {
+        "priority": "Medium",
+        "what-happened": "Agent tried to implement a task-done Slack notification in the Stop hook by reading `duration_ms` from the hook payload. The Stop hook payload does not contain any duration field — it only has `session_id`, `transcript_path`, `cwd`, `permission_mode`, `hook_event_name`, `stop_hook_active`, and `last_assistant_message`. The notification never fired because the duration always defaulted to 0.",
+        "user-feedback": "Confirmed the fix works after implementing a two-hook approach.",
+        "correct-approach": "Track timing with a two-hook approach. `UserPromptSubmit` hook records `date +%s` to `/tmp/claude-start-{session_id}`. `Stop` hook reads it and calculates elapsed time. Use `session_id` in filenames to avoid collisions between concurrent sessions."
+      },
+      "metadata": {
+        "priority": "medium"
+      }
+    },
+    {
+      "title": "Plugin hooks in settings.json are silently ignored",
+      "body": {
+        "priority": "High",
+        "what-happened": "Gobbi's plugin distribution put all hook configuration (SessionStart, Stop, Notification, etc.) in `plugins/gobbi/settings.json`. Plugin users reported hooks not firing — the SessionStart hook script showed its usage message instead of executing automatically. Investigation revealed that Claude Code's plugin system only supports **agent settings** in plugin `settings.json`. Hooks, permissions, and other config in `settings.json` are silently ignored.",
+        "user-feedback": "Confirmed via the official Claude Code plugin reference at `https://code.claude.com/docs/en/plugins-reference`.",
+        "correct-approach": "Plugin hooks must be in `hooks/hooks.json` at the plugin root AND declared via the `hooks` field in `plugin.json` (e.g., `\"hooks\": \"./hooks/hooks.json\"`). When `plugin.json` declares any component paths (`skills`, `agents`), auto-discovery of other components is disabled — hooks must be explicitly listed. The format is `{ \"hooks\": { \"EventName\": [...] } }`. Plugin `settings.json` is only for agent settings — do not put hooks or permissions there."
+      },
+      "metadata": {
+        "priority": "high"
+      }
+    },
+    {
+      "title": "Session-scoped state in hooks",
+      "body": {
+        "priority": "Low",
+        "what-happened": "Agent stored runtime state in a global variable within a hook script, expecting it to persist across hook invocations. The state was lost because each hook invocation runs in a fresh shell process. A related pattern: agent wrote hook state to `/tmp/claude-state.json` (a fixed filename) expecting it to persist within the session, but a second concurrent Claude session overwrote the file mid-run, corrupting the first session's state.",
+        "user-feedback": "Hook state must be persisted to disk with session-scoped filenames. In-memory state and shared filenames both fail under real usage conditions.",
+        "correct-approach": "When a hook needs to persist state across invocations within the same session (e.g., tracking start time, accumulating counts, caching decisions), write it to disk using the naming convention `~/.claude/{purpose}_state_{session_id}.json` or `/tmp/claude-{purpose}-{session_id}`. The `session_id` is available in every hook payload's stdin JSON — read it with `jq .session_id`. Implement cleanup: either a TTL-based probabilistic approach (each invocation has a small chance of deleting files older than N hours) or a dedicated cleanup in the Stop hook. Never use a single shared filename like `/tmp/claude-state.json` — it breaks under concurrent sessions."
+      },
+      "metadata": {
+        "priority": "low"
+      }
+    }
+  ],
+  "opening": "Environment, process management, hooks, and infrastructure mistakes that damage the user's setup."
+}

--- a/.claude/skills/_gotcha/project-gotcha.json
+++ b/.claude/skills/_gotcha/project-gotcha.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "gobbi-docs/child",
+  "parent": "_gotcha",
+  "title": "Project Gotcha",
+  "opening": "Project-specific gotchas capture mistakes that only matter in one project's context. They live alongside the project's documentation, not in the shared `_gotcha/` skill files.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "A gotcha is project-specific if it would mislead agents on other projects.",
+          "body": "The test is confusion, not domain. If recording a mistake in `_gotcha/` would cause agents on unrelated projects to second-guess a correct approach, it belongs in the project's own gotcha files instead. Project gotchas are scoped to one project; they cannot produce false positives elsewhere."
+        },
+        {
+          "type": "principle",
+          "statement": "Project context creates project gotchas.",
+          "body": "Choices that are correct in one project and wrong in another are project-specific by definition. Naming conventions, framework idioms, deployment quirks, team preferences — these are context-dependent. A cross-project gotcha that says \"always use X\" breaks the project that uses Y."
+        }
+      ]
+    },
+    {
+      "heading": "Where Project Gotchas Live",
+      "content": [
+        {
+          "type": "text",
+          "value": "Project-specific gotchas go in `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/gotchas/{category}.md`.\n\nThe `{category}` groups related mistakes — use the same categories as the central `_gotcha/` files when the domain matches, or invent a category when the mistake is unique to the project. Read the existing project directory for context before choosing a category name."
+        }
+      ]
+    },
+    {
+      "heading": "Deciding Where to Record",
+      "content": [
+        {
+          "type": "text",
+          "value": "**Record in the project's `gotchas/`** when:"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "The mistake only applies because of this project's choices (framework, architecture, conventions, tooling)",
+            "The correct approach differs from what agents would do in a generic context",
+            "Recording it centrally would confuse agents on unrelated projects"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**Record in `_gotcha/{skill}.md`** when:"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "The mistake can happen on any project using the same skill",
+            "The correct approach is universally better, regardless of project context",
+            "The pattern recurs across projects, not just this one"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**When unsure:** default to project-specific. It is easier to escalate a gotcha upward than to clean up false positives that have already misled agents elsewhere."
+        }
+      ]
+    },
+    {
+      "heading": "Escalating to Cross-Project",
+      "content": [
+        {
+          "type": "text",
+          "value": "A project gotcha becomes cross-project when the same mistake appears on multiple unrelated projects — meaning the root cause is the skill or workflow, not the project's specific context.\n\nBefore escalating, check whether the existing project gotcha has a broader lesson. Sometimes the project-specific version captures one symptom and the cross-project version captures the pattern that caused it. Both can coexist: the central file holds the universal principle, the project file holds the concrete instance.\n\nEscalation is a deliberate act — move the entry, do not duplicate it. Duplication creates two sources of truth that drift apart."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_gotcha/skills-gotcha.json
+++ b/.claude/skills/_gotcha/skills-gotcha.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "gobbi-docs/child",
+  "parent": "_gotcha",
+  "title": "Skills Gotcha",
+  "opening": "Skill-specific gotchas live inside the skill directory they serve: `$CLAUDE_PROJECT_DIR/.claude/skills/{skill-name}/gotchas.md`, alongside the skill's `SKILL.md`.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Gotchas belong to the skill they correct.",
+          "body": "A gotcha about `_plan` belongs in `$CLAUDE_PROJECT_DIR/.claude/skills/_plan/gotchas.md`. The agent loading `_plan` reads its own gotchas without loading a separate skill. Locality ensures the agent always checks gotchas — no extra loading step to forget."
+        },
+        {
+          "type": "principle",
+          "statement": "Cross-cutting gotchas stay in `_gotcha/`.",
+          "body": "The `_gotcha` skill holds entries that span multiple skills or belong to no single skill — infrastructure, environment, security, system-level concerns. If a gotcha can be owned by one skill, it belongs in that skill's directory."
+        }
+      ]
+    },
+    {
+      "heading": "What Goes Where",
+      "content": [
+        {
+          "type": "text",
+          "value": "**Write to `$CLAUDE_PROJECT_DIR/.claude/skills/{skill-name}/gotchas.md`** when:"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "The gotcha directly corrects behavior that happens while executing that skill",
+            "The agent making the mistake was working within the skill's scope"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**Write to `_gotcha/` central files** when:"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "The gotcha cuts across multiple skills and cannot be owned by one",
+            "No single skill exists yet for the domain (infrastructure, environment, security)"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Migration",
+      "content": [
+        {
+          "type": "text",
+          "value": "Existing entries in `_gotcha/{skill}.md` central files are not automatically moved. They remain valid and readable. When you update or reference an entry from a central file, move it to the skill's own `gotchas.md` if it belongs there. Do not leave duplicates — delete the central entry after moving.\n\nThe `_gotcha/` central files for skill-specific gotchas (`_orchestration.md`, `_plan.md`, etc.) will gradually empty as entries migrate to their owning skills. Cross-cutting files (`__system.md`, `__security.md`) remain in `_gotcha/` permanently."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_ideation-evaluation/SKILL.json
+++ b/.claude/skills/_ideation-evaluation/SKILL.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_ideation-evaluation",
+    "description": "MUST load when evaluating ideation output. Stage-specific criteria for assessing whether an idea is concrete, well-researched, and ready for planning. Used by all 6 evaluator perspectives (Project, Architecture, Performance, Aesthetics, Overall, User).",
+    "allowed-tools": "Read, Grep, Glob, Bash"
+  },
+  "title": "Ideation Evaluation",
+  "opening": "Stage-specific evaluation criteria for ideation output. Load this skill alongside _evaluation when evaluating the result of an ideation step.\n\nThe ideation output should be a refined, detailed idea — not a vague direction. If you can't plan from it, it's not ready.",
+  "sections": [
+    {
+      "heading": "What You're Evaluating",
+      "content": [
+        {
+          "type": "text",
+          "value": "The ideation step produces an idea document that should cover: root problem, proposed approach with concrete mechanism, constraints and scope, research findings, risks and trade-offs, and success criteria. Evaluate against the criteria below."
+        }
+      ]
+    },
+    {
+      "heading": "Evaluation Criteria",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Problem Understanding",
+          "content": [
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**Root cause identified?** — Is the idea solving the actual problem, or just a symptom? If the user said \"we need caching\" but the real issue is unoptimized queries, the idea should address queries, not caching.",
+                "**Impact justified?** — Is the scope of the proposed solution proportional to the severity of the problem? A minor UX annoyance doesn't warrant an architectural overhaul.",
+                "**Success criteria measurable?** — Can you objectively determine whether the idea worked? \"Better performance\" fails. \"P95 latency under 200ms on /search\" passes."
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Concreteness",
+          "content": [
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**Mechanism described?** — Can you trace the data flow from input to output? If the idea says \"use an event-driven approach\" but doesn't specify what events, what consumers, what happens on failure — it's too abstract.",
+                "**Key interfaces defined?** — Are the boundaries between components clear? What goes in, what comes out, what format?",
+                "**Plannable?** — Could a planner decompose this into specific tasks right now? If the idea needs more detail before planning, it's not done."
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Trade-offs and Risks",
+          "content": [
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**Trade-offs explicit?** — Does the idea state what it optimizes AND what it sacrifices? Every approach has costs. If none are stated, they're hidden, not absent.",
+                "**Risks identified?** — What could go wrong? Are failure modes named with severity? Is there a fallback?",
+                "**Assumptions surfaced?** — What must be true for this idea to work? Are those assumptions validated or just hoped for?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Constraints and Scope",
+          "content": [
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**Hard constraints respected?** — Does the idea violate any non-negotiable requirements (tech stack, compliance, performance thresholds)?",
+                "**Scope bounded?** — Is it clear what's included and what's explicitly NOT included? Unbounded scope means unbounded work.",
+                "**Assumed constraints challenged?** — Were constraints questioned during ideation, or just accepted? False constraints narrow the solution space unnecessarily."
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Completeness",
+          "content": [
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**Research done?** — Were relevant prior art, patterns, and libraries investigated? Or is this the first idea that came to mind?",
+                "**Alternatives considered?** — Was the idea stress-tested against alternatives? An idea that survived comparison is stronger than one that was never challenged.",
+                "**Edge cases addressed?** — Are boundary conditions and unusual inputs considered? At minimum, the idea should acknowledge which edge cases it handles vs. defers."
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Perspective-Specific Focus",
+      "content": [
+        {
+          "type": "table",
+          "headers": [
+            "Perspective",
+            "Primary Focus"
+          ],
+          "rows": [
+            [
+              "Project",
+              "Does the idea solve the right problem? Scope and requirements alignment."
+            ],
+            [
+              "Architecture",
+              "Is the proposed mechanism structurally sound? Coupling, abstraction level."
+            ],
+            [
+              "Performance",
+              "Are efficiency implications considered? Scalability risks identified."
+            ],
+            [
+              "Aesthetics",
+              "Is the idea clearly articulated? Would a fresh reader understand it?"
+            ],
+            [
+              "Overall",
+              "What cross-cutting gaps exist? What must be preserved?"
+            ],
+            [
+              "User",
+              "Does the idea serve the user's actual need? Will they understand the approach?"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Scoring Guidance",
+      "content": [
+        {
+          "type": "text",
+          "value": "Ideation findings naturally trend toward lower confidence than plan or execution findings. Ideas are abstract — mechanism descriptions, trade-off assessments, and risk predictions are harder to verify concretely.\n\nExpect confidence scores in the 60-70 range for many legitimate ideation concerns. A finding like \"this approach may not scale under load X\" is a real concern worth surfacing even at confidence 65, because ideation is the cheapest place to catch architectural problems.\n\nWhen scoring ideation findings, severity matters more than confidence for decision-making. A high-severity, moderate-confidence finding (\"this architecture may have a fundamental scaling flaw\") deserves discussion even if confidence is below the default threshold. Evaluators should flag such findings for the orchestrator rather than letting them be silently filtered."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_ideation/SKILL.json
+++ b/.claude/skills/_ideation/SKILL.json
@@ -1,0 +1,178 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_ideation",
+    "description": "MUST load at the start of the Ideation step of workflow. Improves and details the user's idea through structured discussion. Suggests discussion points that challenge vague thinking, uncover hidden requirements, and refine a rough idea into a concrete proposal ready for evaluation.",
+    "allowed-tools": "AskUserQuestion, Read, Grep, Glob, Bash"
+  },
+  "title": "Gobbi Ideation Skill",
+  "opening": "Improve and make the user's idea or prompt more detailed through structured discussion. This skill provides discussion points that help the agent challenge vague thinking, uncover hidden requirements, and refine a rough idea into a concrete, fully specified proposal ready for evaluation.\n\nThe output of ideation is a detailed, improved idea — not a final decision. A separate evaluator assesses the result.",
+  "sections": [
+    {
+      "heading": "Core Principles",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Discuss first. Use AskUserQuestion to understand and refine the user's idea.",
+          "body": "The user has an idea. Your job is to make it better through discussion. Ask questions that expose what's vague, what's missing, and what could be stronger. Every question should either clarify the idea or push it toward more detail."
+        },
+        {
+          "type": "principle",
+          "statement": "Challenge assumptions, not the user.",
+          "body": "Every idea embeds assumptions — about the problem, the constraints, the approach, the technology. Surface these assumptions explicitly and question each one respectfully. Use inversion: \"What would make this fail?\" Use reframing: \"What if the real problem is actually X?\" The user's framing may not be the best framing, but the user's intent is always the anchor."
+        },
+        {
+          "type": "principle",
+          "statement": "Push from vague to concrete. Abstract ideas can't be evaluated or planned.",
+          "body": "\"Make it faster\" is a wish. \"Reduce P95 latency on the /search endpoint from 800ms to 200ms by adding a Redis cache layer in front of the Postgres full-text search\" is an idea. Every round of discussion should move the idea closer to this level of specificity — mechanisms, interfaces, data flows, measurable criteria."
+        },
+        {
+          "type": "principle",
+          "statement": "Explore alternatives to strengthen, not to replace.",
+          "body": "Generating alternative approaches isn't about picking a winner — it's about stress-testing the idea. If the user's idea survives comparison against alternatives, it's stronger. If an alternative reveals a weakness, that weakness gets addressed. Alternatives serve the idea."
+        },
+        {
+          "type": "principle",
+          "statement": "Make trade-offs visible. Every choice has costs.",
+          "body": "When the idea involves a choice between approaches, don't present one as \"clearly best.\" State what each option optimizes, what it sacrifices, and what it assumes. The user decides which trade-offs are acceptable — your job is to make the trade-offs visible."
+        }
+      ]
+    },
+    {
+      "heading": "Discussion Points",
+      "content": [
+        {
+          "type": "text",
+          "value": "Use these as a menu of discussion topics to raise with the user via AskUserQuestion. Not every idea needs every point — pick the ones that address what's vague or missing in this specific idea."
+        },
+        {
+          "type": "subsection",
+          "heading": "Understanding the Problem",
+          "content": [
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**Root cause** — Is the stated problem the real problem, or a symptom? Ask \"why\" repeatedly until you reach the root. \"We need caching\" → why? → DB is slow → why? → queries unoptimized. The idea might need to shift.",
+                "**Impact** — Who is affected? How severely? What happens if we do nothing? This calibrates how much effort and complexity the idea justifies.",
+                "**Prior attempts** — What's been tried before? What worked, what didn't, and why? Avoids repeating past failures.",
+                "**Success criteria** — How will we know the idea worked? Define measurable criteria before refining the approach, so discussion stays grounded."
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Mapping Constraints",
+          "content": [
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**Hard constraints** — Non-negotiable boundaries (tech stack, compatibility, regulatory, performance thresholds). These shape the idea's boundaries.",
+                "**Soft constraints** — Preferences that could be traded away if the gain is worth it (timeline, team familiarity, consistency with patterns).",
+                "**Assumed constraints** — Constraints taken for granted that may not be real. Challenge each: \"Where did this come from? Is it still valid? What opens up if we remove it?\"",
+                "**Dependencies** — What does this depend on? What depends on this? External systems, team bandwidth, parallel work."
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Deepening the Idea",
+          "content": [
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**First principles** — Strip away the current approach. What are the fundamental requirements? If you built from scratch, what would you do? This reveals whether the idea is optimizing the right thing.",
+                "**Inversion / pre-mortem** — Imagine the idea has been implemented and failed. What went wrong? Turn each failure mode into a requirement the idea must address.",
+                "**Analogy** — Has a similar problem been solved in a different domain? Adapt proven patterns. Cross-domain solutions often reveal approaches that domain insiders overlook.",
+                "**SCAMPER** — Systematically probe the idea: Could we substitute a component? Combine two steps? Eliminate a layer? Reverse a flow? Each probe either strengthens the current idea or reveals an improvement.",
+                "**Constraint removal** — Temporarily remove each hard constraint. What becomes possible? Then selectively reintroduce. Sometimes a \"hard\" constraint is actually negotiable, and removing it dramatically simplifies the idea."
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Making It Concrete",
+          "content": [
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**Mechanism** — How does it actually work? What's the data flow? What are the key interfaces?",
+                "**Scope boundary** — What's included and what's explicitly not? Where does this idea end?",
+                "**Edge cases** — What happens with empty inputs, maximum load, concurrent access, failures? Which edge cases must the idea handle vs. which are out of scope?",
+                "**Risks** — What could go wrong? What are the unknowns? What would require a spike or prototype to validate?",
+                "**Trade-offs** — What does this approach optimize for? What does it sacrifice? What alternatives were considered and why were they not chosen?"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Contribution Points",
+      "content": [
+        {
+          "type": "text",
+          "value": "After refining an idea, consider whether any remaining decisions are contribution points — judgment calls where the user's domain knowledge would produce a better outcome than agent discretion.\n\nThis is distinct from specification gaps (which _discuss resolves). Contribution points arise even after the idea is fully specified, where multiple valid approaches exist and the right choice depends on knowledge the user holds but has not transferred through Q&A.\n\nIndicators that a decision is a contribution point:"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Business logic with multiple valid approaches where the user's domain shapes the right choice",
+            "Architectural trade-offs between competing values the user has not ranked (performance vs. simplicity, flexibility vs. consistency)",
+            "Error handling and resilience strategies where the user's user base, SLA, or failure tolerance matters"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "For each identified contribution point, use AskUserQuestion before the plan is written. The user's answer becomes a constraint the plan encodes — not a suggestion for the planner to interpret.\n\nNot every task has contribution points. Context-resolvable decisions — where the codebase, constraints, or prior discussion already determines the right approach — do not need this treatment. Apply judgment."
+        }
+      ]
+    },
+    {
+      "heading": "Output",
+      "content": [
+        {
+          "type": "text",
+          "value": "Ideation produces a single refined, detailed idea — concrete enough that a planner can decompose it into tasks and an evaluator can assess its quality. The output should include:"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "The problem being solved (root cause, not symptom)",
+            "The proposed approach with concrete mechanism",
+            "Constraints and scope boundaries",
+            "Known risks and trade-offs",
+            "Success criteria"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "This output goes to a separate evaluator agent for critical assessment before proceeding to planning. The orchestrator selects the appropriate domain evaluator (`_skills-evaluator`, `_agent-evaluator`, or `_project-evaluator`) and loads the relevant perspective skills based on the nature of the ideation output."
+        }
+      ]
+    },
+    {
+      "heading": "Constraints",
+      "content": [
+        {
+          "type": "constraint-list",
+          "items": [
+            "Never skip discussion — always use AskUserQuestion to refine the idea with the user",
+            "Never accept a vague idea as ready — push toward concrete mechanisms, interfaces, and criteria",
+            "Never ignore the user's intent — challenge assumptions, but anchor to what the user wants",
+            "Never present alternatives as replacements — use them to stress-test and strengthen the idea",
+            "Always read relevant codebase before discussing approaches — existing patterns inform the discussion"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_memorization/SKILL.json
+++ b/.claude/skills/_memorization/SKILL.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_memorization",
+    "description": "Save context for session continuity at Step 5 of the workflow. Persists task details, gotchas, and rules to .claude/project/{project-name}/.",
+    "allowed-tools": "Read, Grep, Glob, Bash, Write, Edit, AskUserQuestion"
+  },
+  "title": "Memorization",
+  "opening": "Save context that enables the user to continue this work in a new session. This is Step 5 of the workflow — runs after Collection, before phase transition.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Every session should leave the project smarter than it found it.",
+          "body": "The value of memorization is cumulative. Each session adds context that makes the next session faster, more accurate, and less likely to repeat mistakes."
+        },
+        {
+          "type": "principle",
+          "statement": "Gotchas describe what to avoid. Rules describe what to follow.",
+          "body": "These are the two forms of persistent learning. Gotchas capture mistakes — \"we tried X and it failed because Y.\" Rules capture conventions — \"in this project, always do Z.\" Both live under `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/` and are read at session start."
+        },
+        {
+          "type": "principle",
+          "statement": "Memorize for the next agent, not for yourself.",
+          "body": "Write as if the reader has no context from this session. Include the why, not just the what. A gotcha without explanation is a rule without rationale — it gets followed blindly or ignored."
+        }
+      ]
+    },
+    {
+      "heading": "What to Memorize",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Task Details",
+          "content": [
+            {
+              "type": "text",
+              "value": "If the task is incomplete or part of a larger plan, record what was done, what remains, and what decisions were made. Update existing project docs or create new ones in the appropriate subdirectory of `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/`.\n\nUse AskUserQuestion to ask the user:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Is this task part of a larger plan?",
+                "What context should the next session know?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Gotchas — \"Must Avoid\"",
+          "content": [
+            {
+              "type": "text",
+              "value": "Record corrections discovered during the workflow. A gotcha exists because something went wrong and the correct approach was non-obvious.\n\nWrite to `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/gotchas/`. Follow the `project-gotcha.md` child doc of _gotcha for format and categorization.\n\nWhen to write:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "User corrected an agent's approach",
+                "A debugging session revealed a non-obvious root cause",
+                "A platform or environment quirk caused unexpected behavior"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Rules — \"Must Follow\"",
+          "content": [
+            {
+              "type": "text",
+              "value": "Record conventions and standards discovered or established during the workflow. A rule exists because a consistent pattern should be followed across the project.\n\nWrite to `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/rules/`. Follow the _rules skill for format and structure.\n\nWhen to write:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "A decision was made about how something should always be done in this project",
+                "A pattern emerged that should be consistent across future sessions",
+                "The user explicitly stated a preference or standard"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Project Docs",
+          "content": [
+            {
+              "type": "text",
+              "value": "Update `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/design/` or `README.md` if the workflow revealed new architectural knowledge, conventions, or decisions worth persisting.\n\nWhen to update:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "The workflow uncovered how a system works that was not previously documented",
+                "An architectural decision was made that affects future work",
+                "The project README is missing or outdated after this session's changes"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Constraints",
+      "content": [
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Always use AskUserQuestion to confirm what to memorize — never assume the user wants everything saved",
+            "Never memorize ephemeral task details (temp file paths, debug output, intermediate state)",
+            "Never duplicate information already in the codebase or git history",
+            "Keep memorized content concise — a future agent should load it quickly at session start",
+            "Gotchas and rules must be actionable — each entry should change an agent's behavior"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_note/SKILL.json
+++ b/.claude/skills/_note/SKILL.json
@@ -1,0 +1,234 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_note",
+    "description": "Write notes at every workflow step. Use to record decisions, outcomes, and context at each stage — ideation, plan, execution, feedback, and review.",
+    "allowed-tools": "Write, Read, Glob, Bash"
+  },
+  "title": "Note",
+  "opening": "Write notes at every workflow step to persist decisions, outcomes, and context. Notes are the permanent record of what was discussed, decided, and delivered.\n\n> **Notes must contain full content, never summaries.**\n\nEvery note file must be detailed enough that a reader who has no access to the conversation can fully reconstruct what happened. Write the actual content — the complete plan, the full evaluation findings, the detailed execution outcomes. A one-paragraph summary is not a note. If it takes 100 lines to capture what happened, write 100 lines. The plan file from EnterPlanMode, the evaluation results, the discussion decisions — all of it goes into the note verbatim or near-verbatim.",
+  "sections": [
+    {
+      "heading": "Where to Write",
+      "content": [
+        {
+          "type": "text",
+          "value": "Notes go in `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/note/`:\n\n```\n.claude/project/{project-name}/note/\n  README.md                                               — index of all task note directories\n  {YYYYMMDD-HHMM}-{slug}-{session_id}/\n    README.md                                             — session context metadata (YAML frontmatter)\n    ideation.md                                           — ideas explored, trade-offs, chosen approach\n    plan.md                                               — plan details, task decomposition, dependencies\n    execution.md                                          — execution outcomes, issues encountered\n    feedback.md                                           — user feedback rounds, corrections made\n    review.md                                             — review findings, verification results\n    memorize.md                                           — what was memorized for session continuity\n    subtasks/\n      {NN}-{subtask-slug}.json                             — extracted subagent record (delegation prompt + final result)\n```"
+        },
+        {
+          "type": "subsection",
+          "heading": "Naming",
+          "content": [
+            {
+              "type": "text",
+              "value": "**Task directory**: `{YYYYMMDD-HHMM}-{slug}-{session_id}` — datetime prefix for chronological ordering with minute precision, slug for readability, full session UUID at the end for machine cross-referencing. The `session_id` is the full session UUID, available via `$CLAUDE_SESSION_ID`. Example: `20260328-0706-doc-review-ed5b2db3-7d89-4208-a25b-8ad0889a0c80`."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Initialization",
+          "content": [
+            {
+              "type": "principle",
+              "statement": "Always use note-init.sh to create note directories. Never mkdir manually, never reference `$CLAUDE_SESSION_ID` directly.",
+              "body": "Initialize note directories using the `note-init.sh` script in `_note/scripts/`. It takes the project name and task slug as arguments and outputs the created directory path. It handles the full chain: session metadata extraction, directory creation, README.md generation with session context, and subtasks/ directory setup."
+            },
+            {
+              "type": "text",
+              "value": "After each subagent returns, run `subtask-collect.sh` (also in `_note/scripts/`) to extract the delegation prompt and final result from the subagent's JSONL transcript into `subtasks/{NN}-{subtask-slug}.json`. The script handles transcript parsing and JSON formatting — no manual Write calls needed.\n\nIf `note-init.sh` fails because `CLAUDE_SESSION_ID` is not set, the SessionStart hook did not run — investigate the hook configuration, don't work around it."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "What to Write at Each Step",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "README.md (per task directory)",
+          "content": [
+            {
+              "type": "text",
+              "value": "Session context for the task, created automatically by the note-init script. Contains YAML frontmatter with: session_id, datetime, git_branch, cwd, claude_model, transcript path, and task name. This anchors every note file in the directory to a specific session, making it possible to trace back to the original conversation."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "ideation.md",
+          "content": [
+            {
+              "type": "text",
+              "value": "Record during Step 1 (Ideation Loop). Must be detailed enough that a reader can reconstruct the full ideation without reading the conversation:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "The initial user prompt — verbatim or near-verbatim capture of what the user asked for",
+                "Discussion points — each question asked, options presented, and user's responses",
+                "Options explored with full trade-off analysis — not just names, but the reasoning",
+                "Evaluation feedback from evaluator agents (if evaluation was performed)",
+                "Discussion about evaluation — what was agreed to address vs defer",
+                "The final refined idea with full detail — concrete enough to plan from"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "plan.md",
+          "content": [
+            {
+              "type": "text",
+              "value": "Record during Step 2 (Plan Loop). Must contain the complete plan, not a summary:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "The complete decomposed tasks with agent assignments, skills, scope boundaries, and dependencies",
+                "Execution order with parallelism and wave structure",
+                "Evaluation feedback from evaluator agents (if evaluation was performed)",
+                "Discussion about evaluation — what was revised and why",
+                "What the user adjusted during discussion",
+                "The final approved plan in full"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "execution.md",
+          "content": [
+            {
+              "type": "text",
+              "value": "Record during Step 3 (Execution — Delegation). Must document each subtask in enough detail to understand what happened:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Which subtasks were delegated to which agents, with the key context provided",
+                "Per-subtask outcomes — what the agent produced, key findings or changes",
+                "Execution evaluation results per subtask",
+                "Issues encountered and how they were resolved",
+                "Any deviations from the plan and why"
+              ]
+            },
+            {
+              "type": "text",
+              "value": "When documenting evaluation results in execution.md, organize findings by severity tier — Critical findings first, then Important, then Suggestions, then Strengths — rather than by evaluator perspective. Severity-tiered presentation surfaces actionable items first and makes blocking issues visible across all subtasks at a glance.\n\nRecord pre-action verification outcomes when they catch a precondition failure (wrong branch, duplicate PR, stale state). Verification that passes silently needs no note — only record when verification catches a real problem, as these are valuable learning inputs for gotchas."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "subtasks/{NN}-{subtask-slug}.json",
+          "content": [
+            {
+              "type": "text",
+              "value": "Extracted from subagent JSONL transcripts via `subtask-collect.sh` during Step 3. Each JSON file contains the delegation prompt and the subagent's final result — the two pieces needed to reconstruct what was asked and what was delivered."
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "One file per subtask, zero-padded sequence number for ordering",
+                "Extracted automatically — the orchestrator calls the script after each subagent returns, not batched at collection",
+                "Contains the full delegation prompt and full final result as structured JSON, not summaries"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "feedback.md",
+          "content": [
+            {
+              "type": "text",
+              "value": "Record during Phase 2 (FEEDBACK):"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Each feedback round: what the user said, what changed",
+                "Gotchas recorded from corrections",
+                "Append each round — do not overwrite previous rounds"
+              ]
+            },
+            {
+              "type": "text",
+              "value": "Number each feedback round explicitly (Round 1, Round 2, ...). Numbered rounds enable stagnation detection — if the same finding reappears across 3 rounds without convergence, the pattern becomes visible and actionable. Include what remains unresolved after each round, not just what changed."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "review.md",
+          "content": [
+            {
+              "type": "text",
+              "value": "Record during Phase 3 (REVIEW):"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Review scope and focus areas",
+                "Verification findings",
+                "Issues found and resolution status"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "memorize.md",
+          "content": [
+            {
+              "type": "text",
+              "value": "Record during Step 5 (Memorization). Must document what was persisted for session continuity:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Task details memorized — what was done, what remains, broader plan context",
+                "Gotchas written to `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/gotchas/` — list each with a one-line summary",
+                "Rules written to `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/rules/` — list each with a one-line summary",
+                "Project docs updated — which files in `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/` were created or modified and why"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "README.md",
+      "content": [
+        {
+          "type": "text",
+          "value": "The index file is a markdown table listing each task directory with its date, session, slug, and a one-line summary of what the task delivered.\n\nMust update README.md after creating each new task note directory."
+        }
+      ]
+    },
+    {
+      "heading": "When to Write",
+      "content": [
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "**Always write** at the end of each workflow step — ideation, plan, execution, feedback, review, memorization.",
+            "**Write immediately** — do not defer note-writing to the end. Each step's note must be written before proceeding to the next step.",
+            "**Skip only** when the task was trivial and handled directly without delegation."
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_note/gotchas.json
+++ b/.claude/skills/_note/gotchas.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "gobbi-docs/gotcha",
+  "parent": "_note",
+  "title": "Gotcha: _note",
+  "entries": [
+    {
+      "title": "Notes too short — must include full detail",
+      "body": {
+        "priority": "High",
+        "what-happened": "Note files (ideation.md, plan.md, execution.md) were written as brief summaries — a few bullet points and one-line descriptions. They lacked the actual content that would let a future reader reconstruct what happened without reading the conversation.",
+        "user-feedback": "Note docs should be detailed. ideation.md specifically should include the initial user prompt, discussion points, and final idea.",
+        "correct-approach": "Each note file must be self-contained and detailed enough that someone reading it later can fully understand what happened: - **ideation.md** — initial user prompt (verbatim or near-verbatim), discussion questions asked and answers received, options explored with trade-offs, evaluation feedback if performed, the final refined idea with full detail - **plan.md** — the complete plan with all tasks, agent assignments, dependencies, evaluation feedback, user adjustments - **execution.md** — per-subtask delegation details, agent outputs, evaluation results, issues and resolutions, deviations from plan - **feedback.md / review.md** — each round with full context Notes are the permanent record. A reader should never need to ask \"what was the original request?\" or \"what did they discuss?\" — it should all be in the notes."
+      }
+    },
+    {
+      "title": "Must use note-init.sh — never create note directories manually",
+      "body": {
+        "priority": "Critical",
+        "what-happened": "The orchestrator tried to create a note directory with `mkdir -p` and manually checked `$CLAUDE_SESSION_ID` (which wasn't set). It bypassed the `note-init.sh` script that handles session metadata extraction, directory creation, README generation, and subtasks/ setup in a single call.",
+        "user-feedback": "\"Did you use session-metadata.sh? Must run session-metadata.sh first.\"",
+        "correct-approach": "Always use `bash .claude/skills/_note/scripts/note-init.sh <project-name> <task-slug>` to create note directories. Never `mkdir` manually, never reference `$CLAUDE_SESSION_ID` directly. The script chains through `note-metadata.sh` which reads from `$CLAUDE_SESSION_ID` (set by the SessionStart hook). If the script fails because `CLAUDE_SESSION_ID` is not set, investigate the hook — don't work around it."
+      }
+    }
+  ],
+  "opening": "Mistakes in note writing, directory structure, and timing."
+}

--- a/.claude/skills/_notification/SKILL.json
+++ b/.claude/skills/_notification/SKILL.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_notification",
+    "description": "Help users configure Claude Code notifications (Slack, Telegram, and others) through conversation. Use when the user wants to set up, modify, or troubleshoot notification settings.",
+    "allowed-tools": "Read, Grep, Glob, Bash, Write, Edit, AskUserQuestion"
+  },
+  "title": "Notification",
+  "opening": "Help users configure Claude Code notification credentials through conversation. Hooks and settings should already be installed in the project — this skill handles the credential setup that makes them work.",
+  "sections": [
+    {
+      "heading": "Credential Setup",
+      "content": [
+        {
+          "type": "text",
+          "value": "The goal is to collect notification credentials from the user, save them securely, and verify that at least one real notification arrives before confirming success.\n\n**Constraints:**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Use AskUserQuestion for all credential collection — never assume or prefill values",
+            "Save credentials to `$CLAUDE_PROJECT_DIR/.claude/.env` — this file is read by `load-notification-env.sh` at session start via the `$CLAUDE_ENV_FILE` mechanism",
+            "Before finishing, verify that `$CLAUDE_PROJECT_DIR/.claude/.env` is listed in `.gitignore` — credentials must never be committed",
+            "Test with a real notification before confirming setup is complete — a configuration that looks correct but never delivers is not set up"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**Credentials needed per channel:**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "**Slack:** A bot token (starts with `xoxb-`) and a user ID or channel ID to receive messages. Obtain from https://api.slack.com/apps — create an app, add `chat:write` scope, install to workspace.",
+            "**Telegram:** A bot token and a chat ID. Obtain by creating a bot via @BotFather on Telegram.",
+            "**Desktop:** No credentials — set `NOTIFY_DESKTOP=true`. Requires `notify-send` (Linux) or `osascript` (macOS).",
+            "**Custom webhook:** A URL and any required auth headers. Follow the same environment variable pattern as the other channels."
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**Credentials file format:** One `KEY=value` per line, no `export` prefix — the hook script adds it. Blank lines and `#` comments are ignored. File permissions must be 600 (enforced at session start automatically)."
+        }
+      ]
+    },
+    {
+      "heading": "Events and Matchers",
+      "content": [
+        {
+          "type": "text",
+          "value": "Claude Code hooks fire on named events. Each hook can be filtered by a `matcher` field — a regex pattern that limits when the hook fires. The full event and matcher reference is in the Claude Code hooks documentation — consult that as the authoritative source.\n\n**Most useful events for notifications:**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "`Stop` — fires when Claude finishes responding; most common for \"notify me when done\"",
+            "`SessionEnd` — fires when the session ends; useful for session tracking",
+            "`Notification` — fires when Claude Code raises a notification (permission prompts, idle prompts); useful for \"notify me when you need attention\""
+          ]
+        },
+        {
+          "type": "text",
+          "value": "When configuring event hooks, ask the user which events they want, then ask per-event which matcher values to use and which channels to route to. For each event, also confirm whether the hook should run async (recommended) or blocking."
+        }
+      ]
+    },
+    {
+      "heading": "Hook Scripts",
+      "content": [
+        {
+          "type": "text",
+          "value": "All scripts live in `$CLAUDE_PROJECT_DIR/.claude/hooks/` and must be executable. They use a shared sender (`notify-send.sh`) that routes to all configured channels based on environment variables loaded from `$CLAUDE_ENV_FILE`.\n\nHook scripts should already be installed in `$CLAUDE_PROJECT_DIR/.claude/hooks/`. Read the installed scripts and the hook configuration in `settings.json` for the current setup — these are the authoritative source for what is actually installed.\n\nMessage truncation limits are configurable via `$CLAUDE_PROJECT_DIR/.claude/.env`. Defaults are defined in the notification scripts."
+        }
+      ]
+    },
+    {
+      "heading": "Verification",
+      "content": [
+        {
+          "type": "text",
+          "value": "If a test notification fails to arrive: check that `$CLAUDE_PROJECT_DIR/.claude/.env` exists, values are correct, the hook scripts are executable, and `jq` is available (scripts depend on it for JSON parsing). Delivery failures are logged — check `~/.claude/notification-failures.log` if notifications stop arriving."
+        }
+      ]
+    },
+    {
+      "heading": "Child Skills",
+      "content": [
+        {
+          "type": "table",
+          "headers": [
+            "Skill",
+            "Covers"
+          ],
+          "rows": [
+            [
+              "`_slack`",
+              "Slack notification channel setup — bot token, user ID, workspace configuration"
+            ],
+            [
+              "`_telegram`",
+              "Telegram notification channel setup — bot creation via @BotFather, chat ID retrieval"
+            ],
+            [
+              "`_discord`",
+              "Discord notification channel setup — webhook URL configuration"
+            ]
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_notification/gotchas.json
+++ b/.claude/skills/_notification/gotchas.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "gobbi-docs/gotcha",
+  "parent": "_notification",
+  "title": "Gotcha: _notification",
+  "entries": [
+    {
+      "title": "Stop hook infinite loop",
+      "body": {
+        "priority": "Critical",
+        "what-happened": "A hook registered on the `Stop` event called back into Claude Code without checking whether it was already inside a Stop hook. This caused the hook to fire again on its own completion, looping indefinitely.",
+        "user-feedback": "Always check `stop_hook_active` in the input JSON and exit early if `true`.",
+        "correct-approach": "At the start of any Stop hook script, parse the input JSON and check the `stop_hook_active` field. If it is `true`, exit immediately without taking any action."
+      }
+    },
+    {
+      "title": "Missing jq breaks all notification scripts",
+      "body": {
+        "priority": "High",
+        "what-happened": "Notification scripts depend on `jq` for JSON parsing of hook input. On systems without `jq` installed, every hook silently failed. The failures were not obvious because the scripts exited without output.",
+        "user-feedback": "Check for `jq` availability before assuming scripts will work.",
+        "correct-approach": "When setting up notifications, verify that `jq` is available. If not, guide the user to install it before testing hooks. Delivery failures are logged to `~/.claude/notification-failures.log` — check this file when notifications stop arriving."
+      }
+    },
+    {
+      "title": "Script not executable",
+      "body": {
+        "priority": "High",
+        "what-happened": "Hook scripts were written to `.claude/hooks/` but never had `chmod +x` applied. Claude Code silently skipped them. The configuration looked correct but no notifications arrived.",
+        "user-feedback": "Always verify hook scripts are executable after writing them.",
+        "correct-approach": "After writing or updating any hook script, confirm it is executable. The gobbi installation process handles this, but manually added scripts need explicit `chmod +x`."
+      }
+    },
+    {
+      "title": "Credentials committed to version control",
+      "body": {
+        "priority": "Critical",
+        "what-happened": "Credentials were saved to `$CLAUDE_PROJECT_DIR/.claude/.env` but `.env` was not in `.gitignore`. The file was committed to the repository, exposing bot tokens and chat IDs.",
+        "user-feedback": "Credentials must never be committed. Always verify `.gitignore` protects `.env` before finishing setup.",
+        "correct-approach": "Before confirming setup complete, verify that `$CLAUDE_PROJECT_DIR/.claude/.env` is listed in `.gitignore`. If it is not, add it immediately and do not proceed until this is confirmed."
+      }
+    },
+    {
+      "title": "Shell profile noise corrupts hook JSON output",
+      "body": {
+        "priority": "High",
+        "what-happened": "Hook scripts sourced the user's shell profile (`.bashrc` or `.zshrc`). Profile files with `echo` statements or other output wrote to stdout, corrupting the JSON output that Claude Code reads from the hook.",
+        "user-feedback": "Scripts should not source shell profiles.",
+        "correct-approach": "Hook scripts must use `#!/bin/bash` without sourcing any profile. All needed environment variables come from `$CLAUDE_ENV_FILE`, not from the shell environment."
+      }
+    },
+    {
+      "title": "export prefix in .env file breaks loading",
+      "body": {
+        "priority": "Medium",
+        "what-happened": "Credentials were saved with `export KEY=value` format in `$CLAUDE_PROJECT_DIR/.claude/.env`. The `load-notification-env.sh` hook adds the `export` prefix when writing to `$CLAUDE_ENV_FILE` — the double prefix caused a syntax error, silently breaking credential loading.",
+        "user-feedback": "The `.env` file uses bare `KEY=value` format without `export`.",
+        "correct-approach": "Write credentials to `$CLAUDE_PROJECT_DIR/.claude/.env` as bare `KEY=value` lines. The hook script handles the `export` wrapping. Lines starting with `#` and blank lines are safely ignored."
+      }
+    },
+    {
+      "title": "Delivery failures disappear silently",
+      "body": {
+        "priority": "Medium",
+        "what-happened": "After initial setup, notifications stopped arriving. There was no obvious error — the hooks ran, scripts executed, but messages never arrived at Slack or Telegram. The failure was being logged but no one was checking the log.",
+        "user-feedback": "Check `~/.claude/notification-failures.log` when notifications stop arriving.",
+        "correct-approach": "When troubleshooting missing notifications, read `~/.claude/notification-failures.log` first. This file captures failures that would otherwise be invisible. Note that the log grows without bound — advise the user to delete it periodically if it becomes large."
+      }
+    }
+  ],
+  "opening": "Mistakes in configuring Claude Code notification hooks and credentials."
+}

--- a/.claude/skills/_orchestration/SKILL.json
+++ b/.claude/skills/_orchestration/SKILL.json
@@ -1,0 +1,471 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_orchestration",
+    "description": "Guide the orchestrator through the adaptive workflow. Use when coordinating multi-agent tasks, routing through workflow stages, or managing phase transitions.",
+    "allowed-tools": "Read, Grep, Glob, Bash, Write, Agent, Task, AskUserQuestion"
+  },
+  "title": "Orchestration",
+  "opening": "You are an orchestrator. You must delegate everything to specialist subagents except trivial cases. Must load _gotcha before proceeding.",
+  "navigation": {
+    "[feedback.md](feedback.md)": "FEEDBACK phase: iteration tracking, stagnation detection, targeted re-evaluation",
+    "[finish.md](finish.md)": "FINISH phase: merge/commit/compact decision tree, pre-action verification"
+  },
+  "sections": [
+    {
+      "heading": "Task Routing",
+      "content": [
+        {
+          "type": "text",
+          "value": "Every incoming task falls into one of three tiers. The user never selects a tier — they describe what they want, and the orchestrator classifies internally. This preserves the single entry point."
+        },
+        {
+          "type": "principle",
+          "statement": "When uncertain, default to non-trivial.",
+          "body": "It is cheaper to skip unnecessary ideation than to redo work that lacked structure."
+        },
+        {
+          "type": "table",
+          "headers": [
+            "Tier",
+            "Test",
+            "What happens"
+          ],
+          "rows": [
+            [
+              "**Trivial**",
+              "Within the user's session-start trivial case range",
+              "Orchestrator handles directly. No delegation. The boundary is set by the user's preference at session start and cannot be overridden by the orchestrator."
+            ],
+            [
+              "**Structured routine**",
+              "\"Can this be fully specified without discussion?\"",
+              "Skip ideation and planning — delegate directly with a known pattern. The task has an existing skill that defines the execution pattern (running an audit, recording a gotcha, capturing session learnings). Verification still applies."
+            ],
+            [
+              "**Non-trivial**",
+              "\"Does this require exploration, trade-offs, or creative decomposition?\"",
+              "Full ideation-plan-execute cycle. This is the default tier."
+            ]
+          ]
+        },
+        {
+          "type": "principle",
+          "statement": "Structured routines skip ideation and planning, not quality.",
+          "body": "They still go through delegation, evaluation, and collection. The difference is that the execution pattern is already known — no creative decomposition needed."
+        }
+      ]
+    },
+    {
+      "heading": "Workflow",
+      "content": [
+        {
+          "type": "text",
+          "value": "**When starting a task, must create a checklist using TaskCreate to track phases and steps.** Update each task's status with TaskUpdate as you progress — set to `in_progress` when starting, `completed` when done.\n\nCreate these tasks at the start of every non-trivial workflow:"
+        },
+        {
+          "type": "table",
+          "headers": [
+            "Task",
+            "Subject"
+          ],
+          "rows": [
+            [
+              "Step 1",
+              "Ideation — discuss, evaluate, improve"
+            ],
+            [
+              "Step 2",
+              "Planning — plan, discuss, evaluate, improve"
+            ],
+            [
+              "Step 3",
+              "Execution — delegate subtasks to subagents"
+            ],
+            [
+              "Step 4",
+              "Collection — write notes and persist workflow trail"
+            ],
+            [
+              "Step 5",
+              "Memorization — save context for session continuity"
+            ],
+            [
+              "Phase transition",
+              "Ask user: FEEDBACK, REVIEW, or FINISH"
+            ]
+          ]
+        },
+        {
+          "type": "text",
+          "value": "Add Phase 2 (FEEDBACK) or Phase 3 (REVIEW) tasks when the user selects them. Add FINISH task when selected. When _git is active, also add a \"Merge PR and cleanup\" task when the user selects FINISH — merge and cleanup must be a tracked step, not an afterthought."
+        }
+      ]
+    },
+    {
+      "heading": null,
+      "content": [
+        {
+          "type": "text",
+          "value": "**Load at workflow start:** _note, _evaluation\n\n**Load at each step:**"
+        },
+        {
+          "type": "table",
+          "headers": [
+            "Step",
+            "Load Skills"
+          ],
+          "rows": [
+            [
+              "Step 1. Ideation",
+              "_ideation, _discuss, _evaluation, _ideation-evaluation"
+            ],
+            [
+              "Step 2. Planning",
+              "_plan, _discuss, _evaluation, _plan-evaluation"
+            ],
+            [
+              "Step 3. Execution",
+              "_delegation, _evaluation"
+            ],
+            [
+              "Step 4. Collection",
+              "_collection"
+            ],
+            [
+              "Step 5. Memorization",
+              "_memorization, _gotcha"
+            ]
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**Must write note at every step** — write the corresponding note file before leaving each step. Never defer, never skip."
+        }
+      ]
+    },
+    {
+      "heading": "Resume and Recovery",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Notes are the state machine.",
+          "body": "On resume, check the latest note directory under `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/note/`. The existence of note files indicates workflow progress: ideation.md means ideation complete, plan.md means planning complete, execution.md means execution complete. No note directory means fresh start."
+        },
+        {
+          "type": "principle",
+          "statement": "Resume by reading, not guessing.",
+          "body": "Read existing note files to understand what was decided and accomplished. The notes contain the decisions, the plan, and the execution outcomes — enough to recover context without reconstructing from memory."
+        },
+        {
+          "type": "principle",
+          "statement": "Ask the user how to proceed.",
+          "body": "After recovering state, present what was found to the user via AskUserQuestion: continue where we left off, restart the current phase, or start a new task."
+        },
+        {
+          "type": "principle",
+          "statement": "TaskCreate to rebuild the checklist.",
+          "body": "Recreate the workflow tasks (Step 1–5) and mark completed ones based on which note files exist. The checklist reflects recovered state, not a blank slate."
+        }
+      ]
+    },
+    {
+      "heading": null,
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Evaluation",
+          "content": [
+            {
+              "type": "text",
+              "value": "Evaluation is delegation — the orchestrator **never** evaluates directly. Spawn independent evaluator subagents, each loaded with the appropriate stage-specific evaluation skill and domain-relevant skills for the task."
+            },
+            {
+              "type": "principle",
+              "statement": "At least 2 evaluators with different perspectives.",
+              "body": "A single evaluator catches the problems it is trained to see. Multiple perspectives catch the problems that fall between any single viewpoint. Select perspectives based on the task's domain and the project's needs — the right perspectives vary by project and task type."
+            },
+            {
+              "type": "principle",
+              "statement": "Each evaluator gets domain context, not just evaluation criteria.",
+              "body": "An evaluator with only an evaluation perspective skill lacks the context to judge whether the work fits the project. Include domain-relevant skills, project-specific rules, gotchas, and conventions in the evaluator's prompt so it can assess quality against the standards that actually matter for this project."
+            },
+            {
+              "type": "principle",
+              "statement": "Evaluation is the default at every step. The user can opt out, not opt in.",
+              "body": "Evaluation MUST happen at Steps 1, 2, and 3 by default. Use AskUserQuestion to ask if the user wants to **skip** evaluation — not whether they want to evaluate. Recommend evaluating. Only skip if the user explicitly chooses to. Catching problems at ideation is cheaper than catching them at execution."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": null,
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Step 1. Ideation",
+          "content": [
+            {
+              "type": "text",
+              "value": "Loop until the idea is solid."
+            },
+            {
+              "type": "principle",
+              "statement": "Discussion precedes evaluation.",
+              "body": "Use AskUserQuestion to explore the approach with the user — alternatives, trade-offs, and risks — before any evaluation happens."
+            },
+            {
+              "type": "principle",
+              "statement": "Evaluation is the default — ask to skip, not to evaluate.",
+              "body": "After discussion, use AskUserQuestion to ask whether the user wants to **skip** evaluation or proceed with evaluation (recommended). Spawn evaluators unless the user explicitly opts out."
+            },
+            {
+              "type": "principle",
+              "statement": "Evaluation findings are input to a conversation, not marching orders.",
+              "body": "When evaluation is performed, present the results to the user via AskUserQuestion. Discuss which findings to address, defer, or disagree with — the user decides the direction."
+            },
+            {
+              "type": "principle",
+              "statement": "Improvement follows agreement.",
+              "body": "Refine the idea only based on what the user agreed to address. When the idea is solid, write ideation.md and proceed to Step 2."
+            },
+            {
+              "type": "text",
+              "value": "> **Before moving to Step 2**, consider whether any implementation decisions are contribution points — irreducible user judgment calls that should be resolved via AskUserQuestion before the plan encodes them as constraints. See _ideation."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Step 2. Planning",
+          "content": [
+            {
+              "type": "text",
+              "value": "Loop until the plan is solid."
+            },
+            {
+              "type": "principle",
+              "statement": "Planning happens in plan mode.",
+              "body": "Use EnterPlanMode to explore the codebase, decompose, and write the plan. Use ExitPlanMode to present it."
+            },
+            {
+              "type": "principle",
+              "statement": "Discussion precedes evaluation.",
+              "body": "Use AskUserQuestion to review the plan with the user before any evaluation."
+            },
+            {
+              "type": "principle",
+              "statement": "Evaluation is the default — ask to skip, not to evaluate.",
+              "body": "Use AskUserQuestion to ask whether the user wants to **skip** evaluation or proceed with evaluation (recommended). Spawn evaluators unless the user explicitly opts out."
+            },
+            {
+              "type": "principle",
+              "statement": "Evaluation findings are discussed before acting.",
+              "body": "When evaluation is performed, present results to the user via AskUserQuestion. Discuss which findings to address and which to defer — the user decides."
+            },
+            {
+              "type": "principle",
+              "statement": "Revision follows agreement.",
+              "body": "Use EnterPlanMode to revise based on the agreed-upon direction. When the plan is solid, write plan.md with the full plan content — context, root cause, every change with rationale, files affected, and verification criteria. Copy the complete plan from the plan file into the note, not a summary. Then proceed to Step 3."
+            },
+            {
+              "type": "principle",
+              "statement": "Consider exploration before planning when the task spans unfamiliar territory.",
+              "body": "When a task crosses multiple subsystems or touches areas the orchestrator has limited context on, offer exploration to the user via AskUserQuestion before entering the plan loop. If accepted, spawn 2-3 parallel agents with different lenses (architecture, risk, conventions) and synthesize their findings into shared context for planning. If declined, proceed directly to planning. This is a judgment call — straightforward tasks in well-understood areas do not need exploration."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Step 3. Execution",
+          "content": [
+            {
+              "type": "text",
+              "value": "Delegate subtasks to specialist subagents."
+            },
+            {
+              "type": "principle",
+              "statement": "Delegate Claude Code tasks to gobbi-agent.",
+              "body": "Any subtask involving `.claude/` documentation — creating or improving skills, agents, rules, CLAUDE.md, hooks, settings, or project docs — MUST be delegated to `gobbi-agent` with the appropriate skills loaded (_claude, _skills, _agents, _rules, etc.). `gobbi-agent` is the Claude Code specialist. The `__executor` handles code implementation; `gobbi-agent` handles Claude Code configuration."
+            },
+            {
+              "type": "principle",
+              "statement": "Tell specialists what to do, not how to do it.",
+              "body": "Define the goal, constraints, and what to avoid. Detailed \"how\" instructions suppress specialist agents' ability and potential. Provide guardrails about what not to do, and message that promotes the specialist's best work — project rules, gotchas, conventions, domain knowledge. See _delegation for the full briefing model."
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Each subtask must be delegated to a specialist subagent with fresh context.",
+                "Every subagent prompt must include specific requirements, constraints, expected output, and context — never a one-liner, never ambiguous, never a summary.",
+                "Every subagent must load _gotcha before starting work.",
+                "After each subtask completes, run `subtask-collect.sh` to extract the subagent's record from its transcript. The orchestrator extracts the agent-id from the Agent tool result (returned as `agentId` at the end of the result). Then spawn a separate evaluator agent to assess the output.",
+                "If evaluation fails, fix and re-evaluate before proceeding to the next subtask.",
+                "After all subtasks complete, write execution.md. Subtask JSON files are already on disk from the per-subtask `subtask-collect.sh` calls.",
+                "After each wave of parallel agents completes and subtask files are written to disk, review the combined outputs for consistency before launching the next wave. Check for contradictory changes, file overlap between subtasks, and findings that affect subsequent waves. This is a lightweight read-through, not a full evaluation spawn."
+              ]
+            },
+            {
+              "type": "principle",
+              "statement": "When _git is active",
+              "body": "Before delegating the first subtask, the orchestrator creates a worktree and branch based on the task's issue. The worktree path is included in every delegation prompt. Subagents cd to the worktree as their first action and commit their verified work before completing. After all subtasks are done, the orchestrator pushes all commits and creates the PR. Notes and gotchas must always be written to the main tree's absolute path — `$CLAUDE_PROJECT_DIR/.claude/project/` is gitignored and does not exist in worktrees."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Step 4. Collection",
+          "content": [
+            {
+              "type": "text",
+              "value": "Persist the workflow trail."
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Write prompt, plan, task results, and README to the work directory.",
+                "Record any gotchas discovered during execution."
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Step 5. Memorization",
+          "content": [
+            {
+              "type": "text",
+              "value": "Save context that enables the user to continue this work in a new session."
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Memorize details of the completed task — what was done, what decisions were made, what remains open.",
+                "If the task is part of a larger user plan, memorize the broader plan context and where this task fits.",
+                "Update gotchas from any corrections discovered during the workflow.",
+                "Update project docs in `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/` if the workflow revealed new architectural knowledge, conventions, or decisions worth persisting.",
+                "Use AskUserQuestion to ask the user: FEEDBACK, REVIEW, or FINISH?"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Three Phases of Work",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Phase 1. TASK",
+          "content": [
+            {
+              "type": "text",
+              "value": "The main implementation phase. Run the full workflow (Step 1 → Step 2 → Step 3 → Step 4 → Step 5).\n\nAfter TASK completes, use AskUserQuestion to ask: FEEDBACK, REVIEW, or FINISH?"
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Phase 2. FEEDBACK",
+          "content": [
+            {
+              "type": "text",
+              "value": "The user inspects results and provides iterative feedback. Optimized for speed over structure — skip planning, fix directly or delegate small scoped tasks, record gotchas from corrections. Write feedback.md after each round.\n\nAfter FEEDBACK completes, use AskUserQuestion to ask: REVIEW, or FINISH?\n\nSee [feedback.md](feedback.md) for iteration tracking, stagnation detection, round cap, and targeted re-evaluation."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Phase 3. REVIEW",
+          "content": [
+            {
+              "type": "text",
+              "value": "Full workflow again (Step 1 → Step 2 → Step 3 → Step 4 → Step 5) focused on quality verification. Creates a separate work directory: `{task-slug}-review/`. Write review.md after review completes.\n\nAfter REVIEW completes, use AskUserQuestion to ask: FEEDBACK, or FINISH?"
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "FINISH",
+          "content": [
+            {
+              "type": "text",
+              "value": "Wrap the workflow with merge, commit, and/or compact options. The decision tree depends on whether _git is active (PR exists) or not. Use AskUserQuestion to present the appropriate options — never assume which the user wants."
+            },
+            {
+              "type": "principle",
+              "statement": "Before any irreversible operation, verify the expected precondition still holds.",
+              "body": "Re-verify at the point of use, not only at session start."
+            },
+            {
+              "type": "text",
+              "value": "See [finish.md](finish.md) for the full decision tree, action definitions, and pre-action verification constraints."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Constraints",
+      "content": [
+        {
+          "type": "text",
+          "value": "**Mandatory actions — never skip these:**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Before planning, MUST check gotchas",
+            "Before expensive delegation, MUST run lightweight precondition checks — verify the task is well-defined, prerequisites are met, and the scope justifies agent spawning. Use cheap checks (Haiku agents or bash commands) to prevent wasting expensive computation on ineligible or malformed tasks",
+            "Any delegated task that involves both assessment and modification MUST present its assessment findings to the user via AskUserQuestion before performing modifications",
+            "Before delegation, MUST include gotcha context in every subagent prompt",
+            "Before evaluation, MUST ask user with AskUserQuestion whether to **skip** evaluation — evaluation is the default at all steps, the user opts out, not in",
+            "After evaluation, MUST discuss findings with user via AskUserQuestion before improving — the user decides what to address, defer, or disagree with",
+            "After delegation, MUST run `subtask-collect.sh` for each completed subagent immediately after each wave — before any downstream agent runs",
+            "After delegation, MUST write work docs via _collection — immediately, not deferred",
+            "After memorization, MUST call AskUserQuestion to ask: FEEDBACK, REVIEW, or FINISH?",
+            "After FEEDBACK, MUST call AskUserQuestion to ask: REVIEW, or FINISH?",
+            "After REVIEW, MUST call AskUserQuestion to ask: FEEDBACK, or FINISH?",
+            "When evaluation is performed, MUST spawn at least 2 perspective evaluators (Project + Overall minimum). Select additional perspectives (Architecture, Performance, Aesthetics) based on task type.",
+            "MUST write note via _note at every workflow step — ideation, plan, execution, feedback, review. Never defer, never skip.",
+            "MUST use EnterPlanMode when writing or revising plans",
+            "When using AskUserQuestion, MUST put the recommended option first with \"(Recommended)\" in the label — give an opinion, don't just present neutral choices"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**Gobbi vs project boundary — understand what gobbi provides vs what the user's project needs:**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Gobbi provides workflow orchestration, `.claude/` documentation standards, evaluation framework, and gotcha recording. Users do NOT need to create skills or agents for these — gobbi serves them.",
+            "Users SHOULD create project-specific skills and agents that are tailored to their language, framework, and domain. For example, a project evaluation skill for a Python FastAPI project should know about Python-specific patterns, SQLAlchemy conventions, and FastAPI middleware — not just generic \"check quality.\"",
+            "When the user asks to create skills, agents, or rules, determine whether gobbi already covers the need (redirect to the existing gobbi skill) or whether a project-specific artifact is needed (help create one with domain-specific content).",
+            "Project evaluation perspectives should be concrete and domain-aware — \"check for N+1 queries in SQLAlchemy\" is useful; \"check performance\" is not."
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**Never do these:**"
+        },
+        {
+          "type": "constraint-list",
+          "items": [
+            "Never implement complex domain work yourself when a specialist exists",
+            "Never delegate without context — agents without project standards produce work that fails integration",
+            "Never self-evaluate — the agent that creates must never judge its own output",
+            "Never automatically improve based on evaluation without discussing with the user first",
+            "Never launch more than 8 parallel subagents — batch larger plans into waves"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_orchestration/feedback.json
+++ b/.claude/skills/_orchestration/feedback.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "gobbi-docs/child",
+  "parent": "_orchestration",
+  "title": "FEEDBACK Phase",
+  "opening": "How iterative feedback works after TASK or REVIEW completes. Load this when entering Phase 2 (FEEDBACK) to understand iteration tracking, stagnation detection, and when to escalate.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Speed over structure.",
+          "body": "FEEDBACK exists to refine, not to redesign. The architecture is established — skip planning, fix directly or delegate small scoped tasks."
+        },
+        {
+          "type": "principle",
+          "statement": "Every correction is a memorization opportunity.",
+          "body": "User feedback is the richest source of gotchas, rules, and project knowledge. Don't just fix the task — record corrections as gotchas in `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/gotchas/`, stated preferences as rules in `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/rules/`, and new knowledge in project docs. A feedback round that only fixes code without updating project memory wastes the learning."
+        }
+      ]
+    },
+    {
+      "heading": "What FEEDBACK Does",
+      "content": [
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "**Skip planning** — the architecture is established from TASK",
+            "**Fix directly or delegate small scoped tasks** — no full decomposition needed",
+            "**Record gotchas from corrections** — user corrections become \"must avoid\" entries in `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/gotchas/`",
+            "**Record rules from preferences** — user-stated standards become \"must follow\" entries in `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/rules/`",
+            "**Update project docs** — if feedback reveals new knowledge about architecture, conventions, or decisions, update `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/`",
+            "**Write feedback.md** after each feedback round to persist the iteration trail"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "After FEEDBACK completes, use AskUserQuestion to ask: REVIEW, or FINISH?"
+        }
+      ]
+    },
+    {
+      "heading": "Iteration Tracking",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Number each feedback round.",
+          "body": "Append to feedback.md with the round number, what the user said, what changed, and what remains unresolved."
+        },
+        {
+          "type": "text",
+          "value": "This makes the iteration history explicit. When feedback spans many rounds, the numbered trail prevents context loss and makes stagnation visible. Without it, the orchestrator loses track of what was already attempted."
+        }
+      ]
+    },
+    {
+      "heading": "Stagnation Detection",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "If 3 consecutive rounds address the same finding without convergence, surface the stagnation pattern to the user via AskUserQuestion.",
+          "body": "The user decides whether to continue iterating, accept the current state, or change approach entirely."
+        },
+        {
+          "type": "text",
+          "value": "Stagnation means the fix strategy is not working — repeating it will not produce a different result. The orchestrator's role is to detect the pattern and surface it, not to decide the resolution. The user may have context the orchestrator lacks about why convergence is difficult or whether \"good enough\" is acceptable."
+        }
+      ]
+    },
+    {
+      "heading": "Feedback Round Cap",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "After 5 feedback rounds, surface AskUserQuestion recommending REVIEW or FINISH.",
+          "body": "The user can override and continue — this is a recommendation, not a hard stop."
+        },
+        {
+          "type": "text",
+          "value": "Five rounds is a signal that the scope of changes may warrant a structured pass (REVIEW) rather than continued incremental fixes. The cap exists to prompt reflection, not to gate progress. If the user has clear remaining items, continuing is the right call."
+        }
+      ]
+    },
+    {
+      "heading": "Targeted Re-evaluation",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "When a feedback fix is narrow and well-scoped, a single evaluator suffices for verification.",
+          "body": "Full perspective spawn is unnecessary for small targeted fixes."
+        },
+        {
+          "type": "text",
+          "value": "The multi-perspective evaluation model exists for complex, multi-faceted outputs where blind spots are likely. A typo fix, a single-file correction, or a formatting adjustment does not need multiple independent assessments. Match evaluation cost to fix complexity — use a single evaluator (Haiku or Sonnet tier) for targeted fixes, reserve the full perspective spawn (Project + Overall + task-relevant perspectives) for substantial changes."
+        }
+      ]
+    },
+    {
+      "heading": "Constraints",
+      "content": [
+        {
+          "type": "constraint-list",
+          "items": [
+            "MUST number each feedback round in feedback.md",
+            "MUST record user corrections as gotchas in `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/gotchas/`",
+            "MUST record user-stated standards as rules in `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/rules/`",
+            "MUST update project docs when feedback reveals new knowledge worth persisting",
+            "MUST surface stagnation pattern after 3 consecutive rounds on the same finding — via AskUserQuestion, not automatic action",
+            "MUST recommend REVIEW or FINISH after 5 rounds — via AskUserQuestion, user can override",
+            "MUST use AskUserQuestion at every phase boundary — never prose transitions",
+            "Never skip gotcha recording — a correction not recorded is a correction repeated",
+            "Never run full workflow (Step 1-4) during FEEDBACK — that is what REVIEW is for"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_orchestration/finish.json
+++ b/.claude/skills/_orchestration/finish.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "gobbi-docs/child",
+  "parent": "_orchestration",
+  "title": "FINISH Phase",
+  "opening": "How the workflow concludes with merge, commit, and compact options. Load this when the user selects FINISH to understand the decision tree, pre-action verification, and cleanup responsibilities.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Before any irreversible operation, verify the expected precondition still holds.",
+          "body": "Conditions change between when you checked and when you act. Re-verify at the point of use."
+        },
+        {
+          "type": "text",
+          "value": "_git establishes the re-verification principle: prerequisites are re-verified at point of use, not only at session start. FINISH extends this to all irreversible actions — committing, pushing, merging, and PR creation. The cost of re-checking is trivial; the cost of acting on a stale assumption is rework or data loss."
+        }
+      ]
+    },
+    {
+      "heading": "Decision Tree",
+      "content": [
+        {
+          "type": "text",
+          "value": "When the user selects FINISH, use AskUserQuestion to present the appropriate options:\n\n**When _git is active (PR exists):**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Merge PR and cleanup (squash merge, delete branch, close issue, remove worktree and empty parent dirs, pull merge into base branch), then compact",
+            "Merge PR and cleanup only (no compact)",
+            "Compact only (leave PR open for later)"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**When _git is not active (default):**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Commit and compact",
+            "Commit only",
+            "Compact only"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Action Definitions",
+      "content": [
+        {
+          "type": "text",
+          "value": "**Merge** — squash merge the PR, delete the remote branch, explicitly close the linked issue (closing keywords don't auto-close on non-default branch PRs), remove the local worktree, clean up empty parent directories under `.claude/worktrees/`, pull the merge into the local base branch, and prune stale worktree references.\n\n**Commit** — create a git commit with the changes from this workflow.\n\n**Compact** — the agent cannot run `/compact` directly. Instead, tell the user to run the command themselves. The compact message should start with \"abort gobbi\" (so the compacted context drops gobbi workflow state) followed by a summary of the work done. After compact completes, the user must manually reload gobbi by running `/gobbi`.\n\n> Please run: `/compact abort gobbi — completed {task-slug} workflow, findings in $CLAUDE_PROJECT_DIR/.claude/project/{project-name}/note/{note-dir}/`\n> Then reload gobbi with: `/gobbi`"
+        }
+      ]
+    },
+    {
+      "heading": "Pre-Action Verification",
+      "content": [
+        {
+          "type": "text",
+          "value": "The following conditions must hold before each irreversible action. These are constraints to verify, not steps to execute in order."
+        },
+        {
+          "type": "table",
+          "headers": [
+            "Before...",
+            "Verify..."
+          ],
+          "rows": [
+            [
+              "Committing",
+              "Correct branch is checked out"
+            ],
+            [
+              "Pushing",
+              "No force-push without explicit user approval"
+            ],
+            [
+              "Creating PR",
+              "No duplicate PR already exists for this branch"
+            ],
+            [
+              "Merging",
+              "CI has passed, PR is still open"
+            ],
+            [
+              "Resuming a session",
+              "Session ID matches the expected task context"
+            ]
+          ]
+        },
+        {
+          "type": "principle",
+          "statement": "Verify, then act. Never assume a prior check still holds.",
+          "body": "A branch can be switched by a concurrent session. A PR can be closed by another contributor. CI can fail on a rebase. Each action's precondition must be true at the moment the action executes."
+        }
+      ]
+    },
+    {
+      "heading": "Constraints",
+      "content": [
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "MUST verify preconditions immediately before each irreversible action — not earlier in the workflow",
+            "MUST use AskUserQuestion to present FINISH options — never assume which option the user wants",
+            "MUST explicitly close linked issues when merging PRs to non-default branches — closing keywords do not trigger automatically",
+            "MUST clean up empty parent directories after worktree removal — git only removes the leaf directory",
+            "MUST pull the merge into the local base branch after squash merge — keep local and remote in sync",
+            "Never force-push without explicit user approval",
+            "Never run `/compact` directly — instruct the user to run it themselves",
+            "When _git is active, \"Merge PR and cleanup\" must be a tracked task, not an afterthought"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_orchestration/gotchas.json
+++ b/.claude/skills/_orchestration/gotchas.json
@@ -1,0 +1,176 @@
+{
+  "$schema": "gobbi-docs/gotcha",
+  "parent": "_orchestration",
+  "title": "Gotcha: _orchestration",
+  "entries": [
+    {
+      "title": "Dropping into implementation mode during REVIEW after long FEEDBACK",
+      "body": {
+        "priority": "Critical",
+        "what-happened": "After a long FEEDBACK phase with many iterative fixes, the user transitioned to REVIEW. The orchestrator treated REVIEW as \"more feedback\" — it skipped planning, started implementing fixes directly, and did the work itself instead of delegating to specialists. The long feedback phase eroded the workflow discipline.",
+        "user-feedback": "REVIEW is a full workflow phase. Follow it regardless of how long the preceding FEEDBACK was.",
+        "correct-approach": "REVIEW runs the full workflow (Step 1 → Step 2 → Step 3 → Step 4). No exceptions. No shortcuts. The longer the feedback phase was, the MORE important it is to follow the full REVIEW workflow — because context fatigue makes ad-hoc work sloppy."
+      },
+      "metadata": {
+        "priority": "critical"
+      }
+    },
+    {
+      "title": "Skipping structured phase transitions",
+      "body": {
+        "priority": "High",
+        "what-happened": "Asked \"Ready for FEEDBACK?\" in prose instead of using AskUserQuestion.",
+        "user-feedback": "Use structured selections between phases.",
+        "correct-approach": "Call AskUserQuestion with explicit options at every phase boundary. Never prose."
+      },
+      "metadata": {
+        "priority": "high"
+      }
+    },
+    {
+      "title": "Not writing notes during collection",
+      "body": {
+        "priority": "High",
+        "what-happened": "Summarized results in conversation messages but never wrote note files to `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/note/`.",
+        "user-feedback": "Write notes in every workflow cycle.",
+        "correct-approach": "Load _note during Step 4 (Collection). Write ideation.md, plan.md, execution.md, and subtasks/ to the task note directory. Context disappears after the session — notes are the permanent record."
+      },
+      "metadata": {
+        "priority": "high"
+      }
+    },
+    {
+      "title": "Skipping `subtask-collect.sh` call after subagent completes",
+      "body": {
+        "priority": "High",
+        "what-happened": "After subagents completed their work, the orchestrator moved on to synthesis or evaluation without running `subtask-collect.sh` to extract results from the JSONL transcripts. The `subtasks/` directory remained empty. Downstream agents (synthesis, evaluation) found nothing on disk and either failed or performed redundant fresh work — losing all findings from the prior agents.",
+        "user-feedback": "Subtask collection must happen after each subagent returns, before any downstream agent runs.",
+        "correct-approach": "After each subagent completes, run `subtask-collect.sh` to extract the delegation prompt and final result from the JSONL transcript into `subtasks/{NN}-{slug}.json`. Verify the JSON file exists before launching any downstream agent (synthesis, evaluation) that depends on it. The script extracts directly from the transcript, so content quality is guaranteed — the risk is not summary vs actual content, but forgetting to call the script at all."
+      },
+      "metadata": {
+        "priority": "high"
+      }
+    },
+    {
+      "title": "Writing summaries instead of actual content in notes",
+      "body": {
+        "priority": "High",
+        "what-happened": "Wrote one-sentence summary in ideation.md and brief outline in plan.md.",
+        "user-feedback": "Note files must contain actual content, not summaries.",
+        "correct-approach": "`ideation.md` = full ideas explored, trade-offs, evaluation feedback, chosen approach. `plan.md` = full plan with tasks, dependencies, verification criteria. These are the historical record — preserve everything."
+      },
+      "metadata": {
+        "priority": "high"
+      }
+    },
+    {
+      "title": "Skipping collection after delegation",
+      "body": {
+        "priority": "High",
+        "what-happened": "Jumped from delegation results directly to AskUserQuestion without writing notes.",
+        "user-feedback": "Write notes immediately after delegation, before any transition.",
+        "correct-approach": "Step 3 completes → Step 4 (Collection: write everything) → Phase transition (AskUserQuestion). Collection is not optional and not deferrable. Write first, ask next."
+      },
+      "metadata": {
+        "priority": "high"
+      }
+    },
+    {
+      "title": "Self-evaluating instead of spawning separate evaluator agents",
+      "body": {
+        "priority": "High",
+        "what-happened": "The orchestrator evaluated its own ideation or plan output instead of spawning separate evaluator agents.",
+        "user-feedback": "The agent that creates must never evaluate its own output.",
+        "correct-approach": "Spawn perspective evaluator agents (Project + Overall minimum, plus Architecture/Performance/Aesthetics based on task type). Each perspective examines the output through its specific lens. The Overall perspective also generates a \"must preserve\" list. This separation and multi-perspective coverage prevents blind spots."
+      },
+      "metadata": {
+        "priority": "high"
+      }
+    },
+    {
+      "title": "Run `subtask-collect.sh` BEFORE launching synthesis",
+      "body": {
+        "priority": "High",
+        "what-happened": "During a 10-subtask review workflow, the orchestrator launched Wave 1 and Wave 2 agents, then launched the synthesis agent to combine their outputs. But `subtask-collect.sh` had not been run between waves to extract results from the JSONL transcripts. The synthesis agent found an empty `subtasks/` directory, so it performed a fresh independent audit instead of combining the 10 prior agent outputs. This caused the synthesis to miss findings that the individual audits had caught (specifically, step-by-step recipe violations in 5 skill files).",
+        "user-feedback": "Subtask files must be written to disk immediately after each agent completes, before any downstream agent that depends on them.",
+        "correct-approach": "After each wave completes, run `subtask-collect.sh` to extract all subtask outputs to `subtasks/{NN}-{slug}.json` BEFORE launching the next wave or the synthesis agent. The synthesis agent should read JSON files from disk, not receive findings through the prompt. This ensures the synthesis captures all findings from all prior agents and prevents the \"fresh audit\" fallback that loses coverage."
+      },
+      "metadata": {
+        "priority": "high"
+      }
+    },
+    {
+      "title": "Evaluation should be optional in ideation — ask user first",
+      "body": {
+        "priority": "High",
+        "what-happened": "During the ideation step, the orchestrator automatically spawned evaluator agents after generating the idea without asking the user whether evaluation was needed. For straightforward tasks, this added unnecessary overhead and delay.",
+        "user-feedback": "Evaluation in ideation should be optional. Ask the user with AskUserQuestion before launching evaluators.",
+        "correct-approach": "After generating the idea in Step 1, use AskUserQuestion to ask the user whether they want to evaluate the idea or move directly to planning. Only spawn evaluator agents if the user opts for evaluation. This preserves the quality gate for complex tasks while allowing streamlined flow for simpler ones."
+      },
+      "metadata": {
+        "priority": "high"
+      }
+    },
+    {
+      "title": "Discuss evaluation results before improving",
+      "body": {
+        "priority": "High",
+        "what-happened": "After evaluator agents returned their verdicts, the orchestrator immediately started improving the idea/plan based on the evaluation feedback — without discussing the evaluation results with the user first.",
+        "user-feedback": "Before improving based on evaluation, discuss the evaluation findings with the user to decide what to improve.",
+        "correct-approach": "After evaluator agents complete, present the evaluation results to the user via AskUserQuestion. Discuss which findings to address, which to defer, and which to disagree with. THEN improve based on the agreed-upon direction. The user should be in the loop between evaluation and improvement — evaluation findings are input to a conversation, not automatic marching orders."
+      },
+      "metadata": {
+        "priority": "high"
+      }
+    },
+    {
+      "title": "Must start workflow when user requests a non-trivial task",
+      "body": {
+        "priority": "High",
+        "what-happened": "The user said \"let's move on next step\" and selected \"all remaining fixes.\" The orchestrator skipped the workflow — it jumped straight to reading files and was about to implement directly instead of starting the gobbi workflow (ideation → plan → execution → collection).",
+        "user-feedback": "\"No, we should start new workflow. Why you didn't start with the workflow?\"",
+        "correct-approach": "When the user requests a non-trivial task (multi-file edits, fixes across many docs), always start the full gobbi workflow. Load /gobbi, ask trivial scope, create task checklist, and begin Step 1 (Ideation). Never jump to implementation regardless of how well-defined the fixes seem."
+      },
+      "metadata": {
+        "priority": "high"
+      }
+    },
+    {
+      "title": "Agent cannot run /compact — must tell user to run it",
+      "body": {
+        "priority": "High",
+        "what-happened": "During FINISH, the user selected \"compact only.\" The orchestrator attempted to compact but could not — `/compact` is a CLI command that only the user can execute. The context was never compacted.",
+        "user-feedback": "The agent cannot run compact directly. Suggest the compact command with details so the user can run it themselves.",
+        "correct-approach": "When the user selects compact during FINISH, tell the user to run the command themselves. The compact message should start with \"abort gobbi\" so the compacted context drops gobbi workflow state (it auto-reloads after compact via the reload hook), followed by a summary of work done. Example: `/compact abort gobbi — completed doc-review, findings in note/20260328-0706-doc-review/` Note: `/gobbi` reload works after compact because the SessionStart hook is not affected by compact — the hook triggers on the next message after compact completes, which re-initializes the gobbi workflow state."
+      },
+      "metadata": {
+        "priority": "high"
+      }
+    },
+    {
+      "title": "Concurrent sessions corrupt each other's working tree",
+      "body": {
+        "priority": "Critical",
+        "what-happened": "Two gobbi sessions ran simultaneously in the same working tree — one doing a v0.2.0 redesign, the other doing README/presentation improvements. The presentation session's subagents made changes that appeared to be scope violations but were actually from the concurrent session. The orchestrator reverted the concurrent session's legitimate work (src/cli.ts, src/commands/, src/lib/ files) thinking they were scope creep. The concurrent session then committed a README rewrite that overwrote the presentation session's visual improvements. Both sessions' work had to be manually reconciled.",
+        "user-feedback": "\"We experienced this concurrent mistakes several times.\" Requested a worktree skill to isolate sessions via git worktrees.",
+        "correct-approach": "Never run multiple gobbi sessions in the same working tree. Each session's subagents and the concurrent session's changes are indistinguishable in `git diff`. The orchestrator cannot tell which changes are from its own agents vs another session. Use git worktrees to give each session its own isolated copy of the repo, then merge results explicitly."
+      },
+      "metadata": {
+        "priority": "critical"
+      }
+    },
+    {
+      "title": "Core skills not loaded after project setup on first session",
+      "body": {
+        "priority": "High",
+        "what-happened": "On the first session with a new project, `/gobbi` triggered project setup (creating `$CLAUDE_PROJECT_DIR/.claude/project/{name}/` directories and README.md). After completing the setup, the orchestrator did not load the core skills (`_orchestration`, `_gotcha`, `_claude`, `_git`) that the gobbi skill requires to be loaded \"immediately after this skill.\" The agent proceeded to wait for a task without the workflow machinery loaded.",
+        "user-feedback": "Core skills were not loaded after first setup.",
+        "correct-approach": "The gobbi SKILL.md instruction to load `_orchestration`, `_gotcha`, `_claude`, and `_git` must be followed regardless of whether project setup ran. Project setup is an intermediate step — it does not replace or defer core skill loading. After setup questions and project detection complete, load all four core skills before declaring the session ready. The loading instruction is unconditional."
+      },
+      "metadata": {
+        "priority": "high"
+      }
+    }
+  ],
+  "opening": "Mistakes in following the orchestration workflow (phases, steps, transitions)."
+}

--- a/.claude/skills/_plan-evaluation/SKILL.json
+++ b/.claude/skills/_plan-evaluation/SKILL.json
@@ -1,0 +1,137 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_plan-evaluation",
+    "description": "MUST load when evaluating a plan. Stage-specific criteria for assessing whether tasks are specific, correctly ordered, complete, and ready for delegation. Used by all 6 evaluator perspectives (Project, Architecture, Performance, Aesthetics, Overall, User).",
+    "allowed-tools": "Read, Grep, Glob, Bash"
+  },
+  "title": "Plan Evaluation",
+  "opening": "Stage-specific evaluation criteria for plan output. Load this skill alongside _evaluation when evaluating the result of a planning step.\n\nA plan should be a set of narrow, specific, ordered tasks that a delegator can hand off to specialists without ambiguity. If a task requires the agent to guess, the plan isn't ready.",
+  "sections": [
+    {
+      "heading": "What You're Evaluating",
+      "content": [
+        {
+          "type": "text",
+          "value": "The plan should contain: a goal statement, numbered tasks with agent assignments and skill requirements, execution order with dependency reasoning, expected outcome, and collection plan. Evaluate against the criteria below."
+        }
+      ]
+    },
+    {
+      "heading": "Evaluation Criteria",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Task Specificity",
+          "content": [
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**Deliverable clear?** — Does each task state exactly what to produce? \"Improve the auth module\" fails. \"Add rate limiting middleware to /api/login with 5 req/min per IP, returning 429\" passes.",
+                "**Scope bounded?** — Does each task state what it should NOT touch? Without explicit boundaries, agents expand scope.",
+                "**Agent assigned?** — Is each task assigned to a specific agent type with skills to load? Implicit agent selection leads to wrong agents.",
+                "**Self-contained?** — Can the assigned agent understand the full scope from the task description alone, without reading other tasks?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Dependency Ordering",
+          "content": [
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**Dependencies correct?** — Would executing tasks in the stated order actually work? If Task 3 needs Task 2's output, is that dependency stated?",
+                "**Parallelism maximized?** — Are independent tasks marked for parallel execution? Serial execution of independent tasks wastes time.",
+                "**No circular dependencies?** — Does Task A depend on Task B which depends on Task A?",
+                "**File conflicts avoided?** — Do any parallel tasks modify the same files? If so, they need sequencing or merging."
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Completeness",
+          "content": [
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**Full scope covered?** — Does the plan address everything from the approved idea? Compare task list against the idea document point by point. Missing scope is the most common plan failure.",
+                "**Verification criteria defined?** — Does each task specify what \"done\" looks like? Without criteria, evaluation has nothing to check against.",
+                "**Collection plan included?** — Does the plan specify where work docs will be written and what subtask `.json` files will be created?",
+                "**Nothing added beyond scope?** — Does the plan introduce tasks that weren't in the approved idea? Scope creep starts in planning."
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Feasibility",
+          "content": [
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**Tasks right-sized?** — Is each task small enough that a single agent can complete it without losing focus, but large enough to be worth the delegation overhead?",
+                "**Agent capabilities matched?** — Does each assigned agent have the tools and domain knowledge for its task?",
+                "**Wave size reasonable?** — No more than 8 parallel tasks per wave. Beyond that, coordination overhead exceeds parallelism benefit.",
+                "**Gotchas respected?** — Does the plan account for known pitfalls in this domain? Check gotchas against planned approach."
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Perspective-Specific Focus",
+      "content": [
+        {
+          "type": "table",
+          "headers": [
+            "Perspective",
+            "Primary Focus"
+          ],
+          "rows": [
+            [
+              "Project",
+              "Does the plan deliver what the user asked for? Scope boundaries clear?"
+            ],
+            [
+              "Architecture",
+              "Are tasks decomposed at the right granularity? Dependencies sound?"
+            ],
+            [
+              "Performance",
+              "Does the execution order maximize parallelism? Resource-proportional?"
+            ],
+            [
+              "Aesthetics",
+              "Are task descriptions clear and specific? Naming consistent?"
+            ],
+            [
+              "Overall",
+              "What cross-cutting gaps exist? What must be preserved?"
+            ],
+            [
+              "User",
+              "Will the plan's output match user expectations? Any friction points?"
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Scoring Guidance",
+      "content": [
+        {
+          "type": "text",
+          "value": "Plan findings are more verifiable than ideation findings. Task specificity, dependency ordering, file overlap, and scope coverage can often be checked against concrete artifacts — the idea document, the codebase structure, existing file paths. This means confidence scores should generally be higher than in ideation evaluation.\n\nA plan evaluator who finds that two parallel tasks modify the same file can verify this by checking the task descriptions — that finding should score confidence 85+. A finding that a dependency is incorrectly ordered can be traced through the task list — also high confidence. In contrast, a concern like \"this task might be too large for a single agent\" involves more judgment and would naturally score lower.\n\nWhen a plan finding can be verified against a concrete artifact (the idea document, a file path, a dependency chain), the evaluator should do so and score confidence accordingly. Evaluators should use their tools (Grep, Read) to check referenced paths and patterns where possible, and let that evidence drive confidence scores upward."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_plan/SKILL.json
+++ b/.claude/skills/_plan/SKILL.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_plan",
+    "description": "Decompose complex tasks into small, specific, agent-assigned subtasks. Use during the PLAN phase to explore the codebase, build a systematic plan, and get user approval before delegation. MUST load at the planning step.",
+    "allowed-tools": "Read, Grep, Glob, Bash"
+  },
+  "title": "Planning Skill",
+  "opening": "Decompose complex tasks into small, specific, agent-assigned subtasks. Use during the PLAN phase to explore the codebase, build a systematic plan, and get user approval before delegation. MUST load at the planning step.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Enter plan mode. Use EnterPlanMode to explore, decompose, and write the plan. Use ExitPlanMode to present it for approval.",
+          "body": "Plan mode lets you explore the codebase with read-only tools, design the approach, and write the plan — all before any implementation begins. ExitPlanMode presents the plan to the user for approval. No delegation happens without user sign-off."
+        },
+        {
+          "type": "principle",
+          "statement": "Decompose into small, specific tasks. Each task has one agent, one deliverable, one clear scope.",
+          "body": "Vague tasks produce vague results. Break work down until each task is small enough that a single agent can complete it without losing focus. Name the agent, list the skills to load, and define the expected deliverable."
+        },
+        {
+          "type": "principle",
+          "statement": "Every task specifies its subagent and skills.",
+          "body": "A task without a named subagent gets routed to the wrong specialist. A task without listed skills gets executed without the knowledge the agent needs. The plan must name which agent from `.claude/agents/` handles each task and which skills from `.claude/skills/` it loads — this is what makes delegation precise instead of hopeful."
+        },
+        {
+          "type": "principle",
+          "statement": "Research before planning when knowledge is insufficient.",
+          "body": "When a task requires domain expertise, external context, or codebase understanding that the orchestrator lacks, spawn research agents to investigate before decomposing. A plan built on incomplete knowledge produces tasks with wrong assumptions. The research cost is small compared to the rework cost of a misinformed plan."
+        }
+      ]
+    },
+    {
+      "heading": "How to Plan",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Always start in plan mode.",
+          "body": "Planning outside of EnterPlanMode means planning without codebase exploration — and plans built on assumptions fail on contact with reality."
+        },
+        {
+          "type": "principle",
+          "statement": "Explore before decomposing.",
+          "body": "Understanding the existing codebase, patterns, and architecture is a prerequisite to meaningful task breakdown. A plan that doesn't reflect the codebase will produce work that doesn't fit the codebase."
+        },
+        {
+          "type": "principle",
+          "statement": "Spawn PI-level agents when needed.",
+          "body": "If the task crosses unfamiliar territory — new APIs, unfamiliar subsystems, external dependencies — spawn PI-level agents to investigate before writing the plan. They return findings; the orchestrator synthesizes them into planning context. Do not guess what you can investigate."
+        },
+        {
+          "type": "principle",
+          "statement": "Decomposition is the core act of planning.",
+          "body": "The plan's quality is determined by how well tasks are broken down — see \"How to Decompose\" below. Everything else (goal statement, execution order, collection plan) supports the task list."
+        },
+        {
+          "type": "principle",
+          "statement": "Exit plan mode to present, not to finish.",
+          "body": "ExitPlanMode surfaces the plan for user approval. No delegation happens until the user signs off. If the plan needs revision after feedback, re-enter plan mode — revisions deserve the same structured exploration as the original."
+        }
+      ]
+    },
+    {
+      "heading": "What a Good Plan Contains",
+      "content": [
+        {
+          "type": "text",
+          "value": "**Goal** — One sentence restating what the user wants, from the DISCUSS phase.\n\n**Tasks** — A numbered list of small, specific tasks. Each task specifies:"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "What to do (specific deliverable, not vague direction)",
+            "Which agent handles it",
+            "Which skills to load",
+            "Dependencies on other tasks, if any",
+            "Scope boundary — what this task should NOT touch",
+            "Files modified — which files this task will create or modify. Making file targets explicit enables overlap detection between parallel tasks, scope verification by evaluators, and post-wave consistency checks. Not every task has meaningful file targets (research, design discussion) — but when files are known, name them.",
+            "Verification approach — how to confirm the task's output is correct. What should an evaluator check? What conditions prove success? This gives evaluators concrete criteria instead of only reasoning about the output. Pure exploration tasks may not have verifiable outputs — that's fine. The principle is explicitness, not rigidity."
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**Execution order** — Which tasks run in parallel (independent) and which run sequentially (dependent). Maximize parallelism — independent tasks launch simultaneously.\n\n**Expected outcome** — What the user will have when all tasks complete.\n\n**Collection plan** — Where work docs will be written after delegation completes. Specify the task directory path and list which subtask `.json` files will be created. This ensures the COLLECT phase has a clear target."
+        }
+      ]
+    },
+    {
+      "heading": "How to Decompose",
+      "content": [
+        {
+          "type": "text",
+          "value": "**Start from the deliverable, work backward.** What does the user need? What pieces make up that deliverable? Each piece is a candidate task.\n\n**Split by domain, not by file.** Assign tasks by specialist expertise, not by which files they touch. Domain expertise matters more than file boundaries.\n\n**Make tasks self-contained.** Each task should make sense on its own without reading the other tasks. The agent receiving it should understand the full scope from the task description alone.\n\n**Keep tasks small.** If a task description uses \"and\" to join two unrelated concerns, split it. If an agent would need to context-switch between different subsystems, split it.\n\n**Name the agent and skills explicitly.** For each task, state the agent type (from `.claude/agents/`), the skills to load, and any project docs to read."
+        }
+      ]
+    },
+    {
+      "heading": "Signs of a Bad Plan",
+      "content": [
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "A task says \"improve X\" or \"work on Y\" without specifying the deliverable",
+            "A task has no agent assigned",
+            "Two tasks modify the same files (merge conflict risk)",
+            "A task is so large the agent will lose focus",
+            "A task is so small it's not worth the delegation overhead",
+            "Dependencies between tasks aren't stated — agents will block each other",
+            "More than 8 parallel tasks in one wave (coordination overhead exceeds parallelism benefit)"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Constraints",
+      "content": [
+        {
+          "type": "constraint-list",
+          "items": [
+            "Always use EnterPlanMode for non-trivial tasks — planning in your head produces worse plans than exploring the codebase first",
+            "Always re-enter EnterPlanMode when revising a plan after evaluation — revisions need the same structured exploration as the original plan",
+            "Always assign an agent and skills to each task — implicit selection leads to wrong agents",
+            "Never delegate before ExitPlanMode approval — the user must sign off on the plan",
+            "Never decompose into more than 8 parallel tasks per wave — batch larger plans into sequential waves",
+            "Never plan tasks that overlap on the same files — combine them or sequence them"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_plan/gotchas.json
+++ b/.claude/skills/_plan/gotchas.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "gobbi-docs/gotcha",
+  "parent": "_plan",
+  "title": "Gotcha: _plan",
+  "entries": [
+    {
+      "title": "Use EnterPlanMode when writing an improved plan",
+      "body": {
+        "priority": "High",
+        "what-happened": "After plan evaluation feedback, the orchestrator rewrote the improved plan in conversation text instead of using EnterPlanMode. The improved plan was not persisted to the plan file and lacked the structured exploration that plan mode provides.",
+        "user-feedback": "When writing an improved plan, use EnterPlanMode tool.",
+        "correct-approach": "Every time the plan needs revision (after evaluation feedback, after user discussion), call EnterPlanMode to enter plan mode. Explore the codebase as needed, write the improved plan, then call ExitPlanMode to present it. This ensures the plan is always written to the plan file and benefits from read-only exploration before committing to changes."
+      }
+    }
+  ],
+  "opening": "Mistakes in planning and task decomposition."
+}

--- a/.claude/skills/_project-evaluation-aesthetics/SKILL.json
+++ b/.claude/skills/_project-evaluation-aesthetics/SKILL.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_project-evaluation-aesthetics",
+    "description": "Perspective skill for evaluating project deliverables for readability and style. Use when evaluating code changes, documentation updates, or any codebase output for naming clarity, style consistency, reader comprehension, and documentation quality.",
+    "allowed-tools": "Read, Grep, Glob, Bash"
+  },
+  "title": "Project Evaluation — Aesthetics Perspective",
+  "opening": "This perspective answers one question: will the next person who reads this code understand it quickly and correctly? Load this skill when evaluating project output — implementations, documentation, configuration — from a readability and style angle.\n\nThe evaluator's job is to find friction for the reader, not to enforce personal preferences.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Readability is correctness for the reader who comes next.",
+          "body": "Code that does the right thing but communicates it badly will be misread, mismodified, and broken. The cost of unclear code accumulates with every future change. This makes readability a correctness concern, not an aesthetic indulgence."
+        },
+        {
+          "type": "principle",
+          "statement": "Style consistency with the codebase matters more than any particular style.",
+          "body": "Code that follows a different style from its neighbors forces readers to context-switch. Read the existing code in the same area before evaluating — the standard is what already exists, not an abstract preference."
+        }
+      ]
+    },
+    {
+      "heading": "Evaluation Lenses",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Naming Clarity",
+          "content": [
+            {
+              "type": "text",
+              "value": "Do names communicate intent precisely, without requiring the reader to read the implementation to understand them?\n\nEvaluate function names against what the function actually does. If the name describes a mechanism (\"processData\", \"handleItem\") rather than an intent (\"validateUserInput\", \"applyDiscountTier\"), the name is weaker than it could be. Variables named for their type rather than their role (\"string\", \"list\", \"obj\") lose all semantic content.\n\nExamine names at the call site — not just the definition. A name that makes sense in context of the implementation may be confusing or ambiguous to a caller who does not see that implementation."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Style Consistency",
+          "content": [
+            {
+              "type": "text",
+              "value": "Does the code follow the style established in the surrounding codebase?\n\nRead several files in the same directory or module before evaluating. Look at: formatting conventions, import organization, function length norms, error handling idioms, and comment style. The deliverable should match these conventions. Deviations — even small ones — introduce noise that readers must filter.\n\nStyle inconsistency is not always the agent's fault. If the surrounding codebase has mixed styles, note the inconsistency as a pre-existing condition and evaluate the deliverable against the dominant pattern."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Reader Comprehension",
+          "content": [
+            {
+              "type": "text",
+              "value": "Could a developer unfamiliar with this area understand the code without reading its dependencies?\n\nWalk through the code as a reader would. At each step, ask: does the current context (function names, variable names, comments, structure) make the next step predictable? When the code makes a non-obvious choice — an algorithm that isn't the naive solution, an order of operations with a specific reason, a conditional that handles an edge case — is there enough signal to understand why?\n\nNon-obvious code without explanation is the primary source of bugs introduced by future agents. It is not enough for code to be correct — it must also be readable as correct."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Documentation Quality",
+          "content": [
+            {
+              "type": "text",
+              "value": "Is documentation present where needed, absent where unnecessary, and accurate where present?\n\nThe threshold for documentation is non-obviousness: explain what cannot be understood from the code itself. Absence of comments is not a failure when the code is clear. Presence of comments that restate the code (\"increment i by 1\") adds noise without value.\n\nWhere documentation exists, check that it matches the actual behavior. Stale documentation that describes what the code used to do is actively harmful — it misleads the next reader.\n\nFor public APIs, check that the interface contract (parameters, return values, side effects, error conditions) is documented clearly enough that a caller does not need to read the implementation."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Signals Worth Investigating",
+      "content": [
+        {
+          "type": "text",
+          "value": "These patterns are not automatically failures, but each warrants examination:"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "A function that takes more than three or four parameters, suggesting a missing concept",
+            "A variable whose name is only meaningful at the point of assignment, not at the points of use",
+            "A complex conditional whose branches are not individually named or explained",
+            "Documentation that describes implementation steps instead of intent and contract",
+            "Code that uses a different style than the four or five closest files in the same directory"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Output Expectations",
+      "content": [
+        {
+          "type": "text",
+          "value": "Report findings as specific reader-perspective observations: name the file and construct, describe what a reader would experience, and explain why the current form creates friction. Avoid \"this is ugly\" framing — identify the specific comprehension risk.\n\nNote where the deliverable improves readability over what it replaced. These are worth preserving. The overall perspective evaluator needs to know what is working, not just what is not."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_project-evaluation-architecture/SKILL.json
+++ b/.claude/skills/_project-evaluation-architecture/SKILL.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_project-evaluation-architecture",
+    "description": "Perspective skill for evaluating project deliverables for structural soundness. Use when evaluating code changes, refactoring output, or new implementations for coupling, cohesion, pattern consistency, type safety, and fit within the existing design.",
+    "allowed-tools": "Read, Grep, Glob, Bash"
+  },
+  "title": "Project Evaluation — Architecture Perspective",
+  "opening": "This perspective answers one question: is the code structurally sound within the existing system? Load this skill when evaluating project output — implementations, refactoring, configuration changes — from a structural and design angle.\n\nThe evaluator's job is to find design problems, not to propose rewrites.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Fit within the existing design, or change the design deliberately.",
+          "body": "New code that imports a pattern inconsistent with the rest of the codebase creates drift — two ways of doing the same thing, neither authoritative. This is not always wrong, but it must be intentional and traceable. Unintentional pattern divergence is a structural failure."
+        },
+        {
+          "type": "principle",
+          "statement": "Abstractions should reduce complexity, not create it.",
+          "body": "An abstraction that requires the reader to understand more than the code it replaced has made the codebase harder to work with. The test is whether the abstraction is learnable from existing usage without reading its implementation."
+        }
+      ]
+    },
+    {
+      "heading": "Evaluation Lenses",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Pattern Consistency",
+          "content": [
+            {
+              "type": "text",
+              "value": "Does the code follow the patterns established in the surrounding codebase?\n\nRead the existing implementations in the same area. Identify the dominant patterns for error handling, data transformation, component composition, and module boundaries. The deliverable should fit these patterns — or, if it diverges, that divergence should be justified by the nature of the new code and not simply a matter of agent preference or unfamiliarity.\n\nInconsistent patterns are not style issues — they are maintenance costs. Future agents reading this code will be confused about which pattern to follow."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Coupling and Cohesion",
+          "content": [
+            {
+              "type": "text",
+              "value": "Are module boundaries respected? Does each unit do one thing?\n\nCoupling: does the deliverable reach into another module's internals, or rely on implementation details that aren't exposed as a stable interface? Tight coupling makes isolated change impossible — modifying one component cascades unpredictably.\n\nCohesion: does each function, class, or module have a single, clear purpose? Mixed responsibilities make code harder to test, harder to reuse, and harder to understand."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Type Safety",
+          "content": [
+            {
+              "type": "text",
+              "value": "Are types used precisely, or are they working around the type system?\n\nAssess how the code uses the type system in place — whether TypeScript, Go, or another typed language. Look for casts that bypass type checking, `any`-equivalent escapes, type assertions without prior narrowing, or data shapes passed as loose maps when a typed structure would make intent clear.\n\nTypes are documentation the compiler enforces. Where the deliverable weakens type precision, it weakens the compiler's ability to catch future mistakes."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Extensibility",
+          "content": [
+            {
+              "type": "text",
+              "value": "Does the code extend naturally, or does it fight the existing design?\n\nChanges that would make future extension difficult — hard-coded specifics where variability is clearly needed, structural decisions that assume the current shape of the data will never change — are design problems, not just aesthetic ones. Assess whether the deliverable was designed for the immediate case only, when the surrounding code clearly anticipates evolution."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Signals Worth Investigating",
+      "content": [
+        {
+          "type": "text",
+          "value": "These patterns are not automatically failures, but each warrants examination:"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "A new abstraction that duplicates an existing one with slightly different semantics",
+            "Accessing internal state of another module that was not designed to be consumed externally",
+            "Type casts or escape hatches used where a type guard or discriminated union would work",
+            "A function or module that grew to handle two or more unrelated concerns",
+            "A pattern introduced here that no other part of the codebase uses"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Output Expectations",
+      "content": [
+        {
+          "type": "text",
+          "value": "Report findings as specific, traceable observations. Name the file, the construct, and the structural problem. Distinguish between violations of the existing design (the code fights the codebase) and missing design choices (the code introduces something new without a clear home). Rate severity: whether the issue creates ongoing maintenance costs (significant) or is a localized inconsistency unlikely to spread (minor).\n\nDo not propose alternative implementations. Describe the problem clearly enough that the implementer can reason about the right solution in context."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_project-evaluation-overall/SKILL.json
+++ b/.claude/skills/_project-evaluation-overall/SKILL.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_project-evaluation-overall",
+    "description": "Perspective skill for synthesizing cross-cutting evaluation of project deliverables. Use after the other four project evaluation perspectives have reported findings — synthesizes gaps, integration concerns, emergent problems, and what must be preserved.",
+    "allowed-tools": "Read, Grep, Glob, Bash"
+  },
+  "title": "Project Evaluation — Overall Perspective",
+  "opening": "This perspective answers one question: what does the full picture look like when the other four perspectives are taken together? Load this skill after the project, architecture, performance, and aesthetics perspectives have reported. The overall evaluator synthesizes, does not re-evaluate.\n\nThe overall evaluator's job is to surface what individual perspectives miss — gaps that fall between lenses, emergent problems from the combination of design choices, integration risks, and what must be preserved.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Individual perspectives are necessary but not sufficient.",
+          "body": "Each specialist evaluator sees one dimension clearly and the others peripherally. The overall perspective holds all four dimensions simultaneously and looks for what falls between them — problems invisible to any single lens."
+        },
+        {
+          "type": "principle",
+          "statement": "Preserve what works. Evaluation is not only a defect list.",
+          "body": "The overall perspective must identify what the deliverable does well and what must not be broken in any fix. Evaluation that produces only a list of problems gives fixers no anchor — they may improve one dimension while unknowingly degrading another."
+        }
+      ]
+    },
+    {
+      "heading": "Evaluation Lenses",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Cross-Cutting Gaps",
+          "content": [
+            {
+              "type": "text",
+              "value": "What did no single perspective fully address?\n\nRead all four perspective reports before beginning. Identify findings that touch multiple perspectives — a naming problem that also reveals a design ambiguity, a performance concern that also indicates a missing abstraction, a scope misalignment that explains an architectural inconsistency. These cross-cutting observations do not belong to any single perspective but are often the most important findings.\n\nAlso look for gaps: areas of the deliverable that no perspective covered in depth. Boundaries between modules, interactions with configuration or environment, error paths that are neither in the hot path (performance) nor obviously readable (aesthetics) but still represent correctness concerns."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Integration Concerns",
+          "content": [
+            {
+              "type": "text",
+              "value": "How does the deliverable interact with work happening in parallel or work that will follow?\n\nFor concurrent work: are there shared interfaces, shared data structures, or shared configuration that this deliverable changes in ways that will conflict with other in-flight work? This requires reading the task context and any notes about parallel tasks.\n\nFor future work: does the deliverable leave the codebase in a state that makes the next step harder? This includes deferred edge cases that the next task will encounter, interfaces that are subtly different from what the calling context expects, and changes that narrow the option space for future design decisions."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Emergent Problems",
+          "content": [
+            {
+              "type": "text",
+              "value": "What problems arise only from the combination of design choices, not from any single choice in isolation?\n\nThis is the most subtle lens. A type system escape that would be harmless in isolation becomes problematic when combined with a pattern that relies on that type's invariants elsewhere. A performance shortcut that is acceptable given current query volume becomes a risk when combined with a caching pattern that reduces the cache hit rate.\n\nRead the deliverable as a whole and ask: do the individual pieces interact in ways that create problems none of them creates alone?"
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "What Must Be Preserved",
+          "content": [
+            {
+              "type": "text",
+              "value": "What does the deliverable get right that any fix must not break?\n\nA fix to an architecture finding must not introduce new performance problems. A fix to a naming problem must not change observable behavior. A fix to a scope misalignment must not reverse progress on the correct parts of the deliverable.\n\nIdentify the strongest aspects of the deliverable — the parts that are clearly correct, clearly well-designed, or clearly aligned with user intent — and name them explicitly. These are the preservation targets for whoever acts on the evaluation findings."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Reporting Format",
+      "content": [
+        {
+          "type": "text",
+          "value": "The overall perspective report should structure its output in four sections:\n\n**Cross-cutting observations** — findings that span multiple perspectives or fall between them.\n\n**Integration concerns** — risks for concurrent or future work.\n\n**Emergent problems** — issues that arise from the combination of choices, not individual choices.\n\n**Must preserve** — what is working and must survive any corrections.\n\nRate findings by whether they block the deliverable from serving its purpose (critical), create meaningful risk or rework (significant), or are minor issues that do not affect the core result (minor). Do not duplicate individual perspective findings — reference them and add the cross-cutting dimension."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_project-evaluation-performance/SKILL.json
+++ b/.claude/skills/_project-evaluation-performance/SKILL.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_project-evaluation-performance",
+    "description": "Perspective skill for evaluating project deliverables for efficiency. Use when evaluating code implementations, database queries, API interactions, or algorithms for computational cost, resource usage, caching patterns, and hot-path awareness.",
+    "allowed-tools": "Read, Grep, Glob, Bash"
+  },
+  "title": "Project Evaluation — Performance Perspective",
+  "opening": "This perspective answers one question: is the implementation efficient relative to the problem it solves? Load this skill when evaluating project output — algorithms, queries, data transformations, network interactions — from an efficiency and resource angle.\n\nThe evaluator's job is to find performance problems, not to micro-optimize acceptable code.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Efficiency is proportional to the problem, not absolute.",
+          "body": "A nested loop over five items is not a performance problem. The same pattern over ten thousand items at request time is. Evaluate efficiency in the context of actual data volumes, call frequency, and the system's performance envelope — not by applying a general rule that nested loops are bad."
+        },
+        {
+          "type": "principle",
+          "statement": "Hot paths deserve scrutiny. Cold paths deserve proportionality.",
+          "body": "Code that runs once at startup has a different efficiency budget than code that runs for every user request or every database row. Identify which code is on the hot path and apply stricter scrutiny there."
+        }
+      ]
+    },
+    {
+      "heading": "Evaluation Lenses",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Algorithm Complexity",
+          "content": [
+            {
+              "type": "text",
+              "value": "Is the computational complexity appropriate for the scale of the problem?\n\nRead the surrounding context to understand the expected data volumes and call patterns. An O(n²) algorithm over a collection that never exceeds a handful of elements is not a problem. The same algorithm over a collection that scales with user data — rows, events, messages — is.\n\nFocus on asymptotic behavior relative to the inputs that actually grow. Look for nested iterations where the nesting is over the same unbounded collection, and for recursive patterns without memoization where sub-problems repeat."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Database and Network Calls",
+          "content": [
+            {
+              "type": "text",
+              "value": "Are queries and network calls structured for the actual access pattern?\n\nQuery structure: are queries fetching more data than needed (over-fetching columns, missing WHERE clauses, pulling related records individually when a join would work)? Are queries issued inside loops when a single batched query would suffice? N+1 query patterns — where a list is fetched and then each item triggers a follow-up query — are the most common failure here.\n\nCaching: where the same external data is accessed multiple times within a single operation or request, is it cached? Where upstream data changes infrequently, is the absence of caching noted and intentional?"
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Resource Allocation",
+          "content": [
+            {
+              "type": "text",
+              "value": "Is resource usage proportional to the work being done?\n\nLook for allocations inside tight loops that could be moved outside — buffers, compiled patterns, formatted strings. Look for deep copies of large structures where a reference or shallow copy would serve. Look for synchronous blocking operations in code that runs on a shared thread or event loop.\n\nThese are not always problems in isolation, but they accumulate. A deliverable that introduces several unnecessary allocations in a hot path is a meaningful regression."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Redundant Computation",
+          "content": [
+            {
+              "type": "text",
+              "value": "Is the same work being done more than once unnecessarily?\n\nRedundant computation is often invisible: the same value derived multiple times from the same input, validation logic repeated at each call site instead of at the boundary, or a transformation applied inside a loop that produces the same result on every iteration. Read the code for repeated patterns that could be computed once and reused."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Signals Worth Investigating",
+      "content": [
+        {
+          "type": "text",
+          "value": "These patterns are not automatically failures, but each warrants examination:"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Iteration over a collection where each element triggers an external call",
+            "A function called inside a loop that performs non-trivial work each time and the result does not vary with the loop variable",
+            "A missing index on a field used in a WHERE or JOIN clause",
+            "Memory allocated and discarded on every invocation of a frequently called function",
+            "A synchronous file or network operation in a code path that handles concurrent requests"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Output Expectations",
+      "content": [
+        {
+          "type": "text",
+          "value": "Report findings with enough specificity to be actionable: name the file and construct, describe the access pattern, and explain why the current approach creates a performance concern at realistic scale. Where scale matters, make the scale explicit — \"this query runs once per row in the events table, which has X million rows.\"\n\nDo not flag theoretical inefficiencies that have no realistic impact given the problem's actual scale. The goal is to catch meaningful performance regressions, not to enforce algorithmic purity."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_project-evaluation-project/SKILL.json
+++ b/.claude/skills/_project-evaluation-project/SKILL.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_project-evaluation-project",
+    "description": "Perspective skill for evaluating project deliverables against requirements. Use when evaluating code changes, documentation updates, configuration modifications, or any codebase output for requirements fit, scope alignment, and goals alignment.",
+    "allowed-tools": "Read, Grep, Glob, Bash"
+  },
+  "title": "Project Evaluation — Project Perspective",
+  "opening": "This perspective answers one question: does the deliverable solve the right problem? Load this skill when evaluating project output — code implementations, documentation updates, configuration changes, refactoring results — from the requirements and goals angle.\n\nThe evaluator's job is to find gaps and misalignments, not to confirm success.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "The task spec is not the goal. The user's intent is the goal.",
+          "body": "A deliverable can satisfy every written requirement and still miss the point. This perspective checks whether the output serves what the user actually needed — not just what was written in the task description."
+        },
+        {
+          "type": "principle",
+          "statement": "Scope alignment works in both directions — expansion and contraction both fail.",
+          "body": "Over-delivering changes things the user didn't ask for. Under-delivering leaves requested work undone. Both are misalignments. Neither is acceptable without explicit sign-off."
+        }
+      ]
+    },
+    {
+      "heading": "Evaluation Lenses",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Requirements Fit",
+          "content": [
+            {
+              "type": "text",
+              "value": "Does the deliverable match what was explicitly asked for?\n\nRead the original task specification and trace each requirement to the output. Requirements that were addressed ambiguously — implemented in a way that technically satisfies the wording but misses the intended behavior — are a failure of requirements fit, not just of aesthetics.\n\nLook for requirements that were silently reinterpreted. When an agent rewrites a requirement as something subtly different and implements that instead, the spec is met on paper but not in substance."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Scope Alignment",
+          "content": [
+            {
+              "type": "text",
+              "value": "Is the scope of the change correct — neither too broad nor too narrow?\n\nScope creep is the more common failure: adjacent code refactored \"while I was in there,\" formatting normalized beyond the task boundary, or additional features added that weren't requested. These changes may be improvements in isolation but represent unauthorized decisions.\n\nScope contraction is less common but equally problematic: partial implementation that stops short of the full requirement, edge cases silently dropped, or deferred handling not flagged as deferred.\n\nWhen scope appears off in either direction, assess whether the deviation was noted and the user given the chance to approve it."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Goals Alignment",
+          "content": [
+            {
+              "type": "text",
+              "value": "Does the output serve the user's intent — the problem behind the task?\n\nThis requires understanding the why, not just the what. A bug fix that closes the reported symptom but leaves the root cause intact solves the wrong problem. A documentation update that answers the literal question but confuses the actual workflow the user is trying to understand misses the goal.\n\nAsk: if the user ran this deliverable, would they feel their original problem was resolved? If not, why not?"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Signals Worth Investigating",
+      "content": [
+        {
+          "type": "text",
+          "value": "These patterns are not automatically failures, but each warrants examination:"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Changes touching files or components not mentioned in the task",
+            "Requirements that appear in the spec but are absent from the output",
+            "Behavior changes that go beyond the stated scope",
+            "Assumptions about user intent that were not confirmed",
+            "Partial implementations without a noted rationale for deferral"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Output Expectations",
+      "content": [
+        {
+          "type": "text",
+          "value": "Report findings as specific, grounded observations — not impressions. For each gap, identify the requirement it traces to, describe the actual output, and explain the misalignment. Rate the severity: whether the gap blocks the deliverable from serving its purpose (critical), creates a visible shortfall (significant), or is a minor deviation that does not affect the core result (minor).\n\nWhere the deliverable is well-aligned to goals, note what is working — not as praise, but because the overall perspective (read by the next evaluator) needs to know what must be preserved."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_project-evaluation-user/SKILL.json
+++ b/.claude/skills/_project-evaluation-user/SKILL.json
@@ -1,0 +1,137 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_project-evaluation-user",
+    "description": "User perspective for evaluating project deliverables — assesses whether the output works from the user's viewpoint, whether it introduces friction, and whether the user's workflow is actually improved. Use when evaluating code changes, documentation, or configuration for their real-world impact on the person who encounters them.",
+    "allowed-tools": "Read, Grep, Glob, Bash"
+  },
+  "title": "Project Evaluation — User Perspective",
+  "opening": "This perspective answers one question: does this deliverable actually work for the person who will use it?\n\nLoad this skill when evaluating project output — implementations, documentation, configuration, interfaces — from the viewpoint of the person who encounters it. The user perspective does not care how clean the internals are. It cares whether the deliverable reduces friction, behaves predictably, and gives the user what they came for.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Internal quality that the user never experiences is not enough. Visible improvement is the measure.",
+          "body": "A refactoring that makes the code cleaner but leaves the user's workflow identical has delivered internal value, not user value. This is not a failure — internal improvements matter — but the user perspective must honestly assess whether this particular deliverable improves anything the user can experience. If it doesn't, that should be named."
+        },
+        {
+          "type": "principle",
+          "statement": "Friction is the enemy. Every extra step, confusing option, or unclear behavior is a tax the user pays.",
+          "body": "Users do not experience a system's design. They experience the gap between what they expected to happen and what actually happened. The user perspective hunts for gaps."
+        }
+      ]
+    },
+    {
+      "heading": "Evaluation Lenses",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Immediate Usability",
+          "content": [
+            {
+              "type": "text",
+              "value": "Can the user use this right now, without reading a manual?\n\nAssess the deliverable as someone encountering it for the first time with a real task in mind. Ask:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Is the entry point obvious — where do they start, what do they invoke, what is the first thing they see?",
+                "If something goes wrong in the first five steps, does the error message tell them what happened and how to recover?",
+                "Are there configuration requirements or prerequisites that the user must satisfy before the deliverable works, and are those requirements surfaced clearly?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Friction Audit",
+          "content": [
+            {
+              "type": "text",
+              "value": "Does this deliverable introduce steps, decisions, or confusion that weren't there before?\n\nNew features often add capability while also adding complexity. The user perspective evaluates whether that trade-off is worth it — or whether the new complexity is accidental and fixable. Assess:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Does the user now need to make a choice they didn't have to make before? Is that choice justified by real user needs, or is it an artifact of the implementation?",
+                "Are there new concepts the user must understand to use this correctly? Are those concepts explained where the user will encounter them, or only in documentation they are unlikely to read?",
+                "Does the deliverable behave differently in edge cases that users will hit — and does it behave in a way the user would recognize as correct?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Understandability of Outputs",
+          "content": [
+            {
+              "type": "text",
+              "value": "When the deliverable produces output — errors, responses, results, documentation — is that output readable by someone who didn't write the code?\n\nInternal terminology, stack traces, and implementation details that leak into user-facing output are a user experience failure. Assess:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Are error messages written for the user or for the developer who wrote the code?",
+                "Does documentation or inline help use vocabulary the user already has, or vocabulary they'd need to learn?",
+                "When something unexpected happens, does the deliverable tell the user what to do, or just what went wrong?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Workflow Impact",
+          "content": [
+            {
+              "type": "text",
+              "value": "Does this change improve the user's workflow, or only the code's internal quality?\n\nThis lens asks for an honest assessment of real-world impact. Some deliverables improve user experience meaningfully — fewer steps, fewer errors, faster results. Others improve internal structure without changing what the user experiences. Name which is true here. Assess:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Would a user who didn't read the changelog notice this change in their daily work?",
+                "If they did notice it, would they notice it as an improvement or as something different that they must now adapt to?",
+                "Does the change reduce the number of things the user must remember, or does it add to that number?"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Signals Worth Investigating",
+      "content": [
+        {
+          "type": "text",
+          "value": "These patterns are not automatic failures, but each warrants examination:"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "A deliverable that improves correctness under conditions the user rarely encounters, while adding configuration the user must always maintain",
+            "Error handling that logs internally but gives the user no actionable path forward",
+            "New options or flags with names that would only make sense to someone who read the implementation",
+            "Documentation that describes the system's behavior accurately but doesn't answer the question a new user is likely to ask",
+            "A change that makes the common case harder in order to support an edge case the user may never hit"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Output Expectations",
+      "content": [
+        {
+          "type": "text",
+          "value": "Report findings as specific user-facing observations: what the user experiences, under what conditions, and why the current deliverable produces that experience. Distinguish between failures that prevent use (blocking), failures that create ongoing friction without preventing use (significant), and improvements that would help but aren't necessary for the deliverable to work (minor).\n\nName at least one thing the deliverable gets right from the user's perspective. Evaluation that produces only a defect list gives no anchor to whoever acts on the findings."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_project/SKILL.json
+++ b/.claude/skills/_project/SKILL.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_project",
+    "description": "Guide for authoring project documentation in .claude/project/{project-name}/. Covers directory structure, README.md, design docs, and notes."
+  },
+  "title": "Claude Project Documentation",
+  "opening": "Guide for authoring project-specific documentation in `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/`. Project docs capture accumulated context — architecture decisions, conventions, technology choices, gotchas — that help agents work effectively on returning sessions. Load this skill when creating, reviewing, or organizing project documentation.\n\nLoad `_claude` for the general documentation writing standard before authoring project docs.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Project docs live in `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/`.",
+          "body": "Each project gets its own directory under `$CLAUDE_PROJECT_DIR/.claude/project/`. All project-specific documentation lives inside that directory — design decisions, architecture, rules, gotchas, notes, references. Co-location makes everything about a project navigable from a single entry point."
+        },
+        {
+          "type": "principle",
+          "statement": "Project docs decay fast — currency matters more than completeness.",
+          "body": "Project docs describe a moving target. A stale doc is worse than no doc — it actively misleads agents into wrong assumptions. Scan for staleness whenever touching related code and docs. Delete superseded content rather than leaving it to accumulate."
+        },
+        {
+          "type": "principle",
+          "statement": "Every directory has a README.md as entry point.",
+          "body": "The README summarizes what the directory is about and lists its contents with one-line descriptions. Agents read the README first to decide which docs to load. Without a README, agents cannot navigate efficiently."
+        }
+      ]
+    },
+    {
+      "heading": "Directory Structure",
+      "content": [
+        {
+          "type": "text",
+          "value": "All projects must follow this structure:\n\n```\n.claude/project/{project-name}/\n  README.md             — project overview and directory index\n  design/               — project design and architecture\n  rules/                — project-specific rules and conventions\n  gotchas/              — project-specific gotchas (not cross-project)\n  note/                 — workflow notes per task (managed by _note)\n  reference/            — external references, API docs, research\n  docs/                 — other project documents\n```\n\nNot every project needs every subdirectory. Create only the directories that have content.\n\n**README.md** — Project overview and index. Must list: project name and purpose (one sentence), links to each subdirectory with one-line descriptions, and current status or active work if any.\n\n**design/** — Project design decisions and architecture. How the system is designed, why decisions were made, and what trade-offs were accepted.\n\n**rules/** — Project-specific rules and conventions. Standards that apply only to this project — coding patterns, naming conventions, deployment rules. Separate from cross-project rules in `.claude/rules/`.\n\n**gotchas/** — Project-specific gotchas, categorized by domain. Mistakes and corrections that apply only to this project. Separate from cross-project gotchas in `_gotcha/`.\n\n**note/** — Workflow notes per task, managed by `_note`. Each task gets a directory named `{YYYYMMDD}-{HHMM}-{slug}-{session_id}`.\n\n**reference/** — External references — API docs, research findings, third-party documentation, links to external systems.\n\n**docs/** — Other project documents that do not fit the above categories."
+        }
+      ]
+    },
+    {
+      "heading": "Writing Pattern",
+      "content": [
+        {
+          "type": "text",
+          "value": "**Self-contained.** Each doc makes sense on its own without reading others. First lines tell the agent what it covers and when to read it — without requiring context from sibling docs.\n\n**Archive, don't hoard.** Delete superseded docs. Do not accumulate stale content from prior sessions or completed features.\n\n**Focused scope.** Split by topic, not by length. If a doc covers multiple unrelated systems, split it. Each doc covers one coherent subject."
+        }
+      ]
+    },
+    {
+      "heading": "Anti-Patterns",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Must Avoid",
+          "content": [
+            {
+              "type": "text",
+              "value": "**Stale docs left in place.** References deleted files or describes \"planned\" features already built. Agents make wrong assumptions from stale content. Delete or update before leaving a session.\n\n**Inconsistent directory structure.** Missing README.md or standard subdirectories breaks agent navigation. Agents rely on the consistent structure to decide what to read.\n\n**Project gotchas in _gotcha.** Project-specific gotchas must go in `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/gotchas/`, not in the cross-project gotcha skill. Mixing them pollutes the cross-project knowledge base with project-specific content."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Should Avoid",
+          "content": [
+            {
+              "type": "text",
+              "value": "**Duplicate docs for the same topic.** Created without checking existing docs. Search before creating — a duplicate creates two sources of truth that diverge.\n\n**No cleanup strategy.** Everything accumulates without active deletion. Set an expectation that outdated docs get removed, not archived."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Review Checklist",
+      "content": [
+        {
+          "type": "text",
+          "value": "Before publishing a project doc:\n\n**Core Principle**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "[ ] Lives inside `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/`",
+            "[ ] Contains project-specific context, not general domain knowledge",
+            "[ ] Content is current — no references to deleted files or outdated architecture",
+            "[ ] Directory has README.md as entry point"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**Writing Pattern**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "[ ] Self-contained — makes sense without reading other docs",
+            "[ ] Organized by topic with clear first-line summary",
+            "[ ] Focused on one coherent system or topic"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**Anti-Pattern**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "[ ] No stale references to removed code or outdated architecture (must avoid)",
+            "[ ] No duplicate covering same topic as existing doc (should avoid)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_rules/SKILL.json
+++ b/.claude/skills/_rules/SKILL.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_rules",
+    "description": "Guide for authoring rule files in .claude/rules/. Covers verifiability, structure, when to create a rule."
+  },
+  "title": "Claude Rules",
+  "opening": "Guide for authoring rule files in `.claude/rules/`. Rules live alongside other project documentation and define verifiable standards that apply across all work in the project. Load this skill when creating or reviewing rule files.\n\nLoad `_claude` for the general documentation writing standard before authoring rules.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "A rule is a verifiable standard enforced across all work in the project.",
+          "body": "Unlike skills (loaded on demand for specific domains), rules define what is required, what is forbidden, and the boundary conditions for work in a specific project. Rules apply universally — they are always active, not loaded on demand."
+        },
+        {
+          "type": "principle",
+          "statement": "If an agent or linter cannot check it mechanically, it is guidance — not a rule.",
+          "body": "The threshold for creating a rule is verifiability. Rules that rely on judgment calls are not rules — they are documentation. A rule must be checkable: either by reading a file and confirming a property, or by running a command and checking the result."
+        },
+        {
+          "type": "principle",
+          "statement": "Rules are project-specific standards, not general domain knowledge.",
+          "body": "Rules enforce conventions for this project — formatting configs, commit conventions, library policies. General domain knowledge (how to think about Python, how to design charts) belongs in skills, not rules."
+        },
+        {
+          "type": "principle",
+          "statement": "Gobbi rules vs project rules — know the boundary.",
+          "body": "Gobbi already provides rules for its own conventions (naming, formatting). Users do NOT need to create rules for `.claude/` documentation standards, skill naming, or gobbi workflow conventions — gobbi serves those. Project rules should enforce project-specific standards: code style for the project's language, testing requirements for the project's framework, deployment conventions for the project's infrastructure. When helping create a rule, first check if gobbi already covers the standard."
+        }
+      ]
+    },
+    {
+      "heading": "When to Create a Rule",
+      "content": [
+        {
+          "type": "text",
+          "value": "Create a rule when:"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "The standard applies to all code or all work in the project",
+            "Violation causes real problems that require rework or break things",
+            "The convention is not obvious from reading the codebase alone"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "Do not create rules for preferences, tooling-enforced standards (the tool already enforces it), or domain-specific guidance (use a skill instead)."
+        }
+      ]
+    },
+    {
+      "heading": "Writing Pattern",
+      "content": [
+        {
+          "type": "text",
+          "value": "**One clear statement.** The rule itself, the rationale, what is forbidden, what is required, and how compliance is verified. Everything in one coherent document.\n\n**Verifiable criteria.** \"All code formatted with Black, line-length 100\" — not \"Write clean code\". The verifiability criterion is the test: can an agent or linter confirm compliance without interpretation?\n\n**Flat structure.** Rules should not need deep nesting. If a rule requires extensive explanation, it is either too broad (split it) or better suited as a skill.\n\n**Descriptive naming.** Name by topic: `code-style.md`, `git.md`. Not by action: `how-to-test.md`. The filename tells the agent what domain the rule covers without reading it.\n\n**Front-load importance.** Agents read less carefully as files get longer. Put the most critical constraints first — the parts where violation causes the most damage."
+        }
+      ]
+    },
+    {
+      "heading": "Anti-Patterns",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Must Avoid",
+          "content": [
+            {
+              "type": "text",
+              "value": "**Rule too vague to enforce.** \"Handle errors properly\" is a preference, not a standard. Make it mechanically verifiable or move it to a skill.\n\n**Rule covers a domain.** Scope too broad — domain expertise belongs in a skill, not a rule. A rule covers a specific, narrow standard within a project."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Should Avoid",
+          "content": [
+            {
+              "type": "text",
+              "value": "**Rule duplicates tooling.** If a linter already catches it, only document the tool configuration. Do not write a rule for something the toolchain enforces automatically.\n\n**Rule has too many exceptions.** If every application of the rule requires judgment about whether an exception applies, the rule is too rigid. Narrow the scope or split into separate rules."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Review Checklist",
+      "content": [
+        {
+          "type": "text",
+          "value": "Before publishing a rule:\n\n**Core Principle**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "[ ] Standard is mechanically verifiable by agent or linter",
+            "[ ] Project-specific — not general domain knowledge (that belongs in a skill)"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**Writing Pattern**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "[ ] Rule stated as one clear, unambiguous statement",
+            "[ ] Verifiable criteria, not subjective guidance",
+            "[ ] Flat structure — no deep nesting",
+            "[ ] Most critical constraints front-loaded"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**Anti-Pattern**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "[ ] Not too vague to enforce (must avoid)",
+            "[ ] Does not duplicate what linters or tooling already catch (should avoid)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_skills-evaluation-aesthetics/SKILL.json
+++ b/.claude/skills/_skills-evaluation-aesthetics/SKILL.json
@@ -1,0 +1,172 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_skills-evaluation-aesthetics",
+    "description": "Evaluate a gobbi skill definition from the aesthetics perspective — naming clarity, writing quality, style consistency with the gobbi skill corpus, and readability for a fresh reader. Use when assessing whether a skill is well-crafted and intelligible without prior context.",
+    "allowed-tools": "Read, Grep, Glob, Bash"
+  },
+  "title": "Skills Evaluation — Aesthetics Perspective",
+  "opening": "You evaluate gobbi skill definitions from the aesthetics perspective. Your question is: is this skill well-crafted — clear naming, readable prose, consistent style, and intelligible to a fresh reader?\n\nAesthetics is not about polish for its own sake. A skill with unclear naming fires on the wrong tasks. A skill with inconsistent style produces agent behavior that doesn't match the system's mental model. A skill that requires prior context to understand produces agents that guess.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "A skill's first job is to be understood. An evaluator that cannot understand it cannot use it.",
+          "body": "The aesthetics evaluator reads the skill as a fresh reader would — someone who has not seen the system before, who is about to load this skill for the first time. If orientation requires context not in the skill itself, the skill has failed its primary job."
+        },
+        {
+          "type": "principle",
+          "statement": "Consistency with the gobbi skill corpus is not a style preference — it is a cognitive load reduction.",
+          "body": "Agents move across many skills in a session. When every skill follows the same writing patterns — blockquotes for principles, tables for navigation, command tone in descriptions — agents spend less effort parsing structure and more effort absorbing content. Inconsistency is friction."
+        }
+      ]
+    },
+    {
+      "heading": "What to Evaluate",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Naming Clarity",
+          "content": [
+            {
+              "type": "text",
+              "value": "The skill's directory name is how agents and orchestrators discover and refer to it. Assess:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Does the name accurately predict the skill's content? Would a reader who knows only the name know when to load it?",
+                "Does the name follow the gobbi naming convention — hyphen-separated, correct tier prefix (`_` or `__`), no underscores in the body?",
+                "Is the name as short as it can be while remaining unambiguous?",
+                "For a multi-word name: does the word order read naturally, or does it feel like a keyword dump?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Description Quality",
+          "content": [
+            {
+              "type": "text",
+              "value": "The `description` field is the skill's one-sentence pitch to the auto-invocation system and to any agent scanning the skill map. Assess:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Does it open with an action phrase or \"Use when...\" that names the specific trigger scenarios?",
+                "Is it written in command tone (\"Use when writing or reviewing X\") rather than feature tone (\"This skill provides X\")?",
+                "Is it specific enough to distinguish this skill from adjacent ones? Could you tell from the description alone which skill to load?",
+                "Is it a single sentence? Multi-sentence descriptions suggest the scope is unclear."
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Prose Quality",
+          "content": [
+            {
+              "type": "text",
+              "value": "The skill teaches a mental model. Prose that is ambiguous, verbose, or uses jargon without definition forces agents to guess. Assess:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Does the opening section tell the reader immediately what this skill is and when to load it?",
+                "Are principles stated as principles — declarative, general, transferable — or as procedures?",
+                "Is jargon either defined inline or obviously understood from context (gobbi-specific terms that appear in the CLAUDE.md or skill map)?",
+                "Are there sentences that a reader would need to re-read to parse? These should be simplified.",
+                "Does the writing feel like the rest of the gobbi skill corpus, or does it have a different voice or register?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Style Consistency",
+          "content": [
+            {
+              "type": "text",
+              "value": "Gobbi skills follow established formatting patterns. Assess by reading a sample of existing skills in `.claude/skills/`:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Are blockquotes (`>`) used for bold principle statements only — not for side notes, warnings, or emphasis?",
+                "Does the \"Navigate deeper from here:\" heading appear when child docs exist, using the exact phrasing?",
+                "Are tables used for structured comparisons and navigation — not for content that would read better as prose?",
+                "Do headings follow the gobbi pattern — title case for `##` sections, sentence case below?",
+                "Is whitespace consistent — blank lines between sections, consistent use of bold and lists?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Fresh-Reader Intelligibility",
+          "content": [
+            {
+              "type": "text",
+              "value": "Load the skill as if you have never seen gobbi before. Assess:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Can a reader understand what this skill does and when to use it from the first few lines alone?",
+                "Does the skill assume context that is never established — acronyms, referenced systems, or prior knowledge of another skill's content?",
+                "Would a reader know what to do after reading the skill, or would they need to read several other skills first to make sense of it?"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Signals Worth Noting",
+      "content": [
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "A description that contains the phrase \"provides\" or \"contains\" (feature tone, not command tone)",
+            "Blockquotes used for caveats, warnings, or emphasis rather than principle statements",
+            "Inconsistent heading levels — `###` for a concept that warrants `##`, or vice versa",
+            "A section titled \"Overview\" or \"Introduction\" that repeats the opening paragraph",
+            "Terms like \"LLM,\" \"context window,\" \"token budget\" used without acknowledgment that the reader is an AI agent, in a way that would be confusing",
+            "The skill uses \"you\" to address the agent clearly in some places and impersonally in others (inconsistent voice)"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Output Format",
+      "content": [
+        {
+          "type": "text",
+          "value": "Report findings as specific, named craft problems. For each problem:"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Quote or reference the specific text, heading, or name that has the issue",
+            "Explain what cognitive problem it creates for a reader or agent",
+            "Suggest a direction for improvement without prescribing the exact wording"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "Note what is well-crafted — clear naming, consistent style, strong principle statements, effective use of formatting. Specific praise helps authors understand what patterns to preserve."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_skills-evaluation-architecture/SKILL.json
+++ b/.claude/skills/_skills-evaluation-architecture/SKILL.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_skills-evaluation-architecture",
+    "description": "Evaluate a gobbi skill definition from the architecture perspective — hierarchy, decomposition, coupling between skills, abstraction level, and structural soundness. Use when assessing whether a skill is well-structured and fits cleanly into the skill system.",
+    "allowed-tools": "Read, Grep, Glob, Bash"
+  },
+  "title": "Skills Evaluation — Architecture Perspective",
+  "opening": "You evaluate gobbi skill definitions from the architecture perspective. Your question is: is this skill structurally sound, and does it compose cleanly with the rest of the skill system?\n\nThis perspective focuses on the internal structure of the skill and its relationships with other skills — not on whether it solves the right problem (project perspective) or whether its prose is clear (aesthetics perspective).",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "A skill's structure determines whether agents can navigate it, use it selectively, and extend it without breaking adjacent skills.",
+          "body": "The architecture evaluator looks at how a skill is organized internally — its hierarchy, its decomposition into child docs, its abstraction level — and how it couples with neighboring skills. A structurally sound skill is one an agent can load selectively, follow without confusion, and extend without introducing drift."
+        },
+        {
+          "type": "principle",
+          "statement": "Hierarchy is not decoration — it is the mechanism by which agents load only what they need.",
+          "body": "The parent-child structure in gobbi skills is a context management strategy. A flat, monolithic skill forces agents to read everything. A well-decomposed skill lets the parent orient and the children specialize. Evaluate whether the structure serves this purpose or undermines it."
+        }
+      ]
+    },
+    {
+      "heading": "What to Evaluate",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Internal Hierarchy",
+          "content": [
+            {
+              "type": "text",
+              "value": "Assess whether the skill's decomposition into SKILL.md and optional child files is appropriate:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Does SKILL.md give the agent enough orientation to decide which child docs to read?",
+                "Are child docs named and described clearly enough to guide selective loading?",
+                "Is content at the right level in the hierarchy — principles in the parent, specifics in children?",
+                "For a skill without child docs: is the content genuinely focused enough to be in a single file, or is it a flat monolith masquerading as a single-topic skill?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Abstraction Level",
+          "content": [
+            {
+              "type": "text",
+              "value": "Each skill should operate at a consistent level of abstraction. Assess:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Does the skill stay at one level, or does it mix high-level principles with low-level implementation details?",
+                "When the skill references external systems or other skills, does it reference them by contract (what they provide) rather than by implementation (how they work)?",
+                "Would a change to an implementation detail in another skill force changes to this one?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Coupling with Adjacent Skills",
+          "content": [
+            {
+              "type": "text",
+              "value": "Gobbi skills interact — one skill may depend on context another skill establishes. Assess:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "When this skill instructs an agent to load other skills, is that coupling necessary or incidental?",
+                "Does this skill duplicate content from a skill it depends on, creating two sources of truth?",
+                "If a sibling skill changed its contract, would this skill need to change? Is that dependency made explicit?",
+                "Are the `allowed-tools` scoped to what the skill actually requires, or does the list include tools defensively?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Structural Completeness",
+          "content": [
+            {
+              "type": "text",
+              "value": "Assess whether the skill has the structural elements that make it navigable and usable:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Is the frontmatter complete and correct — `name` matching directory, `description` in command tone, `allowed-tools` scoped tightly?",
+                "If children exist, is there a \"Navigate deeper from here:\" table in SKILL.md pointing to them?",
+                "Does SKILL.md open with a clear statement of what the skill is and when to load it?",
+                "Are headings structured so an agent can scan and locate relevant sections without reading everything?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Extension Path",
+          "content": [
+            {
+              "type": "text",
+              "value": "A well-architected skill can grow without requiring structural surgery. Assess:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "If this skill needed to add a new subtopic, is there a natural place for it?",
+                "If this skill became too large, what would be the natural child docs?",
+                "Does the current structure make the extension path clear, or does growth require rethinking the whole skill?"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Signals Worth Noting",
+      "content": [
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "A SKILL.md that exceeds the 200-line target with no child docs (suggests decomposition is needed)",
+            "A child doc that could be merged back into SKILL.md without losing anything (suggests over-splitting)",
+            "Two skills with a dependency cycle — each loads the other for orientation",
+            "`allowed-tools` includes `Write` or `Edit` in a skill that teaches read-only knowledge",
+            "The \"Navigate deeper\" table references files that don't exist or have different names than expected"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Output Format",
+      "content": [
+        {
+          "type": "text",
+          "value": "Report findings as specific, named structural problems. For each problem:"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Identify the specific structural element that is problematic",
+            "Explain what failure mode it produces when an agent uses this skill",
+            "Note whether it blocks correct use or merely reduces efficiency"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "Include observations on structural elements that are well-designed — decomposition that makes selective loading easy, coupling that is explicit and minimal, hierarchy that matches the domain's natural abstraction layers."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_skills-evaluation-overall/SKILL.json
+++ b/.claude/skills/_skills-evaluation-overall/SKILL.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_skills-evaluation-overall",
+    "description": "Evaluate a gobbi skill definition from the overall perspective — cross-cutting gaps across the four domain perspectives, integration concerns with adjacent skills, and a must-preserve list of what works well. Use when synthesizing the full evaluation picture for a skill.",
+    "allowed-tools": "Read, Grep, Glob, Bash"
+  },
+  "title": "Skills Evaluation — Overall Perspective",
+  "opening": "You evaluate gobbi skill definitions from the overall perspective. Your role is synthesis, not repetition. You read the findings from all four domain perspectives — project, architecture, performance, aesthetics — and assess what they collectively reveal.\n\nThis perspective is always included in skills evaluation. You identify cross-cutting gaps that no single perspective captures, flag integration concerns with the broader skill system, and document what must be preserved through any revision.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "The overall evaluator finds what the other perspectives cannot see separately.",
+          "body": "Each domain perspective evaluates one dimension. You evaluate the skill as a whole. Cross-cutting problems — where a flaw spans multiple dimensions, or where individually-acceptable choices combine into a systemic issue — are yours to surface."
+        },
+        {
+          "type": "principle",
+          "statement": "Preservation is as important as correction. What works well must survive revision.",
+          "body": "Every skill has strengths. Revision processes that fix problems frequently degrade strengths in the process. Your job is to make those strengths explicit so they are intentionally preserved — not accidentally removed."
+        }
+      ]
+    },
+    {
+      "heading": "What to Evaluate",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Cross-Cutting Gaps",
+          "content": [
+            {
+              "type": "text",
+              "value": "Read all four domain evaluations and look for patterns that span them. A cross-cutting gap is a problem that shows up differently in each domain but has a single root cause. Assess:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Is there a theme — a single underlying issue — that explains multiple findings from different perspectives?",
+                "Are there contradictions between perspectives? (One says \"too long,\" another says \"missing content\" — this tension needs resolution, not just both fixes applied.)",
+                "Is there a gap that none of the four perspectives surfaced but that becomes visible when looking at the full picture?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Integration with Adjacent Skills",
+          "content": [
+            {
+              "type": "text",
+              "value": "A skill does not exist in isolation — it is part of a skill system that agents navigate together in a session. Assess by reading adjacent and related skills:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Does this skill load correctly in the context of the skills that precede it in a typical workflow? Does it assume context established by another skill without stating that dependency?",
+                "Are there integration seams with adjacent skills that will break if this skill is revised? Name them explicitly so revision authors know what to protect.",
+                "Does this skill's revision interact with changes needed in other skills? If so, are those changes worth doing together or sequentially?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Severity and Priority",
+          "content": [
+            {
+              "type": "text",
+              "value": "Not all problems warrant fixing before a skill is used. Assess the full findings — yours and the four domain perspectives — and assign a priority order:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Which problems would cause incorrect agent behavior if unfixed? (High priority — fix before deployment)",
+                "Which problems reduce quality but don't cause failures? (Medium priority — address in the next revision cycle)",
+                "Which problems are refinements that would improve but not transform the skill? (Low priority — capture for future iteration)"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Must Preserve",
+          "content": [
+            {
+              "type": "text",
+              "value": "Every skill has elements that work well and must survive revision. Identify specifically:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Which principle statements capture the domain's mental model accurately and should not be reworded",
+                "Which structural choices — decomposition, navigation, section order — serve agents well and should be kept",
+                "Which specific formulations, examples of principles, or framings are well-calibrated for how agents actually use this skill",
+                "Which relationships with adjacent skills are correct and should not be disturbed"
+              ]
+            },
+            {
+              "type": "text",
+              "value": "Being specific here matters. \"The structure is good\" does not help a revision author. \"The 'Navigate deeper' table at line 12 correctly gates the advanced content behind child docs — preserve this pattern\" does."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Synthesis Format",
+      "content": [
+        {
+          "type": "text",
+          "value": "The overall evaluation should be structured as:\n\n**Cross-cutting themes** — Any patterns or root causes that span multiple domain perspectives, stated as a coherent diagnosis.\n\n**Integration notes** — Specific adjacent skills that interact with this one, and what a reviser needs to know about those relationships before making changes.\n\n**Priority ranking** — The full list of findings from all perspectives, ranked by severity. High-priority issues first. Each item names the originating perspective and the specific problem.\n\n**Must preserve** — A bulleted list of named strengths, with enough specificity that a revision author knows exactly what not to change."
+        }
+      ]
+    },
+    {
+      "heading": "Constraints",
+      "content": [
+        {
+          "type": "constraint-list",
+          "items": [
+            "Never re-evaluate what the domain perspectives have already assessed — synthesize, don't repeat",
+            "Never let the must-preserve section be empty — every skill has something worth naming",
+            "Never assign priority without reading the full skill and all four domain evaluations",
+            "Always read at least two adjacent skills before writing integration notes — integration concerns require actual comparison, not assumption"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_skills-evaluation-performance/SKILL.json
+++ b/.claude/skills/_skills-evaluation-performance/SKILL.json
@@ -1,0 +1,169 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_skills-evaluation-performance",
+    "description": "Evaluate a gobbi skill definition from the performance perspective — context efficiency, line count, conditional vs always-load patterns, and content duplication. Use when assessing whether a skill loads efficiently and avoids wasting agent context.",
+    "allowed-tools": "Read, Grep, Glob, Bash"
+  },
+  "title": "Skills Evaluation — Performance Perspective",
+  "opening": "You evaluate gobbi skill definitions from the performance perspective. Your question is: does this skill use context efficiently, and does it avoid making agents carry knowledge they don't need?\n\nIn the gobbi system, every token an agent loads is context that displaces other context. Skills that are longer than necessary, that duplicate content from other skills, or that force agents to load everything when they need only part — these are performance problems with real consequences for agent quality.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Context is finite. Every line a skill spends on content an agent doesn't need is a line that displaces something it does.",
+          "body": "The performance evaluator looks at the cost of loading this skill: how many tokens, how much of that is relevant to any given use case, and how much could be in a more targeted child doc or removed entirely."
+        },
+        {
+          "type": "principle",
+          "statement": "The goal is not brevity — it is relevance density. Every line should earn its place.",
+          "body": "A 150-line skill can be wasteful if half the lines duplicate content from another skill or cover cases that rarely arise. A 90-line skill can be efficient if every line is load-bearing. Evaluate density, not just length."
+        }
+      ]
+    },
+    {
+      "heading": "What to Evaluate",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Line Count and Load Budget",
+          "content": [
+            {
+              "type": "text",
+              "value": "The gobbi standard sets targets: under 200 lines for a SKILL.md, under 500 as a hard limit. Assess:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "What is the actual line count? Does it fall within the target range?",
+                "If above 200 lines: is the content genuinely irreducible, or could sections be moved to child docs or removed?",
+                "If below the target: this is generally fine, but check that brevity hasn't sacrificed necessary orientation content"
+              ]
+            },
+            {
+              "type": "text",
+              "value": "Line count is a proxy for context cost — it is not the only measure. A dense, compressed 200-line file may be more expensive to use than a well-organized 150-line file with clear sections an agent can scan selectively."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Conditional vs Always-Load Content",
+          "content": [
+            {
+              "type": "text",
+              "value": "Some content in a skill is relevant every time it loads. Other content is relevant only in specific scenarios. Assess:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Does the skill mix always-relevant content with scenario-specific content in the same flat structure?",
+                "When scenario-specific content is large, has it been moved to a child doc that agents load only when needed?",
+                "Does the \"Navigate deeper from here:\" table, if present, let agents load only the section relevant to their task?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Content Duplication",
+          "content": [
+            {
+              "type": "text",
+              "value": "Content that appears in two skills creates two problems: agents may carry redundant context, and the two copies drift over time. Assess by reading adjacent skills the briefing references:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Does this skill restate principles or constraints already taught by a skill it depends on (e.g., `_claude`, `_execution`)?",
+                "Does this skill include content that belongs in a rule or project doc rather than a portable skill?",
+                "Where the skill references another skill's content, does it point to that skill rather than repeat it?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Section Relevance",
+          "content": [
+            {
+              "type": "text",
+              "value": "Not every section an agent loads is relevant to every use case. Assess:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Are there large sections that cover edge cases or advanced scenarios most agents won't need?",
+                "Could those sections be gated behind a child doc that agents load only when facing that scenario?",
+                "Is the skill's opening section focused enough that an agent can orient quickly, or does it bury the entry point in a long preamble?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Allowed-Tools Scope",
+          "content": [
+            {
+              "type": "text",
+              "value": "Tools listed in `allowed-tools` inform the agent's action space. An over-broad list slightly expands what the agent considers doing. Assess:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Does the `allowed-tools` list match what the skill's content actually directs agents to do?",
+                "Are there tools listed that appear nowhere in the skill's guidance?",
+                "Are there tools the skill's content implies but that are not listed?"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Signals Worth Noting",
+      "content": [
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "SKILL.md over 200 lines with no child docs and no explanation for why decomposition was deferred",
+            "Identical or near-identical paragraphs appearing in this skill and a sibling skill",
+            "A section that starts with \"In advanced cases...\" or \"If you need to...\" — a candidate for a child doc",
+            "`allowed-tools` includes tools the skill never instructs the agent to use",
+            "The skill restates the gobbi writing principles verbatim (those belong in `_claude`, not here)"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Output Format",
+      "content": [
+        {
+          "type": "text",
+          "value": "Report findings as specific, actionable efficiency problems. For each problem:"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Identify the specific content that creates the inefficiency (section, line range, or duplicate content)",
+            "Quantify where possible — \"section X is N lines and covers a scenario that applies in M% of uses\"",
+            "Suggest the appropriate fix: move to child doc, remove, or replace with a pointer to the canonical source"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "Note what the skill gets right in terms of efficiency — well-scoped content, effective use of navigation tables, appropriate brevity."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_skills-evaluation-project/SKILL.json
+++ b/.claude/skills/_skills-evaluation-project/SKILL.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_skills-evaluation-project",
+    "description": "Evaluate a gobbi skill definition from the project perspective — purpose fit, trigger accuracy, role alignment, and problem ownership. Use when assessing whether a skill solves the right problem and belongs in the skill map.",
+    "allowed-tools": "Read, Grep, Glob, Bash"
+  },
+  "title": "Skills Evaluation — Project Perspective",
+  "opening": "You evaluate gobbi skill definitions from the project perspective. Your question is: does this skill solve the right problem, and does it belong where it is?\n\nThis perspective is always included in skills evaluation. You look for misalignment between what a skill claims to do and what it actually teaches — and for skills whose scope or placement undermines the agent's ability to find and use them.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "A skill that solves the wrong problem is worse than no skill — it shapes agent behavior in the wrong direction.",
+          "body": "The project evaluator does not assess writing quality or internal structure. It asks whether the skill's existence and purpose are well-reasoned: does it own a real knowledge domain, is it the right place for that domain, and does its trigger description accurately predict when it should be loaded?"
+        },
+        {
+          "type": "principle",
+          "statement": "Trigger accuracy determines whether the skill ever gets used.",
+          "body": "A skill with a misaligned description either fires on tasks it shouldn't, or fails to fire on tasks it should. Both failures cost — one wastes context, the other produces agents working without relevant knowledge."
+        }
+      ]
+    },
+    {
+      "heading": "What to Evaluate",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Purpose Fit",
+          "content": [
+            {
+              "type": "text",
+              "value": "Is this skill solving a real problem? A skill exists to give agents knowledge they'd otherwise lack. Assess:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Is the domain it covers genuinely reusable knowledge — something an agent would need across multiple tasks?",
+                "Is the purpose specific enough that the skill's content can be coherent, or so broad it collapses into a general reference?",
+                "Is there a gap it fills, or does it duplicate what an agent should already know from the codebase or other skills?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Trigger Accuracy",
+          "content": [
+            {
+              "type": "text",
+              "value": "The `description` field drives auto-invocation. Read the description and ask: given only this sentence, would an agent load this skill at the right moments and skip it at the wrong ones? Assess:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Does the description name the specific scenarios that warrant loading, not just the topic area?",
+                "Could the description match tasks where this skill would be irrelevant (over-triggering)?",
+                "Could an agent in the right scenario fail to recognize the description as matching (under-triggering)?",
+                "Is the command tone used (\"Use when...\" not \"This skill provides...\")?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Role in the Skill Map",
+          "content": [
+            {
+              "type": "text",
+              "value": "Every skill belongs to a tier and category in the gobbi skill map. Assess:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Does the skill's tier prefix (`_` vs `__`) reflect its actual visibility? Hidden skills serve the system; internal skills serve gobbi contributors.",
+                "Does the skill's placement in the skill map make it findable? If an agent is doing work in this domain, would it discover this skill?",
+                "Does the skill complement adjacent skills, or does it compete with them for the same domain?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Scope Ownership",
+          "content": [
+            {
+              "type": "text",
+              "value": "A skill should own its domain without bleeding into adjacent ones. Assess:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Is there a clear boundary between what this skill teaches and what neighboring skills teach?",
+                "Does the skill's content stay within its claimed scope, or does it drift into other territories?",
+                "If this skill grows, is there a natural decomposition path, or is the scope already too broad to extend?"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Signals Worth Noting",
+      "content": [
+        {
+          "type": "text",
+          "value": "These are not automatic failures — they are signals that warrant closer examination:"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Description that restates the skill name rather than naming trigger scenarios",
+            "Purpose that is entirely covered by an existing skill",
+            "Content that teaches what to do in a domain already taught by a parent skill (duplication, not specialization)",
+            "A skill with no clear owner — it could belong in multiple places, which means it belongs in none",
+            "Scope so broad that the `allowed-tools` list must include every tool to cover edge cases"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Output Format",
+      "content": [
+        {
+          "type": "text",
+          "value": "Report findings as specific, named problems — not scores or ratings. For each problem:"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "State what the specific gap or misalignment is",
+            "Explain why it matters (what failure mode it produces in practice)",
+            "Note whether it is a blocking issue or a refinement"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "Include a brief \"what works\" note on any aspect of purpose, trigger, or placement that is well-designed. Preserving what works matters as much as finding what doesn't."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_skills-evaluation-user/SKILL.json
+++ b/.claude/skills/_skills-evaluation-user/SKILL.json
@@ -1,0 +1,137 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_skills-evaluation-user",
+    "description": "User perspective for evaluating gobbi skill definitions — assesses discoverability, actionability, predictability, and whether the skill actually serves the person invoking it. Use when evaluating whether a skill delivers real value to the user who triggers it.",
+    "allowed-tools": "Read, Grep, Glob, Bash"
+  },
+  "title": "Skills Evaluation — User Perspective",
+  "opening": "You evaluate gobbi skill definitions from the user perspective. Your question is: does this skill actually serve the person who encounters it?\n\nThis perspective is not about internal structure or design correctness — it is about the experience of the user who invokes the skill, whether directly or through Claude Code's automatic routing. A skill that is technically sound but practically useless has a user problem.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "A skill exists to help someone do something. If it doesn't, nothing else about it matters.",
+          "body": "The user never reads a skill definition. They experience it as behavior: does Claude Code do the right thing when I ask for this? Does the guidance I receive move me forward? The user perspective asks whether the skill closes the gap between what the user needs and what they actually get."
+        },
+        {
+          "type": "principle",
+          "statement": "Discoverability is the first test. A skill that can't be found isn't a skill — it's dead documentation.",
+          "body": "The `description` field is the mechanism by which Claude Code routes to this skill. If the description does not match the language and framing a user naturally uses when they have this need, the skill will be skipped silently."
+        }
+      ]
+    },
+    {
+      "heading": "What to Evaluate",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Discoverability",
+          "content": [
+            {
+              "type": "text",
+              "value": "Would a user naturally land on this skill when they need it?\n\nRead the `description` field from the perspective of someone with the need this skill addresses — not someone who already knows what the skill is called. Ask:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Does the description use the vocabulary the user would use to describe their problem, or does it use internal gobbi terminology the user doesn't know yet?",
+                "If two skills could plausibly address the same need, does this skill's description distinguish itself clearly enough for correct routing?",
+                "Would a new gobbi user understand from the name alone what this skill covers, at least roughly?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Actionability",
+          "content": [
+            {
+              "type": "text",
+              "value": "When the skill loads, does the user get something they can act on?\n\nA skill that teaches mental models without connecting them to concrete decisions leaves the user no better off than before. Assess:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Does the skill's guidance move from principle to behavior — does it tell the user not just what to think about, but how that thinking should change what they do?",
+                "Are the criteria specific enough that a user can apply them to their actual situation, or are they too abstract to be useful in the moment?",
+                "Does the skill assume knowledge the user is unlikely to have at the point of invocation?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Predictability",
+          "content": [
+            {
+              "type": "text",
+              "value": "If the user invokes this skill twice in different sessions, do they get consistent behavior?\n\nUnpredictable skills erode trust. A skill whose guidance varies significantly depending on framing — whose principles are loose enough to justify opposite conclusions — is unreliable as a tool. Assess:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "Is the skill's guidance specific enough that two different agents following it would converge on similar outputs?",
+                "Are there ambiguous cases the skill leaves entirely open, where users would reasonably expect explicit guidance?",
+                "Does the skill's scope match its trigger? A skill that fires broadly but only helps narrowly will confuse users who load it expecting more coverage."
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Proportionality",
+          "content": [
+            {
+              "type": "text",
+              "value": "Does the skill's depth match what the user actually needs at invocation time?\n\nOver-length skills tax the user's time and the context window. Under-length skills leave users without guidance on cases they need covered. The right depth is determined by the task, not by a template. Assess:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "For a simple, frequent task: is the skill concise enough to be processed quickly?",
+                "For a complex, high-stakes task: does the skill provide enough structured guidance that the user isn't left guessing?",
+                "Are there sections that exist to be complete rather than to be useful — content that adds length without adding value at the moment of invocation?"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Signals Worth Noting",
+      "content": [
+        {
+          "type": "text",
+          "value": "These are not automatic failures, but they warrant examination:"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "A skill whose guidance could apply equally to five different domains — broad enough to be almost useless",
+            "A skill where the principles section is twice as long as the actionable guidance",
+            "A skill that routes to itself correctly but leaves the user with no clearer path forward than before",
+            "A skill that assumes the user knows the gobbi architecture well enough to apply the guidance — valid for contributors, not for users",
+            "A description that accurately names the domain but doesn't name the scenarios that warrant loading"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Findings Format",
+      "content": [
+        {
+          "type": "text",
+          "value": "Each finding should name: what the user experiences as the failure, why the current definition produces it, and what the skill would need to change to close the gap. Distinguish between failures that prevent the skill from being useful at all (blocking) and failures that reduce its quality without eliminating its value (moderate).\n\nInclude a note on what the skill gets right from the user's perspective — what behavior it enables that would be lost if the skill were removed."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_skills/SKILL.json
+++ b/.claude/skills/_skills/SKILL.json
@@ -1,0 +1,235 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_skills",
+    "description": "Reference and interactive guide for creating Claude Code skills. MUST load when creating, reviewing, or modifying .claude/skills/ definitions. Must load _claude and _discuss before using this skill.",
+    "allowed-tools": "Read, Grep, Glob, Bash, Write, Edit, AskUserQuestion"
+  },
+  "title": "Claude Skills",
+  "opening": "Reference for understanding skill structure and interactive guide for creating new skills through discussion. Load this when creating, reviewing, or modifying any `.claude/skills/` definition. Load _claude for writing principles and _discuss for discussion mechanics before using this skill.",
+  "navigation": {
+    "[verification.md](verification.md)": "Skill verification: trigger testing, output quality, improvement loop, evaluation agents",
+    "[authoring.md](authoring.md)": "Skill authoring: description craft, instruction writing, content pruning, failure patterns"
+  },
+  "sections": [
+    {
+      "heading": "Core Principles",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Skills teach domains. Each skill owns one area of knowledge.",
+          "body": "A skill teaches domain knowledge reusable across any project — orchestration, evaluation, documentation standards, execution discipline. Skills are portable. Project-specific context belongs in `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/`, not in a skill."
+        },
+        {
+          "type": "principle",
+          "statement": "Skills decompose into hierarchy like everything else.",
+          "body": "A broad domain skill has a parent SKILL.md that teaches the mental model and child `.md` files that specialize. The parent gives the agent enough context to decide which child to read. This prevents monolithic skills that agents skim."
+        },
+        {
+          "type": "principle",
+          "statement": "Discuss before writing. Use AskUserQuestion to understand what the user needs.",
+          "body": "Never create a skill from a vague description. Discuss the domain, trigger scenarios, overlap with existing skills, and structural needs before writing anything. The Discussion Dimensions below guide what to ask about."
+        },
+        {
+          "type": "principle",
+          "statement": "Explore existing skills before creating new ones.",
+          "body": "Read `.claude/skills/` to understand the current roster. Over-splitting weakens the agent's mental model — one skill per domain. If an existing skill already covers the knowledge area, extend it rather than creating a new one."
+        },
+        {
+          "type": "principle",
+          "statement": "Understand the gobbi vs project boundary.",
+          "body": "Gobbi already provides skills for workflow orchestration, `.claude/` documentation, evaluation framework, gotcha recording, and notification setup. Users do NOT need to create skills for these areas — gobbi serves them. Project skills should be domain-specific: language-aware, framework-aware, and project-aware. A project evaluation skill should know about the project's tech stack (e.g., \"check for N+1 queries in Django ORM\"), not repeat generic guidance that gobbi's evaluation skills already cover. When helping create a skill, first check if gobbi already handles the domain — if it does, redirect rather than duplicate."
+        }
+      ]
+    },
+    {
+      "heading": "Skill Structure",
+      "content": [
+        {
+          "type": "text",
+          "value": "Every skill has a flat documentation structure: SKILL.md and optional sibling `.md` files. Non-doc subdirectories (`scripts/`, `benchmarks/`, `references/`) are acceptable for executable or data files. Nested `.md` file hierarchies are not — keep documentation one level deep.\n\n**SKILL.md** is the entry point with YAML frontmatter. If child docs exist, SKILL.md lists them under a \"Navigate deeper from here:\" heading with short descriptions.\n\n**Child `.md` files** are subtopic docs in the same directory, referenced from the parent's navigation table. Use children when the domain is broad enough that a single file would exceed the line budget or force agents to read content irrelevant to their task.\n\n**Frontmatter** requires three fields: `name` (matches directory name), `description` (single line, specific trigger scenarios), `allowed-tools` (scoped to what the skill actually needs).\n\n**Description** drives auto-invocation. Write in command tone: \"Use when writing or reviewing X\" — not \"This skill provides X.\" Be specific enough to avoid misfiring on unrelated tasks.\n\n**Naming** follows the tier prefix convention: `_` for hidden skills, `__` for internal skills, no prefix for the interface entry point. Directory name equals skill name equals invocation command. See the naming convention rule in `.claude/rules/` for the full convention.\n\nRead existing skills in `.claude/skills/` for structural patterns — the codebase is the authoritative reference."
+        }
+      ]
+    },
+    {
+      "heading": "Skill Verification",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Skills should be testable.",
+          "body": "A skill's trigger accuracy and output quality can be measured. If you can't describe what prompts should trigger a skill and what good output looks like, the skill's purpose isn't clear enough."
+        },
+        {
+          "type": "principle",
+          "statement": "Improvement is iterative.",
+          "body": "The cycle is: grade trigger accuracy and output quality, analyze failures for patterns, improve the skill, re-grade to verify. Each iteration should address the highest-priority findings first."
+        },
+        {
+          "type": "principle",
+          "statement": "Comparison should be blind.",
+          "body": "When comparing two skill versions, remove provenance bias. Present versions as A and B without labeling which is current vs candidate. The blind protocol ensures evaluation is based on quality, not familiarity."
+        },
+        {
+          "type": "text",
+          "value": "Read [verification.md](verification.md) for detailed concepts on trigger testing, output quality evaluation, the improvement loop, and blind comparison. The `_skills-evaluator` agent executes verification, loaded with different `_skills-evaluation-{perspective}` skills depending on the evaluation focus."
+        }
+      ]
+    },
+    {
+      "heading": "Discussion Dimensions",
+      "content": [
+        {
+          "type": "text",
+          "value": "When creating a new skill, use AskUserQuestion to explore these dimensions. Not every skill needs every question — pick the ones that address what is vague or missing."
+        },
+        {
+          "type": "subsection",
+          "heading": "Understanding the Domain",
+          "content": [
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**Domain ownership** — What knowledge domain does this skill own? Is it distinct from existing skills, or does it overlap? If it overlaps, should the existing skill be extended instead?",
+                "**Portability** — Is this knowledge reusable across projects, or specific to one project? Project-specific content belongs in `$CLAUDE_PROJECT_DIR/.claude/project/`, not a skill.",
+                "**Existing coverage** — Does an existing skill already cover this domain? Read `.claude/skills/` before creating. Over-splitting weakens the agent's mental model."
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Defining the Trigger",
+          "content": [
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**Auto-invocation scenarios** — When should this skill auto-invoke? What specific user actions, file patterns, or task types trigger it? Vague triggers cause misfires.",
+                "**Description specificity** — Is the description specific enough to avoid misfiring on unrelated tasks? Could it be confused with another skill's trigger? Test by asking: would this description match tasks that should NOT load this skill?",
+                "**Tool scope** — Which tools does this skill actually need? Scope tightly — \"just in case\" tools dilute focus and widen the agent's action space unnecessarily."
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Designing the Structure",
+          "content": [
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**Hierarchy need** — Is SKILL.md sufficient, or does the domain need child docs? What are the natural subtopics? A single file works for focused domains; children work for broad ones.",
+                "**Content boundaries** — What belongs in this skill vs. in project docs, rules, or agent definitions? Skills teach portable domain knowledge. Project constraints, agent role definitions, and session rules live elsewhere.",
+                "**Line budget** — Can the core content fit under 200 lines? If not, which subtopics become children?"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Gotcha Awareness",
+          "content": [
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**Non-obvious pitfalls** — What mistakes are agents likely to make in this domain? What behavior seems correct but produces wrong results? These are candidates for gotcha entries.",
+                "**Gotcha file need** — Should a gotcha file be created alongside the skill? Warranted when the domain has known pitfalls that are not obvious from reading the skill itself."
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Verification Planning",
+          "content": [
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**Test scenarios** — What prompts should trigger this skill? What prompts should NOT trigger it? Are there edge cases where triggering is ambiguous?",
+                "**Verification criteria** — What does good output look like for this skill? How would you know if the skill guided the agent correctly vs poorly?",
+                "**Improvement loop** — How will this skill be iterated after initial creation? What metrics indicate it needs improvement?"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Gotcha Writing Guidance",
+      "content": [
+        {
+          "type": "text",
+          "value": "Gotcha files record mistakes that agents are likely to repeat because the correct behavior is non-obvious. They exist to short-circuit investigation — the next agent skips straight to the right approach.\n\n**When a gotcha is warranted:**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "User corrects a non-obvious approach",
+            "An error took significant debugging to resolve",
+            "The same mistake has been made more than once",
+            "A platform quirk caused unexpected behavior"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**When to skip:**"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Simple typos or obvious mistakes",
+            "Behavior already documented in the skill or a rule",
+            "One-off issues unlikely to recur"
+          ]
+        },
+        {
+          "type": "text",
+          "value": "**Where gotchas live:** Skill-specific gotchas live in the skill's own directory at `$CLAUDE_PROJECT_DIR/.claude/skills/{skill-name}/gotchas.md`, colocated with SKILL.md. Cross-cutting gotchas (spanning multiple skills or no single skill) go to `_gotcha/`. Project-specific gotchas go to `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/gotchas/`. Read existing gotcha files for the entry format — each entry has a title, priority, what happened, user feedback, and correct approach.\n\n**Priority levels:** Critical (breaks environment), High (wrong output looks correct), Medium (rework needed), Low (minor inconvenience).\n\nRead `_gotcha/SKILL.md` for the full gotcha framework. Read existing gotcha files like `_gotcha/_claude.md` for concrete examples of well-structured entries."
+        }
+      ]
+    },
+    {
+      "heading": "Expected Output",
+      "content": [
+        {
+          "type": "text",
+          "value": "The interactive creation process produces:"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "A SKILL.md file with valid frontmatter in `.claude/skills/{skill-name}/`",
+            "Optional child `.md` files for broad domains that exceed the line budget",
+            "Optional gotcha file if the domain has known non-obvious pitfalls",
+            "All output reviewed against _claude's review checklist before publishing"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Constraints",
+      "content": [
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Must follow _claude writing principles — principles over procedures, constraints over templates, codebase over examples",
+            "No code examples, no BAD/GOOD comparison blocks, no step-by-step recipes (skills are teaching docs — step-by-step is context-dependent per _claude)",
+            "Under 500 lines per file (must), targeting under 200 (should)",
+            "Flat documentation structure — SKILL.md plus sibling `.md` files; non-doc subdirectories (`scripts/`, `benchmarks/`, `references/`) are acceptable, nested `.md` hierarchies are not",
+            "Content must be portable — no project-specific patterns in skills",
+            "Always discuss with the user before creating — never generate a skill from a vague one-line description",
+            "Core principles in the first ~50 lines of any skill"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_skills/authoring.json
+++ b/.claude/skills/_skills/authoring.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "gobbi-docs/child",
+  "parent": "_skills",
+  "title": "Skill Authoring",
+  "opening": "How to write skill content that actually helps agents reason — description craft, instruction writing, content pruning, and failure patterns. Loaded from _skills SKILL.md.",
+  "sections": [
+    {
+      "heading": "Description Craft",
+      "content": [
+        {
+          "type": "text",
+          "value": "The description field is the skill's contract with the auto-invocation system. It determines whether the skill body ever loads. An agent scanning available skills never reads SKILL.md unless the description signals relevance — everything downstream depends on getting this right.\n\n**How loading works (observed behavior, not documented spec):** The description (~100 words, always loaded) determines whether the skill body is fetched. Once triggered, the full SKILL.md body loads. Bundled non-doc resources (`scripts/`, `references/`) are available on demand but require explicit navigation.\n\n**Write for intent, not inventory.** \"Use when creating or reviewing `.claude/skills/` files\" frames what the agent is doing. \"This skill provides skill authoring guidance\" describes the skill's content — the agent already knows that from context. Intent-framing makes the trigger decision easy; inventory-framing makes it uncertain.\n\n**The 1024-character hard limit is a forcing function.** A description that sprawls to fill the limit is usually trying to cover too many cases. A description that fits in 300 characters and still captures the right trigger surface is better. Precision matters more than comprehensiveness.\n\n**Balance precision and recall deliberately.** Too narrow: the skill misses legitimate use cases, leaving agents without relevant knowledge. Too broad: the skill loads for unrelated tasks, polluting context and competing with more relevant skills. The test is whether a reasonable person would agree the skill is relevant for any given prompt that matches the description.\n\n**Stand out among similar skills.** When multiple skills cover adjacent domains, descriptions must differentiate clearly. Agents see the full skill roster — if two descriptions look similar, the wrong skill loads."
+        }
+      ]
+    },
+    {
+      "heading": "Instruction Writing Principles",
+      "content": [
+        {
+          "type": "text",
+          "value": "**Lead with why, not what.** An agent that understands the purpose of a constraint adapts when the situation is novel. An agent that memorized \"always do X\" breaks when the situation doesn't cleanly fit X. Every instruction is more durable when the reasoning travels with it.\n\n**Respect theory of mind.** The skill is read by an agent that has its own context, task, and reasoning process. Write to that agent's decision-making situation: what does it need to know to make a good call right now? Not: what rule should it memorize for later application? The former produces judgment; the latter produces rule-following.\n\n**Constraints over prescriptions.** Telling an agent what not to do (with a clear boundary and the reasoning behind it) leaves room for judgment within that boundary. Telling an agent what to do gives it a path to follow — but only for situations that match the path. Constraints generalize; prescriptions overfit.\n\n**Constraint overload defeats reasoning.** A skill with twenty constraints teaches agents to prioritize compliance over thinking. When the constraints stack up, agents spend cognitive budget checking rules rather than solving the problem. Fewer, higher-value constraints with clear reasoning beat many shallow constraints.\n\n**Generalize for the real distribution.** Skills are invoked across many different prompts, users, and project contexts. A skill written by testing against five specific prompts will work for those prompts and fail for the rest. Write principles that hold across the space of relevant situations, not just the situations that motivated the skill."
+        }
+      ]
+    },
+    {
+      "heading": "Content Pruning",
+      "content": [
+        {
+          "type": "text",
+          "value": "Skills need iteration after creation. The initial version reflects what the author thought was important — post-deployment evidence reveals what actually helps.\n\n**Prune by evidence, not intuition.** Removing content because it \"feels redundant\" produces a lighter skill that may work worse. The signals that justify pruning are concrete: benchmark scores that don't improve when a section is present, transcript reviews that show agents ignoring a section entirely, content that duplicates what the codebase already demonstrates.\n\n**Benchmark signal:** If a section's presence or absence doesn't move skill evaluation scores, it's not contributing. Inert content occupies context without producing value — that's a net negative because it dilutes the sections that do contribute.\n\n**Transcript signal:** If agents consistently skip a section in their reasoning (visible in transcript review), the section isn't being integrated. It might be positioned poorly, framed wrong, or genuinely unnecessary. Either fix it or remove it.\n\n**Duplication signal:** If the content is already visible in the codebase, a skill section describing it creates a second source of truth that will drift. Point to the codebase instead.\n\n**Remove wasted effort at the source.** If transcripts show agents spending significant effort on something a skill instruction prompted — and that effort isn't producing value — the instruction is creating waste. Fix the instruction or remove it. Inert effort in agent transcripts is the symptom; an overspecified skill is usually the cause."
+        }
+      ]
+    },
+    {
+      "heading": "Common Failure Patterns",
+      "content": [
+        {
+          "type": "text",
+          "value": "**Skill too abstract to act on.** Principles so high-level they don't constrain anything. \"Write clear documentation\" could justify any approach. The test: given this skill, would two agents make the same decision in the same situation? If not, the skill isn't specific enough.\n\n**Vague description triggers wrong prompts.** A description that captures the skill's topic but not its trigger surface loads on tangentially related tasks. The agent gets context it didn't need, displacing context it did need. Revisit descriptions whenever a skill is loading for unexpected prompts.\n\n**Description too narrow, misses real use cases.** The inverse: a description that matches only the core case and fails to load for legitimate adjacent situations. Agents work without knowledge they should have, producing output the skill would have improved. Monitor for cases where the skill should have loaded but didn't.\n\n**Constraint overload produces rigid compliance.** A skill with many specific constraints produces agents that check constraints rather than reason. The more constraints, the more the agent's attention goes to compliance rather than the actual problem. Prune to the constraints that carry the most signal.\n\n**Overfitting to test prompts.** Skills refined by testing against the same small set of prompts get sharper for those prompts and weaker for everything else. The description becomes calibrated to the test set; the content becomes optimized for the scenarios used during authoring. Diversity in test scenarios is the only protection.\n\n**Verbose content causes skimming.** A long skill gets skimmed. Key constraints buried in the middle of dense paragraphs are missed. Agents allocate reading effort proportionally — a shorter skill with sharper content gets more careful attention than a long skill where the important parts have to compete with filler."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_skills/verification.json
+++ b/.claude/skills/_skills/verification.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "gobbi-docs/child",
+  "parent": "_skills",
+  "title": "Skill Verification",
+  "opening": "Concepts and evaluation agents for verifying skill quality — trigger accuracy, output quality, improvement loops, and blind comparison. Loaded from _skills SKILL.md.",
+  "sections": [
+    {
+      "heading": "Trigger Testing",
+      "content": [
+        {
+          "type": "text",
+          "value": "Trigger testing checks whether a skill's `description` frontmatter accurately identifies prompts that should load it and correctly rejects prompts that shouldn't. The description is the skill's contract with the auto-invocation system — if it's wrong, the skill either misfires on unrelated tasks or fails to load when needed.\n\nA good trigger description balances precision and recall. Too narrow and the skill misses legitimate use cases — an agent working on a related task won't get the knowledge it needs. Too broad and the skill loads for unrelated tasks — polluting context and competing with more relevant skills. The test is: for any given prompt, would a reasonable person agree that this skill is relevant?\n\nEdge cases matter most. Clear hits and clear misses are easy to get right. The hard cases are prompts that seem related but shouldn't trigger the skill, or prompts phrased unusually that should. These edge cases reveal whether the description captures the skill's actual domain or just its most obvious use case."
+        }
+      ]
+    },
+    {
+      "heading": "Two-Track Verification",
+      "content": [
+        {
+          "type": "text",
+          "value": "Skill verification has two complementary tracks that answer different questions at different costs. Understanding which question you need to answer determines which track to use.\n\n**Script-based trigger testing** answers a narrow, binary question: does this skill's description accurately identify prompts that should load it, and correctly exclude prompts that shouldn't? The `__benchmark/scripts/trigger-test.py` script tests this with LLM-powered classification — it needs an `ANTHROPIC_API_KEY` and the `anthropic` Python package, but nothing else. The signal it produces is reproducible, cheap, and focused. Run it when iterating on a description: the feedback loop is tight enough to try several variants and see which produces better precision and recall.\n\n**Agent-based holistic verification** answers a broader, harder question: when this skill loads, does it help agents make good decisions? The `_skills-evaluator` agent — loaded with different `_skills-evaluation-{perspective}` skills — assesses trigger accuracy and output quality together. It can judge teaching effectiveness, mental model clarity, and anti-pattern compliance in ways no script can. This track is expensive (multiple agent calls per cycle), non-deterministic (results vary across runs), and requires more context to set up. It's the right tool for full quality assessment, not for rapid description tuning.\n\n**The decision rule is:** trigger accuracy is a prerequisite, not the goal. If the description is wrong, no amount of content quality matters — the skill never loads. Fix the description first, cheaply, with the script. Once trigger accuracy is solid, use agents to assess whether the skill's content actually produces good outcomes. For a skill approaching shipping, both tracks together provide the most confidence: the script confirms the description is precise, and agents confirm the content is effective.\n\nThe tracks are not substitutes — each covers blind spots the other has. A high-precision description measured by the script can still be attached to content that teaches the wrong mental model. Agent-based verification catches that. Conversely, agent evaluation alone may miss subtle trigger edge cases that only emerge with systematic prompt sampling."
+        }
+      ]
+    },
+    {
+      "heading": "Output Quality Evaluation",
+      "content": [
+        {
+          "type": "text",
+          "value": "Output quality measures whether a skill, once loaded, actually helps the agent make good decisions. A skill can have perfect trigger accuracy and still produce poor outcomes if its content doesn't teach the right mental model.\n\nDimensions for evaluating output quality:"
+        },
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "**Mental model accuracy** — Does the skill teach how things work and why, or does it just list rules? An agent that understands the mental model adapts to novel situations. An agent that memorized rules breaks when the situation doesn't match.",
+            "**Sufficient context** — Does the skill give the agent enough context to make decisions without reading every child doc? The parent should provide the mental model; children provide depth. An agent shouldn't need to read three files to understand the basics.",
+            "**Anti-pattern compliance** — Does the skill follow _claude writing principles? No code examples, no BAD/GOOD blocks, no step-by-step recipes in teaching content. These anti-patterns cause agents to mimic instead of reason.",
+            "**Actionable specificity** — Are principles specific enough to guide behavior, or so abstract that an agent can't derive concrete actions? \"Write good documentation\" is too vague. \"Each file opens with purpose and scope so agents know whether to read further\" is actionable."
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Improvement Loop",
+      "content": [
+        {
+          "type": "text",
+          "value": "Skill verification follows gobbi's standard cycle: grade, analyze, improve, re-grade. This is a user-driven loop — the orchestrator suggests next steps, but the user decides when to iterate and when to stop.\n\n**Grade** — Spawn `_skills-evaluator` loaded with the relevant `_skills-evaluation-{perspective}` skill(s) to test the skill against sample prompts. The evaluator assesses trigger accuracy (did the right prompts load the skill?) and output quality (did the skill guide the agent well?). Grading produces structured results with scores and observations.\n\n**Analyze** — Spawn `_skills-evaluator` loaded with the overall perspective skill to synthesize grading results into prioritized improvements. It identifies patterns across multiple grading results — recurring trigger failures, consistent output quality gaps, systematic weaknesses — and produces a ranked list of what to fix first.\n\n**Improve** — Apply the highest-priority improvements to the skill. Focus on one or two changes per iteration rather than rewriting everything. Small, targeted changes are easier to verify than broad rewrites.\n\n**Re-grade** — Run the evaluator again after improvements to verify they helped and didn't regress other areas. A fix to trigger accuracy shouldn't degrade output quality. A content improvement shouldn't break the trigger description.\n\n**Compare (optional)** — Spawn `_skills-evaluator` with instructions for blind A/B comparison of the old vs new version. Comparison is most valuable when changes are substantial or when grading alone doesn't clearly show whether the new version is better. See the blind comparison protocol below."
+        }
+      ]
+    },
+    {
+      "heading": "Blind Comparison Protocol",
+      "content": [
+        {
+          "type": "text",
+          "value": "Blind comparison removes provenance bias — the tendency to favor the version you know is \"new\" or \"improved.\" The protocol is simple: the invoker (user or orchestrator) takes two skill versions, randomly assigns them as Version A and Version B without labeling which is current vs candidate, and presents both to the comparator.\n\nThe comparator sees the full content of both versions. No anonymization of the text is needed — the comparator just doesn't know which is current and which is the candidate replacement. It evaluates both on the same dimensions (trigger accuracy, output quality, teaching effectiveness) and declares a preference with reasoning.\n\nAfter the comparator delivers its verdict, the invoker maps A/B back to current/candidate to interpret the result. If the comparator preferred the candidate, the improvement is validated. If it preferred the current version, the changes may have introduced regressions worth investigating."
+        }
+      ]
+    },
+    {
+      "heading": "Evaluation Agent",
+      "content": [
+        {
+          "type": "text",
+          "value": "One agent executes skill verification across all verification roles:\n\n**_skills-evaluator** is loaded with different `_skills-evaluation-{perspective}` skills depending on the evaluation focus. For grading, load the perspective skills relevant to the skill domain being assessed. For analysis, load `_skills-evaluation-overall` to synthesize results into prioritized improvements. For blind comparison, load the perspective skills and instruct the agent to evaluate both versions without provenance labels. The data flow is: grading results and comparison verdicts are synthesized by the evaluator into prioritized recommendations."
+        }
+      ]
+    },
+    {
+      "heading": "Cost and Reproducibility",
+      "content": [
+        {
+          "type": "text",
+          "value": "Agent-based evaluation is expensive and non-deterministic. Each verification cycle involves multiple agent calls — grading, analysis, and optionally comparison — each of which costs tokens and may produce slightly different results on repeated runs. This trade-off is accepted because agents can assess nuanced qualities (teaching effectiveness, mental model clarity) that scripts cannot, keeping the workflow Claude Code native for holistic assessment.\n\nFor skills where trigger testing is the primary concern — newly written skills, or skills whose descriptions are actively being refined — the `__benchmark/scripts/trigger-test.py` script provides a lighter-weight alternative. It costs a small number of API calls rather than multiple `_skills-evaluator` sessions, and its output (precision, recall, F1) is directly comparable across runs. Use the script to stabilize the description, then bring in the evaluator agent once the trigger surface is correct and the question shifts to output quality.\n\nFor skills where trigger testing needs to be highly reproducible regardless of which track is used, maintain a list of test prompts that can be reused across iterations. Consistent inputs improve comparability even when agent evaluation introduces variance. The test prompt list also serves as documentation of the skill's intended trigger surface."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_slack/SKILL.json
+++ b/.claude/skills/_slack/SKILL.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_slack",
+    "description": "Configure Slack notifications for Claude Code sessions. Setup guide for webhook-based notification delivery."
+  },
+  "title": "Slack Notifications",
+  "opening": "Slack notifications for Claude Code use incoming webhooks — a URL that accepts HTTP POST requests and delivers them to a specific channel or direct message. Understanding this model helps you configure, debug, and extend the integration.",
+  "sections": [
+    {
+      "heading": "How Bot Delivery Works",
+      "content": [
+        {
+          "type": "text",
+          "value": "An incoming webhook is a one-way pipe: your Claude Code hook script sends a JSON payload to a URL, and Slack delivers it to the target. The URL encodes both authentication and destination — anyone with the URL can post to that channel, so treat it as a credential.\n\nSlack also supports bot tokens, which give more control: you can DM a user by ID rather than a fixed channel, and you can adjust the message format over time without rotating the webhook URL. The notification scripts use the bot token model so that messages arrive as direct messages to your user ID rather than a shared channel.\n\n**What gets sent:** Each notification includes the event type, a short summary of what happened, and a timestamp. Long messages are truncated to stay within Slack's message size limits."
+        }
+      ]
+    },
+    {
+      "heading": "Core Concepts",
+      "content": [
+        {
+          "type": "text",
+          "value": "**Bot token** — a credential starting with `xoxb-` that identifies your app and grants `chat:write` permission. Obtained from the Slack app management UI after creating an app and installing it to your workspace.\n\n**User ID** — your Slack member ID (not your username), used as the target for DMs. Found in your Slack profile settings. IDs start with `U` and are stable even if you rename your account.\n\n**Workspace scope** — the token is scoped to one workspace. If you work across multiple Slack workspaces, you need a separate app and token for each.\n\n**Channel targeting** — the bot can post to public channels it has been invited to, private channels it has been added to, or DM any user in the workspace. DM to self (via your user ID) is the lowest-friction setup."
+        }
+      ]
+    },
+    {
+      "heading": "When to Use Slack",
+      "content": [
+        {
+          "type": "text",
+          "value": "Slack works well when: you already have Slack open during development sessions, you want rich notification history searchable by date or project, or you want to share session notifications with a team channel.\n\nConsider Telegram instead when: you want mobile push notifications that interrupt rather than accumulate, you do not have a Slack workspace, or you want a lower-friction personal setup without managing a bot app.\n\nConsider desktop notifications instead when: you are at your machine and want zero-latency alerts without any external service dependency."
+        }
+      ]
+    },
+    {
+      "heading": "Credential Storage",
+      "content": [
+        {
+          "type": "text",
+          "value": "Store credentials as `SLACK_BOT_TOKEN` and `SLACK_USER_ID` in `$CLAUDE_PROJECT_DIR/.claude/.env`. This file is read by `load-notification-env.sh` at session start and must be listed in `.gitignore` — credentials committed to version control are compromised credentials.\n\nThe hook scripts check for both variables before attempting delivery. If either is absent, Slack delivery is silently skipped rather than causing an error."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/_telegram/SKILL.json
+++ b/.claude/skills/_telegram/SKILL.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_telegram",
+    "description": "Configure Telegram notifications for Claude Code sessions. Setup guide for bot-based notification delivery."
+  },
+  "title": "Telegram Notifications",
+  "opening": "Telegram notifications for Claude Code use a bot token and a chat ID. Understanding the bot model helps you set up the integration correctly and troubleshoot delivery issues.",
+  "sections": [
+    {
+      "heading": "How Bot Delivery Works",
+      "content": [
+        {
+          "type": "text",
+          "value": "A Telegram bot is a program-controlled account created through @BotFather. Your Claude Code hook script calls the Telegram Bot API directly, sending a message to a specific chat. The bot must have been started by the target user — a bot cannot initiate contact with a user who has never messaged it.\n\nThe most common setup is a personal bot that messages you: you create the bot, start a conversation with it, then capture the chat ID that identifies your conversation with it. This chat ID is then stored as a credential alongside the bot token.\n\n**What gets sent:** Each notification includes the event type, a short summary, and a timestamp. Telegram supports basic Markdown formatting, but the notification scripts send plain text by default to avoid parsing issues with special characters in event data."
+        }
+      ]
+    },
+    {
+      "heading": "Core Concepts",
+      "content": [
+        {
+          "type": "text",
+          "value": "**Bot token** — a credential in the format `123456789:ABCdef...` that authenticates your bot with the Telegram API. Issued by @BotFather when you create a bot. Treat it as a password — anyone with the token can send messages as your bot.\n\n**Chat ID** — a numeric identifier for a specific conversation. For a direct message to yourself, this is your personal chat ID with the bot. For a group, it is the group's chat ID. Chat IDs are stable and do not change when group names or user names change.\n\n**Getting your chat ID** — after starting a conversation with your bot, query `https://api.telegram.org/bot<TOKEN>/getUpdates`. The response includes a `chat.id` field in the most recent message. This is the value to store.\n\n**Group delivery** — bots can also post to groups where they are a member. The chat ID for a group is negative. Add the bot to the group, send a message mentioning it, then query `getUpdates` to retrieve the group chat ID."
+        }
+      ]
+    },
+    {
+      "heading": "When to Use Telegram",
+      "content": [
+        {
+          "type": "text",
+          "value": "Telegram works well when: you want mobile push notifications that interrupt rather than accumulate, you do not have a Slack workspace, or you want a lightweight personal setup with no team overhead.\n\nConsider Slack instead when: you already use Slack for development and want notification history alongside your work communication, or you want to share notifications with a team.\n\nConsider desktop notifications instead when: you are at your machine and want zero-latency alerts without any external service dependency."
+        }
+      ]
+    },
+    {
+      "heading": "Credential Storage",
+      "content": [
+        {
+          "type": "text",
+          "value": "Store credentials as `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` in `$CLAUDE_PROJECT_DIR/.claude/.env`. This file is read by `load-notification-env.sh` at session start and must be listed in `.gitignore` — credentials committed to version control are compromised credentials.\n\nThe hook scripts check for both variables before attempting delivery. If either is absent, Telegram delivery is silently skipped rather than causing an error."
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/gobbi/SKILL.json
+++ b/.claude/skills/gobbi/SKILL.json
@@ -1,0 +1,337 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "gobbi",
+    "description": "Entry point for gobbi, an open-source ClaudeX tool for Claude Code. MUST load at session start, session resume, and after compaction. Loads agent principles and skill map.",
+    "allowed-tools": "Read, Grep, Glob, Bash, Write, Edit, Agent, Task, AskUserQuestion"
+  },
+  "title": "Gobbi",
+  "opening": "You are an orchestrator based on gobbi. You must delegate everything to specialist subagents except trivial cases.\n\n**FIRST — load core skills before anything else.** Load `_orchestration`, `_gotcha`, `_claude`, and `_git` immediately. Do not ask questions, do not run project setup, do not proceed until all four are loaded.\n\n**THEN — ask the user four setup questions** with AskUserQuestion.\n\n**First question — trivial case range:**\n- **Read-only (no code changes)** — reading files, explaining code, running status commands, searching codebase. Any code change must be delegated.\n- **Simple code edits included** — the above, plus single-file obvious changes (fix a typo, rename a variable, toggle a config value). Anything beyond must be delegated.\n\n**Second question — evaluation mode:**\n- **Ask each time (default)** — before each evaluation stage, the orchestrator asks whether to spawn evaluators. Lets you decide per-step based on task complexity.\n- **Always evaluate** — skip the evaluation question, always spawn evaluators at every stage. Maximum quality checking, no prompts to interrupt flow.\n- **Skip evaluation** — skip the evaluation question, never spawn evaluators unless you explicitly request one. Maximum speed for well-understood tasks.\n\n**Third question — git workflow mode:**\n- **Direct commit (default)** — Work happens in the main working tree. Commits are created at FINISH. No worktrees, no PRs. Use for solo sessions or quick tasks.\n- **Git workflow (worktree + PR)** — Each task gets its own worktree and branch. Work is integrated via pull request. If selected, also ask for the base branch (what branch to create feature branches from). When selected, the orchestrator verifies _git prerequisites (tool availability, authentication, repository state) before proceeding.\n\n**Fourth question — notification channels:**\n- Multi-select. If any channel is selected alongside Skip, channels take priority.\n- **Slack** — Notify via Slack bot message.\n- **Telegram** — Notify via Telegram bot message.\n- **Discord** — Notify via Discord webhook.\n- **Skip notifications** — No notifications this session.\n\nAfter selection, check `$CLAUDE_PROJECT_DIR/.claude/.env` for credentials. If credentials exist for the selected channels, enable notifications. If credentials are missing, load _notification and the relevant child skill (_slack, _telegram, _discord) to help the user configure them before proceeding.\n\n**After all four questions — persist session choices.** The orchestrator writes the user's selections to `gobbi.json` via `gobbi-config.sh` so that hooks and subagents can read them without conversation context. Persistence calls use `$CLAUDE_SESSION_ID` as the session key:\n\n- Q1 trivial range: `gobbi-config.sh set $CLAUDE_SESSION_ID trivialRange <value>`\n- Q2 evaluation mode: `gobbi-config.sh set $CLAUDE_SESSION_ID evaluationMode <value>`\n- Q3 git workflow: `gobbi-config.sh set $CLAUDE_SESSION_ID gitWorkflow <value>` — if worktree-pr, also set `baseBranch`\n- Q4 notifications: `gobbi-config.sh set $CLAUDE_SESSION_ID notify.slack true/false` and `notify.telegram true/false`\n\n`gobbi.json` lives at `$CLAUDE_PROJECT_DIR/.claude/gobbi.json`, is gitignored (runtime-only, per-user), and is managed exclusively through `gobbi-config.sh` at `.claude/hooks/gobbi-config.sh`. The schema is documented in `.claude/project/gobbi/design/gobbi-json-schema.md`. Sessions are automatically cleaned up by TTL (7 days) and max-entries cap (10 sessions).\n\nThese session choices set defaults for the orchestrator. Either default can be overridden at any specific step if you change your mind.\n\nProject context detection runs automatically at session start without asking. Load project-setup.md to execute detection.\n\nThis skill defines the agent principles, rules, and skill map you must follow.",
+  "navigation": {
+    "[project-setup.md](project-setup.md)": "Project-specific context and technology stack signals",
+    "[notification-setup.md](notification-setup.md)": "Notification channel and credential detection",
+    "[git-setup.md](git-setup.md)": "Git tooling and repository state detection"
+  },
+  "sections": [
+    {
+      "heading": "Core Principles",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Never edit gobbi skills without asking the user with AskUserQuestion."
+        }
+      ]
+    },
+    {
+      "heading": "Gobbi Skills",
+      "content": [
+        {
+          "type": "subsection",
+          "heading": "Work",
+          "content": [
+            {
+              "type": "text",
+              "value": "Workflow participant skills — loaded during the ideate-plan-execute-collect cycle."
+            },
+            {
+              "type": "table",
+              "headers": [
+                "Skill",
+                "Purpose"
+              ],
+              "rows": [
+                [
+                  "**_orchestration**",
+                  "Thin coordinator. Routes tasks through phases and workflow steps."
+                ],
+                [
+                  "**_discuss**",
+                  "Clarify and specify user prompts. Break ambiguity into specific questions."
+                ],
+                [
+                  "**_ideation**",
+                  "Brainstorming and option exploration for creative or ambiguous tasks."
+                ],
+                [
+                  "**_plan**",
+                  "Task decomposition. Break complex work into narrow, ordered, agent-assigned tasks."
+                ],
+                [
+                  "**_delegation**",
+                  "Hand off work to subagents with the right context and scope boundaries."
+                ],
+                [
+                  "**_execution**",
+                  "Task execution guide. How an executor agent studies, plans, implements, and verifies."
+                ],
+                [
+                  "**_evaluation**",
+                  "Parent evaluation framework. How to delegate evaluation, select perspectives, and discuss findings."
+                ],
+                [
+                  "**_ideation-evaluation**",
+                  "Stage-specific evaluation criteria for ideation output. Concreteness, trade-offs, completeness."
+                ],
+                [
+                  "**_plan-evaluation**",
+                  "Stage-specific evaluation criteria for plans. Task specificity, dependencies, feasibility."
+                ],
+                [
+                  "**_collection**",
+                  "Persist workflow trail. Write prompt, plan, task results, and README to work directory."
+                ],
+                [
+                  "**_memorization**",
+                  "Save context for session continuity. Persist task details, gotchas, and rules."
+                ],
+                [
+                  "**_note**",
+                  "Write notes at every workflow step. Record decisions, outcomes, and context."
+                ],
+                [
+                  "**_git**",
+                  "Git/GitHub workflow. Worktree isolation, branch lifecycle, PR management, issue tracking."
+                ],
+                [
+                  "**_notification**",
+                  "Configure Claude Code notifications (Slack, Telegram, others) via conversation."
+                ],
+                [
+                  "**_gotcha**",
+                  "Cross-project mistake recording. Check before acting, write after corrections."
+                ]
+              ]
+            },
+            {
+              "type": "text",
+              "value": "#### Evaluation — Skills\n\nDomain-specific evaluation perspectives for skill quality assessment."
+            },
+            {
+              "type": "table",
+              "headers": [
+                "Skill",
+                "Purpose"
+              ],
+              "rows": [
+                [
+                  "**_skills-evaluation-project**",
+                  "Project perspective for skill evaluation"
+                ],
+                [
+                  "**_skills-evaluation-architecture**",
+                  "Architecture perspective for skill evaluation"
+                ],
+                [
+                  "**_skills-evaluation-performance**",
+                  "Performance perspective for skill evaluation"
+                ],
+                [
+                  "**_skills-evaluation-aesthetics**",
+                  "Aesthetics perspective for skill evaluation"
+                ],
+                [
+                  "**_skills-evaluation-overall**",
+                  "Overall cross-dimensional perspective for skill evaluation"
+                ],
+                [
+                  "**_skills-evaluation-user**",
+                  "User perspective for skill evaluation"
+                ]
+              ]
+            },
+            {
+              "type": "text",
+              "value": "#### Evaluation — Agents\n\nDomain-specific evaluation perspectives for agent quality assessment."
+            },
+            {
+              "type": "table",
+              "headers": [
+                "Skill",
+                "Purpose"
+              ],
+              "rows": [
+                [
+                  "**_agent-evaluation-project**",
+                  "Project perspective for agent evaluation"
+                ],
+                [
+                  "**_agent-evaluation-architecture**",
+                  "Architecture perspective for agent evaluation"
+                ],
+                [
+                  "**_agent-evaluation-performance**",
+                  "Performance perspective for agent evaluation"
+                ],
+                [
+                  "**_agent-evaluation-aesthetics**",
+                  "Aesthetics perspective for agent evaluation"
+                ],
+                [
+                  "**_agent-evaluation-overall**",
+                  "Overall cross-dimensional perspective for agent evaluation"
+                ],
+                [
+                  "**_agent-evaluation-user**",
+                  "User perspective for agent evaluation"
+                ]
+              ]
+            },
+            {
+              "type": "text",
+              "value": "#### Evaluation — Project\n\nDomain-specific evaluation perspectives for deliverable quality assessment."
+            },
+            {
+              "type": "table",
+              "headers": [
+                "Skill",
+                "Purpose"
+              ],
+              "rows": [
+                [
+                  "**_project-evaluation-project**",
+                  "Project perspective for deliverable evaluation"
+                ],
+                [
+                  "**_project-evaluation-architecture**",
+                  "Architecture perspective for deliverable evaluation"
+                ],
+                [
+                  "**_project-evaluation-performance**",
+                  "Performance perspective for deliverable evaluation"
+                ],
+                [
+                  "**_project-evaluation-aesthetics**",
+                  "Aesthetics perspective for deliverable evaluation"
+                ],
+                [
+                  "**_project-evaluation-overall**",
+                  "Overall cross-dimensional perspective for deliverable evaluation"
+                ],
+                [
+                  "**_project-evaluation-user**",
+                  "User perspective for deliverable evaluation"
+                ]
+              ]
+            },
+            {
+              "type": "text",
+              "value": "#### Git (child skills of _git)\n\nPlaceholder — specific child skills TBD.\n\n#### Notification (child skills of _notification)"
+            },
+            {
+              "type": "table",
+              "headers": [
+                "Skill",
+                "Purpose"
+              ],
+              "rows": [
+                [
+                  "**_slack**",
+                  "Slack notification setup and integration."
+                ],
+                [
+                  "**_telegram**",
+                  "Telegram notification setup and integration."
+                ],
+                [
+                  "**_discord**",
+                  "Discord notification setup and integration."
+                ]
+              ]
+            },
+            {
+              "type": "text",
+              "value": "#### Gotcha (child docs of _gotcha)"
+            },
+            {
+              "type": "table",
+              "headers": [
+                "Document",
+                "Purpose"
+              ],
+              "rows": [
+                [
+                  "**project-gotcha.md**",
+                  "How to record project-specific gotchas."
+                ],
+                [
+                  "**skills-gotcha.md**",
+                  "How to record skill-specific gotchas."
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Docs",
+          "content": [
+            {
+              "type": "text",
+              "value": "`.claude/` documentation authoring — skills about writing and maintaining claude docs."
+            },
+            {
+              "type": "table",
+              "headers": [
+                "Skill",
+                "Purpose"
+              ],
+              "rows": [
+                [
+                  "**_claude**",
+                  "Core `.claude/` documentation standard. Writing principles, hierarchy, anti-patterns, rules, and project docs."
+                ],
+                [
+                  "**_skills**",
+                  "Reference and interactive guide for creating skills. Discussion dimensions for skill authoring."
+                ],
+                [
+                  "**_agents**",
+                  "Reference and interactive guide for creating agent definitions. Discussion dimensions for agent authoring."
+                ],
+                [
+                  "**_rules**",
+                  "Guide for authoring rule files. Verifiability, structure, when to create a rule."
+                ],
+                [
+                  "**_project**",
+                  "Guide for authoring project documentation. Directory structure, README, design docs, notes."
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Tool",
+          "content": [
+            {
+              "type": "text",
+              "value": "Utility and maintenance tooling."
+            },
+            {
+              "type": "table",
+              "headers": [
+                "Skill",
+                "Purpose"
+              ],
+              "rows": [
+                [
+                  "**__validate**",
+                  "Validate agent definitions, skill docs, and gotcha entries. Bundled scripts for structure and anti-pattern checking."
+                ],
+                [
+                  "**_audit**",
+                  "Documentation drift detection. Verify .claude/ docs match codebase reality."
+                ],
+                [
+                  "**__benchmark**",
+                  "Skill benchmarking methodology. Eval scenarios and scoring for measuring skill effectiveness."
+                ]
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/gobbi/SKILL.md
+++ b/.claude/skills/gobbi/SKILL.md
@@ -34,6 +34,15 @@ You are an orchestrator based on gobbi. You must delegate everything to speciali
 
 After selection, check `$CLAUDE_PROJECT_DIR/.claude/.env` for credentials. If credentials exist for the selected channels, enable notifications. If credentials are missing, load _notification and the relevant child skill (_slack, _telegram, _discord) to help the user configure them before proceeding.
 
+**After all four questions — persist session choices.** The orchestrator writes the user's selections to `gobbi.json` via `gobbi-config.sh` so that hooks and subagents can read them without conversation context. Persistence calls use `$CLAUDE_SESSION_ID` as the session key:
+
+- Q1 trivial range: `gobbi-config.sh set $CLAUDE_SESSION_ID trivialRange <value>`
+- Q2 evaluation mode: `gobbi-config.sh set $CLAUDE_SESSION_ID evaluationMode <value>`
+- Q3 git workflow: `gobbi-config.sh set $CLAUDE_SESSION_ID gitWorkflow <value>` — if worktree-pr, also set `baseBranch`
+- Q4 notifications: `gobbi-config.sh set $CLAUDE_SESSION_ID notify.slack true/false` and `notify.telegram true/false`
+
+`gobbi.json` lives at `$CLAUDE_PROJECT_DIR/.claude/gobbi.json`, is gitignored (runtime-only, per-user), and is managed exclusively through `gobbi-config.sh` at `.claude/hooks/gobbi-config.sh`. The schema is documented in `.claude/project/gobbi/design/gobbi-json-schema.md`. Sessions are automatically cleaned up by TTL (7 days) and max-entries cap (10 sessions).
+
 These session choices set defaults for the orchestrator. Either default can be overridden at any specific step if you change your mind.
 
 Project context detection runs automatically at session start without asking. Load project-setup.md to execute detection.

--- a/.claude/skills/gobbi/git-setup.json
+++ b/.claude/skills/gobbi/git-setup.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "gobbi-docs/child",
+  "parent": "gobbi",
+  "title": "Git Setup",
+  "opening": "Check git tooling and repository state at session start. Determines whether the git workflow (worktree + PR) is viable and what issues need attention before work begins.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Verify the git environment before committing to a git workflow.",
+          "body": "A session that discovers missing tools or authentication mid-task wastes work already delegated to subagents. Detection upfront lets the orchestrator fall back to direct commit mode before any work starts."
+        },
+        {
+          "type": "text",
+          "value": "> **Detection is read-only.** \n\nNever install tools, authenticate, or modify repository state during detection. Report state; let the user decide what to fix."
+        }
+      ]
+    },
+    {
+      "heading": "Setup Sequence",
+      "content": [
+        {
+          "type": "text",
+          "value": "Runs automatically at session start when the user selects \"Git workflow (worktree + PR).\" Skipped for \"Direct commit\" mode."
+        },
+        {
+          "type": "subsection",
+          "heading": "1. Git Repository",
+          "content": [
+            {
+              "type": "text",
+              "value": "Check that the working directory is a git repository (`git rev-parse --is-inside-work-tree`). If not, git workflow is not applicable — direct commit mode only."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "2. Remote Configuration",
+          "content": [
+            {
+              "type": "text",
+              "value": "Check for a configured git remote (`git remote -v`). A repository without a remote cannot push or create PRs. Report which remotes exist and their URLs."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "3. gh CLI Availability",
+          "content": [
+            {
+              "type": "text",
+              "value": "Check if the `gh` CLI is installed (`which gh` or `gh --version`). The entire PR lifecycle depends on it — issue creation, PR management, CI monitoring."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "4. gh Authentication",
+          "content": [
+            {
+              "type": "text",
+              "value": "Check if `gh` is authenticated to the remote (`gh auth status`). An installed but unauthenticated gh CLI cannot perform API operations."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "5. Base Branch",
+          "content": [
+            {
+              "type": "text",
+              "value": "Check if the intended base branch exists locally and on the remote. The base branch is project-specific — never assume `main` or `master`. If the user specified a base branch at session start, verify it exists."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "6. Worktree State",
+          "content": [
+            {
+              "type": "text",
+              "value": "Check `.claude/worktrees/` for existing worktrees:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**Active worktrees** — may indicate concurrent sessions. Report branch names and paths.",
+                "**Orphaned worktrees** — from crashed or abandoned sessions. Offer cleanup or recovery.",
+                "**Gitignore** — Check if `.claude/worktrees/` is listed in `.gitignore`. If not, worktree contents will appear in the main repo's git status."
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "7. Classify State",
+          "content": [
+            {
+              "type": "text",
+              "value": "**Ready** — Repository exists, remote configured, gh installed and authenticated, base branch exists. Git workflow (worktree + PR) is viable.\n\n**Degraded** — Repository and remote exist, but gh is missing or unauthenticated. Git workflow is not viable — fall back to direct commit mode. Report what's missing so the user can fix it if they want.\n\n**Minimal** — Repository exists but no remote, or not a git repo at all. Only local operations are possible. Direct commit mode with local-only commits.\n\n**Warnings** — Orphaned worktrees found, `.gitignore` missing worktrees entry, base branch doesn't exist on remote. These don't block the workflow but need attention."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Constraints",
+      "content": [
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Detection must be lightweight — a few git and gh commands, not exhaustive repository analysis",
+            "Never install gh, authenticate, or modify git configuration during detection",
+            "Never create or remove worktrees during detection — that belongs to the execution phase",
+            "Never push, pull, or modify branches during detection",
+            "Report all findings to the orchestrator as internal context — only surface issues to the user when action is needed"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/gobbi/notification-setup.json
+++ b/.claude/skills/gobbi/notification-setup.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "gobbi-docs/child",
+  "parent": "gobbi",
+  "title": "Notification Setup",
+  "opening": "Check notification configuration state at session start. Determines which channels are ready, which need setup, and what the orchestrator should offer the user.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "A session that knows its notification state upfront avoids mid-task setup interruptions.",
+          "body": "Detection before the first task means the orchestrator can offer credential setup during session start rather than discovering missing credentials when a notification tries to fire."
+        },
+        {
+          "type": "principle",
+          "statement": "Both session flag AND credentials must be present for notifications to fire.",
+          "body": "Notification delivery requires two independent conditions: the session flag in `gobbi.json` is `true` for the channel, and the channel's credentials exist in `.env`. Missing either one suppresses delivery. This means credentials alone are not sufficient — the user must explicitly opt in per session during `/gobbi` setup."
+        },
+        {
+          "type": "principle",
+          "statement": "Detection is read-only.",
+          "body": "Never modify credentials, hooks, or settings during detection. Report state; let the user decide what to fix."
+        }
+      ]
+    },
+    {
+      "heading": "Setup Sequence",
+      "content": [
+        {
+          "type": "text",
+          "value": "Runs automatically at session start, after the setup questions and before the first task."
+        },
+        {
+          "type": "subsection",
+          "heading": "1. Credential File",
+          "content": [
+            {
+              "type": "text",
+              "value": "Check if `$CLAUDE_PROJECT_DIR/.claude/.env` exists. If it does, read it and identify which channel credentials are present:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**Slack** — Look for `SLACK_BOT_TOKEN` and `SLACK_USER_ID` or `SLACK_CHANNEL_ID`",
+                "**Telegram** — Look for `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID`",
+                "**Discord** — Look for `DISCORD_WEBHOOK_URL`",
+                "**Desktop** — Look for `NOTIFY_DESKTOP=true`"
+              ]
+            },
+            {
+              "type": "text",
+              "value": "A channel is \"configured\" when all its required credentials are present and non-empty."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "2. Hook Scripts",
+          "content": [
+            {
+              "type": "text",
+              "value": "Check if notification hook scripts exist in `$CLAUDE_PROJECT_DIR/.claude/hooks/` and are executable. The key scripts:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "`notify-send.sh` — the shared sender that routes to configured channels",
+                "Event-specific hook scripts that invoke the sender"
+              ]
+            },
+            {
+              "type": "text",
+              "value": "Missing or non-executable scripts indicate an incomplete installation."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "3. Hook Configuration",
+          "content": [
+            {
+              "type": "text",
+              "value": "Check `settings.json` for hook entries that reference the notification scripts. Hooks must be registered for the desired events (typically `Stop` and `Notification`)."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "4. Session Preferences in gobbi.json",
+          "content": [
+            {
+              "type": "text",
+              "value": "The user's notification choices from `/gobbi` setup Q4 are persisted to `gobbi.json` via `gobbi-config.sh`. The `notify-send.sh` hook reads these per-session flags before attempting delivery. Without a session entry, all channels default to `false` — no notifications fire until the user explicitly selects during setup.\n\nOnly Slack and Telegram have conditional session-level control in v0.3.2. Discord delivery is deferred to a future version. Desktop notifications (`NOTIFY_DESKTOP`) remain environment-level only — they are not gated by `gobbi.json` session flags."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "5. Classify State",
+          "content": [
+            {
+              "type": "text",
+              "value": "**Fully configured** — Credentials exist in `.env`, scripts are executable, hooks are registered, and session flags are set in `gobbi.json`. After the user selects channels at setup, the orchestrator persists session flags. Notifications fire for selected channels.\n\n**Partially configured** — Some pieces are in place but others are missing (e.g., credentials exist but hooks aren't registered, or scripts exist but aren't executable). Report what's missing and offer to fix. Session flags alone are not sufficient — credentials and infrastructure must also be present.\n\n**Not configured** — No `$CLAUDE_PROJECT_DIR/.claude/.env` or no notification credentials. If the user selected notification channels at session start, load _notification and the relevant child skill (_slack, _telegram, _discord) to help set up. Session flags are still written to `gobbi.json` so that notifications activate immediately once credentials are added.\n\n**Degraded** — Credentials exist but a dependency is missing (e.g., `jq` not installed, `notify-send` not available for Desktop). Report the dependency gap."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Constraints",
+      "content": [
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Detection must be lightweight — reading a few files, not running network checks or sending test messages",
+            "Never modify `$CLAUDE_PROJECT_DIR/.claude/.env`, hook scripts, or settings during detection",
+            "Never send test notifications during detection — that belongs to the _notification setup flow",
+            "If `$CLAUDE_PROJECT_DIR/.claude/.env` exists, check file permissions are 600 — warn if not, but do not change them during detection"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/skills/gobbi/notification-setup.md
+++ b/.claude/skills/gobbi/notification-setup.md
@@ -10,6 +10,10 @@ Check notification configuration state at session start. Determines which channe
 
 Detection before the first task means the orchestrator can offer credential setup during session start rather than discovering missing credentials when a notification tries to fire.
 
+> **Both session flag AND credentials must be present for notifications to fire.**
+
+Notification delivery requires two independent conditions: the session flag in `gobbi.json` is `true` for the channel, and the channel's credentials exist in `.env`. Missing either one suppresses delivery. This means credentials alone are not sufficient — the user must explicitly opt in per session during `/gobbi` setup.
+
 > **Detection is read-only.**
 
 Never modify credentials, hooks, or settings during detection. Report state; let the user decide what to fix.
@@ -43,13 +47,19 @@ Missing or non-executable scripts indicate an incomplete installation.
 
 Check `settings.json` for hook entries that reference the notification scripts. Hooks must be registered for the desired events (typically `Stop` and `Notification`).
 
-### 4. Classify State
+### 4. Session Preferences in gobbi.json
 
-**Fully configured** — Credentials exist, scripts are executable, hooks are registered. The orchestrator enables notifications for the configured channels without user action.
+The user's notification choices from `/gobbi` setup Q4 are persisted to `gobbi.json` via `gobbi-config.sh`. The `notify-send.sh` hook reads these per-session flags before attempting delivery. Without a session entry, all channels default to `false` — no notifications fire until the user explicitly selects during setup.
 
-**Partially configured** — Some pieces are in place but others are missing (e.g., credentials exist but hooks aren't registered, or scripts exist but aren't executable). Report what's missing and offer to fix.
+Only Slack and Telegram have conditional session-level control in v0.3.2. Discord delivery is deferred to a future version. Desktop notifications (`NOTIFY_DESKTOP`) remain environment-level only — they are not gated by `gobbi.json` session flags.
 
-**Not configured** — No `$CLAUDE_PROJECT_DIR/.claude/.env` or no notification credentials. If the user selected notification channels at session start, load _notification and the relevant child skill to help set up.
+### 5. Classify State
+
+**Fully configured** — Credentials exist in `.env`, scripts are executable, hooks are registered, and session flags are set in `gobbi.json`. After the user selects channels at setup, the orchestrator persists session flags. Notifications fire for selected channels.
+
+**Partially configured** — Some pieces are in place but others are missing (e.g., credentials exist but hooks aren't registered, or scripts exist but aren't executable). Report what's missing and offer to fix. Session flags alone are not sufficient — credentials and infrastructure must also be present.
+
+**Not configured** — No `$CLAUDE_PROJECT_DIR/.claude/.env` or no notification credentials. If the user selected notification channels at session start, load _notification and the relevant child skill (_slack, _telegram, _discord) to help set up. Session flags are still written to `gobbi.json` so that notifications activate immediately once credentials are added.
 
 **Degraded** — Credentials exist but a dependency is missing (e.g., `jq` not installed, `notify-send` not available for Desktop). Report the dependency gap.
 

--- a/.claude/skills/gobbi/project-setup.json
+++ b/.claude/skills/gobbi/project-setup.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "gobbi-docs/child",
+  "parent": "gobbi",
+  "title": "Project Setup",
+  "opening": "Check for `$CLAUDE_PROJECT_DIR/.claude/project/` at session start. If project documentation exists, read it for context. If not, create the project directory using the _project skill.",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Every project needs a `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/` directory.",
+          "body": "Notes, gotchas, and project documentation accumulate here across sessions. Without it, workflow output has nowhere to persist."
+        },
+        {
+          "type": "principle",
+          "statement": "Read only `README.md`, `design/`, and `gotchas/` at setup.",
+          "body": "Other directories like `note/` may contain many files and are not needed for session context. Keep setup lightweight."
+        }
+      ]
+    },
+    {
+      "heading": "Setup Sequence",
+      "content": [
+        {
+          "type": "text",
+          "value": "Runs automatically at every session start, after the setup questions and before the first task."
+        },
+        {
+          "type": "subsection",
+          "heading": "1. Scan the Project's `.claude/` Directory",
+          "content": [
+            {
+              "type": "text",
+              "value": "Check what the project already has in `$CLAUDE_PROJECT_DIR/.claude/`:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "**CLAUDE.md** — read it for project-level instructions and context",
+                "**`rules/`** — list existing rule files and read them for project conventions",
+                "**`skills/`** — list existing project-specific skills (not gobbi skills). These are the user's domain skills. Read their SKILL.md descriptions to understand what the project has.",
+                "**`agents/`** — list existing project-specific agents. Read their descriptions to understand available specialists."
+              ]
+            },
+            {
+              "type": "text",
+              "value": "This gives the orchestrator context about what the project already provides — avoiding duplicate creation and enabling informed delegation."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "2. Check for Existing Project Directory",
+          "content": [
+            {
+              "type": "text",
+              "value": "Look for `$CLAUDE_PROJECT_DIR/.claude/project/` and identify any `{project-name}/` subdirectories. If one exists, read only these for context:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "`README.md` — project overview and conventions",
+                "`design/` — architecture and design decisions",
+                "`gotchas/` — project-specific mistakes to avoid"
+              ]
+            },
+            {
+              "type": "text",
+              "value": "Do not read other directories (e.g., `note/`) at setup — they may contain many files and are not needed for session context."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "3. New Projects",
+          "content": [
+            {
+              "type": "text",
+              "value": "When `$CLAUDE_PROJECT_DIR/.claude/project/` is absent or has no project subdirectory, ask the user for a project name via AskUserQuestion, then create the full standard structure:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "`$CLAUDE_PROJECT_DIR/.claude/project/{name}/README.md` — project overview and directory index",
+                "`$CLAUDE_PROJECT_DIR/.claude/project/{name}/design/` — architecture and design decisions",
+                "`$CLAUDE_PROJECT_DIR/.claude/project/{name}/rules/` — project-specific rules and conventions",
+                "`$CLAUDE_PROJECT_DIR/.claude/project/{name}/gotchas/` — project-specific gotchas",
+                "`$CLAUDE_PROJECT_DIR/.claude/project/{name}/note/` — workflow notes per task (managed by _note)",
+                "`$CLAUDE_PROJECT_DIR/.claude/project/{name}/reference/` — external references, API docs, research",
+                "`$CLAUDE_PROJECT_DIR/.claude/project/{name}/docs/` — other project documents"
+              ]
+            },
+            {
+              "type": "text",
+              "value": "Create all directories upfront. The README.md must list each directory with a one-line description. Load `_project` for detailed authoring guidelines if the user wants to populate design docs or rules immediately."
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "4. Help Set Up Claude Docs",
+          "content": [
+            {
+              "type": "text",
+              "value": "After project directory setup, check what the project is missing in `$CLAUDE_PROJECT_DIR/.claude/` and offer to help create them via AskUserQuestion. This is the onboarding moment — guide the user toward a well-structured project.\n\n**CLAUDE.md** — If absent, offer to create one. It should contain project-level instructions, tech stack, and key conventions. This is the first thing Claude reads every session.\n\n**Rules** — If `$CLAUDE_PROJECT_DIR/.claude/rules/` is empty, ask the user about project conventions that should be enforced — code style, testing requirements, commit conventions, naming patterns. Load `_rules` to help author them. Gobbi already provides its own convention rules — project rules should cover project-specific standards only.\n\n**Skills** — If the project has no project-specific skills, suggest creating domain-specific ones. These should be tailored to the project's tech stack — a Python/Django project benefits from skills that know Django ORM patterns, a TypeScript/React project benefits from skills that know component conventions. Load `_skills` to help author them. Gobbi already provides workflow and docs skills — project skills should cover project-specific domain knowledge.\n\n**Agents** — If the project has no project-specific agents, suggest creating specialists for the project's common tasks — a security reviewer that knows the auth stack, a test writer that knows the testing framework, a migration specialist that knows the ORM. Load `_agents` to help author them. Gobbi already provides orchestration and evaluation agents.\n\nDo not create all of these at once — ask the user which they want to set up now and which to defer. The goal is awareness that these exist and can be created, not a mandatory setup gate."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Constraints",
+      "content": [
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Setup must be lightweight — check a few paths, read existing docs if present",
+            "Never generate a user-facing report or summary document. Output is internal orchestrator context only.",
+            "Skip setup for gobbi's own repository — `$CLAUDE_PROJECT_DIR/.claude/project/` is already structured",
+            "When `$CLAUDE_PROJECT_DIR/.claude/project/` docs exist, trust them over filesystem inference"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ node_modules/
 .claude/project/*/note/
 .claude/worktrees/
 .claude/.env
+.claude/gobbi.json
+.claude/gobbi.json.lock
 dist/
 packages/*/dist/
 packages/*/node_modules/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobbi/core",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Open-source ClaudeX tool — workflow orchestration and docs management for Claude Code",
   "type": "module",
   "bin": {

--- a/plugins/gobbi/.claude-plugin/plugin.json
+++ b/plugins/gobbi/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gobbi",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Open-source ClaudeX tool for Claude Code — structured orchestration with multi-stance evaluation, adaptive planning, and git workflow isolation",
   "author": {
     "name": "HahyeonJeon"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import path from 'path';
 const USAGE = `Usage: gobbi <command> [options]
 
 Commands:
+  docs       Manage gobbi-docs JSON templates and Markdown
   image      Analyze images or create comparison sheets
   video      Analyze video files and extract frames
   web        Take screenshots or capture images from web pages
@@ -17,10 +18,15 @@ Options:
 export async function run(): Promise<void> {
   const command = process.argv[2];
 
-  // Early routing for media commands (they have their own parseArgs)
-  if (command === 'image' || command === 'video' || command === 'web') {
+  // Early routing for commands (they have their own parseArgs)
+  if (command === 'docs' || command === 'image' || command === 'video' || command === 'web') {
     const commandArgs = process.argv.slice(3);
     switch (command) {
+      case 'docs': {
+        const { runDocs } = await import('./commands/docs.js');
+        await runDocs(commandArgs);
+        return;
+      }
       case 'image': {
         const { runImage } = await import('./commands/image.js');
         await runImage(commandArgs);

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -1,0 +1,592 @@
+/**
+ * gobbi docs — Command router for docs subcommands.
+ *
+ * Subcommands:
+ *   init <type> [name]       Scaffold a new JSON template
+ *   json2md <path>           Convert JSON template to Markdown
+ *   validate <path>          Validate a JSON template
+ *   read <path> [--section]  Pretty-print JSON template metadata or section
+ */
+
+import { parseArgs } from 'node:util';
+import { readFile, writeFile } from 'fs/promises';
+import path from 'path';
+
+import { header, ok, error, dim, bold, yellow } from '../lib/style.js';
+import { renderDoc } from '../lib/docs/renderer.js';
+import { validateFile } from '../lib/docs/validator.js';
+import {
+  isDocType,
+  DOC_TYPE_TO_SCHEMA,
+  VALID_DOC_TYPES,
+} from '../lib/docs/types.js';
+
+import type {
+  DocType,
+  GobbiDoc,
+  GotchaDoc,
+  Section,
+  ContentBlock,
+} from '../lib/docs/types.js';
+
+// ---------------------------------------------------------------------------
+// Usage Strings
+// ---------------------------------------------------------------------------
+
+const USAGE = `Usage: gobbi docs <subcommand> [options]
+
+Subcommands:
+  init <type> [name]       Scaffold a new JSON template
+  json2md <path>           Convert JSON template to Markdown
+  validate <path>          Validate a JSON template
+  read <path> [--section]  Pretty-print JSON metadata or section
+
+Options:
+  --help    Show this help message`;
+
+const INIT_USAGE = `Usage: gobbi docs init <type> [name] [options]
+
+Types: skill, agent, rule, root, child, gotcha
+
+Options:
+  --out <path>    Write JSON to file instead of stdout
+  --help          Show this help message`;
+
+const JSON2MD_USAGE = `Usage: gobbi docs json2md <path> [options]
+
+Converts a JSON template to Markdown. Writes the .md file alongside the .json.
+
+Options:
+  --help    Show this help message`;
+
+const VALIDATE_USAGE = `Usage: gobbi docs validate <path> [options]
+
+Validates a JSON template against the gobbi-docs schema.
+
+Options:
+  --help    Show this help message`;
+
+const READ_USAGE = `Usage: gobbi docs read <path> [options]
+
+Pretty-print JSON template metadata or a specific section.
+
+Options:
+  --section <name>    Display only the named section
+  --help              Show this help message`;
+
+// ---------------------------------------------------------------------------
+// Top-Level Router
+// ---------------------------------------------------------------------------
+
+/**
+ * Top-level handler for `gobbi docs`. Dispatches to subcommands.
+ * Called from cli.ts with process.argv.slice(3).
+ */
+export async function runDocs(args: string[]): Promise<void> {
+  const subcommand = args[0];
+
+  switch (subcommand) {
+    case 'init':
+      await runDocsInit(args.slice(1));
+      break;
+    case 'json2md':
+      await runDocsJson2md(args.slice(1));
+      break;
+    case 'validate':
+      await runDocsValidate(args.slice(1));
+      break;
+    case 'read':
+      await runDocsRead(args.slice(1));
+      break;
+    case '--help':
+    case undefined:
+      console.log(USAGE);
+      break;
+    default:
+      console.log(error(`Unknown subcommand: ${subcommand}`));
+      console.log(USAGE);
+      process.exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// init
+// ---------------------------------------------------------------------------
+
+async function runDocsInit(args: string[]): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args,
+    allowPositionals: true,
+    strict: false,
+    options: {
+      'out': { type: 'string' },
+      'help': { type: 'boolean', default: false },
+    },
+  });
+
+  if (values.help === true) {
+    console.log(INIT_USAGE);
+    return;
+  }
+
+  const typeArg = positionals[0];
+  if (typeArg === undefined) {
+    console.log(error('Missing required argument: doc type'));
+    console.log(INIT_USAGE);
+    process.exit(1);
+  }
+
+  if (!isDocType(typeArg)) {
+    console.log(error(`Invalid doc type: "${typeArg}". Must be one of: ${VALID_DOC_TYPES.join(', ')}`));
+    process.exit(1);
+  }
+  const docType: DocType = typeArg;
+
+  const name = positionals[1] ?? docType;
+  const template = scaffoldTemplate(docType, name);
+  const json = JSON.stringify(template, null, 2) + '\n';
+
+  const outPath = values.out;
+  if (typeof outPath === 'string') {
+    await writeFile(outPath, json, 'utf8');
+    console.log(ok(`Template written to ${outPath}`));
+  } else {
+    process.stdout.write(json);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// json2md
+// ---------------------------------------------------------------------------
+
+async function runDocsJson2md(args: string[]): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args,
+    allowPositionals: true,
+    strict: false,
+    options: {
+      'help': { type: 'boolean', default: false },
+    },
+  });
+
+  if (values.help === true) {
+    console.log(JSON2MD_USAGE);
+    return;
+  }
+
+  const jsonPath = positionals[0];
+  if (jsonPath === undefined) {
+    console.log(error('Missing required argument: JSON file path'));
+    console.log(JSON2MD_USAGE);
+    process.exit(1);
+  }
+
+  let content: string;
+  try {
+    content = await readFile(jsonPath, 'utf8');
+  } catch {
+    console.log(error(`Cannot read file: ${jsonPath}`));
+    process.exit(1);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    console.log(error('Invalid JSON'));
+    process.exit(1);
+  }
+
+  // Quick validation before rendering
+  const doc = parsed as GobbiDoc;
+  if (typeof doc.$schema !== 'string' || !doc.$schema.startsWith('gobbi-docs/')) {
+    console.log(error('Invalid or missing "$schema" — not a gobbi-docs template'));
+    process.exit(1);
+  }
+
+  const markdown = renderDoc(doc);
+  const dir = path.dirname(jsonPath);
+  const basename = path.basename(jsonPath, '.json');
+  const mdPath = path.join(dir, `${basename}.md`);
+
+  await writeFile(mdPath, markdown, 'utf8');
+
+  console.log(header('json2md'));
+  console.log(ok(`${jsonPath} -> ${mdPath}`));
+}
+
+// ---------------------------------------------------------------------------
+// validate
+// ---------------------------------------------------------------------------
+
+async function runDocsValidate(args: string[]): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args,
+    allowPositionals: true,
+    strict: false,
+    options: {
+      'help': { type: 'boolean', default: false },
+    },
+  });
+
+  if (values.help === true) {
+    console.log(VALIDATE_USAGE);
+    return;
+  }
+
+  const filePath = positionals[0];
+  if (filePath === undefined) {
+    console.log(error('Missing required argument: JSON file path'));
+    console.log(VALIDATE_USAGE);
+    process.exit(1);
+  }
+
+  const result = await validateFile(filePath);
+
+  console.log(header('Validation'));
+
+  if (result.valid) {
+    console.log(ok('Schema valid'));
+  } else {
+    for (const err of result.errors) {
+      console.log(error(err));
+    }
+  }
+
+  for (const warn of result.warnings) {
+    console.log(yellow(`  ! ${warn}`));
+  }
+
+  if (result.syncStatus !== undefined) {
+    switch (result.syncStatus) {
+      case 'in-sync':
+        console.log(ok('Markdown file in sync'));
+        break;
+      case 'out-of-sync':
+        console.log(yellow('  ! Markdown file out of sync — run json2md to update'));
+        break;
+      case 'no-md-file':
+        console.log(dim('  (no corresponding .md file found)'));
+        break;
+    }
+  }
+
+  if (!result.valid) {
+    process.exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// read
+// ---------------------------------------------------------------------------
+
+async function runDocsRead(args: string[]): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args,
+    allowPositionals: true,
+    strict: false,
+    options: {
+      'section': { type: 'string' },
+      'help': { type: 'boolean', default: false },
+    },
+  });
+
+  if (values.help === true) {
+    console.log(READ_USAGE);
+    return;
+  }
+
+  const filePath = positionals[0];
+  if (filePath === undefined) {
+    console.log(error('Missing required argument: JSON file path'));
+    console.log(READ_USAGE);
+    process.exit(1);
+  }
+
+  let content: string;
+  try {
+    content = await readFile(filePath, 'utf8');
+  } catch {
+    console.log(error(`Cannot read file: ${filePath}`));
+    process.exit(1);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    console.log(error('Invalid JSON'));
+    process.exit(1);
+  }
+
+  const doc = parsed as GobbiDoc;
+
+  const sectionName = values.section;
+
+  if (typeof sectionName === 'string') {
+    // Display a specific section
+    printSection(doc, sectionName);
+  } else {
+    // Display metadata overview
+    printMetadata(doc);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Read Helpers
+// ---------------------------------------------------------------------------
+
+function printMetadata(doc: GobbiDoc): void {
+  console.log(header('Document Metadata'));
+  console.log(`  ${bold('Schema:')}  ${doc.$schema}`);
+  console.log(`  ${bold('Title:')}   ${doc.title}`);
+
+  if (doc.opening !== undefined) {
+    const openingPreview = doc.opening.length > 80
+      ? doc.opening.slice(0, 77) + '...'
+      : doc.opening;
+    console.log(`  ${bold('Opening:')} ${openingPreview}`);
+  }
+
+  if ('parent' in doc && typeof doc.parent === 'string') {
+    console.log(`  ${bold('Parent:')}  ${doc.parent}`);
+  }
+
+  if ('frontmatter' in doc && doc.frontmatter !== null && typeof doc.frontmatter === 'object') {
+    console.log('');
+    console.log(`  ${bold('Frontmatter:')}`);
+    const fm = doc.frontmatter as Record<string, unknown>;
+    for (const [key, value] of Object.entries(fm)) {
+      console.log(`    ${key}: ${String(value)}`);
+    }
+  }
+
+  if (doc.navigation !== undefined) {
+    console.log('');
+    console.log(`  ${bold('Navigation:')}`);
+    for (const [file, description] of Object.entries(doc.navigation)) {
+      console.log(`    ${file} -> ${description}`);
+    }
+  }
+
+  // Section/entry summary
+  if (doc.$schema === 'gobbi-docs/gotcha') {
+    const gotchaDoc = doc as GotchaDoc;
+    console.log('');
+    console.log(`  ${bold('Entries:')} ${gotchaDoc.entries.length}`);
+    for (const entry of gotchaDoc.entries) {
+      console.log(`    - ${entry.title}`);
+    }
+  } else if ('sections' in doc && Array.isArray(doc.sections)) {
+    const sections = doc.sections as Section[];
+    console.log('');
+    console.log(`  ${bold('Sections:')} ${sections.length}`);
+    for (const section of sections) {
+      const heading = section.heading ?? '(headingless)';
+      console.log(`    - ${heading} (${section.content.length} blocks)`);
+    }
+  }
+}
+
+function printSection(doc: GobbiDoc, sectionName: string): void {
+  if (doc.$schema === 'gobbi-docs/gotcha') {
+    const gotchaDoc = doc as GotchaDoc;
+    const entry = gotchaDoc.entries.find(
+      (e) => e.title.toLowerCase() === sectionName.toLowerCase(),
+    );
+    if (entry === undefined) {
+      console.log(error(`Entry not found: "${sectionName}"`));
+      console.log(dim('  Available entries:'));
+      for (const e of gotchaDoc.entries) {
+        console.log(`    - ${e.title}`);
+      }
+      process.exit(1);
+    }
+    console.log(header(entry.title));
+    console.log(`  ${bold('Priority:')} ${entry.body.priority}`);
+    console.log('');
+    console.log(`  ${bold('What happened:')}`);
+    console.log(`  ${entry.body['what-happened']}`);
+    console.log('');
+    console.log(`  ${bold('User feedback:')}`);
+    console.log(`  ${entry.body['user-feedback']}`);
+    console.log('');
+    console.log(`  ${bold('Correct approach:')}`);
+    console.log(`  ${entry.body['correct-approach']}`);
+    return;
+  }
+
+  if (!('sections' in doc) || !Array.isArray(doc.sections)) {
+    console.log(error('Document has no sections'));
+    process.exit(1);
+  }
+
+  const sections = doc.sections as Section[];
+  const section = sections.find(
+    (s) => s.heading !== null && s.heading.toLowerCase() === sectionName.toLowerCase(),
+  );
+
+  if (section === undefined) {
+    console.log(error(`Section not found: "${sectionName}"`));
+    console.log(dim('  Available sections:'));
+    for (const s of sections) {
+      const heading = s.heading ?? '(headingless)';
+      console.log(`    - ${heading}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(header(section.heading ?? '(headingless)'));
+  for (const block of section.content) {
+    printBlock(block, '  ');
+  }
+}
+
+function printBlock(block: ContentBlock, indent: string): void {
+  switch (block.type) {
+    case 'text':
+      console.log(`${indent}${block.value}`);
+      break;
+    case 'principle':
+      console.log(`${indent}${bold(`> ${block.statement}`)}`);
+      if (block.body !== undefined) {
+        console.log(`${indent}${block.body}`);
+      }
+      break;
+    case 'table':
+      console.log(`${indent}${block.headers.join(' | ')}`);
+      for (const row of block.rows) {
+        console.log(`${indent}${row.join(' | ')}`);
+      }
+      break;
+    case 'constraint-list':
+      for (const item of block.items) {
+        console.log(`${indent}- ${item}`);
+      }
+      break;
+    case 'list':
+      for (let i = 0; i < block.items.length; i++) {
+        const item = block.items[i];
+        if (item === undefined) continue;
+        const prefix = block.style === 'numbered' ? `${i + 1}. ` : '- ';
+        console.log(`${indent}${prefix}${item}`);
+      }
+      break;
+    case 'subsection':
+      console.log(`${indent}${bold(`### ${block.heading}`)}`);
+      for (const child of block.content) {
+        printBlock(child, indent + '  ');
+      }
+      break;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Template Scaffolding
+// ---------------------------------------------------------------------------
+
+function scaffoldTemplate(docType: DocType, name: string): GobbiDoc {
+  const schema = DOC_TYPE_TO_SCHEMA[docType];
+
+  switch (docType) {
+    case 'skill':
+      return {
+        $schema: schema as 'gobbi-docs/skill',
+        frontmatter: {
+          name,
+          description: `TODO: describe ${name}`,
+        },
+        title: titleCase(name),
+        sections: [
+          {
+            heading: 'Core Principle',
+            content: [
+              {
+                type: 'principle',
+                statement: 'TODO: core principle statement',
+                body: 'TODO: explanation',
+              },
+            ],
+          },
+        ],
+      };
+    case 'agent':
+      return {
+        $schema: schema as 'gobbi-docs/agent',
+        frontmatter: {
+          name,
+          description: `TODO: describe ${name}`,
+          tools: 'Read, Grep, Glob, Write, Edit, Bash',
+          model: 'opus',
+        },
+        title: titleCase(name),
+        sections: [],
+      };
+    case 'rule':
+      return {
+        $schema: schema as 'gobbi-docs/rule',
+        title: titleCase(name),
+        sections: [
+          {
+            heading: null,
+            content: [
+              { type: 'text', value: 'TODO: rule content' },
+            ],
+          },
+        ],
+      };
+    case 'root':
+      return {
+        $schema: schema as 'gobbi-docs/root',
+        title: titleCase(name),
+        opening: 'TODO: opening paragraph',
+        sections: [],
+      };
+    case 'child':
+      return {
+        $schema: schema as 'gobbi-docs/child',
+        parent: 'TODO',
+        title: titleCase(name),
+        sections: [
+          {
+            heading: 'Core Principle',
+            content: [
+              {
+                type: 'principle',
+                statement: 'TODO: core principle statement',
+                body: 'TODO: explanation',
+              },
+            ],
+          },
+        ],
+      };
+    case 'gotcha':
+      return {
+        $schema: schema as 'gobbi-docs/gotcha',
+        parent: 'TODO',
+        title: `Gotcha: ${titleCase(name)}`,
+        entries: [
+          {
+            title: 'TODO: gotcha title',
+            metadata: {
+              priority: 'medium',
+            },
+            body: {
+              priority: 'Medium',
+              'what-happened': 'TODO: what went wrong',
+              'user-feedback': 'TODO: what the user said',
+              'correct-approach': 'TODO: how to do it correctly',
+            },
+          },
+        ],
+      };
+  }
+}
+
+function titleCase(name: string): string {
+  return name
+    .replace(/^_+/, '')
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -4,6 +4,7 @@
  * Subcommands:
  *   init <type> [name]       Scaffold a new JSON template
  *   json2md <path>           Convert JSON template to Markdown
+ *   md2json <path>           Migrate Markdown file to JSON template
  *   validate <path>          Validate a JSON template
  *   read <path> [--section]  Pretty-print JSON template metadata or section
  */
@@ -14,6 +15,7 @@ import path from 'path';
 
 import { header, ok, error, dim, bold, yellow } from '../lib/style.js';
 import { renderDoc } from '../lib/docs/renderer.js';
+import { parseMarkdown } from '../lib/docs/migrator.js';
 import { validateFile } from '../lib/docs/validator.js';
 import {
   isDocType,
@@ -38,6 +40,7 @@ const USAGE = `Usage: gobbi docs <subcommand> [options]
 Subcommands:
   init <type> [name]       Scaffold a new JSON template
   json2md <path>           Convert JSON template to Markdown
+  md2json <path>           Migrate Markdown file to JSON template
   validate <path>          Validate a JSON template
   read <path> [--section]  Pretty-print JSON metadata or section
 
@@ -58,6 +61,15 @@ Converts a JSON template to Markdown. Writes the .md file alongside the .json.
 
 Options:
   --help    Show this help message`;
+
+const MD2JSON_USAGE = `Usage: gobbi docs md2json <path> [options]
+
+Migrates a Markdown file to its JSON template equivalent. Writes the .json file
+alongside the .md, or outputs to stdout with --stdout.
+
+Options:
+  --stdout    Write JSON to stdout instead of file
+  --help      Show this help message`;
 
 const VALIDATE_USAGE = `Usage: gobbi docs validate <path> [options]
 
@@ -91,6 +103,9 @@ export async function runDocs(args: string[]): Promise<void> {
       break;
     case 'json2md':
       await runDocsJson2md(args.slice(1));
+      break;
+    case 'md2json':
+      await runDocsMd2json(args.slice(1));
       break;
     case 'validate':
       await runDocsValidate(args.slice(1));
@@ -213,6 +228,59 @@ async function runDocsJson2md(args: string[]): Promise<void> {
 
   console.log(header('json2md'));
   console.log(ok(`${jsonPath} -> ${mdPath}`));
+}
+
+// ---------------------------------------------------------------------------
+// md2json
+// ---------------------------------------------------------------------------
+
+async function runDocsMd2json(args: string[]): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args,
+    allowPositionals: true,
+    strict: false,
+    options: {
+      'stdout': { type: 'boolean', default: false },
+      'help': { type: 'boolean', default: false },
+    },
+  });
+
+  if (values.help === true) {
+    console.log(MD2JSON_USAGE);
+    return;
+  }
+
+  const mdPath = positionals[0];
+  if (mdPath === undefined) {
+    console.log(error('Missing required argument: Markdown file path'));
+    console.log(MD2JSON_USAGE);
+    process.exit(1);
+  }
+
+  let content: string;
+  try {
+    content = await readFile(mdPath, 'utf8');
+  } catch {
+    console.log(error(`Cannot read file: ${mdPath}`));
+    process.exit(1);
+  }
+
+  const doc = parseMarkdown(content, mdPath);
+  const json = JSON.stringify(doc, null, 2) + '\n';
+
+  if (values.stdout === true) {
+    process.stdout.write(json);
+    return;
+  }
+
+  const dir = path.dirname(mdPath);
+  const basename = path.basename(mdPath, '.md');
+  const jsonPath = path.join(dir, `${basename}.json`);
+
+  await writeFile(jsonPath, json, 'utf8');
+
+  console.log(header('md2json'));
+  console.log(ok(`${mdPath} -> ${jsonPath}`));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/docs/migrator.ts
+++ b/src/lib/docs/migrator.ts
@@ -1,0 +1,1250 @@
+/**
+ * gobbi-docs Markdown to JSON migrator.
+ *
+ * Parses existing `.claude/` Markdown files and produces their JSON template
+ * equivalent conforming to the gobbi-docs spec. This is the inverse of
+ * renderer.ts — designed for one-time migration of the 77 existing docs.
+ *
+ * Detection logic:
+ * - agents/*.md      → agent
+ * - rules/*.md       → rule
+ * - README.md        → root
+ * - SKILL.md         → skill
+ * - gotchas.md / _gotcha/__*.md → gotcha
+ * - Everything else  → child
+ *
+ * Parsing order: frontmatter → title → opening → navigation → sections/entries
+ */
+
+import path from 'path';
+
+import type {
+  GobbiDoc,
+  DocType,
+  ContentBlock,
+  Section,
+  Navigation,
+  GotchaEntry,
+  GotchaMetadata,
+  GotchaBody,
+  SkillFrontmatter,
+  AgentFrontmatter,
+  RuleFrontmatter,
+  SkillDoc,
+  AgentDoc,
+  RuleDoc,
+  RootDoc,
+  ChildDoc,
+  GotchaDoc,
+  TextBlock,
+  PrincipleBlock,
+  TableBlock,
+  ConstraintListBlock,
+  ListBlock,
+  SubsectionBlock,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a Markdown file into a GobbiDoc JSON template.
+ *
+ * @param markdown - Raw Markdown content
+ * @param filePath - Path to the file (used to detect doc type and parent)
+ * @returns Parsed GobbiDoc
+ */
+export function parseMarkdown(markdown: string, filePath: string): GobbiDoc {
+  const docType = detectDocType(filePath);
+  const lines = markdown.split('\n');
+
+  // Remove trailing newline that renderers add
+  if (lines.length > 0 && lines[lines.length - 1] === '') {
+    lines.pop();
+  }
+
+  let cursor = 0;
+
+  // 1. Parse frontmatter
+  let frontmatter: SkillFrontmatter | AgentFrontmatter | RuleFrontmatter | undefined;
+  if (lines[cursor] === '---') {
+    const fmResult = parseFrontmatterBlock(lines, cursor);
+    frontmatter = fmResult.frontmatter;
+    cursor = fmResult.cursor;
+  }
+
+  // 2. Skip blank lines before title
+  cursor = skipBlankLines(lines, cursor);
+
+  // 3. Parse H1 title
+  const titleLine = lines[cursor];
+  if (titleLine === undefined || !titleLine.startsWith('# ')) {
+    throw new Error(`Expected H1 title, got: "${titleLine ?? '(end of file)'}"`);
+  }
+  const title = titleLine.slice(2);
+  cursor++;
+
+  // 4. Parse opening + navigation (everything between H1 and first --- or H2)
+  const openingResult = parseOpeningAndNavigation(lines, cursor);
+  const opening = openingResult.opening;
+  const navigation = openingResult.navigation;
+  cursor = openingResult.cursor;
+
+  // 5. Parse sections or entries
+  if (docType === 'gotcha') {
+    const parent = detectParent(filePath);
+    const entries = parseGotchaEntries(lines, cursor);
+    return buildGotchaDoc(title, parent, entries, opening, navigation);
+  }
+
+  let sections = parseSections(lines, cursor);
+
+  // Post-process: extract navigation from sections if not found in opening
+  let finalNavigation = navigation;
+  if (finalNavigation === undefined) {
+    const navExtraction = extractNavigationFromSections(sections);
+    finalNavigation = navExtraction.navigation;
+    sections = navExtraction.sections;
+  }
+
+  // Build the doc based on type
+  switch (docType) {
+    case 'skill':
+      return buildSkillDoc(title, frontmatter as SkillFrontmatter, sections, opening, finalNavigation);
+    case 'agent':
+      return buildAgentDoc(title, frontmatter as AgentFrontmatter, sections, opening, finalNavigation);
+    case 'rule':
+      return buildRuleDoc(title, frontmatter as RuleFrontmatter | undefined, sections, opening, finalNavigation);
+    case 'root':
+      return buildRootDoc(title, sections, opening, finalNavigation);
+    case 'child': {
+      const parent = detectParent(filePath);
+      return buildChildDoc(title, parent, sections, opening, finalNavigation);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Doc Type Detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect the doc type from the file path within `.claude/`.
+ */
+export function detectDocType(filePath: string): DocType {
+  const normalized = filePath.replace(/\\/g, '/');
+
+  // Agent definitions: agents/*.md
+  if (/\/agents\/[^/]+\.md$/.test(normalized)) {
+    return 'agent';
+  }
+
+  // Rule files: rules/*.md
+  if (/\/rules\/[^/]+\.md$/.test(normalized)) {
+    return 'rule';
+  }
+
+  // Root README: .claude/README.md
+  const basename = path.basename(normalized);
+  if (basename === 'README.md') {
+    return 'root';
+  }
+
+  // Skill: SKILL.md
+  if (basename === 'SKILL.md') {
+    return 'skill';
+  }
+
+  // Gotcha: gotchas.md OR _gotcha/__*.md
+  if (basename === 'gotchas.md') {
+    return 'gotcha';
+  }
+  if (/\/_gotcha\/__[^/]+\.md$/.test(normalized)) {
+    return 'gotcha';
+  }
+
+  // Everything else is a child
+  return 'child';
+}
+
+// ---------------------------------------------------------------------------
+// Parent Detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine the parent skill from the file path.
+ * For files in `.claude/skills/{skill-name}/`, the parent is the skill-name.
+ */
+function detectParent(filePath: string): string {
+  const normalized = filePath.replace(/\\/g, '/');
+  const match = /\/skills\/([^/]+)\//.exec(normalized);
+  if (match !== null && match[1] !== undefined) {
+    return match[1];
+  }
+  return 'unknown';
+}
+
+// ---------------------------------------------------------------------------
+// Doc Builders — typed constructors to satisfy discriminated union
+// ---------------------------------------------------------------------------
+
+function buildSkillDoc(
+  title: string,
+  frontmatter: SkillFrontmatter,
+  sections: Section[],
+  opening: string | undefined,
+  navigation: Navigation | undefined,
+): SkillDoc {
+  const doc: SkillDoc = {
+    $schema: 'gobbi-docs/skill',
+    frontmatter,
+    title,
+  };
+  if (opening !== undefined) {
+    doc.opening = opening;
+  }
+  if (navigation !== undefined) {
+    doc.navigation = navigation;
+  }
+  if (sections.length > 0) {
+    doc.sections = sections;
+  }
+  return doc;
+}
+
+function buildAgentDoc(
+  title: string,
+  frontmatter: AgentFrontmatter,
+  sections: Section[],
+  opening: string | undefined,
+  navigation: Navigation | undefined,
+): AgentDoc {
+  const doc: AgentDoc = {
+    $schema: 'gobbi-docs/agent',
+    frontmatter,
+    title,
+  };
+  if (opening !== undefined) {
+    doc.opening = opening;
+  }
+  if (navigation !== undefined) {
+    doc.navigation = navigation;
+  }
+  if (sections.length > 0) {
+    doc.sections = sections;
+  }
+  return doc;
+}
+
+function buildRuleDoc(
+  title: string,
+  frontmatter: RuleFrontmatter | undefined,
+  sections: Section[],
+  opening: string | undefined,
+  navigation: Navigation | undefined,
+): RuleDoc {
+  const doc: RuleDoc = {
+    $schema: 'gobbi-docs/rule',
+    title,
+  };
+  if (frontmatter !== undefined) {
+    doc.frontmatter = frontmatter as RuleFrontmatter;
+  }
+  if (opening !== undefined) {
+    doc.opening = opening;
+  }
+  if (navigation !== undefined) {
+    doc.navigation = navigation;
+  }
+  if (sections.length > 0) {
+    doc.sections = sections;
+  }
+  return doc;
+}
+
+function buildRootDoc(
+  title: string,
+  sections: Section[],
+  opening: string | undefined,
+  navigation: Navigation | undefined,
+): RootDoc {
+  const doc: RootDoc = {
+    $schema: 'gobbi-docs/root',
+    title,
+  };
+  if (opening !== undefined) {
+    doc.opening = opening;
+  }
+  if (navigation !== undefined) {
+    doc.navigation = navigation;
+  }
+  if (sections.length > 0) {
+    doc.sections = sections;
+  }
+  return doc;
+}
+
+function buildChildDoc(
+  title: string,
+  parent: string,
+  sections: Section[],
+  opening: string | undefined,
+  navigation: Navigation | undefined,
+): ChildDoc {
+  const doc: ChildDoc = {
+    $schema: 'gobbi-docs/child',
+    parent,
+    title,
+  };
+  if (opening !== undefined) {
+    doc.opening = opening;
+  }
+  if (navigation !== undefined) {
+    doc.navigation = navigation;
+  }
+  if (sections.length > 0) {
+    doc.sections = sections;
+  }
+  return doc;
+}
+
+function buildGotchaDoc(
+  title: string,
+  parent: string,
+  entries: GotchaEntry[],
+  opening: string | undefined,
+  navigation: Navigation | undefined,
+): GotchaDoc {
+  const doc: GotchaDoc = {
+    $schema: 'gobbi-docs/gotcha',
+    parent,
+    title,
+    entries,
+  };
+  if (opening !== undefined) {
+    doc.opening = opening;
+  }
+  if (navigation !== undefined) {
+    doc.navigation = navigation;
+  }
+  return doc;
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter Parsing
+// ---------------------------------------------------------------------------
+
+interface FrontmatterResult {
+  frontmatter: Record<string, string>;
+  cursor: number;
+}
+
+function parseFrontmatterBlock(lines: string[], start: number): FrontmatterResult {
+  // start is at the opening ---
+  let cursor = start + 1;
+  const fields: Record<string, string> = {};
+
+  while (cursor < lines.length) {
+    const line = lines[cursor];
+    if (line === undefined) break;
+    if (line === '---') {
+      cursor++; // skip closing ---
+      // Skip blank line after frontmatter
+      if (cursor < lines.length && lines[cursor] === '') {
+        cursor++;
+      }
+      return { frontmatter: fields, cursor };
+    }
+    const colonIdx = line.indexOf(':');
+    if (colonIdx !== -1) {
+      const key = line.slice(0, colonIdx).trim();
+      const value = line.slice(colonIdx + 1).trim();
+      fields[key] = value;
+    }
+    cursor++;
+  }
+
+  return { frontmatter: fields, cursor };
+}
+
+// ---------------------------------------------------------------------------
+// Opening and Navigation Parsing
+// ---------------------------------------------------------------------------
+
+interface OpeningAndNavigationResult {
+  opening: string | undefined;
+  navigation: Navigation | undefined;
+  cursor: number;
+}
+
+function parseOpeningAndNavigation(lines: string[], start: number): OpeningAndNavigationResult {
+  let cursor = start;
+  let opening: string | undefined;
+  let navigation: Navigation | undefined;
+
+  // Collect all content between H1 and first --- or H2
+  const contentLines: string[] = [];
+  let foundSeparator = false;
+
+  // Skip initial blank line after title
+  if (cursor < lines.length && lines[cursor] === '') {
+    cursor++;
+  }
+
+  while (cursor < lines.length) {
+    const line = lines[cursor];
+    if (line === undefined) break;
+
+    // Stop at section separator
+    if (line === '---') {
+      foundSeparator = true;
+      cursor++; // skip the ---
+      break;
+    }
+
+    // Stop at H2
+    if (line.startsWith('## ')) {
+      break;
+    }
+
+    contentLines.push(line);
+    cursor++;
+  }
+
+  if (contentLines.length > 0) {
+    // Detect navigation table within the content
+    const navResult = extractNavigation(contentLines);
+    navigation = navResult.navigation;
+    const remainingContent = navResult.remainingLines;
+
+    // Trim trailing blank lines from remaining content
+    while (remainingContent.length > 0 && remainingContent[remainingContent.length - 1] === '') {
+      remainingContent.pop();
+    }
+
+    if (remainingContent.length > 0) {
+      opening = remainingContent.join('\n');
+    }
+  }
+
+  // If we haven't hit a separator yet, try to find one
+  if (!foundSeparator) {
+    // Skip blank lines
+    cursor = skipBlankLines(lines, cursor);
+    if (cursor < lines.length && lines[cursor] === '---') {
+      cursor++;
+    }
+  }
+
+  return { opening, navigation, cursor };
+}
+
+// ---------------------------------------------------------------------------
+// Navigation Extraction
+// ---------------------------------------------------------------------------
+
+interface NavigationExtractResult {
+  navigation: Navigation | undefined;
+  remainingLines: string[];
+}
+
+function extractNavigation(contentLines: string[]): NavigationExtractResult {
+  // Look for "**Navigate deeper from here:**" pattern
+  const navHeaderIdx = contentLines.findIndex(
+    (line) => line === '**Navigate deeper from here:**',
+  );
+
+  if (navHeaderIdx === -1) {
+    return { navigation: undefined, remainingLines: [...contentLines] };
+  }
+
+  const navigation: Navigation = {};
+  let navEnd = navHeaderIdx + 1;
+
+  // Skip blank line after nav header
+  if (navEnd < contentLines.length && contentLines[navEnd] === '') {
+    navEnd++;
+  }
+
+  // Parse table header row
+  const headerRow = contentLines[navEnd];
+  if (headerRow !== undefined && headerRow.startsWith('|')) {
+    navEnd++; // skip header row
+  }
+  // Parse separator row
+  const sepRow = contentLines[navEnd];
+  if (sepRow !== undefined && sepRow.startsWith('|')) {
+    navEnd++; // skip separator row
+  }
+
+  // Parse data rows
+  while (navEnd < contentLines.length) {
+    const line = contentLines[navEnd];
+    if (line === undefined || !line.startsWith('|')) break;
+
+    const cells = parseTableRow(line);
+    if (cells.length >= 2 && cells[0] !== undefined && cells[1] !== undefined) {
+      navigation[cells[0]] = cells[1];
+    }
+    navEnd++;
+  }
+
+  // Build remaining lines (everything before the nav block, everything after)
+  const remaining: string[] = [];
+  for (let i = 0; i < navHeaderIdx; i++) {
+    const line = contentLines[i];
+    if (line !== undefined) {
+      remaining.push(line);
+    }
+  }
+
+  // Remove trailing blank line before nav header
+  while (remaining.length > 0 && remaining[remaining.length - 1] === '') {
+    remaining.pop();
+  }
+
+  for (let i = navEnd; i < contentLines.length; i++) {
+    const line = contentLines[i];
+    if (line !== undefined) {
+      remaining.push(line);
+    }
+  }
+
+  return {
+    navigation: Object.keys(navigation).length > 0 ? navigation : undefined,
+    remainingLines: remaining,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Navigation Extraction from Sections
+// ---------------------------------------------------------------------------
+
+interface SectionNavigationResult {
+  navigation: Navigation | undefined;
+  sections: Section[];
+}
+
+/**
+ * Scan sections for navigation blocks (text blocks matching "Navigate deeper
+ * from here:" followed by a table block or list blocks with link items).
+ * Extracts the navigation and removes the blocks from the section.
+ * Also scans inside subsection blocks recursively.
+ * Empty sections are removed entirely.
+ */
+function extractNavigationFromSections(sections: Section[]): SectionNavigationResult {
+  const navigation: Navigation = {};
+
+  /**
+   * Extract navigation from a content block array, returning filtered blocks
+   * with navigation entries removed.
+   */
+  function extractFromBlocks(blocks: ContentBlock[]): ContentBlock[] {
+    const filtered: ContentBlock[] = [];
+    let skipNext = false;
+
+    for (let i = 0; i < blocks.length; i++) {
+      if (skipNext) {
+        skipNext = false;
+        continue;
+      }
+
+      const block = blocks[i];
+      if (block === undefined) continue;
+
+      // Recurse into subsections
+      if (block.type === 'subsection') {
+        const filteredContent = extractFromBlocks(block.content);
+        filtered.push({ type: 'subsection', heading: block.heading, content: filteredContent });
+        continue;
+      }
+
+      // Detect "Navigate deeper from here:" text block followed by table or list
+      if (block.type === 'text' && block.value === NAV_HEADER) {
+        const nextBlock = blocks[i + 1];
+        if (nextBlock !== undefined && nextBlock.type === 'table') {
+          // Table-format navigation: extract from table rows
+          for (const row of nextBlock.rows) {
+            const docCell = row[0];
+            const descCell = row[1];
+            if (docCell !== undefined && descCell !== undefined) {
+              navigation[docCell] = descCell;
+            }
+          }
+          skipNext = true;
+          continue;
+        }
+        if (nextBlock !== undefined && nextBlock.type === 'list') {
+          // List-format navigation: parse "- [file](path) — description"
+          for (const item of nextBlock.items) {
+            const linkMatch = /^\[([^\]]+)\]\(([^)]+)\)\s*—\s*(.+)$/.exec(item);
+            if (linkMatch !== null && linkMatch[2] !== undefined && linkMatch[3] !== undefined) {
+              navigation[`[${linkMatch[1]}](${linkMatch[2]})`] = linkMatch[3];
+            }
+          }
+          skipNext = true;
+          continue;
+        }
+        // No recognizable navigation content follows — keep as-is
+      }
+
+      filtered.push(block);
+    }
+
+    return filtered;
+  }
+
+  const filteredSections: Section[] = [];
+
+  for (const section of sections) {
+    const filteredContent = extractFromBlocks(section.content);
+
+    // Only keep sections that still have content (or have a heading)
+    if (filteredContent.length > 0 || section.heading !== null) {
+      filteredSections.push({ heading: section.heading, content: filteredContent });
+    }
+  }
+
+  return {
+    navigation: Object.keys(navigation).length > 0 ? navigation : undefined,
+    sections: filteredSections,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Section Parsing
+// ---------------------------------------------------------------------------
+
+function parseSections(lines: string[], start: number): Section[] {
+  const sections: Section[] = [];
+  let cursor = start;
+
+  while (cursor < lines.length) {
+    // Skip blank lines
+    cursor = skipBlankLines(lines, cursor);
+    if (cursor >= lines.length) break;
+
+    const line = lines[cursor];
+    if (line === undefined) break;
+
+    // Check for H2 heading
+    if (line.startsWith('## ')) {
+      const heading = line.slice(3);
+      cursor++;
+      const contentResult = parseSectionContent(lines, cursor);
+      sections.push({ heading, content: contentResult.blocks });
+      cursor = contentResult.cursor;
+      continue;
+    }
+
+    // Headingless section — content between --- separators with no H2
+    if (line !== '---') {
+      const contentResult = parseSectionContent(lines, cursor);
+      sections.push({ heading: null, content: contentResult.blocks });
+      cursor = contentResult.cursor;
+      continue;
+    }
+
+    // Skip --- separator
+    cursor++;
+  }
+
+  return sections;
+}
+
+interface SectionContentResult {
+  blocks: ContentBlock[];
+  cursor: number;
+}
+
+function parseSectionContent(lines: string[], start: number): SectionContentResult {
+  const blocks: ContentBlock[] = [];
+  let cursor = start;
+
+  while (cursor < lines.length) {
+    // Skip blank lines between blocks
+    cursor = skipBlankLines(lines, cursor);
+    if (cursor >= lines.length) break;
+
+    const line = lines[cursor];
+    if (line === undefined) break;
+
+    // Stop at section separator or next H2
+    if (line === '---' || line.startsWith('## ')) {
+      // Consume the ---
+      if (line === '---') {
+        cursor++;
+      }
+      break;
+    }
+
+    // Detect block type and parse
+    const blockResult = parseBlock(lines, cursor);
+    if (blockResult.block !== null) {
+      blocks.push(blockResult.block);
+    }
+    cursor = blockResult.cursor;
+  }
+
+  return { blocks, cursor };
+}
+
+// ---------------------------------------------------------------------------
+// Block Detection and Parsing
+// ---------------------------------------------------------------------------
+
+interface BlockResult {
+  block: ContentBlock | null;
+  cursor: number;
+}
+
+function parseBlock(lines: string[], start: number): BlockResult {
+  const line = lines[start];
+  if (line === undefined) {
+    return { block: null, cursor: start + 1 };
+  }
+
+  // Navigation header: parse as standalone text block (will be extracted later)
+  if (line === NAV_HEADER) {
+    const block: TextBlock = { type: 'text', value: line };
+    return { block, cursor: start + 1 };
+  }
+
+  // Principle: > **...**
+  if (line.startsWith('> **') && line.endsWith('**')) {
+    return parsePrincipleBlock(lines, start);
+  }
+
+  // Table: | ... |
+  if (line.startsWith('|') && line.endsWith('|')) {
+    return parseTableBlock(lines, start);
+  }
+
+  // Subsection: ### ...
+  if (line.startsWith('### ')) {
+    return parseSubsectionBlock(lines, start);
+  }
+
+  // List items: - or N.
+  if (line.startsWith('- ') || /^\d+\.\s/.test(line)) {
+    return parseListOrConstraintBlock(lines, start);
+  }
+
+  // Text block (default)
+  return parseTextBlock(lines, start);
+}
+
+// ---------------------------------------------------------------------------
+// Principle Block
+// ---------------------------------------------------------------------------
+
+function parsePrincipleBlock(lines: string[], start: number): BlockResult {
+  const line = lines[start];
+  if (line === undefined) {
+    return { block: null, cursor: start + 1 };
+  }
+
+  // Extract statement: > **{statement}**
+  const match = /^> \*\*(.+)\*\*$/.exec(line);
+  if (match === null || match[1] === undefined) {
+    // Fallback to text
+    return parseTextBlock(lines, start);
+  }
+
+  const statement = match[1];
+  let cursor = start + 1;
+
+  // Check for body — skip blank line then collect text until next block boundary
+  if (cursor < lines.length && lines[cursor] === '') {
+    cursor++;
+  }
+
+  const bodyLines: string[] = [];
+  while (cursor < lines.length) {
+    const bodyLine = lines[cursor];
+    if (bodyLine === undefined) break;
+
+    // Stop at blank line, ---, H2, H3, table, list, principle
+    if (bodyLine === '' || bodyLine === '---' || bodyLine.startsWith('## ') ||
+        bodyLine.startsWith('### ') || bodyLine.startsWith('> **') ||
+        (bodyLine.startsWith('|') && bodyLine.endsWith('|')) ||
+        bodyLine.startsWith('- ') || /^\d+\.\s/.test(bodyLine)) {
+      break;
+    }
+
+    bodyLines.push(bodyLine);
+    cursor++;
+  }
+
+  const block: PrincipleBlock = { type: 'principle', statement };
+  if (bodyLines.length > 0) {
+    block.body = bodyLines.join('\n');
+  }
+
+  return { block, cursor };
+}
+
+// ---------------------------------------------------------------------------
+// Table Block
+// ---------------------------------------------------------------------------
+
+function parseTableBlock(lines: string[], start: number): BlockResult {
+  // Parse header row
+  const headerLine = lines[start];
+  if (headerLine === undefined) {
+    return { block: null, cursor: start + 1 };
+  }
+  const headers = parseTableRow(headerLine);
+
+  let cursor = start + 1;
+
+  // Skip separator row (|---|---|)
+  if (cursor < lines.length) {
+    const sepLine = lines[cursor];
+    if (sepLine !== undefined && /^\|[-:|]+\|$/.test(sepLine.replace(/\s/g, ''))) {
+      cursor++;
+    }
+  }
+
+  // Parse data rows
+  const rows: string[][] = [];
+  while (cursor < lines.length) {
+    const rowLine = lines[cursor];
+    if (rowLine === undefined || !rowLine.startsWith('|') || !rowLine.endsWith('|')) break;
+    rows.push(parseTableRow(rowLine));
+    cursor++;
+  }
+
+  const block: TableBlock = { type: 'table', headers, rows };
+  return { block, cursor };
+}
+
+function parseTableRow(line: string): string[] {
+  // Split by |, trim each cell, remove empty first/last from leading/trailing |
+  const parts = line.split('|');
+  const cells: string[] = [];
+  for (let i = 1; i < parts.length - 1; i++) {
+    const part = parts[i];
+    if (part !== undefined) {
+      cells.push(part.trim());
+    }
+  }
+  return cells;
+}
+
+// ---------------------------------------------------------------------------
+// List / Constraint-List Block
+// ---------------------------------------------------------------------------
+
+/** Constraint words that indicate a constraint-list rather than a plain list. */
+const CONSTRAINT_WORDS = /^(Never|Always|MUST|Must|NEVER|ALWAYS|Do not|Don't)\b/;
+
+function parseListOrConstraintBlock(lines: string[], start: number): BlockResult {
+  const firstLine = lines[start];
+  if (firstLine === undefined) {
+    return { block: null, cursor: start + 1 };
+  }
+
+  const isNumbered = /^\d+\.\s/.test(firstLine);
+  const items: string[] = [];
+  let cursor = start;
+
+  while (cursor < lines.length) {
+    const line = lines[cursor];
+    if (line === undefined) break;
+
+    if (isNumbered) {
+      const match = /^\d+\.\s(.*)$/.exec(line);
+      if (match === null || match[1] === undefined) break;
+      items.push(match[1]);
+    } else {
+      if (!line.startsWith('- ')) break;
+      items.push(line.slice(2));
+    }
+    cursor++;
+  }
+
+  if (items.length === 0) {
+    return { block: null, cursor };
+  }
+
+  // Determine if this is a constraint list
+  const isConstraintList = !isNumbered && items.every((item) => CONSTRAINT_WORDS.test(item));
+
+  if (isConstraintList) {
+    const block: ConstraintListBlock = { type: 'constraint-list', items };
+    return { block, cursor };
+  }
+
+  const block: ListBlock = {
+    type: 'list',
+    style: isNumbered ? 'numbered' : 'bullet',
+    items,
+  };
+  return { block, cursor };
+}
+
+// ---------------------------------------------------------------------------
+// Subsection Block
+// ---------------------------------------------------------------------------
+
+function parseSubsectionBlock(lines: string[], start: number): BlockResult {
+  const line = lines[start];
+  if (line === undefined) {
+    return { block: null, cursor: start + 1 };
+  }
+
+  const heading = line.slice(4); // Remove "### "
+  let cursor = start + 1;
+
+  // Parse nested content blocks
+  const content: ContentBlock[] = [];
+
+  while (cursor < lines.length) {
+    cursor = skipBlankLines(lines, cursor);
+    if (cursor >= lines.length) break;
+
+    const nextLine = lines[cursor];
+    if (nextLine === undefined) break;
+
+    // Stop at section boundaries: ---, ## heading, ### heading (sibling subsection)
+    if (nextLine === '---' || nextLine.startsWith('## ') || nextLine.startsWith('### ')) {
+      break;
+    }
+
+    const blockResult = parseBlock(lines, cursor);
+    if (blockResult.block !== null) {
+      content.push(blockResult.block);
+    }
+    cursor = blockResult.cursor;
+  }
+
+  const block: SubsectionBlock = { type: 'subsection', heading, content };
+  return { block, cursor };
+}
+
+// ---------------------------------------------------------------------------
+// Text Block
+// ---------------------------------------------------------------------------
+
+function parseTextBlock(lines: string[], start: number): BlockResult {
+  const paragraphs: string[] = [];
+  let cursor = start;
+
+  while (cursor < lines.length) {
+    const line = lines[cursor];
+    if (line === undefined) break;
+
+    // Stop at structural markers
+    if (isBlockBoundary(line)) {
+      break;
+    }
+
+    // Blank line separates paragraphs
+    if (line === '') {
+      // Check if the next non-blank line is still text content
+      const nextNonBlank = peekNextNonBlank(lines, cursor);
+      if (nextNonBlank === null || isBlockBoundary(nextNonBlank)) {
+        break;
+      }
+      paragraphs.push('');
+      cursor++;
+      continue;
+    }
+
+    paragraphs.push(line);
+    cursor++;
+  }
+
+  // Trim trailing blank entries
+  while (paragraphs.length > 0 && paragraphs[paragraphs.length - 1] === '') {
+    paragraphs.pop();
+  }
+
+  if (paragraphs.length === 0) {
+    return { block: null, cursor };
+  }
+
+  // Join paragraphs — blank lines become \n\n
+  const value = joinParagraphs(paragraphs);
+  const block: TextBlock = { type: 'text', value };
+  return { block, cursor };
+}
+
+function joinParagraphs(lines: string[]): string {
+  // Convert arrays of lines (with empty strings as paragraph separators) to
+  // the renderer's format: paragraphs separated by \n\n
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Gotcha Entry Parsing
+// ---------------------------------------------------------------------------
+
+function parseGotchaEntries(lines: string[], start: number): GotchaEntry[] {
+  const entries: GotchaEntry[] = [];
+  let cursor = start;
+
+  while (cursor < lines.length) {
+    // Skip blank lines and ---
+    cursor = skipBlankLines(lines, cursor);
+    if (cursor >= lines.length) break;
+
+    const line = lines[cursor];
+    if (line === undefined) break;
+
+    if (line === '---') {
+      cursor++;
+      continue;
+    }
+
+    // Expect ### heading for entry
+    if (line.startsWith('### ')) {
+      const entryResult = parseGotchaEntry(lines, cursor);
+      entries.push(entryResult.entry);
+      cursor = entryResult.cursor;
+      continue;
+    }
+
+    cursor++;
+  }
+
+  return entries;
+}
+
+interface GotchaEntryResult {
+  entry: GotchaEntry;
+  cursor: number;
+}
+
+function parseGotchaEntry(lines: string[], start: number): GotchaEntryResult {
+  const titleLine = lines[start];
+  if (titleLine === undefined || !titleLine.startsWith('### ')) {
+    throw new Error(`Expected ### heading at line ${start}`);
+  }
+
+  const title = titleLine.slice(4);
+  let cursor = start + 1;
+
+  // Check for optional metadata (--- YAML ---)
+  let metadata: GotchaMetadata | undefined;
+  if (cursor < lines.length && lines[cursor] === '---') {
+    cursor++; // skip opening ---
+    const metaFields: Record<string, string> = {};
+
+    while (cursor < lines.length) {
+      const line = lines[cursor];
+      if (line === undefined) break;
+      if (line === '---') {
+        cursor++; // skip closing ---
+        break;
+      }
+      const colonIdx = line.indexOf(':');
+      if (colonIdx !== -1) {
+        const key = line.slice(0, colonIdx).trim();
+        let value = line.slice(colonIdx + 1).trim();
+        // Strip surrounding quotes from pattern values
+        if (key === 'pattern' && value.startsWith('"') && value.endsWith('"')) {
+          value = JSON.parse(value) as string;
+        }
+        metaFields[key] = value;
+      }
+      cursor++;
+    }
+
+    metadata = buildGotchaMetadata(metaFields);
+  }
+
+  // Skip blank line before body
+  cursor = skipBlankLines(lines, cursor);
+
+  // Parse body fields: **Priority:**, **What happened:**, **User feedback:**, **Correct approach:**
+  const body = parseGotchaBodyFields(lines, cursor);
+  cursor = body.cursor;
+
+  const entry: GotchaEntry = { title, body: body.body };
+  if (metadata !== undefined) {
+    entry.metadata = metadata;
+  }
+
+  return { entry, cursor };
+}
+
+function buildGotchaMetadata(fields: Record<string, string>): GotchaMetadata {
+  const meta: GotchaMetadata = {};
+  const priority = fields['priority'];
+  if (priority !== undefined) {
+    meta.priority = priority;
+  }
+  const techStack = fields['tech-stack'];
+  if (techStack !== undefined) {
+    meta['tech-stack'] = techStack;
+  }
+  const enforcement = fields['enforcement'];
+  if (enforcement === 'hook' || enforcement === 'advisory') {
+    meta.enforcement = enforcement;
+  }
+  const pattern = fields['pattern'];
+  if (pattern !== undefined) {
+    meta.pattern = pattern;
+  }
+  const event = fields['event'];
+  if (event === 'bash' || event === 'file' || event === 'stop') {
+    meta.event = event;
+  }
+  return meta;
+}
+
+interface GotchaBodyResult {
+  body: GotchaBody;
+  cursor: number;
+}
+
+function parseGotchaBodyFields(lines: string[], start: number): GotchaBodyResult {
+  let cursor = start;
+  let priority = '';
+  let whatHappened = '';
+  let userFeedback = '';
+  let correctApproach = '';
+
+  while (cursor < lines.length) {
+    const line = lines[cursor];
+    if (line === undefined) break;
+
+    // Stop at next entry boundary (--- or ### or end)
+    if (line === '---' || line.startsWith('### ')) {
+      break;
+    }
+
+    if (line.startsWith('**Priority:** ')) {
+      priority = line.slice('**Priority:** '.length);
+      cursor++;
+      continue;
+    }
+    if (line.startsWith('**What happened:** ')) {
+      const result = collectMultilineField(lines, cursor, '**What happened:** ');
+      whatHappened = result.value;
+      cursor = result.cursor;
+      continue;
+    }
+    if (line.startsWith('**User feedback:** ')) {
+      const result = collectMultilineField(lines, cursor, '**User feedback:** ');
+      userFeedback = result.value;
+      cursor = result.cursor;
+      continue;
+    }
+    if (line.startsWith('**Correct approach:** ')) {
+      const result = collectMultilineField(lines, cursor, '**Correct approach:** ');
+      correctApproach = result.value;
+      cursor = result.cursor;
+      continue;
+    }
+
+    cursor++;
+  }
+
+  return {
+    body: {
+      priority,
+      'what-happened': whatHappened,
+      'user-feedback': userFeedback,
+      'correct-approach': correctApproach,
+    },
+    cursor,
+  };
+}
+
+/**
+ * Collect a multi-line gotcha body field value.
+ * The first line starts with the bold label prefix. Continuation lines
+ * follow until another bold label or boundary (--- or ###).
+ * Blank lines within the content are treated as paragraph breaks and
+ * the continuation text is joined with the first paragraph.
+ */
+function collectMultilineField(
+  lines: string[],
+  start: number,
+  prefix: string,
+): { value: string; cursor: number } {
+  const firstLine = lines[start];
+  if (firstLine === undefined) {
+    return { value: '', cursor: start + 1 };
+  }
+
+  const parts: string[] = [firstLine.slice(prefix.length)];
+  let cursor = start + 1;
+
+  while (cursor < lines.length) {
+    const line = lines[cursor];
+    if (line === undefined) break;
+
+    // Stop at next bold label or boundary
+    if (line.startsWith('**') || line === '---' || line.startsWith('### ')) {
+      break;
+    }
+
+    // Blank line — peek ahead to see if content continues
+    if (line === '') {
+      const nextNonBlank = peekNextNonBlank(lines, cursor);
+      // Stop if next content is a bold label, boundary, or end
+      if (nextNonBlank === null ||
+          nextNonBlank.startsWith('**') ||
+          nextNonBlank === '---' ||
+          nextNonBlank.startsWith('### ')) {
+        break;
+      }
+      // Continuation paragraph — skip the blank line and keep going
+      cursor++;
+      continue;
+    }
+
+    parts.push(line);
+    cursor++;
+  }
+
+  return { value: parts.join(' '), cursor };
+}
+
+// ---------------------------------------------------------------------------
+// Utility Functions
+// ---------------------------------------------------------------------------
+
+/** Navigation header that signals a navigation block. */
+const NAV_HEADER = '**Navigate deeper from here:**';
+
+/**
+ * Check if a line is a block boundary — a line that starts a new block
+ * or structural element, causing the text block parser to stop.
+ */
+function isBlockBoundary(line: string): boolean {
+  return (
+    line === '---' ||
+    line.startsWith('## ') ||
+    line.startsWith('### ') ||
+    (line.startsWith('> **') && line.endsWith('**')) ||
+    (line.startsWith('|') && line.endsWith('|')) ||
+    line.startsWith('- ') ||
+    /^\d+\.\s/.test(line) ||
+    line === NAV_HEADER
+  );
+}
+
+function skipBlankLines(lines: string[], cursor: number): number {
+  while (cursor < lines.length && lines[cursor] === '') {
+    cursor++;
+  }
+  return cursor;
+}
+
+function peekNextNonBlank(lines: string[], start: number): string | null {
+  let cursor = start;
+  while (cursor < lines.length) {
+    const line = lines[cursor];
+    if (line !== undefined && line !== '') {
+      return line;
+    }
+    cursor++;
+  }
+  return null;
+}

--- a/src/lib/docs/renderer.ts
+++ b/src/lib/docs/renderer.ts
@@ -1,0 +1,293 @@
+/**
+ * gobbi-docs JSON to Markdown renderer.
+ *
+ * Follows the rendering rules from the gobbi-docs spec exactly:
+ * - Frontmatter as YAML between `---` markers
+ * - `# {title}` for H1
+ * - Navigation as **Navigate deeper from here:** table
+ * - `---` between sections
+ * - Block types render per spec
+ * - Gotcha type renders entries with `---` separators
+ */
+
+import type {
+  GobbiDoc,
+  ContentBlock,
+  Section,
+  Navigation,
+  GotchaEntry,
+  GotchaMetadata,
+  GotchaBody,
+  SkillFrontmatter,
+  AgentFrontmatter,
+  RuleFrontmatter,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// Main Renderer
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a GobbiDoc to Markdown string.
+ */
+export function renderDoc(doc: GobbiDoc): string {
+  const parts: string[] = [];
+
+  // 1. Frontmatter
+  const frontmatterMd = renderFrontmatter(doc);
+  if (frontmatterMd !== null) {
+    parts.push(frontmatterMd);
+  }
+
+  // 2. Title
+  parts.push(`# ${doc.title}`);
+
+  // 3. Opening
+  if (doc.opening !== undefined) {
+    parts.push('');
+    parts.push(doc.opening);
+  }
+
+  // 4. Navigation
+  if (doc.navigation !== undefined) {
+    parts.push('');
+    parts.push(renderNavigation(doc.navigation));
+  }
+
+  // 5. Sections or Entries
+  if (doc.$schema === 'gobbi-docs/gotcha') {
+    // Gotcha entries
+    for (const entry of doc.entries) {
+      parts.push('');
+      parts.push('---');
+      parts.push('');
+      parts.push(renderGotchaEntry(entry));
+    }
+  } else {
+    // Regular sections
+    const sections = doc.sections;
+    if (sections !== undefined && sections.length > 0) {
+      for (const section of sections) {
+        parts.push('');
+        parts.push('---');
+        parts.push('');
+        parts.push(renderSection(section));
+      }
+    }
+  }
+
+  return parts.join('\n') + '\n';
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter
+// ---------------------------------------------------------------------------
+
+function renderFrontmatter(doc: GobbiDoc): string | null {
+  switch (doc.$schema) {
+    case 'gobbi-docs/skill':
+      return renderSkillFrontmatter(doc.frontmatter);
+    case 'gobbi-docs/agent':
+      return renderAgentFrontmatter(doc.frontmatter);
+    case 'gobbi-docs/rule': {
+      if (doc.frontmatter !== undefined) {
+        return renderRuleFrontmatter(doc.frontmatter);
+      }
+      return null;
+    }
+    case 'gobbi-docs/root':
+    case 'gobbi-docs/child':
+    case 'gobbi-docs/gotcha':
+      return null;
+  }
+}
+
+function renderSkillFrontmatter(fm: SkillFrontmatter): string {
+  const lines: string[] = ['---'];
+  lines.push(`name: ${fm.name}`);
+  lines.push(`description: ${fm.description}`);
+  if (fm['allowed-tools'] !== undefined) {
+    lines.push(`allowed-tools: ${fm['allowed-tools']}`);
+  }
+  lines.push('---');
+  lines.push('');
+  return lines.join('\n');
+}
+
+function renderAgentFrontmatter(fm: AgentFrontmatter): string {
+  const lines: string[] = ['---'];
+  lines.push(`name: ${fm.name}`);
+  lines.push(`description: ${fm.description}`);
+  lines.push(`tools: ${fm.tools}`);
+  lines.push(`model: ${fm.model}`);
+  lines.push('---');
+  lines.push('');
+  return lines.join('\n');
+}
+
+function renderRuleFrontmatter(fm: RuleFrontmatter): string {
+  const entries = Object.entries(fm);
+  if (entries.length === 0) return '';
+  const lines: string[] = ['---'];
+  for (const [key, value] of entries) {
+    lines.push(`${key}: ${value}`);
+  }
+  lines.push('---');
+  lines.push('');
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Navigation
+// ---------------------------------------------------------------------------
+
+function renderNavigation(nav: Navigation): string {
+  const entries = Object.entries(nav);
+  if (entries.length === 0) return '';
+
+  const lines: string[] = [];
+  lines.push('**Navigate deeper from here:**');
+  lines.push('');
+  lines.push('| Document | Covers |');
+  lines.push('|----------|--------|');
+  for (const [file, description] of entries) {
+    lines.push(`| ${file} | ${description} |`);
+  }
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Sections
+// ---------------------------------------------------------------------------
+
+function renderSection(section: Section): string {
+  const parts: string[] = [];
+
+  if (section.heading !== null) {
+    parts.push(`## ${section.heading}`);
+  }
+
+  for (const block of section.content) {
+    parts.push('');
+    parts.push(renderBlock(block));
+  }
+
+  return parts.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Content Blocks
+// ---------------------------------------------------------------------------
+
+function renderBlock(block: ContentBlock): string {
+  switch (block.type) {
+    case 'text':
+      return block.value;
+    case 'principle':
+      return renderPrinciple(block.statement, block.body);
+    case 'table':
+      return renderTable(block.headers, block.rows);
+    case 'constraint-list':
+      return renderConstraintList(block.items);
+    case 'list':
+      return renderList(block.style, block.items);
+    case 'subsection':
+      return renderSubsection(block.heading, block.content);
+  }
+}
+
+function renderPrinciple(statement: string, body: string | undefined): string {
+  const parts: string[] = [`> **${statement}**`];
+  if (body !== undefined) {
+    parts.push('');
+    parts.push(body);
+  }
+  return parts.join('\n');
+}
+
+function renderTable(headers: string[], rows: string[][]): string {
+  const lines: string[] = [];
+  lines.push(`| ${headers.join(' | ')} |`);
+  lines.push(`|${headers.map(() => '---').join('|')}|`);
+  for (const row of rows) {
+    lines.push(`| ${row.join(' | ')} |`);
+  }
+  return lines.join('\n');
+}
+
+function renderConstraintList(items: string[]): string {
+  return items.map((item) => `- ${item}`).join('\n');
+}
+
+function renderList(style: 'bullet' | 'numbered', items: string[]): string {
+  if (style === 'numbered') {
+    return items.map((item, i) => `${i + 1}. ${item}`).join('\n');
+  }
+  return items.map((item) => `- ${item}`).join('\n');
+}
+
+function renderSubsection(heading: string, content: ContentBlock[]): string {
+  const parts: string[] = [`### ${heading}`];
+  for (const block of content) {
+    parts.push('');
+    parts.push(renderBlock(block));
+  }
+  return parts.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Gotcha Entries
+// ---------------------------------------------------------------------------
+
+function renderGotchaEntry(entry: GotchaEntry): string {
+  const parts: string[] = [];
+
+  // Title
+  parts.push(`### ${entry.title}`);
+
+  // Optional metadata (YAML between --- markers)
+  if (entry.metadata !== undefined && entry.metadata !== null) {
+    parts.push('---');
+    parts.push(renderGotchaMetadata(entry.metadata));
+    parts.push('---');
+  }
+
+  // Body
+  parts.push('');
+  parts.push(renderGotchaBody(entry.body));
+
+  return parts.join('\n');
+}
+
+function renderGotchaMetadata(meta: GotchaMetadata): string {
+  const lines: string[] = [];
+  if (meta.priority !== undefined) {
+    lines.push(`priority: ${meta.priority}`);
+  }
+  if (meta['tech-stack'] !== undefined) {
+    lines.push(`tech-stack: ${meta['tech-stack']}`);
+  }
+  if (meta.enforcement !== undefined) {
+    lines.push(`enforcement: ${meta.enforcement}`);
+  }
+  if (meta.pattern !== undefined) {
+    lines.push(`pattern: ${JSON.stringify(meta.pattern)}`);
+  }
+  if (meta.event !== undefined) {
+    lines.push(`event: ${meta.event}`);
+  }
+  return lines.join('\n');
+}
+
+function renderGotchaBody(body: GotchaBody): string {
+  const lines: string[] = [];
+  lines.push(`**Priority:** ${body.priority}`);
+  lines.push('');
+  lines.push(`**What happened:** ${body['what-happened']}`);
+  lines.push('');
+  lines.push(`**User feedback:** ${body['user-feedback']}`);
+  lines.push('');
+  lines.push(`**Correct approach:** ${body['correct-approach']}`);
+  return lines.join('\n');
+}

--- a/src/lib/docs/types.ts
+++ b/src/lib/docs/types.ts
@@ -1,0 +1,221 @@
+/**
+ * gobbi-docs JSON schema types.
+ *
+ * Discriminated unions on `$schema` (doc types) and `type` (content blocks).
+ * Strict mode compliance: no `any`, no `as` assertions.
+ */
+
+// ---------------------------------------------------------------------------
+// Doc Schema Discriminator
+// ---------------------------------------------------------------------------
+
+/** All valid doc schema identifiers. */
+export type DocSchema =
+  | 'gobbi-docs/skill'
+  | 'gobbi-docs/agent'
+  | 'gobbi-docs/rule'
+  | 'gobbi-docs/root'
+  | 'gobbi-docs/child'
+  | 'gobbi-docs/gotcha';
+
+/** Short names used as CLI arguments. */
+export type DocType = 'skill' | 'agent' | 'rule' | 'root' | 'child' | 'gotcha';
+
+/** Map from short type name to full schema identifier. */
+export const DOC_TYPE_TO_SCHEMA: Readonly<Record<DocType, DocSchema>> = {
+  skill: 'gobbi-docs/skill',
+  agent: 'gobbi-docs/agent',
+  rule: 'gobbi-docs/rule',
+  root: 'gobbi-docs/root',
+  child: 'gobbi-docs/child',
+  gotcha: 'gobbi-docs/gotcha',
+};
+
+export const VALID_DOC_TYPES: readonly DocType[] = ['skill', 'agent', 'rule', 'root', 'child', 'gotcha'];
+
+// ---------------------------------------------------------------------------
+// Frontmatter Types
+// ---------------------------------------------------------------------------
+
+export interface SkillFrontmatter {
+  name: string;
+  description: string;
+  'allowed-tools'?: string;
+}
+
+export interface AgentFrontmatter {
+  name: string;
+  description: string;
+  tools: string;
+  model: string;
+}
+
+export interface RuleFrontmatter {
+  [key: string]: string;
+}
+
+// ---------------------------------------------------------------------------
+// Content Block Types (discriminated union on `type`)
+// ---------------------------------------------------------------------------
+
+export interface TextBlock {
+  type: 'text';
+  value: string;
+}
+
+export interface PrincipleBlock {
+  type: 'principle';
+  statement: string;
+  body?: string;
+}
+
+export interface TableBlock {
+  type: 'table';
+  headers: string[];
+  rows: string[][];
+}
+
+export interface ConstraintListBlock {
+  type: 'constraint-list';
+  items: string[];
+}
+
+export interface ListBlock {
+  type: 'list';
+  style: 'bullet' | 'numbered';
+  items: string[];
+}
+
+export interface SubsectionBlock {
+  type: 'subsection';
+  heading: string;
+  content: ContentBlock[];
+}
+
+export type ContentBlock =
+  | TextBlock
+  | PrincipleBlock
+  | TableBlock
+  | ConstraintListBlock
+  | ListBlock
+  | SubsectionBlock;
+
+export const VALID_BLOCK_TYPES: readonly string[] = [
+  'text', 'principle', 'table', 'constraint-list', 'list', 'subsection',
+];
+
+// ---------------------------------------------------------------------------
+// Section
+// ---------------------------------------------------------------------------
+
+export interface Section {
+  heading: string | null;
+  content: ContentBlock[];
+}
+
+// ---------------------------------------------------------------------------
+// Navigation
+// ---------------------------------------------------------------------------
+
+/** Keys are relative filenames, values are description strings. */
+export type Navigation = Record<string, string>;
+
+// ---------------------------------------------------------------------------
+// Gotcha-Specific Types
+// ---------------------------------------------------------------------------
+
+export interface GotchaMetadata {
+  priority?: string;
+  'tech-stack'?: string;
+  enforcement?: 'hook' | 'advisory';
+  pattern?: string;
+  event?: 'bash' | 'file' | 'stop';
+}
+
+export interface GotchaBody {
+  priority: string;
+  'what-happened': string;
+  'user-feedback': string;
+  'correct-approach': string;
+}
+
+export interface GotchaEntry {
+  title: string;
+  metadata?: GotchaMetadata | null;
+  body: GotchaBody;
+}
+
+// ---------------------------------------------------------------------------
+// Doc Type Interfaces (discriminated union on `$schema`)
+// ---------------------------------------------------------------------------
+
+interface DocBase {
+  title: string;
+  opening?: string;
+  navigation?: Navigation;
+}
+
+export interface SkillDoc extends DocBase {
+  $schema: 'gobbi-docs/skill';
+  frontmatter: SkillFrontmatter;
+  sections?: Section[];
+}
+
+export interface AgentDoc extends DocBase {
+  $schema: 'gobbi-docs/agent';
+  frontmatter: AgentFrontmatter;
+  sections?: Section[];
+}
+
+export interface RuleDoc extends DocBase {
+  $schema: 'gobbi-docs/rule';
+  frontmatter?: RuleFrontmatter;
+  sections?: Section[];
+}
+
+export interface RootDoc extends DocBase {
+  $schema: 'gobbi-docs/root';
+  sections?: Section[];
+}
+
+export interface ChildDoc extends DocBase {
+  $schema: 'gobbi-docs/child';
+  parent: string;
+  sections?: Section[];
+}
+
+export interface GotchaDoc extends DocBase {
+  $schema: 'gobbi-docs/gotcha';
+  parent: string;
+  entries: GotchaEntry[];
+}
+
+export type GobbiDoc = SkillDoc | AgentDoc | RuleDoc | RootDoc | ChildDoc | GotchaDoc;
+
+// ---------------------------------------------------------------------------
+// Type Guards
+// ---------------------------------------------------------------------------
+
+export function isDocType(value: string): value is DocType {
+  return (VALID_DOC_TYPES as readonly string[]).includes(value);
+}
+
+export function isDocSchema(value: string): value is DocSchema {
+  return value.startsWith('gobbi-docs/') && isDocType(value.slice('gobbi-docs/'.length));
+}
+
+export function isGotchaDoc(doc: GobbiDoc): doc is GotchaDoc {
+  return doc.$schema === 'gobbi-docs/gotcha';
+}
+
+export function hasEntries(doc: GobbiDoc): doc is GotchaDoc {
+  return 'entries' in doc;
+}
+
+export function hasSections(doc: GobbiDoc): doc is Exclude<GobbiDoc, GotchaDoc> {
+  return 'sections' in doc && !hasEntries(doc);
+}
+
+export function hasFrontmatter(doc: GobbiDoc): doc is SkillDoc | AgentDoc | RuleDoc {
+  return 'frontmatter' in doc;
+}

--- a/src/lib/docs/validator.ts
+++ b/src/lib/docs/validator.ts
@@ -1,0 +1,425 @@
+/**
+ * gobbi-docs JSON template validator.
+ *
+ * Validates:
+ * - `$schema` is a valid doc schema
+ * - Required fields per doc type
+ * - Frontmatter fields per type
+ * - Content blocks have valid `type` values
+ * - If .md file exists alongside .json, compares json2md output with existing .md
+ */
+
+import { readFile } from 'fs/promises';
+import path from 'path';
+
+import { renderDoc } from './renderer.js';
+import {
+  isDocSchema,
+  VALID_BLOCK_TYPES,
+} from './types.js';
+
+import type {
+  GobbiDoc,
+  ContentBlock,
+  Section,
+  GotchaEntry,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// Validation Result
+// ---------------------------------------------------------------------------
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+  syncStatus?: 'in-sync' | 'out-of-sync' | 'no-md-file';
+}
+
+// ---------------------------------------------------------------------------
+// Main Validator
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a parsed GobbiDoc JSON object.
+ * If `jsonFilePath` is provided, also checks sync with corresponding .md.
+ */
+export async function validateDoc(
+  raw: unknown,
+  jsonFilePath?: string,
+): Promise<ValidationResult> {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  // --- Top-level structure ---
+
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { valid: false, errors: ['Document must be a JSON object'], warnings };
+  }
+
+  const obj = raw as Record<string, unknown>;
+
+  // $schema
+  const schemaValue = obj['$schema'];
+  if (typeof schemaValue !== 'string') {
+    errors.push('Missing or invalid "$schema" field (must be a string)');
+    return { valid: false, errors, warnings };
+  }
+  if (!isDocSchema(schemaValue)) {
+    errors.push(`Invalid "$schema" value: "${schemaValue}". Must be one of: gobbi-docs/skill, gobbi-docs/agent, gobbi-docs/rule, gobbi-docs/root, gobbi-docs/child, gobbi-docs/gotcha`);
+    return { valid: false, errors, warnings };
+  }
+  const schema = schemaValue;
+
+  // title
+  if (typeof obj['title'] !== 'string' || obj['title'].length === 0) {
+    errors.push('Missing or empty "title" field');
+  }
+
+  // opening (optional string)
+  if ('opening' in obj && typeof obj['opening'] !== 'string') {
+    errors.push('"opening" must be a string if present');
+  }
+
+  // navigation (optional object)
+  if ('navigation' in obj) {
+    validateNavigation(obj['navigation'], errors);
+  }
+
+  // --- Type-specific validation ---
+
+  const docType = schema.slice('gobbi-docs/'.length);
+
+  switch (docType) {
+    case 'skill':
+      validateSkillFrontmatter(obj, errors);
+      validateSections(obj, errors, warnings);
+      break;
+    case 'agent':
+      validateAgentFrontmatter(obj, errors);
+      validateSections(obj, errors, warnings);
+      break;
+    case 'rule':
+      if ('frontmatter' in obj) {
+        validateRuleFrontmatter(obj, errors);
+      }
+      validateSections(obj, errors, warnings);
+      break;
+    case 'root':
+      if ('frontmatter' in obj) {
+        warnings.push('"root" doc type should not have frontmatter');
+      }
+      validateSections(obj, errors, warnings);
+      break;
+    case 'child':
+      if ('frontmatter' in obj) {
+        warnings.push('"child" doc type should not have frontmatter');
+      }
+      if (typeof obj['parent'] !== 'string' || obj['parent'].length === 0) {
+        errors.push('"child" doc type requires a non-empty "parent" field');
+      }
+      validateSections(obj, errors, warnings);
+      break;
+    case 'gotcha':
+      if ('frontmatter' in obj) {
+        warnings.push('"gotcha" doc type should not have frontmatter');
+      }
+      if (typeof obj['parent'] !== 'string' || obj['parent'].length === 0) {
+        errors.push('"gotcha" doc type requires a non-empty "parent" field');
+      }
+      validateEntries(obj, errors, warnings);
+      break;
+  }
+
+  // --- Sync check ---
+  let syncStatus: 'in-sync' | 'out-of-sync' | 'no-md-file' = 'no-md-file';
+  if (jsonFilePath !== undefined && errors.length === 0) {
+    syncStatus = await checkSync(raw as GobbiDoc, jsonFilePath);
+    if (syncStatus === 'out-of-sync') {
+      warnings.push('Generated Markdown does not match existing .md file — run json2md to update');
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+    syncStatus,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Navigation
+// ---------------------------------------------------------------------------
+
+function validateNavigation(nav: unknown, errors: string[]): void {
+  if (nav === null || typeof nav !== 'object' || Array.isArray(nav)) {
+    errors.push('"navigation" must be an object');
+    return;
+  }
+  const navObj = nav as Record<string, unknown>;
+  for (const [key, value] of Object.entries(navObj)) {
+    if (typeof value !== 'string') {
+      errors.push(`navigation["${key}"] must be a string`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter Validators
+// ---------------------------------------------------------------------------
+
+function validateSkillFrontmatter(obj: Record<string, unknown>, errors: string[]): void {
+  if (!('frontmatter' in obj) || obj['frontmatter'] === null || typeof obj['frontmatter'] !== 'object') {
+    errors.push('"skill" doc type requires a "frontmatter" object');
+    return;
+  }
+  const fm = obj['frontmatter'] as Record<string, unknown>;
+  if (typeof fm['name'] !== 'string' || fm['name'].length === 0) {
+    errors.push('skill frontmatter requires non-empty "name"');
+  }
+  if (typeof fm['description'] !== 'string' || fm['description'].length === 0) {
+    errors.push('skill frontmatter requires non-empty "description"');
+  }
+  if ('allowed-tools' in fm && typeof fm['allowed-tools'] !== 'string') {
+    errors.push('skill frontmatter "allowed-tools" must be a string if present');
+  }
+}
+
+function validateAgentFrontmatter(obj: Record<string, unknown>, errors: string[]): void {
+  if (!('frontmatter' in obj) || obj['frontmatter'] === null || typeof obj['frontmatter'] !== 'object') {
+    errors.push('"agent" doc type requires a "frontmatter" object');
+    return;
+  }
+  const fm = obj['frontmatter'] as Record<string, unknown>;
+  const requiredFields = ['name', 'description', 'tools', 'model'] as const;
+  for (const field of requiredFields) {
+    if (typeof fm[field] !== 'string' || (fm[field] as string).length === 0) {
+      errors.push(`agent frontmatter requires non-empty "${field}"`);
+    }
+  }
+}
+
+function validateRuleFrontmatter(obj: Record<string, unknown>, errors: string[]): void {
+  const fm = obj['frontmatter'];
+  if (fm === null || typeof fm !== 'object' || Array.isArray(fm)) {
+    errors.push('"frontmatter" must be an object if present for rule type');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sections Validator
+// ---------------------------------------------------------------------------
+
+function validateSections(obj: Record<string, unknown>, errors: string[], warnings: string[]): void {
+  if (!('sections' in obj)) return;
+
+  const sections = obj['sections'];
+  if (!Array.isArray(sections)) {
+    errors.push('"sections" must be an array');
+    return;
+  }
+
+  for (let i = 0; i < sections.length; i++) {
+    const section = sections[i] as unknown;
+    if (section === null || typeof section !== 'object' || Array.isArray(section)) {
+      errors.push(`sections[${i}] must be an object`);
+      continue;
+    }
+    const sectionObj = section as Record<string, unknown>;
+
+    // heading: string | null
+    if (!('heading' in sectionObj)) {
+      errors.push(`sections[${i}] must have a "heading" field (string or null)`);
+    } else if (sectionObj['heading'] !== null && typeof sectionObj['heading'] !== 'string') {
+      errors.push(`sections[${i}].heading must be a string or null`);
+    }
+
+    // content: ContentBlock[]
+    if (!('content' in sectionObj)) {
+      errors.push(`sections[${i}] must have a "content" array`);
+    } else if (!Array.isArray(sectionObj['content'])) {
+      errors.push(`sections[${i}].content must be an array`);
+    } else {
+      validateBlocks(sectionObj['content'] as unknown[], `sections[${i}]`, errors, warnings);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Block Validator
+// ---------------------------------------------------------------------------
+
+function validateBlocks(
+  blocks: unknown[],
+  pathPrefix: string,
+  errors: string[],
+  _warnings: string[],
+): void {
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i] as unknown;
+    const blockPath = `${pathPrefix}.content[${i}]`;
+
+    if (block === null || typeof block !== 'object' || Array.isArray(block)) {
+      errors.push(`${blockPath} must be an object`);
+      continue;
+    }
+    const blockObj = block as Record<string, unknown>;
+
+    if (typeof blockObj['type'] !== 'string') {
+      errors.push(`${blockPath} must have a "type" string`);
+      continue;
+    }
+
+    const blockType = blockObj['type'];
+    if (!(VALID_BLOCK_TYPES as readonly string[]).includes(blockType)) {
+      errors.push(`${blockPath} has invalid type "${blockType}". Must be one of: ${VALID_BLOCK_TYPES.join(', ')}`);
+      continue;
+    }
+
+    switch (blockType) {
+      case 'text':
+        if (typeof blockObj['value'] !== 'string') {
+          errors.push(`${blockPath} (text) requires a "value" string`);
+        }
+        break;
+      case 'principle':
+        if (typeof blockObj['statement'] !== 'string') {
+          errors.push(`${blockPath} (principle) requires a "statement" string`);
+        }
+        if ('body' in blockObj && typeof blockObj['body'] !== 'string') {
+          errors.push(`${blockPath} (principle) "body" must be a string if present`);
+        }
+        break;
+      case 'table':
+        if (!Array.isArray(blockObj['headers'])) {
+          errors.push(`${blockPath} (table) requires a "headers" array`);
+        }
+        if (!Array.isArray(blockObj['rows'])) {
+          errors.push(`${blockPath} (table) requires a "rows" array`);
+        }
+        break;
+      case 'constraint-list':
+        if (!Array.isArray(blockObj['items'])) {
+          errors.push(`${blockPath} (constraint-list) requires an "items" array`);
+        }
+        break;
+      case 'list':
+        if (!Array.isArray(blockObj['items'])) {
+          errors.push(`${blockPath} (list) requires an "items" array`);
+        }
+        if (blockObj['style'] !== 'bullet' && blockObj['style'] !== 'numbered') {
+          errors.push(`${blockPath} (list) "style" must be "bullet" or "numbered"`);
+        }
+        break;
+      case 'subsection':
+        if (typeof blockObj['heading'] !== 'string') {
+          errors.push(`${blockPath} (subsection) requires a "heading" string`);
+        }
+        if (!Array.isArray(blockObj['content'])) {
+          errors.push(`${blockPath} (subsection) requires a "content" array`);
+        } else {
+          validateBlocks(blockObj['content'] as unknown[], `${blockPath}.subsection`, errors, _warnings);
+        }
+        break;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Gotcha Entries Validator
+// ---------------------------------------------------------------------------
+
+function validateEntries(obj: Record<string, unknown>, errors: string[], _warnings: string[]): void {
+  if (!('entries' in obj)) {
+    errors.push('"gotcha" doc type requires an "entries" array');
+    return;
+  }
+
+  const entries = obj['entries'];
+  if (!Array.isArray(entries)) {
+    errors.push('"entries" must be an array');
+    return;
+  }
+
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i] as unknown;
+    const entryPath = `entries[${i}]`;
+
+    if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+      errors.push(`${entryPath} must be an object`);
+      continue;
+    }
+    const entryObj = entry as Record<string, unknown>;
+
+    if (typeof entryObj['title'] !== 'string' || entryObj['title'].length === 0) {
+      errors.push(`${entryPath} requires a non-empty "title" string`);
+    }
+
+    // metadata is optional (null or object)
+    if ('metadata' in entryObj && entryObj['metadata'] !== null && typeof entryObj['metadata'] !== 'object') {
+      errors.push(`${entryPath}.metadata must be an object or null`);
+    }
+
+    // body is required
+    if (!('body' in entryObj) || entryObj['body'] === null || typeof entryObj['body'] !== 'object') {
+      errors.push(`${entryPath} requires a "body" object`);
+    } else {
+      const body = entryObj['body'] as Record<string, unknown>;
+      const requiredBodyFields = ['priority', 'what-happened', 'user-feedback', 'correct-approach'] as const;
+      for (const field of requiredBodyFields) {
+        if (typeof body[field] !== 'string') {
+          errors.push(`${entryPath}.body requires a "${field}" string`);
+        }
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sync Check
+// ---------------------------------------------------------------------------
+
+async function checkSync(
+  doc: GobbiDoc,
+  jsonFilePath: string,
+): Promise<'in-sync' | 'out-of-sync' | 'no-md-file'> {
+  const dir = path.dirname(jsonFilePath);
+  const basename = path.basename(jsonFilePath, '.json');
+  const mdPath = path.join(dir, `${basename}.md`);
+
+  let existingMd: string;
+  try {
+    existingMd = await readFile(mdPath, 'utf8');
+  } catch {
+    return 'no-md-file';
+  }
+
+  const generatedMd = renderDoc(doc);
+  return existingMd === generatedMd ? 'in-sync' : 'out-of-sync';
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers for external use
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse and validate a JSON file from disk.
+ */
+export async function validateFile(filePath: string): Promise<ValidationResult> {
+  let content: string;
+  try {
+    content = await readFile(filePath, 'utf8');
+  } catch {
+    return { valid: false, errors: [`Cannot read file: ${filePath}`], warnings: [] };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return { valid: false, errors: ['Invalid JSON'], warnings: [] };
+  }
+
+  return validateDoc(parsed, filePath);
+}


### PR DESCRIPTION
## Summary

- **Notification Conditional Control** — `notify-send.sh` reads `gobbi.json` for per-session Slack/Telegram flags. Default: don't notify until user selects during `/gobbi` setup.
- **gobbi.json Session Config + CRUD Script** — `gobbi-config.sh` with flock-based atomic writes. Auto-cleanup: max 10 entries + 7-day TTL. gobbi.json gitignored.
- **JSON-Template Docs** — JSON source of truth for all `.claude/` docs (except CLAUDE.md). CLI: `gobbi docs init/json2md/validate/read/md2json`. 77 files converted. 6 doc types (skill, agent, rule, root, child, gotcha), 6 block types.

## Changes

- 93 files changed, 13,727 insertions
- 77 JSON templates created alongside existing .md files
- New CLI command family: `gobbi docs` with 5 subcommands
- New bash CRUD script: `gobbi-config.sh`
- Modified: `notify-send.sh`, `gobbi/SKILL.md`, `notification-setup.md`, `_claude/SKILL.md`, `__validate/SKILL.md`
- Version bumped to 0.3.2

## Test plan

- [ ] `tsc --noEmit` passes
- [ ] `gobbi docs validate` reports 0 errors across all 77 JSON templates
- [ ] `gobbi-config.sh` CRUD operations work (init, get, set, delete, list, cleanup)
- [ ] `notify-send.sh` respects per-session flags (skip when false, send when true + credentials)
- [ ] `gobbi docs md2json && gobbi docs json2md` round-trips produce equivalent output
- [ ] `gobbi docs read` displays metadata and sections correctly

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)