### PR TITLE
feat: gobbi doctor --plan/--fix remediation layer

### DIFF
--- a/.claude/skills/_doctor/SKILL.json
+++ b/.claude/skills/_doctor/SKILL.json
@@ -61,7 +61,7 @@
             [
               "JSON/MD sync",
               "Pairs where the `.json` source and `.md` output have drifted — the `.md` was edited directly or `json2md` was not re-run after a JSON change",
-              "New: mtime comparison between `.json` and `.md` pairs"
+              "Content-based comparison: renders JSON via `renderDoc` and compares with existing `.md`"
             ],
             [
               "Completeness scoring",
@@ -274,12 +274,114 @@
             [
               "`gobbi doctor --format json`",
               "Structured JSON output for programmatic consumption"
+            ],
+            [
+              "`gobbi doctor --plan`",
+              "Terraform-plan-style preview of remediations — shows auto-fixable, suggested, and skipped counts without changing anything"
+            ],
+            [
+              "`gobbi doctor --fix`",
+              "Auto-apply deterministic fixes, then re-run doctor to show new state"
             ]
           ]
         },
         {
           "type": "text",
-          "value": "JSON output schema: `{ status: \"clean\" | \"attention-needed\" | \"degraded\", maturityLevel: 0-4, findings: Finding[], completeness: { score, missing }, summary: string }`. Exit code 0 for `clean` or `attention-needed`, exit code 1 for `degraded` (errors present). The `gobbi audit` command remains as a deprecated alias that prints a deprecation warning and forwards to `gobbi doctor`."
+          "value": "JSON output schema: `{ status: \"clean\" | \"attention-needed\" | \"degraded\", maturityLevel: 0-4, findings: Finding[], completeness: { score, missing }, summary: string }`. The `gobbi audit` command remains as a deprecated alias that prints a deprecation warning and forwards to `gobbi doctor`."
+        }
+      ]
+    },
+    {
+      "heading": "Remediation Layer (--plan / --fix)",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "Show what would change before changing anything.",
+          "body": "The `--plan` flag previews all remediations without modifying the filesystem. This gives the user (and CI) a clear picture of what `--fix` will do. Run `--plan` first, review the output, then run `--fix` to apply."
+        },
+        {
+          "type": "subsection",
+          "heading": "Auto-Fixable Categories",
+          "content": [
+            {
+              "type": "text",
+              "value": "These categories have deterministic fixes that `--fix` applies automatically:"
+            },
+            {
+              "type": "table",
+              "headers": [
+                "Category",
+                "Fix strategy",
+                "What it does"
+              ],
+              "rows": [
+                [
+                  "`sync-out-of-date`",
+                  "json2md",
+                  "Re-generates the `.md` file from its `.json` source to bring the pair back in sync"
+                ],
+                [
+                  "`bidirectional-consistency`",
+                  "add-nav-entry",
+                  "Adds missing navigation entries so child docs are reachable from their parent"
+                ],
+                [
+                  "`naming-mismatch`",
+                  "rename-frontmatter",
+                  "Updates the frontmatter `name` field to match the directory or filename convention"
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Suggested Categories",
+          "content": [
+            {
+              "type": "text",
+              "value": "These categories appear in `--plan` output as suggestions but are not auto-fixed — they require human judgment:"
+            },
+            {
+              "type": "list",
+              "style": "bullet",
+              "items": [
+                "`stale-reference` — a backtick-quoted path or markdown link points to a file that no longer exists. The fix depends on whether the file was moved, renamed, or intentionally deleted.",
+                "`stale-directory-claim` — a doc claims a directory contains certain items but the directory contents have changed. Requires understanding the intended scope before updating."
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Exit Codes",
+          "content": [
+            {
+              "type": "table",
+              "headers": [
+                "Exit code",
+                "Meaning",
+                "When"
+              ],
+              "rows": [
+                [
+                  "0",
+                  "Clean or attention-needed",
+                  "`gobbi doctor` — no errors (warnings OK). `gobbi doctor --fix` — all issues resolved after fix. `gobbi doctor --plan` — nothing auto-fixable."
+                ],
+                [
+                  "1",
+                  "Degraded",
+                  "`gobbi doctor` — errors present. `gobbi doctor --fix` — still degraded after applying fixes (non-auto-fixable errors remain)."
+                ],
+                [
+                  "2",
+                  "Has auto-fixes available",
+                  "`gobbi doctor --plan` only — auto-fixable items exist. Intended as a CI signal: exit code 2 means `--fix` can improve the state."
+                ]
+              ]
+            }
+          ]
         }
       ]
     }

--- a/.claude/skills/_doctor/SKILL.md
+++ b/.claude/skills/_doctor/SKILL.md
@@ -37,7 +37,7 @@ Doctor consolidates six categories of checks into a single unified report. All c
 | File existence and broken references | Backtick-quoted paths and markdown links pointing to files or directories that do not exist on disk | From `gobbi audit references/conventions/commands` |
 | Structural health | Orphan docs (not reachable from navigation), missing navigation entries, empty sections with no content | From `gobbi docs health` |
 | Schema validation | JSON source files that do not conform to the gobbi-docs schema — missing required fields, invalid block types, malformed structure | From `gobbi docs validate` |
-| JSON/MD sync | Pairs where the `.json` source and `.md` output have drifted — the `.md` was edited directly or `json2md` was not re-run after a JSON change | New: mtime comparison between `.json` and `.md` pairs |
+| JSON/MD sync | Pairs where the `.json` source and `.md` output have drifted — the `.md` was edited directly or `json2md` was not re-run after a JSON change | Content-based comparison: renders JSON via `renderDoc` and compares with existing `.md` |
 | Completeness scoring | Inventory of what documentation exists versus a healthy baseline — missing CLAUDE.md, missing rules, missing project directory | New |
 | Maturity level (0-4) | Progressive assessment of documentation adoption from Level 0 (no `.claude/` directory) to Level 4 (fully JSON-first with zero issues) | New |
 
@@ -127,5 +127,40 @@ Doctor is invoked as a single unified command. Internally it calls `checkHealth(
 |---|---|
 | `gobbi doctor` | Run unified health check with human-readable text output |
 | `gobbi doctor --format json` | Structured JSON output for programmatic consumption |
+| `gobbi doctor --plan` | Terraform-plan-style preview of remediations — shows auto-fixable, suggested, and skipped counts without changing anything |
+| `gobbi doctor --fix` | Auto-apply deterministic fixes, then re-run doctor to show new state |
 
-JSON output schema: `{ status: "clean" | "attention-needed" | "degraded", maturityLevel: 0-4, findings: Finding[], completeness: { score, missing }, summary: string }`. Exit code 0 for `clean` or `attention-needed`, exit code 1 for `degraded` (errors present). The `gobbi audit` command remains as a deprecated alias that prints a deprecation warning and forwards to `gobbi doctor`.
+JSON output schema: `{ status: "clean" | "attention-needed" | "degraded", maturityLevel: 0-4, findings: Finding[], completeness: { score, missing }, summary: string }`. The `gobbi audit` command remains as a deprecated alias that prints a deprecation warning and forwards to `gobbi doctor`.
+
+---
+
+## Remediation Layer (--plan / --fix)
+
+> **Show what would change before changing anything.**
+
+The `--plan` flag previews all remediations without modifying the filesystem. This gives the user (and CI) a clear picture of what `--fix` will do. Run `--plan` first, review the output, then run `--fix` to apply.
+
+### Auto-Fixable Categories
+
+These categories have deterministic fixes that `--fix` applies automatically:
+
+| Category | Fix strategy | What it does |
+|---|---|---|
+| `sync-out-of-date` | json2md | Re-generates the `.md` file from its `.json` source to bring the pair back in sync |
+| `bidirectional-consistency` | add-nav-entry | Adds missing navigation entries so child docs are reachable from their parent |
+| `naming-mismatch` | rename-frontmatter | Updates the frontmatter `name` field to match the directory or filename convention |
+
+### Suggested Categories
+
+These categories appear in `--plan` output as suggestions but are not auto-fixed — they require human judgment:
+
+- `stale-reference` — a backtick-quoted path or markdown link points to a file that no longer exists. The fix depends on whether the file was moved, renamed, or intentionally deleted.
+- `stale-directory-claim` — a doc claims a directory contains certain items but the directory contents have changed. Requires understanding the intended scope before updating.
+
+### Exit Codes
+
+| Exit code | Meaning | When |
+|---|---|---|
+| 0 | Clean or attention-needed | `gobbi doctor` — no errors (warnings OK). `gobbi doctor --fix` — all issues resolved after fix. `gobbi doctor --plan` — nothing auto-fixable. |
+| 1 | Degraded | `gobbi doctor` — errors present. `gobbi doctor --fix` — still degraded after applying fixes (non-auto-fixable errors remain). |
+| 2 | Has auto-fixes available | `gobbi doctor --plan` only — auto-fixable items exist. Intended as a CI signal: exit code 2 means `--fix` can improve the state. |

--- a/.claude/skills/gobbi/cli-setup.json
+++ b/.claude/skills/gobbi/cli-setup.json
@@ -163,6 +163,14 @@
               "Unified health check for .claude/ documentation"
             ],
             [
+              "`gobbi doctor --plan`",
+              "Preview remediations without changing anything (exit code 2 if auto-fixable items exist)"
+            ],
+            [
+              "`gobbi doctor --fix`",
+              "Auto-apply deterministic fixes and re-run doctor to show new state"
+            ],
+            [
               "`gobbi audit`",
               "Deprecated alias for `gobbi doctor`"
             ]

--- a/.claude/skills/gobbi/cli-setup.md
+++ b/.claude/skills/gobbi/cli-setup.md
@@ -91,6 +91,8 @@ The gobbi CLI replaces the shell scripts that were previously in `.claude/skills
 | `gobbi notify <event>` | Send notifications (used by hooks) |
 | `gobbi validate <type> <path>` | Validate agent, skill, or gotcha definitions |
 | `gobbi doctor` | Unified health check for .claude/ documentation |
+| `gobbi doctor --plan` | Preview remediations without changing anything (exit code 2 if auto-fixable items exist) |
+| `gobbi doctor --fix` | Auto-apply deterministic fixes and re-run doctor to show new state |
 | `gobbi audit` | Deprecated alias for `gobbi doctor` |
 
 ---

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "tsc && node --test dist/test/doctor.test.js"
+    "test": "tsc && node --test dist/test/doctor.test.js dist/test/remediation.test.js"
   },
   "dependencies": {
     "proper-lockfile": "^4.1.2"

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -6,7 +6,18 @@
  */
 
 import { parseArgs } from 'node:util';
-import { runDoctorCheck, MATURITY_LABELS, type DoctorReport } from '../lib/docs/doctor.js';
+import {
+  runDoctorCheck,
+  runDoctorPlan,
+  runDoctorFix,
+  MATURITY_LABELS,
+  type DoctorReport,
+  type DoctorPlanResult,
+  type DoctorFixResult,
+  type RemediationPlan,
+  type Remediation,
+  type RemediationResult,
+} from '../lib/docs/doctor.js';
 import { getRepoRoot } from '../lib/repo.js';
 import { header, ok, error, yellow, dim, bold } from '../lib/style.js';
 
@@ -20,6 +31,8 @@ Run unified health checks on .claude/ documentation.
 
 Options:
   --format <fmt>   Output format: text (default), json
+  --plan           Show what would be fixed (terraform plan style)
+  --fix            Auto-apply safe fixes, then re-run doctor
   --help           Show this help message`;
 
 // ---------------------------------------------------------------------------
@@ -90,6 +103,73 @@ function printTextReport(report: DoctorReport): void {
 }
 
 // ---------------------------------------------------------------------------
+// Plan report printer
+// ---------------------------------------------------------------------------
+
+function printPlanReport(result: DoctorPlanResult): void {
+  // Print standard report first
+  printTextReport(result.report);
+
+  const { plan } = result;
+
+  console.log(bold('  Remediation Plan'));
+  console.log('');
+
+  if (plan.auto.length > 0) {
+    console.log(dim('  Auto-fixable (run gobbi doctor --fix to apply):'));
+    for (const rem of plan.auto) {
+      const symbol = rem.action === 'add-nav-entry' ? '+' : '~';
+      console.log(`    ${symbol} ${rem.action} ${rem.description}`);
+    }
+    console.log('');
+  }
+
+  if (plan.suggested.length > 0) {
+    console.log(dim('  Suggested (review manually):'));
+    for (const rem of plan.suggested) {
+      console.log(dim(`    ? ${rem.finding.path}: ${rem.description}`));
+    }
+    console.log('');
+  }
+
+  console.log(dim(`  ${plan.auto.length} auto-fixable, ${plan.suggested.length} suggested, ${plan.skipped.length} skipped`));
+  console.log('');
+}
+
+// ---------------------------------------------------------------------------
+// Fix report printer
+// ---------------------------------------------------------------------------
+
+function printFixReport(result: DoctorFixResult): void {
+  console.log(header('Doctor'));
+  console.log('');
+
+  if (result.results.length === 0) {
+    console.log('  No auto-fixable issues found.');
+    console.log('');
+  } else {
+    const succeeded = result.results.filter((r) => r.success).length;
+    const failed = result.results.length - succeeded;
+    console.log(`  Applied ${succeeded} fix${succeeded !== 1 ? 'es' : ''}${failed > 0 ? `, ${failed} failed` : ''}:`);
+
+    for (const r of result.results) {
+      if (r.success) {
+        console.log(ok(`  ${r.remediation.action} ${r.remediation.description}`));
+      } else {
+        console.log(error(`  ${r.remediation.action} ${r.remediation.description} — ${r.error ?? 'Unknown error'}`));
+      }
+    }
+    console.log('');
+  }
+
+  console.log(dim('  Re-running doctor...'));
+  console.log('');
+
+  // Print the after-fix report
+  printTextReport(result.afterReport);
+}
+
+// ---------------------------------------------------------------------------
 // Entry point
 // ---------------------------------------------------------------------------
 
@@ -100,6 +180,8 @@ export async function runDoctor(args: string[]): Promise<void> {
     strict: false,
     options: {
       'format': { type: 'string' },
+      'plan': { type: 'boolean', default: false },
+      'fix': { type: 'boolean', default: false },
       'help': { type: 'boolean', default: false },
     },
   });
@@ -109,10 +191,53 @@ export async function runDoctor(args: string[]): Promise<void> {
     return;
   }
 
-  const repoRoot = getRepoRoot();
-  const report = await runDoctorCheck(repoRoot);
+  // Mutual exclusion
+  if (values.plan === true && values.fix === true) {
+    console.log(error('--plan and --fix are mutually exclusive'));
+    process.exit(1);
+  }
 
+  const repoRoot = getRepoRoot();
   const fmt = typeof values.format === 'string' ? values.format : 'text';
+
+  // --plan mode
+  if (values.plan === true) {
+    const result = await runDoctorPlan(repoRoot);
+
+    if (fmt === 'json') {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      printPlanReport(result);
+    }
+
+    // Exit 2 if auto-fixable items exist (CI signal)
+    if (result.plan.auto.length > 0) {
+      process.exit(2);
+    }
+    if (result.report.status === 'degraded') {
+      process.exit(1);
+    }
+    return;
+  }
+
+  // --fix mode
+  if (values.fix === true) {
+    const result = await runDoctorFix(repoRoot);
+
+    if (fmt === 'json') {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      printFixReport(result);
+    }
+
+    if (result.afterReport.status === 'degraded') {
+      process.exit(1);
+    }
+    return;
+  }
+
+  // Default mode (no flags)
+  const report = await runDoctorCheck(repoRoot);
 
   if (fmt === 'json') {
     console.log(JSON.stringify(report, null, 2));

--- a/packages/cli/src/lib/docs/audit.ts
+++ b/packages/cli/src/lib/docs/audit.ts
@@ -294,13 +294,16 @@ export async function auditConventions(opts: AuditOptions): Promise<Finding[]> {
 
     const fmName = extractFrontmatterName(lines);
     if (fmName !== null && fmName !== dirName) {
+      const jsonPath = path.join(skillDir, 'SKILL.json');
+      const hasJsonPeer = existsSync(jsonPath);
       findings.push({
         path: relativePath,
         severity: 'warning',
         category: 'naming-mismatch',
         message: `line 1: frontmatter name '${fmName}' != directory name '${dirName}'`,
         suggestion: 'Update the frontmatter name to match the directory name',
-        fixable: 'auto',
+        fixable: hasJsonPeer ? 'auto' : 'suggested',
+        context: hasJsonPeer ? { jsonPath, dirName } : undefined,
       });
     }
   }

--- a/packages/cli/src/lib/docs/doctor.ts
+++ b/packages/cli/src/lib/docs/doctor.ts
@@ -16,6 +16,9 @@ import { checkHealth, SEVERITY_ORDER } from './health.js';
 import { auditReferences, auditConventions, auditCommands } from './audit.js';
 import { scanCorpus } from './scanner.js';
 import { validateDoc } from './validator.js';
+import { computeRemediations, applyRemediations, type RemediationPlan, type RemediationResult } from './remediation.js';
+
+export type { RemediationPlan, RemediationResult, Remediation, RemediationAction } from './remediation.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -613,6 +616,7 @@ export async function runDoctorCheck(repoRoot: string): Promise<DoctorReport> {
         message: 'JSON and Markdown are out of sync',
         suggestion: 'Run gobbi docs json2md to regenerate the Markdown file',
         fixable: 'auto',
+        context: { jsonPath: scannedDoc.path },
       });
     }
   }
@@ -644,4 +648,50 @@ export async function runDoctorCheck(repoRoot: string): Promise<DoctorReport> {
     completeness,
     summary,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Plan / Fix result types
+// ---------------------------------------------------------------------------
+
+export interface DoctorPlanResult {
+  report: DoctorReport;
+  plan: RemediationPlan;
+}
+
+export interface DoctorFixResult {
+  beforeReport: DoctorReport;
+  results: RemediationResult[];
+  afterReport: DoctorReport;
+}
+
+// ---------------------------------------------------------------------------
+// runDoctorPlan
+// ---------------------------------------------------------------------------
+
+/**
+ * Run doctor checks and compute a remediation plan without applying fixes.
+ * Used by `gobbi doctor --plan`.
+ */
+export async function runDoctorPlan(repoRoot: string): Promise<DoctorPlanResult> {
+  const report = await runDoctorCheck(repoRoot);
+  const plan = computeRemediations(report.findings);
+  return { report, plan };
+}
+
+// ---------------------------------------------------------------------------
+// runDoctorFix
+// ---------------------------------------------------------------------------
+
+/**
+ * Run doctor checks, apply auto-fixable remediations, then re-run doctor.
+ * The double-run mirrors ESLint --fix: apply fixes, then show new state.
+ * Used by `gobbi doctor --fix`.
+ */
+export async function runDoctorFix(repoRoot: string): Promise<DoctorFixResult> {
+  const beforeReport = await runDoctorCheck(repoRoot);
+  const plan = computeRemediations(beforeReport.findings);
+  const results = await applyRemediations(plan);
+  const afterReport = await runDoctorCheck(repoRoot);
+  return { beforeReport, results, afterReport };
 }

--- a/packages/cli/src/lib/docs/health.ts
+++ b/packages/cli/src/lib/docs/health.ts
@@ -24,6 +24,7 @@ export interface Finding {
   message: string;
   suggestion: string;
   fixable?: Fixability | undefined;  // Phase 2 prep: how this finding can be remediated
+  context?: Record<string, string> | undefined;
 }
 
 export interface HealthReport {
@@ -212,6 +213,12 @@ function checkBidirectionalConsistency(
         category: 'bidirectional-consistency',
         message: `${path.relative(scanDir, childPath)} claims parent '${path.relative(scanDir, parentPath)}' but parent's navigation does not reference it`,
         suggestion: 'Add a navigation entry in the parent document pointing back to this child',
+        fixable: 'auto',
+        context: {
+          parentJsonPath: parentPath,
+          childTitle: graph.nodes.get(childPath)?.doc.title ?? path.basename(childPath, '.json'),
+          childNavKey: path.relative(scanDir, childPath).replace(/\.json$/, '.md'),
+        },
       });
     }
   }

--- a/packages/cli/src/lib/docs/remediation.ts
+++ b/packages/cli/src/lib/docs/remediation.ts
@@ -1,0 +1,327 @@
+/**
+ * Remediation library for gobbi doctor --plan / --fix.
+ *
+ * Computes available remediations from health/audit findings and applies
+ * auto-fixable ones. Pure computation in `computeRemediations`, side-effects
+ * isolated to `applyRemediation` and `applyRemediations`. No console output.
+ */
+
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { Finding } from './health.js';
+import type { GobbiDoc } from './types.js';
+import { renderDoc } from './renderer.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type RemediationAction = 'json2md' | 'add-nav-entry' | 'rename-frontmatter' | 'review';
+
+export interface Remediation {
+  action: RemediationAction;
+  finding: Finding;
+  description: string;
+  targetPath: string;
+}
+
+export interface RemediationResult {
+  remediation: Remediation;
+  success: boolean;
+  error?: string | undefined;
+}
+
+export interface RemediationPlan {
+  auto: Remediation[];
+  suggested: Remediation[];
+  skipped: Finding[];
+}
+
+// ---------------------------------------------------------------------------
+// Context extraction helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Safely extract a context value from a finding, returning undefined when the
+ * key is absent or the context object itself is undefined.
+ */
+function ctx(finding: Finding, key: string): string | undefined {
+  if (finding.context === undefined) return undefined;
+  return finding.context[key];
+}
+
+// ---------------------------------------------------------------------------
+// computeRemediations — pure function
+// ---------------------------------------------------------------------------
+
+/**
+ * Route findings into auto-fixable, suggested, or skipped buckets.
+ *
+ * Auto-fixable findings must have all required context fields present;
+ * those missing context are demoted to skipped.
+ */
+export function computeRemediations(findings: Finding[]): RemediationPlan {
+  const auto: Remediation[] = [];
+  const suggested: Remediation[] = [];
+  const skipped: Finding[] = [];
+
+  for (const finding of findings) {
+    if (finding.fixable === 'auto') {
+      const remediation = buildAutoRemediation(finding);
+      if (remediation !== undefined) {
+        auto.push(remediation);
+      } else {
+        // Auto finding but missing required context — demote to skipped
+        skipped.push(finding);
+      }
+    } else if (finding.fixable === 'suggested') {
+      suggested.push({
+        action: 'review',
+        finding,
+        description: finding.suggestion,
+        targetPath: finding.path,
+      });
+    } else {
+      skipped.push(finding);
+    }
+  }
+
+  return { auto, suggested, skipped };
+}
+
+/**
+ * Build an auto remediation from a finding, or return undefined if the
+ * required context fields are missing.
+ */
+function buildAutoRemediation(finding: Finding): Remediation | undefined {
+  if (finding.category === 'sync-out-of-date') {
+    const jsonPath = ctx(finding, 'jsonPath');
+    if (jsonPath === undefined) return undefined;
+
+    const jsonBasename = path.basename(jsonPath);
+    const mdBasename = path.basename(jsonPath, '.json') + '.md';
+    return {
+      action: 'json2md',
+      finding,
+      description: `Regenerate ${mdBasename} from ${jsonBasename}`,
+      targetPath: jsonPath.replace(/\.json$/, '.md'),
+    };
+  }
+
+  if (finding.category === 'bidirectional-consistency') {
+    const parentJsonPath = ctx(finding, 'parentJsonPath');
+    const childTitle = ctx(finding, 'childTitle');
+    const childNavKey = ctx(finding, 'childNavKey');
+    if (parentJsonPath === undefined || childTitle === undefined || childNavKey === undefined) {
+      return undefined;
+    }
+
+    const parentBasename = path.basename(parentJsonPath);
+    return {
+      action: 'add-nav-entry',
+      finding,
+      description: `Add navigation entry for ${childNavKey} to ${parentBasename}`,
+      targetPath: parentJsonPath,
+    };
+  }
+
+  if (finding.category === 'naming-mismatch') {
+    const jsonPath = ctx(finding, 'jsonPath');
+    const dirName = ctx(finding, 'dirName');
+    if (jsonPath === undefined || dirName === undefined) return undefined;
+
+    const jsonBasename = path.basename(jsonPath);
+    return {
+      action: 'rename-frontmatter',
+      finding,
+      description: `Update frontmatter name to '${dirName}' in ${jsonBasename}`,
+      targetPath: jsonPath,
+    };
+  }
+
+  // Auto finding with unrecognized category — cannot build remediation
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// applyRemediation — single fix
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply a single auto-fix remediation. Returns success/failure with error
+ * detail on failure.
+ */
+export async function applyRemediation(remediation: Remediation): Promise<RemediationResult> {
+  try {
+    switch (remediation.action) {
+      case 'json2md':
+        return await applyJson2Md(remediation);
+      case 'add-nav-entry':
+        return await applyAddNavEntry(remediation);
+      case 'rename-frontmatter':
+        return await applyRenameFrontmatter(remediation);
+      case 'review':
+        return { remediation, success: false, error: 'Review actions cannot be applied automatically' };
+    }
+  } catch (err) {
+    return { remediation, success: false, error: String(err) };
+  }
+}
+
+async function applyJson2Md(remediation: Remediation): Promise<RemediationResult> {
+  const jsonPath = ctx(remediation.finding, 'jsonPath');
+  if (jsonPath === undefined) {
+    return { remediation, success: false, error: 'Missing context.jsonPath' };
+  }
+
+  const content = await readFile(jsonPath, 'utf8');
+  const doc = JSON.parse(content) as GobbiDoc;
+  const markdown = renderDoc(doc, jsonPath);
+  const mdPath = jsonPath.replace(/\.json$/, '.md');
+  await writeFile(mdPath, markdown, 'utf8');
+
+  return { remediation, success: true };
+}
+
+async function applyAddNavEntry(remediation: Remediation): Promise<RemediationResult> {
+  const parentJsonPath = ctx(remediation.finding, 'parentJsonPath');
+  const childNavKey = ctx(remediation.finding, 'childNavKey');
+  const childTitle = ctx(remediation.finding, 'childTitle');
+  if (parentJsonPath === undefined || childNavKey === undefined || childTitle === undefined) {
+    return { remediation, success: false, error: 'Missing required context fields' };
+  }
+
+  const content = await readFile(parentJsonPath, 'utf8');
+  const doc = JSON.parse(content) as GobbiDoc;
+
+  // Add navigation entry (skip if already present for idempotency)
+  if (!Object.hasOwn(doc.navigation, childNavKey)) {
+    doc.navigation[childNavKey] = childTitle;
+  }
+
+  // Write updated JSON
+  await writeFile(parentJsonPath, JSON.stringify(doc, null, 2) + '\n', 'utf8');
+
+  // Regenerate .md
+  const markdown = renderDoc(doc, parentJsonPath);
+  const mdPath = parentJsonPath.replace(/\.json$/, '.md');
+  await writeFile(mdPath, markdown, 'utf8');
+
+  return { remediation, success: true };
+}
+
+async function applyRenameFrontmatter(remediation: Remediation): Promise<RemediationResult> {
+  const jsonPath = ctx(remediation.finding, 'jsonPath');
+  const dirName = ctx(remediation.finding, 'dirName');
+  if (jsonPath === undefined || dirName === undefined) {
+    return { remediation, success: false, error: 'Missing required context fields' };
+  }
+
+  const content = await readFile(jsonPath, 'utf8');
+  const doc = JSON.parse(content) as GobbiDoc;
+
+  // Update frontmatter name — naming-mismatch findings target skill docs
+  if (doc.$schema === 'gobbi-docs/skill' || doc.$schema === 'gobbi-docs/agent') {
+    doc.frontmatter.name = dirName;
+  }
+
+  // Write updated JSON
+  await writeFile(jsonPath, JSON.stringify(doc, null, 2) + '\n', 'utf8');
+
+  // Regenerate .md
+  const markdown = renderDoc(doc, jsonPath);
+  const mdPath = jsonPath.replace(/\.json$/, '.md');
+  await writeFile(mdPath, markdown, 'utf8');
+
+  return { remediation, success: true };
+}
+
+// ---------------------------------------------------------------------------
+// applyRemediations — batch with write coalescing
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply all auto remediations from a plan. Coalesces multiple `add-nav-entry`
+ * actions targeting the same parent JSON file into a single read/write cycle.
+ * Deduplicates `json2md` fixes for files that already get structural fixes
+ * (add-nav-entry and rename-frontmatter both regenerate the .md).
+ */
+export async function applyRemediations(plan: RemediationPlan): Promise<RemediationResult[]> {
+  const results: RemediationResult[] = [];
+
+  // Group add-nav-entry by targetPath for coalescing
+  const navGroups = new Map<string, Remediation[]>();
+  const otherRemediations: Remediation[] = [];
+
+  // Collect all JSON paths that get structural fixes (they regenerate .md already)
+  const structuralFixJsonPaths = new Set<string>();
+  for (const rem of plan.auto) {
+    if (rem.action === 'add-nav-entry' || rem.action === 'rename-frontmatter') {
+      structuralFixJsonPaths.add(rem.targetPath);
+    }
+  }
+
+  for (const rem of plan.auto) {
+    if (rem.action === 'add-nav-entry') {
+      const group = navGroups.get(rem.targetPath) ?? [];
+      group.push(rem);
+      navGroups.set(rem.targetPath, group);
+    } else if (rem.action === 'json2md') {
+      // Skip json2md if a structural fix already covers this file's .md regeneration
+      const jsonPath = ctx(rem.finding, 'jsonPath');
+      if (jsonPath !== undefined && structuralFixJsonPaths.has(jsonPath)) {
+        results.push({ remediation: rem, success: true });
+        continue;
+      }
+      otherRemediations.push(rem);
+    } else {
+      otherRemediations.push(rem);
+    }
+  }
+
+  // Apply coalesced nav entries — one read/write per parent
+  for (const [parentJsonPath, group] of navGroups) {
+    try {
+      const content = await readFile(parentJsonPath, 'utf8');
+      const doc = JSON.parse(content) as GobbiDoc;
+
+      for (const rem of group) {
+        const childNavKey = ctx(rem.finding, 'childNavKey');
+        const childTitle = ctx(rem.finding, 'childTitle');
+        if (childNavKey === undefined || childTitle === undefined) {
+          results.push({ remediation: rem, success: false, error: 'Missing required context fields' });
+          continue;
+        }
+        if (!Object.hasOwn(doc.navigation, childNavKey)) {
+          doc.navigation[childNavKey] = childTitle;
+        }
+      }
+
+      await writeFile(parentJsonPath, JSON.stringify(doc, null, 2) + '\n', 'utf8');
+      const markdown = renderDoc(doc, parentJsonPath);
+      const mdPath = parentJsonPath.replace(/\.json$/, '.md');
+      await writeFile(mdPath, markdown, 'utf8');
+
+      for (const rem of group) {
+        // Only mark as success if not already recorded as failure above
+        if (!results.some((r) => r.remediation === rem)) {
+          results.push({ remediation: rem, success: true });
+        }
+      }
+    } catch (err) {
+      for (const rem of group) {
+        if (!results.some((r) => r.remediation === rem)) {
+          results.push({ remediation: rem, success: false, error: String(err) });
+        }
+      }
+    }
+  }
+
+  // Apply other remediations sequentially
+  for (const rem of otherRemediations) {
+    const result = await applyRemediation(rem);
+    results.push(result);
+  }
+
+  return results;
+}

--- a/packages/cli/src/lib/docs/validator.ts
+++ b/packages/cli/src/lib/docs/validator.ts
@@ -401,7 +401,7 @@ async function checkSync(
     return 'no-md-file';
   }
 
-  const generatedMd = renderDoc(doc);
+  const generatedMd = renderDoc(doc, jsonFilePath);
   return existingMd === generatedMd ? 'in-sync' : 'out-of-sync';
 }
 

--- a/packages/cli/src/test/doctor.test.ts
+++ b/packages/cli/src/test/doctor.test.ts
@@ -10,6 +10,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   computeStatus,
   computeMaturityLevel,
@@ -324,9 +325,7 @@ describe('generateSummary', () => {
 
 describe('runDoctorCheck integration', () => {
   it('returns a valid DoctorReport shape', async () => {
-    const repoRoot = path.resolve(
-      '/playinganalytics/git/gobbi/.claude/worktrees/54-gobbi-doctor',
-    );
+    const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
     const report = await runDoctorCheck(repoRoot);
 
     assert.ok(
@@ -352,9 +351,7 @@ describe('runDoctorCheck integration', () => {
 // ---------------------------------------------------------------------------
 
 describe('audit library functions', () => {
-  const repoRoot = path.resolve(
-    '/playinganalytics/git/gobbi/.claude/worktrees/54-gobbi-doctor',
-  );
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
   const claudeDir = path.join(repoRoot, '.claude');
 
   it('auditReferences returns well-shaped Finding[]', async () => {

--- a/packages/cli/src/test/remediation.test.ts
+++ b/packages/cli/src/test/remediation.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Tests for the remediation library (gobbi doctor --plan / --fix).
+ *
+ * Uses Node's built-in test runner (`node:test`) and strict assertions.
+ * Run via: npm test (which compiles first, then runs the compiled JS).
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  computeRemediations,
+  applyRemediation,
+  type RemediationPlan,
+  type Remediation,
+} from '../lib/docs/remediation.js';
+import type { Finding } from '../lib/docs/health.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'gobbi-remediation-test-'));
+}
+
+function removeTempDir(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+/** Create a file (and any missing parent dirs) with the given content. Returns the full path. */
+function createFile(dir: string, relativePath: string, content: string): string {
+  const fullPath = path.join(dir, relativePath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, content, 'utf8');
+  return fullPath;
+}
+
+// ---------------------------------------------------------------------------
+// computeRemediations
+// ---------------------------------------------------------------------------
+
+describe('computeRemediations', () => {
+  it('empty findings produces empty plan', () => {
+    const plan = computeRemediations([]);
+    assert.equal(plan.auto.length, 0);
+    assert.equal(plan.suggested.length, 0);
+    assert.equal(plan.skipped.length, 0);
+  });
+
+  it('findings without fixable go to skipped', () => {
+    const finding: Finding = {
+      path: 'test.json',
+      severity: 'error',
+      category: 'validation-error',
+      message: 'test',
+      suggestion: 'fix it',
+    };
+    const plan = computeRemediations([finding]);
+    assert.equal(plan.skipped.length, 1);
+    assert.equal(plan.auto.length, 0);
+  });
+
+  it('sync-out-of-date with auto + valid context produces json2md action', () => {
+    const finding: Finding = {
+      path: 'skills/_claude/SKILL.json',
+      severity: 'warning',
+      category: 'sync-out-of-date',
+      message: 'JSON and Markdown are out of sync',
+      suggestion: 'Run gobbi docs json2md',
+      fixable: 'auto',
+      context: { jsonPath: '/tmp/test/skills/_claude/SKILL.json' },
+    };
+    const plan = computeRemediations([finding]);
+    assert.equal(plan.auto.length, 1);
+    assert.equal(plan.auto[0]!.action, 'json2md');
+  });
+
+  it('bidirectional-consistency with auto + valid context produces add-nav-entry', () => {
+    const finding: Finding = {
+      path: 'skills/_claude/gotchas.json',
+      severity: 'warning',
+      category: 'bidirectional-consistency',
+      message: 'test',
+      suggestion: 'fix it',
+      fixable: 'auto',
+      context: {
+        parentJsonPath: '/tmp/test/skills/_claude/SKILL.json',
+        childTitle: 'Gotcha: _claude',
+        childNavKey: 'skills/_claude/gotchas.md',
+      },
+    };
+    const plan = computeRemediations([finding]);
+    assert.equal(plan.auto.length, 1);
+    assert.equal(plan.auto[0]!.action, 'add-nav-entry');
+  });
+
+  it('naming-mismatch with auto + valid context produces rename-frontmatter', () => {
+    const finding: Finding = {
+      path: 'skills/gobbi/SKILL.md',
+      severity: 'warning',
+      category: 'naming-mismatch',
+      message: 'test',
+      suggestion: 'fix it',
+      fixable: 'auto',
+      context: { jsonPath: '/tmp/test/skills/gobbi/SKILL.json', dirName: 'gobbi' },
+    };
+    const plan = computeRemediations([finding]);
+    assert.equal(plan.auto.length, 1);
+    assert.equal(plan.auto[0]!.action, 'rename-frontmatter');
+  });
+
+  it('suggested findings go to suggested array', () => {
+    const finding: Finding = {
+      path: 'test.md',
+      severity: 'warning',
+      category: 'stale-reference',
+      message: 'broken ref',
+      suggestion: 'Check if renamed',
+      fixable: 'suggested',
+    };
+    const plan = computeRemediations([finding]);
+    assert.equal(plan.suggested.length, 1);
+    assert.equal(plan.auto.length, 0);
+  });
+
+  it('manual findings go to skipped', () => {
+    const finding: Finding = {
+      path: 'test.json',
+      severity: 'error',
+      category: 'validation-error',
+      message: 'test',
+      suggestion: 'fix it',
+      fixable: 'manual',
+    };
+    const plan = computeRemediations([finding]);
+    assert.equal(plan.skipped.length, 1);
+  });
+
+  it('auto finding missing required context demotes to skipped', () => {
+    const finding: Finding = {
+      path: 'test.json',
+      severity: 'warning',
+      category: 'sync-out-of-date',
+      message: 'out of sync',
+      suggestion: 'run json2md',
+      fixable: 'auto',
+      // No context — should demote to skipped
+    };
+    const plan = computeRemediations([finding]);
+    assert.equal(plan.skipped.length, 1);
+    assert.equal(plan.auto.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyRemediation
+// ---------------------------------------------------------------------------
+
+describe('applyRemediation', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTempDir();
+  });
+
+  afterEach(() => {
+    removeTempDir(tmpDir);
+  });
+
+  it('json2md: regenerates .md from .json', async () => {
+    // Create a minimal skill JSON
+    const jsonContent = JSON.stringify(
+      {
+        $schema: 'gobbi-docs/skill',
+        title: 'Test Skill',
+        frontmatter: { name: 'test', description: 'A test skill' },
+        navigation: {},
+      },
+      null,
+      2,
+    );
+    const jsonPath = createFile(tmpDir, 'SKILL.json', jsonContent);
+    // Create an out-of-date .md
+    createFile(tmpDir, 'SKILL.md', 'old content');
+
+    const remediation: Remediation = {
+      action: 'json2md',
+      finding: {
+        path: 'SKILL.json',
+        severity: 'warning',
+        category: 'sync-out-of-date',
+        message: 'out of sync',
+        suggestion: 'run json2md',
+        fixable: 'auto',
+        context: { jsonPath },
+      },
+      description: 'Regenerate SKILL.md from SKILL.json',
+      targetPath: jsonPath.replace(/\.json$/, '.md'),
+    };
+
+    const result = await applyRemediation(remediation);
+    assert.equal(result.success, true);
+
+    // Verify .md was regenerated
+    const mdContent = fs.readFileSync(jsonPath.replace(/\.json$/, '.md'), 'utf8');
+    assert.ok(mdContent.includes('# Test Skill'));
+    assert.ok(!mdContent.includes('old content'));
+  });
+
+  it('add-nav-entry: adds navigation to parent JSON and regenerates .md', async () => {
+    // Create parent SKILL.json without child nav
+    const parentJson = JSON.stringify(
+      {
+        $schema: 'gobbi-docs/skill',
+        title: 'Parent Skill',
+        frontmatter: { name: 'parent', description: 'Parent' },
+        navigation: {},
+      },
+      null,
+      2,
+    );
+    const parentJsonPath = createFile(tmpDir, 'skills/parent/SKILL.json', parentJson);
+    createFile(tmpDir, 'skills/parent/SKILL.md', 'old');
+
+    const remediation: Remediation = {
+      action: 'add-nav-entry',
+      finding: {
+        path: 'skills/parent/gotchas.json',
+        severity: 'warning',
+        category: 'bidirectional-consistency',
+        message: 'test',
+        suggestion: 'add nav',
+        fixable: 'auto',
+        context: {
+          parentJsonPath,
+          childTitle: 'Gotchas: parent',
+          childNavKey: 'skills/parent/gotchas.md',
+        },
+      },
+      description: 'Add nav entry',
+      targetPath: parentJsonPath,
+    };
+
+    const result = await applyRemediation(remediation);
+    assert.equal(result.success, true);
+
+    // Verify parent JSON has new nav entry
+    const updatedJson = JSON.parse(fs.readFileSync(parentJsonPath, 'utf8'));
+    assert.equal(updatedJson.navigation['skills/parent/gotchas.md'], 'Gotchas: parent');
+
+    // Verify .md was regenerated
+    const mdContent = fs.readFileSync(parentJsonPath.replace(/\.json$/, '.md'), 'utf8');
+    assert.ok(mdContent.includes('Gotchas: parent'));
+  });
+
+  it('rename-frontmatter: updates name in JSON and regenerates .md', async () => {
+    const jsonContent = JSON.stringify(
+      {
+        $schema: 'gobbi-docs/skill',
+        title: 'My Skill',
+        frontmatter: { name: 'wrong-name', description: 'A skill' },
+        navigation: {},
+      },
+      null,
+      2,
+    );
+    const jsonPath = createFile(tmpDir, 'skills/correct-name/SKILL.json', jsonContent);
+    createFile(tmpDir, 'skills/correct-name/SKILL.md', 'old');
+
+    const remediation: Remediation = {
+      action: 'rename-frontmatter',
+      finding: {
+        path: 'skills/correct-name/SKILL.md',
+        severity: 'warning',
+        category: 'naming-mismatch',
+        message: 'name mismatch',
+        suggestion: 'update name',
+        fixable: 'auto',
+        context: { jsonPath, dirName: 'correct-name' },
+      },
+      description: 'Rename frontmatter',
+      targetPath: jsonPath,
+    };
+
+    const result = await applyRemediation(remediation);
+    assert.equal(result.success, true);
+
+    // Verify JSON frontmatter was updated
+    const updatedJson = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+    assert.equal(updatedJson.frontmatter.name, 'correct-name');
+
+    // Verify .md was regenerated with new name
+    const mdContent = fs.readFileSync(jsonPath.replace(/\.json$/, '.md'), 'utf8');
+    assert.ok(mdContent.includes('correct-name'));
+  });
+
+  it('returns failure for non-existent file', async () => {
+    const remediation: Remediation = {
+      action: 'json2md',
+      finding: {
+        path: 'nonexistent.json',
+        severity: 'warning',
+        category: 'sync-out-of-date',
+        message: 'test',
+        suggestion: 'test',
+        fixable: 'auto',
+        context: { jsonPath: path.join(tmpDir, 'nonexistent.json') },
+      },
+      description: 'Should fail',
+      targetPath: path.join(tmpDir, 'nonexistent.md'),
+    };
+
+    const result = await applyRemediation(remediation);
+    assert.equal(result.success, false);
+    assert.ok(result.error !== undefined);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `--plan` flag to `gobbi doctor`: terraform-plan-style preview of available remediations
- Add `--fix` flag to `gobbi doctor`: auto-apply deterministic fixes, then re-run doctor
- Three auto-fix actions: `json2md` (sync), `add-nav-entry` (bidirectional-consistency), `rename-frontmatter` (naming-mismatch)
- Fix pre-existing `checkSync` bug in `validator.ts` (missing `jsonFilePath` arg to `renderDoc` causing false out-of-sync reports)
- New `remediation.ts` library with write coalescing for batched nav-entry fixes
- 12 new tests (38 total), all passing

## Changes

| File | Change |
|---|---|
| `packages/cli/src/lib/docs/remediation.ts` | NEW — core remediation types, computation, application |
| `packages/cli/src/lib/docs/health.ts` | Added `context` field to `Finding` interface |
| `packages/cli/src/lib/docs/validator.ts` | Fixed `checkSync` bug |
| `packages/cli/src/lib/docs/doctor.ts` | Added `runDoctorPlan`/`runDoctorFix` orchestration |
| `packages/cli/src/lib/docs/audit.ts` | Added context to naming-mismatch findings |
| `packages/cli/src/commands/doctor.ts` | Added `--plan`/`--fix` CLI flags and output formatting |
| `packages/cli/src/test/remediation.test.ts` | NEW — 12 tests for remediation logic |
| `packages/cli/src/test/doctor.test.ts` | Fixed pre-existing test path issue |
| `.claude/skills/_doctor/SKILL.json` + `.md` | Updated docs with --plan/--fix |
| `.claude/skills/gobbi/cli-setup.json` + `.md` | Updated CLI command table |

## Exit codes

| Code | Meaning |
|---|---|
| 0 | Clean or attention-needed |
| 1 | Degraded (errors) or `--plan --fix` mutual exclusion |
| 2 | `--plan` only: auto-fixable items exist (CI signal) |

## Test plan

- [x] `gobbi doctor` — no regression from Phase 1
- [x] `gobbi doctor --plan` — shows remediation plan
- [x] `gobbi doctor --plan --format json` — valid JSON
- [x] `gobbi doctor --fix` — applies 82 fixes, re-runs doctor
- [x] `gobbi doctor --fix --format json` — valid JSON
- [x] `gobbi doctor --plan --fix` — error + exit 1
- [x] `npm test` — 38/38 pass
- [x] `tsc --noEmit` — zero errors

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)