### PR TITLE
feat: add 6 gobbi docs utility subcommands

### DIFF
--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -8,8 +8,8 @@
  */
 
 import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
-import { execSync } from 'node:child_process';
 import path from 'node:path';
+import { getRepoRoot } from '../lib/repo.js';
 
 // ---------------------------------------------------------------------------
 // Usage strings
@@ -60,15 +60,6 @@ export async function runAudit(args: string[]): Promise<void> {
 // ---------------------------------------------------------------------------
 // Shared utilities
 // ---------------------------------------------------------------------------
-
-/** Detect git repo root via git rev-parse. Falls back to cwd on failure. */
-function getRepoRoot(): string {
-  try {
-    return execSync('git rev-parse --show-toplevel', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
-  } catch {
-    return process.cwd();
-  }
-}
 
 /** Collect all .md files recursively under a directory. */
 function collectMdFiles(dir: string): string[] {

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -726,14 +726,21 @@ async function runDocsTree(args: string[]): Promise<void> {
   const result = buildTree(graph, directory);
 
   if (fmt === 'json') {
-    console.log(JSON.stringify(result.roots, null, 2));
+    console.log(JSON.stringify({ roots: result.roots, orphans: result.orphans }, null, 2));
   } else {
-    if (result.roots.length === 0) {
+    if (result.roots.length === 0 && result.orphans.length === 0) {
       console.log(dim('  No navigation tree found.'));
     } else {
-      console.log(header('Navigation Tree'));
-      console.log(formatTreeText(result.roots));
-      console.log('');
+      if (result.roots.length > 0) {
+        console.log(header('Navigation Tree'));
+        console.log(formatTreeText(result.roots));
+        console.log('');
+      }
+      if (result.orphans.length > 0) {
+        console.log(header('Orphaned Documents'));
+        console.log(formatTreeText(result.orphans));
+        console.log('');
+      }
       console.log(dim(`  ${result.flatCount} documents total`));
     }
   }
@@ -773,7 +780,17 @@ async function runDocsSearch(args: string[]): Promise<void> {
   const blockFilter = typeof values.block === 'string' ? values.block : undefined;
   const fmt = typeof values.format === 'string' ? values.format : 'text';
 
+  if (typeFilter !== undefined && !isDocType(typeFilter)) {
+    console.log(error(`Invalid doc type: "${typeFilter}". Must be one of: ${VALID_DOC_TYPES.join(', ')}`));
+    process.exit(1);
+  }
+
   const result = await searchDocs(directory, pattern, typeFilter, blockFilter);
+
+  if (result.error !== undefined) {
+    console.log(error(result.error));
+    process.exit(1);
+  }
 
   if (fmt === 'json') {
     console.log(JSON.stringify(result.matches, null, 2));
@@ -797,6 +814,11 @@ async function runDocsSearch(args: string[]): Promise<void> {
         for (const match of matches) {
           console.log(`  ${dim(match.section)} ${dim('[')}${match.blockType}${dim(']')}`);
           console.log(`    ${match.match}`);
+          // Show the extract command for actionable follow-up
+          const extractQuery = match.section !== '(document)'
+            ? `sections.${match.section}`
+            : match.blockType;
+          console.log(dim(`    -> gobbi docs extract ${filePath} "${extractQuery}"`));
         }
         console.log('');
       }
@@ -845,8 +867,9 @@ async function runDocsExtract(args: string[]): Promise<void> {
   let result;
   try {
     result = await extractFromDoc(filePath, query);
-  } catch {
-    console.log(error(`Cannot read or parse file: ${filePath}`));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : `Cannot read or parse file: ${filePath}`;
+    console.log(error(message));
     process.exit(1);
   }
 
@@ -1007,6 +1030,13 @@ async function runDocsStats(args: string[]): Promise<void> {
     console.log(`    Min: ${stats.sizeDistribution.minSections}`);
     console.log(`    Max: ${stats.sizeDistribution.maxSections}`);
     console.log(`    Avg: ${stats.sizeDistribution.avgSections}`);
+    console.log('');
+
+    console.log(`  ${bold('Estimated tokens:')}`);
+    console.log(`    Total: ~${stats.tokens.total.toLocaleString()}`);
+    for (const [type, count] of Object.entries(stats.tokens.byType)) {
+      console.log(`    ${type}: ~${count.toLocaleString()}`);
+    }
   }
 }
 
@@ -1055,6 +1085,7 @@ async function runDocsHealth(args: string[]): Promise<void> {
         console.log(bold('  Errors:'));
         for (const finding of errors) {
           console.log(error(`[${finding.category}] ${finding.path}: ${finding.message}`));
+          console.log(dim(`    -> ${finding.suggestion}`));
         }
         console.log('');
       }
@@ -1063,6 +1094,7 @@ async function runDocsHealth(args: string[]): Promise<void> {
         console.log(bold('  Warnings:'));
         for (const finding of warnings) {
           console.log(yellow(`  ! [${finding.category}] ${finding.path}: ${finding.message}`));
+          console.log(dim(`    -> ${finding.suggestion}`));
         }
         console.log('');
       }
@@ -1071,6 +1103,7 @@ async function runDocsHealth(args: string[]): Promise<void> {
         console.log(bold('  Info:'));
         for (const finding of infos) {
           console.log(dim(`  i [${finding.category}] ${finding.path}: ${finding.message}`));
+          console.log(dim(`    -> ${finding.suggestion}`));
         }
         console.log('');
       }

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -13,7 +13,7 @@ import { parseArgs } from 'node:util';
 import { readFile, writeFile } from 'fs/promises';
 import path from 'path';
 
-import { header, ok, error, dim, bold, yellow } from '../lib/style.js';
+import { header, ok, error, dim, bold, yellow, formatTable } from '../lib/style.js';
 import { renderDoc } from '../lib/docs/renderer.js';
 import { parseMarkdown } from '../lib/docs/migrator.js';
 import { validateFile } from '../lib/docs/validator.js';
@@ -21,7 +21,17 @@ import {
   isDocType,
   DOC_TYPE_TO_SCHEMA,
   VALID_DOC_TYPES,
+  VALID_BLOCK_TYPES,
 } from '../lib/docs/types.js';
+import { listDocs } from '../lib/docs/lister.js';
+import { buildTree, formatTreeText } from '../lib/docs/tree.js';
+import { searchDocs } from '../lib/docs/search.js';
+import { extractFromDoc, formatExtractMd } from '../lib/docs/extract.js';
+import { computeStats } from '../lib/docs/stats.js';
+import { checkHealth } from '../lib/docs/health.js';
+import { scanCorpus } from '../lib/docs/scanner.js';
+import { buildGraph } from '../lib/docs/graph.js';
+import { getClaudeDir } from '../lib/repo.js';
 
 import type {
   DocType,
@@ -43,6 +53,12 @@ Subcommands:
   md2json <path>           Migrate Markdown file to JSON template
   validate <path>          Validate a JSON template
   read <path> [--section]  Pretty-print JSON metadata or section
+  list [directory]         List all gobbi-docs templates with metadata
+  tree [directory]         Show navigation hierarchy as a tree
+  search <pattern> [dir]   Search content across all templates
+  extract <path> <query>   Extract content by dot-path query
+  stats [directory]        Show aggregate corpus statistics
+  health [directory]       Run cross-document health checks
 
 Options:
   --help    Show this help message`;
@@ -86,6 +102,68 @@ Options:
   --section <name>    Display only the named section
   --help              Show this help message`;
 
+const LIST_USAGE = `Usage: gobbi docs list [directory] [options]
+
+List all gobbi-docs JSON templates with type, title, and content count.
+Defaults to the .claude/ directory in the current repository.
+
+Options:
+  --type <type>       Filter by doc type (${VALID_DOC_TYPES.join(', ')})
+  --format <fmt>      Output format: table (default), json
+  --help              Show this help message`;
+
+const TREE_USAGE = `Usage: gobbi docs tree [directory] [options]
+
+Show the navigation hierarchy of gobbi-docs templates as a tree.
+Defaults to the .claude/ directory in the current repository.
+
+Options:
+  --format <fmt>      Output format: text (default), json
+  --help              Show this help message`;
+
+const SEARCH_USAGE = `Usage: gobbi docs search <pattern> [directory] [options]
+
+Search content across all gobbi-docs JSON templates using a regex pattern.
+Defaults to the .claude/ directory in the current repository.
+
+Options:
+  --type <type>       Filter by doc type (${VALID_DOC_TYPES.join(', ')})
+  --block <type>      Filter by block type (${VALID_BLOCK_TYPES.join(', ')}, title, opening, frontmatter)
+  --format <fmt>      Output format: text (default), json
+  --help              Show this help message`;
+
+const EXTRACT_USAGE = `Usage: gobbi docs extract <path> <query> [options]
+
+Extract content from a JSON template by dot-path query.
+
+Queries: title, $schema, opening, frontmatter, frontmatter.name,
+         sections, sections.Setup, entries, entries.<title>
+
+Options:
+  --format <fmt>      Output format: json (default), md, text
+  --help              Show this help message`;
+
+const STATS_USAGE = `Usage: gobbi docs stats [directory] [options]
+
+Show aggregate statistics for all gobbi-docs templates in a directory.
+Defaults to the .claude/ directory in the current repository.
+
+Options:
+  --format <fmt>      Output format: text (default), json
+  --help              Show this help message`;
+
+const HEALTH_USAGE = `Usage: gobbi docs health [directory] [options]
+
+Run cross-document health checks: orphans, broken links, empty sections,
+incomplete gotchas, missing parents, bidirectional consistency.
+Defaults to the .claude/ directory in the current repository.
+
+Exits with code 1 if any errors are found.
+
+Options:
+  --format <fmt>      Output format: text (default), json
+  --help              Show this help message`;
+
 // ---------------------------------------------------------------------------
 // Top-Level Router
 // ---------------------------------------------------------------------------
@@ -112,6 +190,24 @@ export async function runDocs(args: string[]): Promise<void> {
       break;
     case 'read':
       await runDocsRead(args.slice(1));
+      break;
+    case 'list':
+      await runDocsList(args.slice(1));
+      break;
+    case 'tree':
+      await runDocsTree(args.slice(1));
+      break;
+    case 'search':
+      await runDocsSearch(args.slice(1));
+      break;
+    case 'extract':
+      await runDocsExtract(args.slice(1));
+      break;
+    case 'stats':
+      await runDocsStats(args.slice(1));
+      break;
+    case 'health':
+      await runDocsHealth(args.slice(1));
       break;
     case '--help':
     case undefined:
@@ -546,6 +642,443 @@ function printBlock(block: ContentBlock, indent: string): void {
         printBlock(child, indent + '  ');
       }
       break;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// list
+// ---------------------------------------------------------------------------
+
+async function runDocsList(args: string[]): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args,
+    allowPositionals: true,
+    strict: false,
+    options: {
+      'type': { type: 'string' },
+      'format': { type: 'string' },
+      'help': { type: 'boolean', default: false },
+    },
+  });
+
+  if (values.help === true) {
+    console.log(LIST_USAGE);
+    return;
+  }
+
+  const directory = typeof positionals[0] === 'string' ? positionals[0] : getClaudeDir();
+  const typeFilter = typeof values.type === 'string' ? values.type : undefined;
+  const fmt = typeof values.format === 'string' ? values.format : 'table';
+
+  if (typeFilter !== undefined && !isDocType(typeFilter)) {
+    console.log(error(`Invalid doc type: "${typeFilter}". Must be one of: ${VALID_DOC_TYPES.join(', ')}`));
+    process.exit(1);
+  }
+
+  const result = await listDocs(directory, typeFilter);
+
+  if (fmt === 'json') {
+    console.log(JSON.stringify(result.entries, null, 2));
+  } else {
+    if (result.entries.length === 0) {
+      console.log(dim('  No gobbi-docs templates found.'));
+    } else {
+      const headers = ['PATH', 'TYPE', 'TITLE', 'COUNT'];
+      const rows = result.entries.map((e) => [e.path, e.type, e.title, String(e.count)]);
+      console.log(formatTable(headers, rows));
+    }
+  }
+
+  if (result.errors.length > 0) {
+    console.log('');
+    console.log(yellow(`  ${result.errors.length} scan error(s):`));
+    for (const err of result.errors) {
+      console.log(error(`${err.path}: ${err.error}`));
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// tree
+// ---------------------------------------------------------------------------
+
+async function runDocsTree(args: string[]): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args,
+    allowPositionals: true,
+    strict: false,
+    options: {
+      'format': { type: 'string' },
+      'help': { type: 'boolean', default: false },
+    },
+  });
+
+  if (values.help === true) {
+    console.log(TREE_USAGE);
+    return;
+  }
+
+  const directory = typeof positionals[0] === 'string' ? positionals[0] : getClaudeDir();
+  const fmt = typeof values.format === 'string' ? values.format : 'text';
+
+  const corpus = await scanCorpus(directory);
+  const graph = buildGraph(corpus.docs);
+  const result = buildTree(graph, directory);
+
+  if (fmt === 'json') {
+    console.log(JSON.stringify(result.roots, null, 2));
+  } else {
+    if (result.roots.length === 0) {
+      console.log(dim('  No navigation tree found.'));
+    } else {
+      console.log(header('Navigation Tree'));
+      console.log(formatTreeText(result.roots));
+      console.log('');
+      console.log(dim(`  ${result.flatCount} documents total`));
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// search
+// ---------------------------------------------------------------------------
+
+async function runDocsSearch(args: string[]): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args,
+    allowPositionals: true,
+    strict: false,
+    options: {
+      'type': { type: 'string' },
+      'block': { type: 'string' },
+      'format': { type: 'string' },
+      'help': { type: 'boolean', default: false },
+    },
+  });
+
+  if (values.help === true) {
+    console.log(SEARCH_USAGE);
+    return;
+  }
+
+  const pattern = positionals[0];
+  if (typeof pattern !== 'string') {
+    console.log(error('Missing required argument: search pattern'));
+    console.log(SEARCH_USAGE);
+    process.exit(1);
+  }
+
+  const directory = typeof positionals[1] === 'string' ? positionals[1] : getClaudeDir();
+  const typeFilter = typeof values.type === 'string' ? values.type : undefined;
+  const blockFilter = typeof values.block === 'string' ? values.block : undefined;
+  const fmt = typeof values.format === 'string' ? values.format : 'text';
+
+  const result = await searchDocs(directory, pattern, typeFilter, blockFilter);
+
+  if (fmt === 'json') {
+    console.log(JSON.stringify(result.matches, null, 2));
+  } else {
+    if (result.matches.length === 0) {
+      console.log(dim('  No matches found.'));
+    } else {
+      // Group matches by file path
+      const groups = new Map<string, typeof result.matches>();
+      for (const match of result.matches) {
+        const existing = groups.get(match.path);
+        if (existing !== undefined) {
+          existing.push(match);
+        } else {
+          groups.set(match.path, [match]);
+        }
+      }
+
+      for (const [filePath, matches] of groups) {
+        console.log(bold(filePath));
+        for (const match of matches) {
+          console.log(`  ${dim(match.section)} ${dim('[')}${match.blockType}${dim(']')}`);
+          console.log(`    ${match.match}`);
+        }
+        console.log('');
+      }
+    }
+
+    console.log(dim(`  ${result.matches.length} match(es) in ${result.scannedCount} document(s)`));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// extract
+// ---------------------------------------------------------------------------
+
+async function runDocsExtract(args: string[]): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args,
+    allowPositionals: true,
+    strict: false,
+    options: {
+      'format': { type: 'string' },
+      'help': { type: 'boolean', default: false },
+    },
+  });
+
+  if (values.help === true) {
+    console.log(EXTRACT_USAGE);
+    return;
+  }
+
+  const filePath = positionals[0];
+  if (typeof filePath !== 'string') {
+    console.log(error('Missing required argument: JSON file path'));
+    console.log(EXTRACT_USAGE);
+    process.exit(1);
+  }
+
+  const query = positionals[1];
+  if (typeof query !== 'string') {
+    console.log(error('Missing required argument: dot-path query'));
+    console.log(EXTRACT_USAGE);
+    process.exit(1);
+  }
+
+  const fmt = typeof values.format === 'string' ? values.format : 'json';
+
+  let result;
+  try {
+    result = await extractFromDoc(filePath, query);
+  } catch {
+    console.log(error(`Cannot read or parse file: ${filePath}`));
+    process.exit(1);
+  }
+
+  if (!result.found) {
+    console.log(error(`Path not found: "${query}"`));
+    if (result.availablePaths !== undefined && result.availablePaths.length > 0) {
+      console.log(dim('  Available paths:'));
+      for (const p of result.availablePaths) {
+        console.log(`    ${p}`);
+      }
+    }
+    process.exit(1);
+  }
+
+  switch (fmt) {
+    case 'json':
+      console.log(JSON.stringify(result.value, null, 2));
+      break;
+    case 'md':
+      console.log(formatExtractMd(result.value));
+      break;
+    case 'text':
+      printExtractedValue(result.value);
+      break;
+    default:
+      console.log(JSON.stringify(result.value, null, 2));
+      break;
+  }
+}
+
+/**
+ * Print an extracted value in plain text, using `printBlock` for typed
+ * content structures and JSON.stringify for everything else.
+ */
+function printExtractedValue(value: unknown): void {
+  if (value === undefined || value === null) return;
+
+  if (typeof value === 'string') {
+    console.log(value);
+    return;
+  }
+
+  if (typeof value !== 'object') {
+    console.log(String(value));
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      printExtractedValue(item);
+    }
+    return;
+  }
+
+  const record = value as Record<string, unknown>;
+
+  // Section: has heading and content array
+  if ('heading' in record && 'content' in record && Array.isArray(record['content'])) {
+    const heading = record['heading'];
+    if (typeof heading === 'string') {
+      console.log(header(heading));
+    }
+    for (const block of record['content'] as unknown[]) {
+      if (isContentBlock(block)) {
+        printBlock(block, '  ');
+      }
+    }
+    return;
+  }
+
+  // ContentBlock: has type field
+  if ('type' in record && typeof record['type'] === 'string') {
+    if (isContentBlock(value)) {
+      printBlock(value, '');
+    }
+    return;
+  }
+
+  // Fallback
+  console.log(JSON.stringify(value, null, 2));
+}
+
+/** Type guard for ContentBlock. */
+function isContentBlock(value: unknown): value is ContentBlock {
+  if (typeof value !== 'object' || value === null) return false;
+  const record = value as Record<string, unknown>;
+  const type = record['type'];
+  return typeof type === 'string' && (VALID_BLOCK_TYPES as readonly string[]).includes(type);
+}
+
+// ---------------------------------------------------------------------------
+// stats
+// ---------------------------------------------------------------------------
+
+async function runDocsStats(args: string[]): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args,
+    allowPositionals: true,
+    strict: false,
+    options: {
+      'format': { type: 'string' },
+      'help': { type: 'boolean', default: false },
+    },
+  });
+
+  if (values.help === true) {
+    console.log(STATS_USAGE);
+    return;
+  }
+
+  const directory = typeof positionals[0] === 'string' ? positionals[0] : getClaudeDir();
+  const fmt = typeof values.format === 'string' ? values.format : 'text';
+
+  const stats = await computeStats(directory);
+
+  if (fmt === 'json') {
+    console.log(JSON.stringify(stats, null, 2));
+  } else {
+    console.log(header('Corpus Statistics'));
+    console.log('');
+    console.log(`  ${bold('Total documents:')} ${stats.total}`);
+    console.log('');
+
+    console.log(`  ${bold('By doc type:')}`);
+    for (const [type, count] of Object.entries(stats.byType)) {
+      console.log(`    ${type}: ${count}`);
+    }
+    console.log('');
+
+    console.log(`  ${bold('Content:')}`);
+    console.log(`    Sections: ${stats.totalSections}`);
+    console.log(`    Blocks: ${stats.totalBlocks}`);
+    console.log('');
+
+    if (Object.keys(stats.byBlockType).length > 0) {
+      console.log(`  ${bold('By block type:')}`);
+      for (const [type, count] of Object.entries(stats.byBlockType)) {
+        console.log(`    ${type}: ${count}`);
+      }
+      console.log('');
+    }
+
+    console.log(`  ${bold('Navigation:')}`);
+    console.log(`    With navigation: ${stats.navigation.with}`);
+    console.log(`    Without navigation: ${stats.navigation.without}`);
+    console.log('');
+
+    if (stats.gotchas.totalEntries > 0) {
+      console.log(`  ${bold('Gotchas:')}`);
+      console.log(`    Total entries: ${stats.gotchas.totalEntries}`);
+      for (const [priority, count] of Object.entries(stats.gotchas.byPriority)) {
+        console.log(`    ${priority}: ${count}`);
+      }
+      console.log('');
+    }
+
+    console.log(`  ${bold('Section size distribution:')}`);
+    console.log(`    Min: ${stats.sizeDistribution.minSections}`);
+    console.log(`    Max: ${stats.sizeDistribution.maxSections}`);
+    console.log(`    Avg: ${stats.sizeDistribution.avgSections}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// health
+// ---------------------------------------------------------------------------
+
+async function runDocsHealth(args: string[]): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args,
+    allowPositionals: true,
+    strict: false,
+    options: {
+      'format': { type: 'string' },
+      'help': { type: 'boolean', default: false },
+    },
+  });
+
+  if (values.help === true) {
+    console.log(HEALTH_USAGE);
+    return;
+  }
+
+  const directory = typeof positionals[0] === 'string' ? positionals[0] : getClaudeDir();
+  const fmt = typeof values.format === 'string' ? values.format : 'text';
+
+  const report = await checkHealth(directory);
+
+  if (fmt === 'json') {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(header('Health Check'));
+    console.log('');
+    console.log(`  ${report.summary.errors} error(s), ${report.summary.warnings} warning(s), ${report.summary.info} info`);
+    console.log('');
+
+    if (report.findings.length === 0) {
+      console.log(ok('No issues found'));
+    } else {
+      // Group by severity for display
+      const errors = report.findings.filter((f) => f.severity === 'error');
+      const warnings = report.findings.filter((f) => f.severity === 'warning');
+      const infos = report.findings.filter((f) => f.severity === 'info');
+
+      if (errors.length > 0) {
+        console.log(bold('  Errors:'));
+        for (const finding of errors) {
+          console.log(error(`[${finding.category}] ${finding.path}: ${finding.message}`));
+        }
+        console.log('');
+      }
+
+      if (warnings.length > 0) {
+        console.log(bold('  Warnings:'));
+        for (const finding of warnings) {
+          console.log(yellow(`  ! [${finding.category}] ${finding.path}: ${finding.message}`));
+        }
+        console.log('');
+      }
+
+      if (infos.length > 0) {
+        console.log(bold('  Info:'));
+        for (const finding of infos) {
+          console.log(dim(`  i [${finding.category}] ${finding.path}: ${finding.message}`));
+        }
+        console.log('');
+      }
+    }
+  }
+
+  if (report.summary.errors > 0) {
+    process.exit(1);
   }
 }
 

--- a/src/lib/docs/extract.ts
+++ b/src/lib/docs/extract.ts
@@ -1,0 +1,282 @@
+/**
+ * Structural content extraction from a single gobbi-docs JSON template.
+ *
+ * Resolves dot-path queries like `sections.Setup`, `frontmatter.name`, or
+ * `entries.Never use any` against the typed document structure.
+ */
+
+import { readFile } from 'node:fs/promises';
+import {
+  isDocSchema,
+  isGotchaDoc,
+  hasSections,
+  hasFrontmatter,
+  type GobbiDoc,
+  type Section,
+  type GotchaEntry,
+} from './types.js';
+import { renderSection, renderBlock } from './renderer.js';
+import type { ContentBlock } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface ExtractResult {
+  value: unknown;            // the extracted JSON value
+  found: boolean;
+  availablePaths?: string[]; // shown on error
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Split a query on the first `.` to separate root from subpath.
+ * Returns [root, subpath | undefined].
+ */
+function splitQuery(query: string): [string, string | undefined] {
+  const dotIndex = query.indexOf('.');
+  if (dotIndex === -1) return [query, undefined];
+  return [query.slice(0, dotIndex), query.slice(dotIndex + 1)];
+}
+
+/** Check if a string is a non-negative integer. */
+function isNumericIndex(value: string): boolean {
+  return /^\d+$/.test(value);
+}
+
+/**
+ * Build the list of valid top-level paths for a given document,
+ * used in error responses.
+ */
+function availablePathsFor(doc: GobbiDoc): string[] {
+  const paths: string[] = ['$schema', 'title'];
+
+  if (doc.opening !== undefined) paths.push('opening');
+  if (doc.navigation !== undefined) paths.push('navigation');
+  if (hasFrontmatter(doc)) paths.push('frontmatter');
+
+  if (doc.$schema === 'gobbi-docs/child' || doc.$schema === 'gobbi-docs/gotcha') {
+    paths.push('parent');
+  }
+
+  if (isGotchaDoc(doc)) {
+    paths.push('entries');
+  } else if (hasSections(doc) && doc.sections !== undefined) {
+    paths.push('sections');
+  }
+
+  return paths;
+}
+
+/**
+ * Resolve a sections query with an optional subpath.
+ * Subpath can be a numeric index or a case-insensitive heading match.
+ */
+function resolveSections(
+  sections: Section[],
+  subpath: string | undefined,
+): ExtractResult {
+  if (subpath === undefined) {
+    return { value: sections, found: true };
+  }
+
+  if (isNumericIndex(subpath)) {
+    const index = Number(subpath);
+    const section = sections[index];
+    if (section === undefined) {
+      return {
+        value: undefined,
+        found: false,
+        availablePaths: sections.map((_s, i) => `sections.${i}`),
+      };
+    }
+    return { value: section, found: true };
+  }
+
+  // Case-insensitive heading match
+  const lowerSub = subpath.toLowerCase();
+  const section = sections.find(
+    (s) => s.heading !== null && s.heading.toLowerCase() === lowerSub,
+  );
+
+  if (section === undefined) {
+    return {
+      value: undefined,
+      found: false,
+      availablePaths: sections.map((s, i) =>
+        s.heading !== null ? `sections.${s.heading}` : `sections.${i}`,
+      ),
+    };
+  }
+
+  return { value: section, found: true };
+}
+
+/**
+ * Resolve an entries query with an optional subpath.
+ * Subpath is a case-insensitive title match.
+ */
+function resolveEntries(
+  entries: GotchaEntry[],
+  subpath: string | undefined,
+): ExtractResult {
+  if (subpath === undefined) {
+    return { value: entries, found: true };
+  }
+
+  const lowerSub = subpath.toLowerCase();
+  const entry = entries.find(
+    (e) => e.title.toLowerCase() === lowerSub,
+  );
+
+  if (entry === undefined) {
+    return {
+      value: undefined,
+      found: false,
+      availablePaths: entries.map((e) => `entries.${e.title}`),
+    };
+  }
+
+  return { value: entry, found: true };
+}
+
+// ---------------------------------------------------------------------------
+// Main extract function
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract content from a single gobbi-docs JSON template by dot-path query.
+ *
+ * @param filePath  Absolute path to the JSON template file
+ * @param query     Dot-path query (e.g., `title`, `sections.Setup`, `frontmatter.name`)
+ */
+export async function extractFromDoc(
+  filePath: string,
+  query: string,
+): Promise<ExtractResult> {
+  const raw = await readFile(filePath, 'utf8');
+  const parsed: unknown = JSON.parse(raw);
+
+  // Validate schema
+  if (typeof parsed !== 'object' || parsed === null) {
+    return { value: undefined, found: false, availablePaths: [] };
+  }
+  const record = parsed as Record<string, unknown>;
+  const schema = record['$schema'];
+  if (typeof schema !== 'string' || !isDocSchema(schema)) {
+    return { value: undefined, found: false, availablePaths: [] };
+  }
+
+  const doc = parsed as GobbiDoc;
+  const [root, subpath] = splitQuery(query);
+
+  switch (root) {
+    case '$schema':
+      return { value: doc.$schema, found: true };
+
+    case 'title':
+      return { value: doc.title, found: true };
+
+    case 'opening':
+      if (doc.opening !== undefined) {
+        return { value: doc.opening, found: true };
+      }
+      return { value: undefined, found: false, availablePaths: availablePathsFor(doc) };
+
+    case 'navigation':
+      if (doc.navigation !== undefined) {
+        return { value: doc.navigation, found: true };
+      }
+      return { value: undefined, found: false, availablePaths: availablePathsFor(doc) };
+
+    case 'parent':
+      if (doc.$schema === 'gobbi-docs/child' || doc.$schema === 'gobbi-docs/gotcha') {
+        return { value: doc.parent, found: true };
+      }
+      return { value: undefined, found: false, availablePaths: availablePathsFor(doc) };
+
+    case 'frontmatter':
+      if (hasFrontmatter(doc)) {
+        if (subpath !== undefined) {
+          const fm = doc.frontmatter as Record<string, unknown>;
+          const fieldVal = fm[subpath];
+          if (fieldVal !== undefined) {
+            return { value: fieldVal, found: true };
+          }
+          return {
+            value: undefined,
+            found: false,
+            availablePaths: Object.keys(fm).map((k) => `frontmatter.${k}`),
+          };
+        }
+        return { value: doc.frontmatter, found: true };
+      }
+      return { value: undefined, found: false, availablePaths: availablePathsFor(doc) };
+
+    case 'sections':
+      if (isGotchaDoc(doc)) {
+        return { value: undefined, found: false, availablePaths: availablePathsFor(doc) };
+      }
+      if (hasSections(doc) && doc.sections !== undefined) {
+        return resolveSections(doc.sections, subpath);
+      }
+      return { value: undefined, found: false, availablePaths: availablePathsFor(doc) };
+
+    case 'entries':
+      if (isGotchaDoc(doc)) {
+        return resolveEntries(doc.entries, subpath);
+      }
+      return { value: undefined, found: false, availablePaths: availablePathsFor(doc) };
+
+    default:
+      return { value: undefined, found: false, availablePaths: availablePathsFor(doc) };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Markdown formatter for extracted values
+// ---------------------------------------------------------------------------
+
+/**
+ * Format an extracted value as Markdown.
+ *
+ * Uses the renderer's `renderSection()` and `renderBlock()` for typed
+ * structures; falls back to `JSON.stringify` for scalar/unknown values.
+ */
+export function formatExtractMd(value: unknown): string {
+  if (value === undefined || value === null) return '';
+
+  // String scalar
+  if (typeof value === 'string') return value;
+
+  // Number/boolean scalar
+  if (typeof value !== 'object') return String(value);
+
+  // Array — could be sections, entries, or content blocks
+  if (Array.isArray(value)) {
+    const parts: string[] = [];
+    for (const item of value) {
+      parts.push(formatExtractMd(item));
+    }
+    return parts.join('\n\n---\n\n');
+  }
+
+  // Object — try to detect typed structures
+  const record = value as Record<string, unknown>;
+
+  // Section: has `heading` (string | null) and `content` (array)
+  if ('heading' in record && 'content' in record && Array.isArray(record['content'])) {
+    return renderSection(value as Section);
+  }
+
+  // ContentBlock: has `type` field
+  if ('type' in record && typeof record['type'] === 'string') {
+    return renderBlock(value as ContentBlock);
+  }
+
+  // Fallback: JSON
+  return JSON.stringify(value, null, 2);
+}

--- a/src/lib/docs/extract.ts
+++ b/src/lib/docs/extract.ts
@@ -157,8 +157,21 @@ export async function extractFromDoc(
   filePath: string,
   query: string,
 ): Promise<ExtractResult> {
-  const raw = await readFile(filePath, 'utf8');
-  const parsed: unknown = JSON.parse(raw);
+  let raw: string;
+  try {
+    raw = await readFile(filePath, 'utf8');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Cannot read file: ${message}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Invalid JSON: ${message}`);
+  }
 
   // Validate schema
   if (typeof parsed !== 'object' || parsed === null) {

--- a/src/lib/docs/graph.ts
+++ b/src/lib/docs/graph.ts
@@ -136,25 +136,45 @@ export function buildGraph(corpus: ScannedDoc[]): DocGraph {
 
     for (const key of Object.keys(nav)) {
       const resolved = resolveNavKey(key, sourceDir, skillPathLookup);
-      const isResolved = resolved !== undefined && nodes.has(resolved);
 
-      const edge: GraphEdge = {
-        from: doc.path,
-        to: isResolved ? resolved : (resolved ?? key),
-        type: 'navigation',
-        resolved: isResolved,
-      };
-      edges.push(edge);
+      // Navigation keys often point to .md files, but corpus nodes are .json files.
+      // Check both the resolved path and its .json equivalent.
+      let target: string | undefined;
+      if (resolved !== undefined) {
+        if (nodes.has(resolved)) {
+          target = resolved;
+        } else if (resolved.endsWith('.md')) {
+          const jsonEquiv = resolved.slice(0, -3) + '.json';
+          if (nodes.has(jsonEquiv)) {
+            target = jsonEquiv;
+          }
+        }
+      }
+      if (target !== undefined) {
+        const edge: GraphEdge = {
+          from: doc.path,
+          to: target,
+          type: 'navigation',
+          resolved: true,
+        };
+        edges.push(edge);
 
-      if (isResolved) {
         const adj = adjacency.get(doc.path);
         if (adj !== undefined) {
-          adj.push(resolved);
+          adj.push(target);
         }
-        const count = incomingCount.get(resolved);
+        const count = incomingCount.get(target);
         if (count !== undefined) {
-          incomingCount.set(resolved, count + 1);
+          incomingCount.set(target, count + 1);
         }
+      } else {
+        const edge: GraphEdge = {
+          from: doc.path,
+          to: resolved ?? key,
+          type: 'navigation',
+          resolved: false,
+        };
+        edges.push(edge);
       }
     }
   }

--- a/src/lib/docs/graph.ts
+++ b/src/lib/docs/graph.ts
@@ -1,0 +1,203 @@
+/**
+ * Navigation graph builder from a scanned gobbi-docs corpus.
+ *
+ * Builds a directed graph of navigation and parent relationships between
+ * documents, enabling orphan detection and link resolution checks.
+ */
+
+import path from 'node:path';
+import type { ScannedDoc } from './scanner.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface GraphEdge {
+  from: string;       // source doc path
+  to: string;         // target doc path or unresolved reference
+  type: 'navigation' | 'parent';
+  resolved: boolean;
+}
+
+export interface DocGraph {
+  nodes: Map<string, ScannedDoc>;
+  edges: GraphEdge[];
+  adjacency: Map<string, string[]>;  // path -> connected paths
+  orphans: string[];                  // nodes with no incoming edges (except roots)
+}
+
+// ---------------------------------------------------------------------------
+// Navigation key parsing
+// ---------------------------------------------------------------------------
+
+/** Markdown link pattern: `[text](path)` — extract the path portion. */
+const MD_LINK_RE = /^\[.*?\]\((.+)\)$/;
+
+/**
+ * Attempt to resolve a navigation key to an absolute file path.
+ *
+ * Navigation keys appear in three formats:
+ * 1. Markdown links `[text](path)` — resolve path relative to source doc dir
+ * 2. Skill names like `_rules` — resolve to `skills/{name}/SKILL.json` within corpus
+ * 3. Descriptive text like `"Benchmark scenarios"` — unresolvable
+ *
+ * Returns the resolved absolute path if matched, or undefined if unresolvable.
+ */
+function resolveNavKey(
+  key: string,
+  sourceDir: string,
+  skillPathLookup: Map<string, string>,
+): string | undefined {
+  // Format 1: Markdown link [text](path)
+  const mdMatch = MD_LINK_RE.exec(key);
+  if (mdMatch !== null) {
+    const linkPath = mdMatch[1];
+    if (linkPath !== undefined && linkPath !== '') {
+      return path.resolve(sourceDir, linkPath);
+    }
+    return undefined;
+  }
+
+  // Format 2: Skill name (starts with _ or __ prefix, or matches a known skill directory name)
+  const skillPath = skillPathLookup.get(key);
+  if (skillPath !== undefined) {
+    return skillPath;
+  }
+
+  // Format 3: Descriptive text — unresolvable
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Graph builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build skill name lookup: map from skill directory name to its SKILL.json absolute path.
+ * Extracts from corpus nodes whose filename is SKILL.json.
+ */
+function buildSkillPathLookup(corpus: ScannedDoc[]): Map<string, string> {
+  const lookup = new Map<string, string>();
+  for (const doc of corpus) {
+    if (path.basename(doc.path) === 'SKILL.json') {
+      const skillDirName = path.basename(path.dirname(doc.path));
+      lookup.set(skillDirName, doc.path);
+    }
+  }
+  return lookup;
+}
+
+/**
+ * Resolve a parent field value to an absolute SKILL.json path.
+ * Parent fields contain skill directory names (e.g., `"_claude"`, `"gobbi"`).
+ */
+function resolveParent(
+  parentName: string,
+  skillPathLookup: Map<string, string>,
+): string | undefined {
+  return skillPathLookup.get(parentName);
+}
+
+/** Entry point file names that are not considered orphans. */
+const ENTRY_POINT_NAMES: ReadonlySet<string> = new Set([
+  'SKILL.json',
+  'README.json',
+]);
+
+/**
+ * Build a navigation graph from a scanned corpus.
+ *
+ * Resolves navigation links and parent references between documents,
+ * builds adjacency lists, and identifies orphan documents.
+ */
+export function buildGraph(corpus: ScannedDoc[]): DocGraph {
+  const nodes = new Map<string, ScannedDoc>();
+  for (const doc of corpus) {
+    nodes.set(doc.path, doc);
+  }
+
+  const skillPathLookup = buildSkillPathLookup(corpus);
+  const edges: GraphEdge[] = [];
+  const adjacency = new Map<string, string[]>();
+  const incomingCount = new Map<string, number>();
+
+  // Initialize adjacency and incoming counts for all nodes
+  for (const docPath of nodes.keys()) {
+    adjacency.set(docPath, []);
+    incomingCount.set(docPath, 0);
+  }
+
+  // Navigation edges
+  for (const doc of corpus) {
+    const nav = doc.doc.navigation;
+    if (nav === undefined) continue;
+
+    const sourceDir = path.dirname(doc.path);
+
+    for (const key of Object.keys(nav)) {
+      const resolved = resolveNavKey(key, sourceDir, skillPathLookup);
+      const isResolved = resolved !== undefined && nodes.has(resolved);
+
+      const edge: GraphEdge = {
+        from: doc.path,
+        to: isResolved ? resolved : (resolved ?? key),
+        type: 'navigation',
+        resolved: isResolved,
+      };
+      edges.push(edge);
+
+      if (isResolved) {
+        const adj = adjacency.get(doc.path);
+        if (adj !== undefined) {
+          adj.push(resolved);
+        }
+        const count = incomingCount.get(resolved);
+        if (count !== undefined) {
+          incomingCount.set(resolved, count + 1);
+        }
+      }
+    }
+  }
+
+  // Parent edges: child and gotcha docs have a `parent` field
+  for (const doc of corpus) {
+    const { $schema } = doc.doc;
+    if ($schema !== 'gobbi-docs/child' && $schema !== 'gobbi-docs/gotcha') continue;
+    const parentField = doc.doc.parent;
+
+    const resolved = resolveParent(parentField, skillPathLookup);
+    const isResolved = resolved !== undefined && nodes.has(resolved);
+
+    const edge: GraphEdge = {
+      from: doc.path,
+      to: isResolved ? resolved : parentField,
+      type: 'parent',
+      resolved: isResolved,
+    };
+    edges.push(edge);
+
+    if (isResolved) {
+      const adj = adjacency.get(doc.path);
+      if (adj !== undefined) {
+        adj.push(resolved);
+      }
+      const count = incomingCount.get(resolved);
+      if (count !== undefined) {
+        incomingCount.set(resolved, count + 1);
+      }
+    }
+  }
+
+  // Compute orphans: nodes with no incoming edges, excluding entry point files
+  const orphans: string[] = [];
+  for (const [docPath, count] of incomingCount) {
+    if (count === 0) {
+      const filename = path.basename(docPath);
+      if (!ENTRY_POINT_NAMES.has(filename)) {
+        orphans.push(docPath);
+      }
+    }
+  }
+
+  return { nodes, edges, adjacency, orphans };
+}

--- a/src/lib/docs/health.ts
+++ b/src/lib/docs/health.ts
@@ -21,6 +21,7 @@ export interface Finding {
   severity: FindingSeverity;
   category: string;
   message: string;
+  suggestion: string;
 }
 
 export interface HealthReport {
@@ -59,6 +60,7 @@ function checkOrphans(graph: DocGraph, scanDir: string): Finding[] {
       severity: 'warning',
       category: 'orphaned-document',
       message: `No other document references ${path.relative(scanDir, absPath)}`,
+      suggestion: 'Add a navigation link to this document from its parent, or check if it should have a parent field',
     });
   }
   return findings;
@@ -79,6 +81,7 @@ function checkBrokenNavLinks(graph: DocGraph, scanDir: string): Finding[] {
           severity: 'error',
           category: 'broken-navigation',
           message: `${path.relative(scanDir, edge.from)} has navigation link to '${edge.to}' which does not resolve`,
+          suggestion: 'Check the navigation key format — ensure it points to an existing .json or .md file',
         });
       }
     }
@@ -104,6 +107,7 @@ function checkEmptySections(docs: ScannedDoc[], scanDir: string): Finding[] {
           severity: 'warning',
           category: 'empty-section',
           message: `${path.relative(scanDir, scanned.path)} section '${heading}' has no content blocks`,
+          suggestion: 'Add content blocks to this section or remove the empty section',
         });
       }
     }
@@ -140,6 +144,7 @@ function checkIncompleteGotchas(docs: ScannedDoc[], scanDir: string): Finding[] 
           severity: 'error',
           category: 'incomplete-gotcha',
           message: `entries[${i}] '${entry.title}' is missing required body fields: ${missingFields.join(', ')}`,
+          suggestion: 'Add the missing body field(s) to this gotcha entry',
         });
       }
     }
@@ -159,6 +164,7 @@ function checkMissingParents(graph: DocGraph, scanDir: string): Finding[] {
         severity: 'error',
         category: 'missing-parent',
         message: `${path.relative(scanDir, edge.from)} declares parent '${edge.to}' but no matching skill exists`,
+        suggestion: 'Update the parent field to reference an existing skill directory name',
       });
     }
   }
@@ -203,6 +209,7 @@ function checkBidirectionalConsistency(
         severity: 'warning',
         category: 'bidirectional-consistency',
         message: `${path.relative(scanDir, childPath)} claims parent '${path.relative(scanDir, parentPath)}' but parent's navigation does not reference it`,
+        suggestion: 'Add a navigation entry in the parent document pointing back to this child',
       });
     }
   }
@@ -223,6 +230,7 @@ function checkUnresolvableNavKeys(graph: DocGraph, scanDir: string): Finding[] {
         severity: 'info',
         category: 'unresolvable-nav-key',
         message: `Navigation key '${edge.to}' could not be resolved to any file`,
+        suggestion: 'This navigation key uses a descriptive format that cannot be resolved to a file',
       });
     }
   }

--- a/src/lib/docs/health.ts
+++ b/src/lib/docs/health.ts
@@ -1,0 +1,317 @@
+/**
+ * Cross-document health checker for gobbi-docs corpus.
+ *
+ * Runs structural and referential integrity checks across all documents
+ * in a scanned corpus, producing a categorized findings report.
+ */
+
+import path from 'node:path';
+import { scanCorpus, type ScannedDoc } from './scanner.js';
+import { buildGraph, type DocGraph, type GraphEdge } from './graph.js';
+import { isGotchaDoc, hasSections } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type FindingSeverity = 'error' | 'warning' | 'info';
+
+export interface Finding {
+  path: string;
+  severity: FindingSeverity;
+  category: string;
+  message: string;
+}
+
+export interface HealthReport {
+  summary: {
+    total: number;
+    errors: number;
+    warnings: number;
+    info: number;
+  };
+  findings: Finding[];
+}
+
+// ---------------------------------------------------------------------------
+// Severity sort order
+// ---------------------------------------------------------------------------
+
+const SEVERITY_ORDER: Readonly<Record<FindingSeverity, number>> = {
+  error: 0,
+  warning: 1,
+  info: 2,
+};
+
+// ---------------------------------------------------------------------------
+// Individual checks
+// ---------------------------------------------------------------------------
+
+/**
+ * Check 1: Orphaned documents — docs with no incoming edges.
+ * Uses the graph's pre-computed orphan list.
+ */
+function checkOrphans(graph: DocGraph, scanDir: string): Finding[] {
+  const findings: Finding[] = [];
+  for (const absPath of graph.orphans) {
+    findings.push({
+      path: path.relative(scanDir, absPath),
+      severity: 'warning',
+      category: 'orphaned-document',
+      message: `No other document references ${path.relative(scanDir, absPath)}`,
+    });
+  }
+  return findings;
+}
+
+/**
+ * Check 2: Broken navigation links — navigation edges that failed to resolve.
+ */
+function checkBrokenNavLinks(graph: DocGraph, scanDir: string): Finding[] {
+  const findings: Finding[] = [];
+  for (const edge of graph.edges) {
+    if (edge.type === 'navigation' && !edge.resolved) {
+      // Only report as error if it looks like a file path (markdown link format)
+      // Descriptive text keys are handled by Check 7
+      if (isFilePath(edge.to)) {
+        findings.push({
+          path: path.relative(scanDir, edge.from),
+          severity: 'error',
+          category: 'broken-navigation',
+          message: `${path.relative(scanDir, edge.from)} has navigation link to '${edge.to}' which does not resolve`,
+        });
+      }
+    }
+  }
+  return findings;
+}
+
+/**
+ * Check 3: Empty sections — sections with zero content blocks.
+ */
+function checkEmptySections(docs: ScannedDoc[], scanDir: string): Finding[] {
+  const findings: Finding[] = [];
+  for (const scanned of docs) {
+    if (!hasSections(scanned.doc)) continue;
+    const sections = scanned.doc.sections;
+    if (sections === undefined) continue;
+
+    for (const section of sections) {
+      if (section.content.length === 0) {
+        const heading = section.heading ?? '(unnamed)';
+        findings.push({
+          path: path.relative(scanDir, scanned.path),
+          severity: 'warning',
+          category: 'empty-section',
+          message: `${path.relative(scanDir, scanned.path)} section '${heading}' has no content blocks`,
+        });
+      }
+    }
+  }
+  return findings;
+}
+
+/**
+ * Check 4: Incomplete gotcha entries — entries missing required body fields.
+ */
+function checkIncompleteGotchas(docs: ScannedDoc[], scanDir: string): Finding[] {
+  const REQUIRED_BODY_FIELDS = ['priority', 'what-happened', 'user-feedback', 'correct-approach'] as const;
+  const findings: Finding[] = [];
+
+  for (const scanned of docs) {
+    if (!isGotchaDoc(scanned.doc)) continue;
+
+    for (let i = 0; i < scanned.doc.entries.length; i++) {
+      const entry = scanned.doc.entries[i];
+      if (entry === undefined) continue;
+
+      const body = entry.body;
+      const missingFields: string[] = [];
+
+      for (const field of REQUIRED_BODY_FIELDS) {
+        if (typeof body[field] !== 'string' || body[field].length === 0) {
+          missingFields.push(field);
+        }
+      }
+
+      if (missingFields.length > 0) {
+        findings.push({
+          path: path.relative(scanDir, scanned.path),
+          severity: 'error',
+          category: 'incomplete-gotcha',
+          message: `entries[${i}] '${entry.title}' is missing required body fields: ${missingFields.join(', ')}`,
+        });
+      }
+    }
+  }
+  return findings;
+}
+
+/**
+ * Check 5: Missing parent references — parent field points to nonexistent skill.
+ */
+function checkMissingParents(graph: DocGraph, scanDir: string): Finding[] {
+  const findings: Finding[] = [];
+  for (const edge of graph.edges) {
+    if (edge.type === 'parent' && !edge.resolved) {
+      findings.push({
+        path: path.relative(scanDir, edge.from),
+        severity: 'error',
+        category: 'missing-parent',
+        message: `${path.relative(scanDir, edge.from)} declares parent '${edge.to}' but no matching skill exists`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * Check 6: Parent-child bidirectional consistency.
+ * For each child/gotcha doc with a resolved parent, verifies the parent's
+ * navigation includes a reference back to this child.
+ */
+function checkBidirectionalConsistency(
+  graph: DocGraph,
+  scanDir: string,
+): Finding[] {
+  const findings: Finding[] = [];
+
+  // Build set of paths that each parent navigates to (resolved targets)
+  const parentNavTargets = new Map<string, Set<string>>();
+  for (const edge of graph.edges) {
+    if (edge.type === 'navigation' && edge.resolved) {
+      let targets = parentNavTargets.get(edge.from);
+      if (targets === undefined) {
+        targets = new Set<string>();
+        parentNavTargets.set(edge.from, targets);
+      }
+      targets.add(edge.to);
+    }
+  }
+
+  // Check each parent edge: does the parent's navigation point back to child?
+  for (const edge of graph.edges) {
+    if (edge.type !== 'parent' || !edge.resolved) continue;
+
+    const childPath = edge.from;
+    const parentPath = edge.to;
+    const targets = parentNavTargets.get(parentPath);
+
+    if (targets === undefined || !targets.has(childPath)) {
+      findings.push({
+        path: path.relative(scanDir, childPath),
+        severity: 'warning',
+        category: 'bidirectional-consistency',
+        message: `${path.relative(scanDir, childPath)} claims parent '${path.relative(scanDir, parentPath)}' but parent's navigation does not reference it`,
+      });
+    }
+  }
+
+  return findings;
+}
+
+/**
+ * Check 7: Unresolvable navigation keys — descriptive text that cannot map
+ * to a file. Reported as info since these are often intentional labels.
+ */
+function checkUnresolvableNavKeys(graph: DocGraph, scanDir: string): Finding[] {
+  const findings: Finding[] = [];
+  for (const edge of graph.edges) {
+    if (edge.type === 'navigation' && !edge.resolved && !isFilePath(edge.to)) {
+      findings.push({
+        path: path.relative(scanDir, edge.from),
+        severity: 'info',
+        category: 'unresolvable-nav-key',
+        message: `Navigation key '${edge.to}' could not be resolved to any file`,
+      });
+    }
+  }
+  return findings;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Heuristic: does this string look like a file path rather than descriptive text?
+ * File paths contain path separators, file extensions, or start with `.` or `/`.
+ */
+function isFilePath(value: string): boolean {
+  return (
+    value.includes('/') ||
+    value.includes('\\') ||
+    value.includes('.json') ||
+    value.includes('.md') ||
+    value.startsWith('.')
+  );
+}
+
+/** Compare findings by severity (errors first, then warnings, then info). */
+function compareFindings(a: Finding, b: Finding): number {
+  const aOrder = SEVERITY_ORDER[a.severity];
+  const bOrder = SEVERITY_ORDER[b.severity];
+  if (aOrder !== bOrder) return aOrder - bOrder;
+  if (a.path < b.path) return -1;
+  if (a.path > b.path) return 1;
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Run all health checks on a gobbi-docs corpus.
+ *
+ * Scans the given directory, builds a navigation graph, and runs structural
+ * and referential integrity checks. Returns a report with categorized findings
+ * sorted by severity.
+ */
+export async function checkHealth(directory: string): Promise<HealthReport> {
+  const absDir = path.resolve(directory);
+  const corpus = await scanCorpus(absDir);
+  const graph = buildGraph(corpus.docs);
+
+  // Run all checks
+  const findings: Finding[] = [
+    ...checkOrphans(graph, absDir),
+    ...checkBrokenNavLinks(graph, absDir),
+    ...checkEmptySections(corpus.docs, absDir),
+    ...checkIncompleteGotchas(corpus.docs, absDir),
+    ...checkMissingParents(graph, absDir),
+    ...checkBidirectionalConsistency(graph, absDir),
+    ...checkUnresolvableNavKeys(graph, absDir),
+  ];
+
+  // Sort by severity
+  findings.sort(compareFindings);
+
+  // Compute summary
+  let errors = 0;
+  let warnings = 0;
+  let info = 0;
+  for (const finding of findings) {
+    switch (finding.severity) {
+      case 'error':
+        errors += 1;
+        break;
+      case 'warning':
+        warnings += 1;
+        break;
+      case 'info':
+        info += 1;
+        break;
+    }
+  }
+
+  return {
+    summary: {
+      total: findings.length,
+      errors,
+      warnings,
+      info,
+    },
+    findings,
+  };
+}

--- a/src/lib/docs/lister.ts
+++ b/src/lib/docs/lister.ts
@@ -1,0 +1,95 @@
+/**
+ * List all gobbi-docs JSON templates with metadata.
+ *
+ * Scans a directory for gobbi-docs files and returns a sorted list of
+ * entries with type, title, and content counts.
+ */
+
+import path from 'node:path';
+import { isDocType, type DocType } from './types.js';
+import { scanCorpus, type ScanError, type ScannedDoc } from './scanner.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface ListEntry {
+  path: string;        // relative to scan directory
+  type: string;        // DocType
+  title: string;
+  count: number;       // sectionCount or entryCount
+}
+
+export interface ListResult {
+  entries: ListEntry[];
+  errors: ScanError[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Extract the content count from a scanned document. */
+function getCount(doc: ScannedDoc): number {
+  if (doc.doc.$schema === 'gobbi-docs/gotcha') {
+    return doc.doc.entries.length;
+  }
+
+  if ('sections' in doc.doc) {
+    const sections = doc.doc.sections;
+    return sections !== undefined ? sections.length : 0;
+  }
+
+  return 0;
+}
+
+/** Convert a ScannedDoc to a ListEntry relative to scanDir. */
+function toListEntry(doc: ScannedDoc, scanDir: string): ListEntry {
+  return {
+    path: path.relative(scanDir, doc.path),
+    type: doc.type,
+    title: doc.doc.title,
+    count: getCount(doc),
+  };
+}
+
+/** Sort comparator: by type ascending, then path ascending. */
+function compareEntries(a: ListEntry, b: ListEntry): number {
+  if (a.type < b.type) return -1;
+  if (a.type > b.type) return 1;
+  if (a.path < b.path) return -1;
+  if (a.path > b.path) return 1;
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * List gobbi-docs templates in a directory.
+ *
+ * Scans recursively for JSON files with valid gobbi-docs `$schema` fields,
+ * optionally filtering by DocType. Results are sorted by type then path.
+ */
+export async function listDocs(
+  directory: string,
+  typeFilter?: string,
+): Promise<ListResult> {
+  const absDir = path.resolve(directory);
+  const result = await scanCorpus(absDir);
+
+  // Validate and apply type filter
+  const validFilter: DocType | undefined =
+    typeFilter !== undefined && isDocType(typeFilter) ? typeFilter : undefined;
+
+  const entries: ListEntry[] = [];
+  for (const doc of result.docs) {
+    if (validFilter !== undefined && doc.type !== validFilter) continue;
+    entries.push(toListEntry(doc, absDir));
+  }
+
+  entries.sort(compareEntries);
+
+  return { entries, errors: result.errors };
+}

--- a/src/lib/docs/renderer.ts
+++ b/src/lib/docs/renderer.ts
@@ -161,7 +161,7 @@ function renderNavigation(nav: Navigation): string {
 // Sections
 // ---------------------------------------------------------------------------
 
-function renderSection(section: Section): string {
+export function renderSection(section: Section): string {
   const parts: string[] = [];
 
   if (section.heading !== null) {
@@ -180,7 +180,7 @@ function renderSection(section: Section): string {
 // Content Blocks
 // ---------------------------------------------------------------------------
 
-function renderBlock(block: ContentBlock): string {
+export function renderBlock(block: ContentBlock): string {
   switch (block.type) {
     case 'text':
       return block.value;

--- a/src/lib/docs/scanner.ts
+++ b/src/lib/docs/scanner.ts
@@ -1,0 +1,154 @@
+/**
+ * Corpus scanner for gobbi-docs JSON templates.
+ *
+ * Recursively walks a directory, collects all `.json` files with a valid
+ * `$schema` matching `gobbi-docs/*`, and returns parsed documents alongside
+ * any parse errors encountered.
+ */
+
+import { readdir, stat, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { isDocSchema, type DocType, type GobbiDoc, type DocSchema } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface ScanError {
+  path: string;
+  error: string;
+}
+
+export interface ScannedDoc {
+  path: string;       // absolute path to .json file
+  doc: GobbiDoc;      // parsed and type-narrowed
+  type: DocType;      // extracted from $schema
+}
+
+export interface ScanResult {
+  docs: ScannedDoc[];
+  errors: ScanError[];
+}
+
+// ---------------------------------------------------------------------------
+// Excluded directory names
+// ---------------------------------------------------------------------------
+
+const EXCLUDED_DIRS: ReadonlySet<string> = new Set([
+  'node_modules',
+  'worktrees',
+  'note',
+  'project',
+]);
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+/** Extract `DocType` from a valid `DocSchema` string. */
+function extractDocType(schema: DocSchema): DocType {
+  return schema.slice('gobbi-docs/'.length) as DocType;
+}
+
+/**
+ * Check if an unknown parsed JSON value has a string `$schema` property.
+ * Returns the schema string if present, undefined otherwise.
+ */
+function getSchemaString(value: unknown): string | undefined {
+  if (typeof value !== 'object' || value === null) return undefined;
+  const record = value as Record<string, unknown>;
+  const schema = record['$schema'];
+  if (typeof schema !== 'string') return undefined;
+  return schema;
+}
+
+/**
+ * Recursively walk a directory, collecting `.json` file paths.
+ * Skips directories in the EXCLUDED_DIRS set.
+ */
+async function collectJsonFiles(dir: string): Promise<string[]> {
+  const results: string[] = [];
+  await collectJsonFilesInto(dir, results);
+  return results;
+}
+
+async function collectJsonFilesInto(dir: string, results: string[]): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await readdir(dir, { encoding: 'utf8' });
+  } catch {
+    return;
+  }
+
+  for (const name of entries) {
+    const fullPath = path.join(dir, name);
+
+    let isDir = false;
+    let isFile = false;
+    try {
+      const st = await stat(fullPath);
+      isDir = st.isDirectory();
+      isFile = st.isFile();
+    } catch {
+      continue;
+    }
+
+    if (isDir) {
+      if (!EXCLUDED_DIRS.has(name)) {
+        await collectJsonFilesInto(fullPath, results);
+      }
+    } else if (isFile && name.endsWith('.json')) {
+      results.push(fullPath);
+    }
+  }
+}
+
+/**
+ * Scan a directory for gobbi-docs JSON templates.
+ *
+ * Walks the directory recursively, parses each `.json` file, and checks for
+ * a valid `$schema` field. Files that fail JSON parsing are reported as errors.
+ * Files without a valid gobbi-docs `$schema` are silently skipped.
+ */
+export async function scanCorpus(directory: string): Promise<ScanResult> {
+  const absDir = path.resolve(directory);
+  const jsonFiles = await collectJsonFiles(absDir);
+
+  const docs: ScannedDoc[] = [];
+  const errors: ScanError[] = [];
+
+  for (const filePath of jsonFiles) {
+    let raw: string;
+    try {
+      raw = await readFile(filePath, 'utf8');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      errors.push({ path: filePath, error: `Failed to read file: ${message}` });
+      continue;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw) as unknown;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      errors.push({ path: filePath, error: `JSON parse error: ${message}` });
+      continue;
+    }
+
+    const schemaStr = getSchemaString(parsed);
+    if (schemaStr === undefined || !isDocSchema(schemaStr)) {
+      // Not a gobbi-docs file — silently skip
+      continue;
+    }
+
+    const docType = extractDocType(schemaStr);
+    docs.push({
+      path: filePath,
+      doc: parsed as GobbiDoc,
+      type: docType,
+    });
+  }
+
+  return { docs, errors };
+}

--- a/src/lib/docs/search.ts
+++ b/src/lib/docs/search.ts
@@ -30,6 +30,7 @@ export interface SearchMatch {
 export interface SearchResult {
   matches: SearchMatch[];
   scannedCount: number;
+  error?: string | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -44,9 +45,16 @@ function truncate(text: string): string {
   return text.slice(0, MAX_SNIPPET) + '...';
 }
 
-/** Build a case-insensitive regex from a user-supplied pattern string. */
-function toRegex(pattern: string): RegExp {
-  return new RegExp(pattern, 'i');
+/**
+ * Build a case-insensitive regex from a user-supplied pattern string.
+ * Returns the compiled RegExp, or an Error if the pattern is invalid.
+ */
+function toRegex(pattern: string): RegExp | Error {
+  try {
+    return new RegExp(pattern, 'i');
+  } catch (err) {
+    return err instanceof Error ? err : new Error(String(err));
+  }
 }
 
 /** Test whether a blockType string passes the block filter. */
@@ -236,7 +244,11 @@ export async function searchDocs(
   blockFilter?: string,
 ): Promise<SearchResult> {
   const result = await scanCorpus(directory);
-  const regex = toRegex(pattern);
+  const regexOrError = toRegex(pattern);
+  if (regexOrError instanceof Error) {
+    return { matches: [], scannedCount: 0, error: `Invalid regex pattern: ${regexOrError.message}` };
+  }
+  const regex = regexOrError;
   const matches: SearchMatch[] = [];
   const absDir = path.resolve(directory);
 

--- a/src/lib/docs/search.ts
+++ b/src/lib/docs/search.ts
@@ -1,0 +1,312 @@
+/**
+ * Schema-aware content search across gobbi-docs JSON templates.
+ *
+ * Walks the typed content tree of every scanned document, matching a regex
+ * pattern against text fields, principles, table cells, list items, and
+ * gotcha entry bodies. Supports doc-type and block-type filtering.
+ */
+
+import path from 'node:path';
+import { scanCorpus, type ScannedDoc } from './scanner.js';
+import type {
+  ContentBlock,
+  Section,
+  GotchaEntry,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface SearchMatch {
+  path: string;        // relative to scan directory
+  docType: string;     // DocType
+  section: string;     // section heading or entry title
+  blockType: string;   // ContentBlock type or 'title'/'opening'/'frontmatter'
+  blockIndex: number;  // index within section, -1 for non-block matches
+  match: string;       // matched text snippet (truncated to ~100 chars)
+}
+
+export interface SearchResult {
+  matches: SearchMatch[];
+  scannedCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MAX_SNIPPET = 100;
+
+/** Truncate a string to roughly MAX_SNIPPET characters, adding ellipsis. */
+function truncate(text: string): string {
+  if (text.length <= MAX_SNIPPET) return text;
+  return text.slice(0, MAX_SNIPPET) + '...';
+}
+
+/** Build a case-insensitive regex from a user-supplied pattern string. */
+function toRegex(pattern: string): RegExp {
+  return new RegExp(pattern, 'i');
+}
+
+/** Test whether a blockType string passes the block filter. */
+function blockFilterMatch(blockType: string, filter: string | undefined): boolean {
+  if (filter === undefined) return true;
+  return blockType === filter;
+}
+
+// ---------------------------------------------------------------------------
+// Block text extraction + matching
+// ---------------------------------------------------------------------------
+
+/**
+ * Collect search matches from a single content block.
+ * Recurses into subsections.
+ */
+function searchBlock(
+  block: ContentBlock,
+  blockIndex: number,
+  sectionLabel: string,
+  regex: RegExp,
+  blockFilter: string | undefined,
+  base: Omit<SearchMatch, 'section' | 'blockType' | 'blockIndex' | 'match'>,
+): SearchMatch[] {
+  const matches: SearchMatch[] = [];
+
+  if (!blockFilterMatch(block.type, blockFilter)) {
+    // subsection still needs recursive check even if filter doesn't match the container
+    if (block.type === 'subsection') {
+      for (let i = 0; i < block.content.length; i++) {
+        const child = block.content[i];
+        if (child === undefined) continue;
+        matches.push(
+          ...searchBlock(child, i, block.heading, regex, blockFilter, base),
+        );
+      }
+    }
+    return matches;
+  }
+
+  const push = (text: string): void => {
+    if (regex.test(text)) {
+      matches.push({
+        ...base,
+        section: sectionLabel,
+        blockType: block.type,
+        blockIndex,
+        match: truncate(text),
+      });
+    }
+  };
+
+  switch (block.type) {
+    case 'text':
+      push(block.value);
+      break;
+    case 'principle':
+      push(block.statement);
+      if (block.body !== undefined) {
+        push(block.body);
+      }
+      break;
+    case 'table':
+      push(block.headers.join(' '));
+      for (const row of block.rows) {
+        push(row.join(' '));
+      }
+      break;
+    case 'constraint-list':
+    case 'list':
+      for (const item of block.items) {
+        push(item);
+      }
+      break;
+    case 'subsection':
+      for (let i = 0; i < block.content.length; i++) {
+        const child = block.content[i];
+        if (child === undefined) continue;
+        matches.push(
+          ...searchBlock(child, i, block.heading, regex, blockFilter, base),
+        );
+      }
+      break;
+  }
+
+  return matches;
+}
+
+/**
+ * Search a single section (heading + content blocks).
+ */
+function searchSection(
+  section: Section,
+  regex: RegExp,
+  blockFilter: string | undefined,
+  base: Omit<SearchMatch, 'section' | 'blockType' | 'blockIndex' | 'match'>,
+): SearchMatch[] {
+  const matches: SearchMatch[] = [];
+  const sectionLabel = section.heading ?? '(headingless)';
+
+  // Match against heading itself
+  if (section.heading !== null && blockFilterMatch('title', blockFilter) && regex.test(section.heading)) {
+    matches.push({
+      ...base,
+      section: sectionLabel,
+      blockType: 'title',
+      blockIndex: -1,
+      match: truncate(section.heading),
+    });
+  }
+
+  // Walk content blocks
+  for (let i = 0; i < section.content.length; i++) {
+    const block = section.content[i];
+    if (block === undefined) continue;
+    matches.push(
+      ...searchBlock(block, i, sectionLabel, regex, blockFilter, base),
+    );
+  }
+
+  return matches;
+}
+
+/**
+ * Search a gotcha entry's title and body fields.
+ */
+function searchGotchaEntry(
+  entry: GotchaEntry,
+  regex: RegExp,
+  blockFilter: string | undefined,
+  base: Omit<SearchMatch, 'section' | 'blockType' | 'blockIndex' | 'match'>,
+): SearchMatch[] {
+  const matches: SearchMatch[] = [];
+
+  // Title
+  if (blockFilterMatch('title', blockFilter) && regex.test(entry.title)) {
+    matches.push({
+      ...base,
+      section: entry.title,
+      blockType: 'title',
+      blockIndex: -1,
+      match: truncate(entry.title),
+    });
+  }
+
+  // Body fields — treat as text-like content
+  if (blockFilterMatch('text', blockFilter)) {
+    const bodyFields: readonly string[] = [
+      entry.body.priority,
+      entry.body['what-happened'],
+      entry.body['user-feedback'],
+      entry.body['correct-approach'],
+    ];
+    for (const field of bodyFields) {
+      if (regex.test(field)) {
+        matches.push({
+          ...base,
+          section: entry.title,
+          blockType: 'text',
+          blockIndex: -1,
+          match: truncate(field),
+        });
+      }
+    }
+  }
+
+  return matches;
+}
+
+// ---------------------------------------------------------------------------
+// Main search function
+// ---------------------------------------------------------------------------
+
+/**
+ * Search all gobbi-docs JSON templates in a directory for content matching
+ * a regex pattern.
+ *
+ * @param directory   Root directory to scan
+ * @param pattern     Regex pattern string (case-insensitive)
+ * @param typeFilter  Optional DocType to restrict to (e.g., 'skill', 'gotcha')
+ * @param blockFilter Optional block type to restrict to (e.g., 'text', 'principle', 'frontmatter')
+ */
+export async function searchDocs(
+  directory: string,
+  pattern: string,
+  typeFilter?: string,
+  blockFilter?: string,
+): Promise<SearchResult> {
+  const result = await scanCorpus(directory);
+  const regex = toRegex(pattern);
+  const matches: SearchMatch[] = [];
+  const absDir = path.resolve(directory);
+
+  let docs: ScannedDoc[] = result.docs;
+  if (typeFilter !== undefined) {
+    docs = docs.filter((d) => d.type === typeFilter);
+  }
+
+  for (const scanned of docs) {
+    const relPath = path.relative(absDir, scanned.path);
+    const base = { path: relPath, docType: scanned.type };
+    const doc = scanned.doc;
+
+    // Check title
+    if (blockFilterMatch('title', blockFilter) && regex.test(doc.title)) {
+      matches.push({
+        ...base,
+        section: '(document)',
+        blockType: 'title',
+        blockIndex: -1,
+        match: truncate(doc.title),
+      });
+    }
+
+    // Check opening
+    if (doc.opening !== undefined && blockFilterMatch('opening', blockFilter) && regex.test(doc.opening)) {
+      matches.push({
+        ...base,
+        section: '(document)',
+        blockType: 'opening',
+        blockIndex: -1,
+        match: truncate(doc.opening),
+      });
+    }
+
+    // Check frontmatter (skill, agent, rule docs)
+    if (blockFilterMatch('frontmatter', blockFilter) && 'frontmatter' in doc) {
+      const fm = doc.frontmatter as Record<string, unknown>;
+      for (const val of Object.values(fm)) {
+        if (typeof val === 'string' && regex.test(val)) {
+          matches.push({
+            ...base,
+            section: '(document)',
+            blockType: 'frontmatter',
+            blockIndex: -1,
+            match: truncate(val),
+          });
+        }
+      }
+    }
+
+    // Gotcha entries
+    if (doc.$schema === 'gobbi-docs/gotcha') {
+      for (const entry of doc.entries) {
+        matches.push(
+          ...searchGotchaEntry(entry, regex, blockFilter, base),
+        );
+      }
+    } else {
+      // Regular sections
+      const sections = 'sections' in doc ? doc.sections : undefined;
+      if (sections !== undefined) {
+        for (const section of sections) {
+          matches.push(
+            ...searchSection(section, regex, blockFilter, base),
+          );
+        }
+      }
+    }
+  }
+
+  return { matches, scannedCount: docs.length };
+}

--- a/src/lib/docs/stats.ts
+++ b/src/lib/docs/stats.ts
@@ -28,6 +28,23 @@ export interface CorpusStats {
     maxSections: number;
     avgSections: number;
   };
+  tokens: {
+    total: number;
+    byType: Record<string, number>;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Token estimation
+// ---------------------------------------------------------------------------
+
+/** Rough characters-per-token ratio for estimating token counts. */
+const CHARS_PER_TOKEN = 4;
+
+/** Estimate token count from a JSON-stringified document's character length. */
+function estimateTokens(doc: unknown): number {
+  const chars = JSON.stringify(doc).length;
+  return Math.ceil(chars / CHARS_PER_TOKEN);
 }
 
 // ---------------------------------------------------------------------------
@@ -88,12 +105,22 @@ export async function computeStats(directory: string): Promise<CorpusStats> {
   // Per-doc section counts for distribution calculation
   const sectionCounts: number[] = [];
 
+  // Token estimation accumulators
+  let totalTokens = 0;
+  const tokensByType: Record<string, number> = {};
+
   for (const scanned of docs) {
     const doc = scanned.doc;
 
     // --- By doc type ---
     const typeCount = byType[scanned.type];
     byType[scanned.type] = typeCount !== undefined ? typeCount + 1 : 1;
+
+    // --- Token estimation ---
+    const docTokens = estimateTokens(doc);
+    totalTokens += docTokens;
+    const existingTokens = tokensByType[scanned.type];
+    tokensByType[scanned.type] = existingTokens !== undefined ? existingTokens + docTokens : docTokens;
 
     // --- Navigation presence ---
     if (doc.navigation !== undefined) {
@@ -150,5 +177,6 @@ export async function computeStats(directory: string): Promise<CorpusStats> {
     navigation: { with: navWith, without: navWithout },
     gotchas: { totalEntries: gotchaTotalEntries, byPriority: gotchaByPriority },
     sizeDistribution: { minSections, maxSections, avgSections },
+    tokens: { total: totalTokens, byType: tokensByType },
   };
 }

--- a/src/lib/docs/stats.ts
+++ b/src/lib/docs/stats.ts
@@ -1,0 +1,154 @@
+/**
+ * Corpus statistics aggregator for gobbi-docs JSON templates.
+ *
+ * Scans a directory and computes aggregate counts by doc type, block type,
+ * navigation presence, gotcha priority distribution, and section size
+ * distribution.
+ */
+
+import path from 'node:path';
+import { scanCorpus } from './scanner.js';
+import { isGotchaDoc, hasSections } from './types.js';
+import type { ContentBlock, Section } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface CorpusStats {
+  total: number;
+  byType: Record<string, number>;
+  byBlockType: Record<string, number>;
+  totalSections: number;
+  totalBlocks: number;
+  navigation: { with: number; without: number };
+  gotchas: { totalEntries: number; byPriority: Record<string, number> };
+  sizeDistribution: {
+    minSections: number;
+    maxSections: number;
+    avgSections: number;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Block counting helpers
+// ---------------------------------------------------------------------------
+
+/** Recursively count content blocks by type, including nested subsection blocks. */
+function countBlocks(blocks: ContentBlock[], counts: Record<string, number>): number {
+  let total = 0;
+  for (const block of blocks) {
+    const current = counts[block.type];
+    counts[block.type] = current !== undefined ? current + 1 : 1;
+    total += 1;
+
+    if (block.type === 'subsection') {
+      total += countBlocks(block.content, counts);
+    }
+  }
+  return total;
+}
+
+/** Count total blocks in a sections array and accumulate per-type counts. */
+function countSectionBlocks(
+  sections: Section[],
+  blockCounts: Record<string, number>,
+): number {
+  let total = 0;
+  for (const section of sections) {
+    total += countBlocks(section.content, blockCounts);
+  }
+  return total;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute aggregate statistics for a gobbi-docs corpus.
+ *
+ * Scans the given directory for all gobbi-docs JSON templates and returns
+ * counts broken down by doc type, content block type, navigation presence,
+ * gotcha priorities, and section size distribution.
+ */
+export async function computeStats(directory: string): Promise<CorpusStats> {
+  const absDir = path.resolve(directory);
+  const { docs } = await scanCorpus(absDir);
+
+  const byType: Record<string, number> = {};
+  const byBlockType: Record<string, number> = {};
+  let totalSections = 0;
+  let totalBlocks = 0;
+  let navWith = 0;
+  let navWithout = 0;
+  let gotchaTotalEntries = 0;
+  const gotchaByPriority: Record<string, number> = {};
+
+  // Per-doc section counts for distribution calculation
+  const sectionCounts: number[] = [];
+
+  for (const scanned of docs) {
+    const doc = scanned.doc;
+
+    // --- By doc type ---
+    const typeCount = byType[scanned.type];
+    byType[scanned.type] = typeCount !== undefined ? typeCount + 1 : 1;
+
+    // --- Navigation presence ---
+    if (doc.navigation !== undefined) {
+      navWith += 1;
+    } else {
+      navWithout += 1;
+    }
+
+    // --- Gotcha entries ---
+    if (isGotchaDoc(doc)) {
+      gotchaTotalEntries += doc.entries.length;
+      for (const entry of doc.entries) {
+        const priority = entry.body.priority;
+        const priorityCount = gotchaByPriority[priority];
+        gotchaByPriority[priority] = priorityCount !== undefined ? priorityCount + 1 : 1;
+      }
+    }
+
+    // --- Sections and blocks ---
+    if (hasSections(doc)) {
+      const sections = doc.sections;
+      if (sections !== undefined) {
+        const sectionCount = sections.length;
+        totalSections += sectionCount;
+        sectionCounts.push(sectionCount);
+        totalBlocks += countSectionBlocks(sections, byBlockType);
+      } else {
+        sectionCounts.push(0);
+      }
+    } else if (isGotchaDoc(doc)) {
+      // Gotcha docs have no sections — push 0 for distribution
+      sectionCounts.push(0);
+    }
+  }
+
+  // --- Size distribution ---
+  let minSections = 0;
+  let maxSections = 0;
+  let avgSections = 0;
+
+  if (sectionCounts.length > 0) {
+    minSections = Math.min(...sectionCounts);
+    maxSections = Math.max(...sectionCounts);
+    const sum = sectionCounts.reduce((a, b) => a + b, 0);
+    avgSections = Math.round((sum / sectionCounts.length) * 100) / 100;
+  }
+
+  return {
+    total: docs.length,
+    byType,
+    byBlockType,
+    totalSections,
+    totalBlocks,
+    navigation: { with: navWith, without: navWithout },
+    gotchas: { totalEntries: gotchaTotalEntries, byPriority: gotchaByPriority },
+    sizeDistribution: { minSections, maxSections, avgSections },
+  };
+}

--- a/src/lib/docs/tree.ts
+++ b/src/lib/docs/tree.ts
@@ -1,0 +1,148 @@
+/**
+ * Navigation hierarchy tree builder for gobbi-docs.
+ *
+ * Builds a tree structure from the document graph's navigation edges,
+ * identifies root nodes (no incoming navigation/parent edges), and provides
+ * text formatting with tree connectors.
+ */
+
+import path from 'node:path';
+import type { DocGraph } from './graph.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface TreeNode {
+  name: string;        // filename without extension
+  type: string;        // DocType
+  path: string;        // relative path
+  children: TreeNode[];
+}
+
+export interface TreeResult {
+  roots: TreeNode[];   // top-level nodes (no parent referencing them)
+  flatCount: number;   // total nodes
+}
+
+// ---------------------------------------------------------------------------
+// Tree builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a tree from the document graph.
+ *
+ * Finds root nodes — those with no incoming navigation or parent edges —
+ * and recursively constructs a tree from outgoing navigation edges.
+ * Uses a visited set to handle cycles safely.
+ */
+export function buildTree(graph: DocGraph, scanDir: string): TreeResult {
+  const absScanDir = path.resolve(scanDir);
+
+  // Compute incoming edges per node (navigation edges only go from parent to child;
+  // parent-type edges go from child to parent, so both contribute incoming edges)
+  const hasIncoming = new Set<string>();
+  for (const edge of graph.edges) {
+    if (!edge.resolved) continue;
+    hasIncoming.add(edge.to);
+  }
+
+  // Build a map of outgoing navigation targets per node
+  const navChildren = new Map<string, string[]>();
+  for (const edge of graph.edges) {
+    if (edge.type !== 'navigation' || !edge.resolved) continue;
+    const existing = navChildren.get(edge.from);
+    if (existing !== undefined) {
+      existing.push(edge.to);
+    } else {
+      navChildren.set(edge.from, [edge.to]);
+    }
+  }
+
+  // Root nodes: nodes in the graph that have no resolved incoming edges
+  const rootPaths: string[] = [];
+  for (const nodePath of graph.nodes.keys()) {
+    if (!hasIncoming.has(nodePath)) {
+      rootPaths.push(nodePath);
+    }
+  }
+  rootPaths.sort();
+
+  // Recursive builder with cycle protection
+  let flatCount = 0;
+  const visited = new Set<string>();
+
+  function buildNode(nodePath: string): TreeNode | undefined {
+    if (visited.has(nodePath)) return undefined;
+    visited.add(nodePath);
+    flatCount++;
+
+    const doc = graph.nodes.get(nodePath);
+    const docType = doc !== undefined ? doc.type : 'unknown';
+
+    const children: TreeNode[] = [];
+    const childPaths = navChildren.get(nodePath);
+    if (childPaths !== undefined) {
+      for (const childPath of childPaths) {
+        const childNode = buildNode(childPath);
+        if (childNode !== undefined) {
+          children.push(childNode);
+        }
+      }
+    }
+
+    return {
+      name: path.basename(nodePath, path.extname(nodePath)),
+      type: docType,
+      path: path.relative(absScanDir, nodePath),
+      children,
+    };
+  }
+
+  const roots: TreeNode[] = [];
+  for (const rootPath of rootPaths) {
+    const node = buildNode(rootPath);
+    if (node !== undefined) {
+      roots.push(node);
+    }
+  }
+
+  return { roots, flatCount };
+}
+
+// ---------------------------------------------------------------------------
+// Text formatter
+// ---------------------------------------------------------------------------
+
+/**
+ * Format tree nodes as indented text with tree connectors.
+ *
+ * Uses `├──` and `└──` connectors like the `tree` command.
+ * Each line shows `name (type)`.
+ */
+export function formatTreeText(roots: TreeNode[], indent?: string): string {
+  const lines: string[] = [];
+  const prefix = indent ?? '';
+
+  function formatNode(node: TreeNode, linePrefix: string, isLast: boolean): void {
+    const connector = isLast ? '└── ' : '├── ';
+    lines.push(`${linePrefix}${connector}${node.name} (${node.type})`);
+
+    const childPrefix = linePrefix + (isLast ? '    ' : '│   ');
+    for (let i = 0; i < node.children.length; i++) {
+      const child = node.children[i];
+      if (child !== undefined) {
+        formatNode(child, childPrefix, i === node.children.length - 1);
+      }
+    }
+  }
+
+  for (let i = 0; i < roots.length; i++) {
+    const root = roots[i];
+    if (root !== undefined) {
+      formatNode(root, prefix, i === roots.length - 1);
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/src/lib/docs/tree.ts
+++ b/src/lib/docs/tree.ts
@@ -21,8 +21,9 @@ export interface TreeNode {
 }
 
 export interface TreeResult {
-  roots: TreeNode[];   // top-level nodes (no parent referencing them)
-  flatCount: number;   // total nodes
+  roots: TreeNode[];     // legitimate top-level entry points
+  orphans: TreeNode[];   // nodes with no incoming edges that are not entry points
+  flatCount: number;     // total nodes
 }
 
 // ---------------------------------------------------------------------------
@@ -59,14 +60,21 @@ export function buildTree(graph: DocGraph, scanDir: string): TreeResult {
     }
   }
 
-  // Root nodes: nodes in the graph that have no resolved incoming edges
+  // Separate legitimate roots from orphans using the graph's orphan list
+  const orphanSet = new Set(graph.orphans);
   const rootPaths: string[] = [];
+  const orphanPaths: string[] = [];
   for (const nodePath of graph.nodes.keys()) {
     if (!hasIncoming.has(nodePath)) {
-      rootPaths.push(nodePath);
+      if (orphanSet.has(nodePath)) {
+        orphanPaths.push(nodePath);
+      } else {
+        rootPaths.push(nodePath);
+      }
     }
   }
   rootPaths.sort();
+  orphanPaths.sort();
 
   // Recursive builder with cycle protection
   let flatCount = 0;
@@ -107,7 +115,15 @@ export function buildTree(graph: DocGraph, scanDir: string): TreeResult {
     }
   }
 
-  return { roots, flatCount };
+  const orphanNodes: TreeNode[] = [];
+  for (const orphanPath of orphanPaths) {
+    const node = buildNode(orphanPath);
+    if (node !== undefined) {
+      orphanNodes.push(node);
+    }
+  }
+
+  return { roots, orphans: orphanNodes, flatCount };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/repo.ts
+++ b/src/lib/repo.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared repository root utilities.
+ *
+ * Memoized git repo detection used by audit, docs, and other commands.
+ */
+
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+
+let cachedRoot: string | undefined;
+
+/** Detect git repo root via git rev-parse. Falls back to cwd on failure. Memoized. */
+export function getRepoRoot(): string {
+  if (cachedRoot !== undefined) return cachedRoot;
+  try {
+    cachedRoot = execSync('git rev-parse --show-toplevel', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+  } catch {
+    cachedRoot = process.cwd();
+  }
+  return cachedRoot;
+}
+
+/** Return the `.claude` directory path within the repo root. */
+export function getClaudeDir(): string {
+  return path.join(getRepoRoot(), '.claude');
+}

--- a/src/lib/style.ts
+++ b/src/lib/style.ts
@@ -205,3 +205,62 @@ export function printUpdateSuccess(): void {
   console.log('');
   console.log('Content updated in .claude/');
 }
+
+// ---------------------------------------------------------------------------
+// Table formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Format tabular data as aligned plain-text columns.
+ *
+ * Calculates max width per column from headers and data, pads each cell,
+ * and separates columns with double spaces. A dashed separator line appears
+ * below the header row.
+ */
+export function formatTable(headers: string[], rows: string[][]): string {
+  // Calculate column widths from headers and all data rows
+  const colWidths: number[] = headers.map((h) => h.length);
+  for (const row of rows) {
+    for (let i = 0; i < headers.length; i++) {
+      const cell = row[i];
+      if (cell !== undefined) {
+        const current = colWidths[i];
+        if (current !== undefined && cell.length > current) {
+          colWidths[i] = cell.length;
+        }
+      }
+    }
+  }
+
+  const sep = '  ';
+
+  function padRow(cells: string[]): string {
+    const parts: string[] = [];
+    for (let i = 0; i < headers.length; i++) {
+      const cell = cells[i] ?? '';
+      const width = colWidths[i] ?? 0;
+      parts.push(cell.padEnd(width));
+    }
+    return parts.join(sep).trimEnd();
+  }
+
+  const lines: string[] = [];
+
+  // Header row
+  lines.push(padRow(headers));
+
+  // Separator line
+  const dashes: string[] = [];
+  for (let i = 0; i < headers.length; i++) {
+    const width = colWidths[i] ?? 0;
+    dashes.push('-'.repeat(width));
+  }
+  lines.push(dashes.join(sep));
+
+  // Data rows
+  for (const row of rows) {
+    lines.push(padRow(row));
+  }
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary

- Add 6 new `gobbi docs` subcommands for agent-facing documentation utilities: `list`, `tree`, `search`, `extract`, `stats`, `health`
- Create shared infrastructure: corpus scanner (`scanner.ts`), navigation graph builder (`graph.ts`), shared `getRepoRoot()` utility (`repo.ts`)
- Add `formatTable()` utility to `style.ts` and export `renderSection`/`renderBlock` from `renderer.ts`
- Fix .md → .json navigation resolution in graph builder

## Test plan

- [ ] `npx gobbi docs list .claude/` — lists 87+ docs with type/title in table format
- [ ] `npx gobbi docs list --format json .claude/` — parseable JSON array
- [ ] `npx gobbi docs tree .claude/` — shows navigation hierarchy with connectors
- [ ] `npx gobbi docs search "evaluation" --type skill .claude/` — finds matches in skill docs
- [ ] `npx gobbi docs search "Never" --block principle .claude/` — finds principle blocks only
- [ ] `npx gobbi docs extract .claude/skills/_plan/SKILL.json frontmatter` — returns frontmatter JSON
- [ ] `npx gobbi docs extract .claude/skills/_plan/SKILL.json "sections.Core Principle" --format md` — renders section as markdown
- [ ] `npx gobbi docs stats .claude/` — shows corpus statistics
- [ ] `npx gobbi docs stats --format json .claude/` — parseable JSON
- [ ] `npx gobbi docs health .claude/` — reports findings (0 errors expected)
- [ ] `npx gobbi docs health --format json .claude/` — parseable JSON report
- [ ] `npx tsc --noEmit` — zero type errors

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)