### PR TITLE
feat: add _gobbi-cli skill — intent-first CLI reference

### DIFF
--- a/.claude/skills/_gobbi-cli/SKILL.json
+++ b/.claude/skills/_gobbi-cli/SKILL.json
@@ -6,7 +6,7 @@
     "allowed-tools": "Read, Bash"
   },
   "title": "Gobbi CLI",
-  "opening": "Intent-first reference for the `gobbi` CLI. Start from what you need to accomplish, find the command, then follow the cross-reference to the domain skill that teaches the full workflow context.\n\nThis skill answers \"which command?\" — domain skills answer \"when and why?\"",
+  "opening": "Intent-first reference for the `gobbi` CLI. Start from what you need to accomplish, find the command, then follow the cross-reference to the domain skill that teaches the full workflow context. This skill is loaded on-demand when agents need CLI command guidance, not proactively at session start.\n\nThis skill answers \"which command?\" — domain skills answer \"when and why?\"",
   "sections": [
     {
       "heading": "Core Principle",
@@ -43,6 +43,7 @@
             ["Read a session config value", "`gobbi config get <session-id> [key]`"],
             ["Write a session config value", "`gobbi config set <session-id> <key> <val>`"],
             ["Create or migrate config file", "`gobbi config init`"],
+            ["Output session metadata to stdout", "`gobbi note metadata`"],
             ["Load session metadata into env", "`gobbi session metadata`"],
             ["Load `.claude/.env` into session", "`gobbi session load-env`"],
             ["Check documentation health", "`gobbi doctor`"]
@@ -65,7 +66,7 @@
           "type": "table",
           "headers": ["Intent", "Command"],
           "rows": [
-            ["Extract subagent result to note", "`gobbi note collect <agent-id> <n> <slug> <note-dir> --phase <phase>`"],
+            ["Extract subagent result to note", "`gobbi note collect <agent-id> <n> <slug> <note-dir> [--phase <phase>]`"],
             ["Extract plan from session transcript", "`gobbi note plan <note-dir>`"]
           ]
         },
@@ -121,7 +122,7 @@
         },
         {
           "type": "text",
-          "value": "Filtering options: `docs list` and `docs search` accept `--type <type>` to filter by doc type. `docs search` also accepts `--block <type>` to filter by block type. Most exploration commands support `--format json` for programmatic consumption.\n\nCross-reference: `_doctor` for interpreting health check results."
+          "value": "Filtering options: `docs list` and `docs search` accept `--type <type>` to filter by doc type. `docs search` also accepts `--block <type>` to filter by block type. Most exploration commands support `--format json` for programmatic consumption.\n\n`gobbi docs health` checks cross-document consistency only. For the full health check (references, schema, sync, maturity), use `gobbi doctor`.\n\nCross-reference: `_doctor` for interpreting health check results."
         }
       ]
     },
@@ -194,6 +195,10 @@
             ["Take a screenshot of a web page", "`gobbi web screenshot <url>`"],
             ["Download images from a web page", "`gobbi web capture <url>`"]
           ]
+        },
+        {
+          "type": "text",
+          "value": "No dedicated domain skill — run `gobbi <command> --help` for detailed options."
         }
       ]
     },
@@ -221,7 +226,7 @@
           "items": [
             "`gobbi audit` is deprecated -- use `gobbi doctor` instead",
             "This skill documents what commands exist and when to use them; domain skills (`_claude`, `_note`, `_doctor`, `_notification`) teach the full workflow context",
-            "Installation and troubleshooting are in `gobbi/cli-setup.md`, not here",
+            "Installation and troubleshooting are in `skills/gobbi/cli-setup.md`, not here",
             "Run `gobbi <command> --help` for the most current synopsis if this reference and the CLI disagree -- the CLI is the source of truth"
           ]
         }
@@ -229,6 +234,7 @@
     }
   ],
   "navigation": {
-    "skills/_gobbi-cli/commands.md": "Complete CLI syntax reference by command group"
+    "skills/_gobbi-cli/commands.md": "Complete CLI syntax reference by command group",
+    "skills/_gobbi-cli/gotchas.md": "Known CLI usage mistakes and corrections"
   }
 }

--- a/.claude/skills/_gobbi-cli/SKILL.json
+++ b/.claude/skills/_gobbi-cli/SKILL.json
@@ -1,0 +1,234 @@
+{
+  "$schema": "gobbi-docs/skill",
+  "frontmatter": {
+    "name": "_gobbi-cli",
+    "description": "Intent-first CLI guide. Load when an agent needs a gobbi command but does not know which one.",
+    "allowed-tools": "Read, Bash"
+  },
+  "title": "Gobbi CLI",
+  "opening": "Intent-first reference for the `gobbi` CLI. Start from what you need to accomplish, find the command, then follow the cross-reference to the domain skill that teaches the full workflow context.\n\nThis skill answers \"which command?\" — domain skills answer \"when and why?\"",
+  "sections": [
+    {
+      "heading": "Core Principle",
+      "content": [
+        {
+          "type": "principle",
+          "statement": "CLI is the interface to gobbi's runtime. Always use CLI commands, never manual alternatives.",
+          "body": "Manual `mkdir` instead of `gobbi note init`, hand-editing `.md` instead of editing `.json` and running `gobbi docs json2md`, checking directory existence instead of running `gobbi note collect` — these are the most common mistakes agents make. The CLI handles naming conventions, directory structure, metadata generation, and format consistency. Manual alternatives bypass all of that."
+        },
+        {
+          "type": "principle",
+          "statement": "Come with an intent, leave with a command.",
+          "body": "The intent map below is organized by what agents need to do, not by command group. If you already know the command group, use the child doc `commands.md` for the full syntax reference."
+        },
+        {
+          "type": "principle",
+          "statement": "This skill routes to commands. Domain skills teach when and why.",
+          "body": "Each intent map section cross-references the domain skill that owns the workflow context. `_gobbi-cli` tells you the command exists and what arguments it takes. `_note`, `_claude`, `_doctor`, and `_notification` tell you the full workflow around that command."
+        }
+      ]
+    },
+    {
+      "heading": "Start a Workflow",
+      "content": [
+        {
+          "type": "text",
+          "value": "Commands for initializing a work session: creating note directories, loading configuration, setting up session environment, and checking documentation health before starting."
+        },
+        {
+          "type": "table",
+          "headers": ["Intent", "Command"],
+          "rows": [
+            ["Create a note directory for a new task", "`gobbi note init <project-name> <task-slug>`"],
+            ["Read a session config value", "`gobbi config get <session-id> [key]`"],
+            ["Write a session config value", "`gobbi config set <session-id> <key> <val>`"],
+            ["Create or migrate config file", "`gobbi config init`"],
+            ["Load session metadata into env", "`gobbi session metadata`"],
+            ["Load `.claude/.env` into session", "`gobbi session load-env`"],
+            ["Check documentation health", "`gobbi doctor`"]
+          ]
+        },
+        {
+          "type": "text",
+          "value": "Cross-reference: `_orchestration`, `_note` for workflow setup context. `gobbi` skill for session setup questions."
+        }
+      ]
+    },
+    {
+      "heading": "Capture Subagent Output",
+      "content": [
+        {
+          "type": "text",
+          "value": "After every subagent completes, extract its delegation prompt and final result from the JSONL transcript into the note directory."
+        },
+        {
+          "type": "table",
+          "headers": ["Intent", "Command"],
+          "rows": [
+            ["Extract subagent result to note", "`gobbi note collect <agent-id> <n> <slug> <note-dir> --phase <phase>`"],
+            ["Extract plan from session transcript", "`gobbi note plan <note-dir>`"]
+          ]
+        },
+        {
+          "type": "text",
+          "value": "Preconditions for `gobbi note collect`: you must have the `agent-id` from the Agent tool result, the subtask number (`n`) for ordering, a descriptive slug, the note directory path from `gobbi note init`, and the `--phase` flag (`ideation`, `plan`, `research`, `execution`, or `review`) to route output to the correct step's `subtasks/` subdirectory.\n\nCross-reference: `_note` for the full note-writing workflow and subtask JSON format."
+        }
+      ]
+    },
+    {
+      "heading": "Write Documentation",
+      "content": [
+        {
+          "type": "text",
+          "value": "Commands for the JSON-first documentation workflow: scaffold new templates, convert between JSON and Markdown, validate schema compliance, inspect template contents, and view the schema specification."
+        },
+        {
+          "type": "table",
+          "headers": ["Intent", "Command"],
+          "rows": [
+            ["Scaffold a new JSON template", "`gobbi docs init <type> [name]`"],
+            ["Convert JSON template to Markdown", "`gobbi docs json2md <path>`"],
+            ["Migrate existing Markdown to JSON", "`gobbi docs md2json <path>`"],
+            ["Validate a JSON template against schema", "`gobbi docs validate <path>`"],
+            ["Inspect template metadata or section", "`gobbi docs read <path> [--section <name>]`"],
+            ["View the gobbi-docs JSON schema", "`gobbi docs spec`"]
+          ]
+        },
+        {
+          "type": "text",
+          "value": "The `docs init` types are: `skill`, `agent`, `rule`, `root`, `child`, `gotcha`. Use `--out <path>` to write directly to a file instead of stdout.\n\nCross-reference: `_claude` for the documentation standard and writing guidelines."
+        }
+      ]
+    },
+    {
+      "heading": "Explore Documentation",
+      "content": [
+        {
+          "type": "text",
+          "value": "Commands for navigating and analyzing the documentation corpus. All default to the `.claude/` directory in the current repository."
+        },
+        {
+          "type": "table",
+          "headers": ["Intent", "Command"],
+          "rows": [
+            ["List all templates with metadata", "`gobbi docs list [directory]`"],
+            ["Show navigation hierarchy as tree", "`gobbi docs tree [directory]`"],
+            ["Search content across templates", "`gobbi docs search <pattern> [directory]`"],
+            ["Extract content by dot-path query", "`gobbi docs extract <path> <query>`"],
+            ["Show aggregate corpus statistics", "`gobbi docs stats [directory]`"],
+            ["Run cross-document health checks", "`gobbi docs health [directory]`"]
+          ]
+        },
+        {
+          "type": "text",
+          "value": "Filtering options: `docs list` and `docs search` accept `--type <type>` to filter by doc type. `docs search` also accepts `--block <type>` to filter by block type. Most exploration commands support `--format json` for programmatic consumption.\n\nCross-reference: `_doctor` for interpreting health check results."
+        }
+      ]
+    },
+    {
+      "heading": "Check and Fix Health",
+      "content": [
+        {
+          "type": "text",
+          "value": "Unified documentation health checking with optional auto-remediation. Doctor consolidates reference checking, structural health, schema validation, JSON/MD sync, and completeness scoring into one command."
+        },
+        {
+          "type": "table",
+          "headers": ["Intent", "Command"],
+          "rows": [
+            ["Run full health check (human-readable)", "`gobbi doctor`"],
+            ["Run full health check (machine-readable)", "`gobbi doctor --format json`"],
+            ["Preview what auto-fix would change", "`gobbi doctor --plan`"],
+            ["Auto-apply safe fixes and re-check", "`gobbi doctor --fix`"],
+            ["Validate an agent definition", "`gobbi validate agent <file.md>`"],
+            ["Validate a skill definition", "`gobbi validate skill <SKILL.md>`"],
+            ["Validate gotcha entries", "`gobbi validate gotcha <file.md>`"],
+            ["Lint for documentation anti-patterns", "`gobbi validate lint <file.md>`"]
+          ]
+        },
+        {
+          "type": "text",
+          "value": "Cross-reference: `_doctor` for the full maturity model, check categories, and remediation strategy."
+        }
+      ]
+    },
+    {
+      "heading": "Send Notifications",
+      "content": [
+        {
+          "type": "text",
+          "value": "Commands for sending messages through configured notification channels (Slack, Telegram, Desktop). Most notification commands are invoked by hooks, not directly by agents."
+        },
+        {
+          "type": "table",
+          "headers": ["Intent", "Command"],
+          "rows": [
+            ["Send a plain-text message", "`gobbi notify send [--title \"Title\"]`"],
+            ["Send attention-needed notification", "`gobbi notify attention`"],
+            ["Send error notification", "`gobbi notify error`"],
+            ["Send completion notification", "`gobbi notify completion`"],
+            ["Send session lifecycle notification", "`gobbi notify session`"],
+            ["Send subagent completion notification", "`gobbi notify subagent`"]
+          ]
+        },
+        {
+          "type": "text",
+          "value": "`gobbi notify send` reads message body from stdin. The event-specific commands (`attention`, `error`, `completion`, `session`, `subagent`) read hook event payloads from stdin and map them to formatted messages.\n\nCross-reference: `_notification` for channel configuration and credentials setup."
+        }
+      ]
+    },
+    {
+      "heading": "Analyze Media",
+      "content": [
+        {
+          "type": "text",
+          "value": "Commands for image analysis, video frame extraction, and web page capture. These are standalone utilities without a dedicated domain skill."
+        },
+        {
+          "type": "table",
+          "headers": ["Intent", "Command"],
+          "rows": [
+            ["Analyze an image (metadata + resize)", "`gobbi image analyze <path>`"],
+            ["Compare images side-by-side", "`gobbi image compare <paths...>`"],
+            ["Analyze a video (extract frames)", "`gobbi video analyze <path>`"],
+            ["Take a screenshot of a web page", "`gobbi web screenshot <url>`"],
+            ["Download images from a web page", "`gobbi web capture <url>`"]
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Common Mistakes",
+      "content": [
+        {
+          "type": "list",
+          "style": "bullet",
+          "items": [
+            "Editing `.md` directly instead of editing `.json` and running `gobbi docs json2md` -- the `.md` file will be overwritten on next generation, losing all manual edits",
+            "Not running `gobbi note collect` after a subagent completes -- directory existence is not collection, only the command parses the transcript and populates subtask files",
+            "Using `mkdir` to create note directories instead of `gobbi note init` -- manual creation misses `metadata.json`, session ID embedding, and the full subdirectory structure",
+            "Checking whether a directory exists as proof that collection happened -- the directory is created by `gobbi note init`, but the subtask files inside it are only created by `gobbi note collect`",
+            "Using `gobbi audit` instead of `gobbi doctor` -- `audit` is deprecated and prints a deprecation warning before forwarding to `doctor`"
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "Constraints",
+      "content": [
+        {
+          "type": "constraint-list",
+          "items": [
+            "`gobbi audit` is deprecated -- use `gobbi doctor` instead",
+            "This skill documents what commands exist and when to use them; domain skills (`_claude`, `_note`, `_doctor`, `_notification`) teach the full workflow context",
+            "Installation and troubleshooting are in `gobbi/cli-setup.md`, not here",
+            "Run `gobbi <command> --help` for the most current synopsis if this reference and the CLI disagree -- the CLI is the source of truth"
+          ]
+        }
+      ]
+    }
+  ],
+  "navigation": {
+    "skills/_gobbi-cli/commands.md": "Complete CLI syntax reference by command group"
+  }
+}

--- a/.claude/skills/_gobbi-cli/SKILL.md
+++ b/.claude/skills/_gobbi-cli/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: _gobbi-cli
+description: Intent-first CLI guide. Load when an agent needs a gobbi command but does not know which one.
+allowed-tools: Read, Bash
+---
+
+# Gobbi CLI
+
+Intent-first reference for the `gobbi` CLI. Start from what you need to accomplish, find the command, then follow the cross-reference to the domain skill that teaches the full workflow context.
+
+This skill answers "which command?" — domain skills answer "when and why?"
+
+**Navigate deeper from here:**
+
+| Document | Covers |
+|----------|--------|
+| [commands.md](commands.md) | Complete CLI syntax reference by command group |
+
+---
+
+## Core Principle
+
+> **CLI is the interface to gobbi's runtime. Always use CLI commands, never manual alternatives.**
+
+Manual `mkdir` instead of `gobbi note init`, hand-editing `.md` instead of editing `.json` and running `gobbi docs json2md`, checking directory existence instead of running `gobbi note collect` — these are the most common mistakes agents make. The CLI handles naming conventions, directory structure, metadata generation, and format consistency. Manual alternatives bypass all of that.
+
+> **Come with an intent, leave with a command.**
+
+The intent map below is organized by what agents need to do, not by command group. If you already know the command group, use the child doc `commands.md` for the full syntax reference.
+
+> **This skill routes to commands. Domain skills teach when and why.**
+
+Each intent map section cross-references the domain skill that owns the workflow context. `_gobbi-cli` tells you the command exists and what arguments it takes. `_note`, `_claude`, `_doctor`, and `_notification` tell you the full workflow around that command.
+
+---
+
+## Start a Workflow
+
+Commands for initializing a work session: creating note directories, loading configuration, setting up session environment, and checking documentation health before starting.
+
+| Intent | Command |
+|---|---|
+| Create a note directory for a new task | `gobbi note init <project-name> <task-slug>` |
+| Read a session config value | `gobbi config get <session-id> [key]` |
+| Write a session config value | `gobbi config set <session-id> <key> <val>` |
+| Create or migrate config file | `gobbi config init` |
+| Load session metadata into env | `gobbi session metadata` |
+| Load `.claude/.env` into session | `gobbi session load-env` |
+| Check documentation health | `gobbi doctor` |
+
+Cross-reference: `_orchestration`, `_note` for workflow setup context. `gobbi` skill for session setup questions.
+
+---
+
+## Capture Subagent Output
+
+After every subagent completes, extract its delegation prompt and final result from the JSONL transcript into the note directory.
+
+| Intent | Command |
+|---|---|
+| Extract subagent result to note | `gobbi note collect <agent-id> <n> <slug> <note-dir> --phase <phase>` |
+| Extract plan from session transcript | `gobbi note plan <note-dir>` |
+
+Preconditions for `gobbi note collect`: you must have the `agent-id` from the Agent tool result, the subtask number (`n`) for ordering, a descriptive slug, the note directory path from `gobbi note init`, and the `--phase` flag (`ideation`, `plan`, `research`, `execution`, or `review`) to route output to the correct step's `subtasks/` subdirectory.
+
+Cross-reference: `_note` for the full note-writing workflow and subtask JSON format.
+
+---
+
+## Write Documentation
+
+Commands for the JSON-first documentation workflow: scaffold new templates, convert between JSON and Markdown, validate schema compliance, inspect template contents, and view the schema specification.
+
+| Intent | Command |
+|---|---|
+| Scaffold a new JSON template | `gobbi docs init <type> [name]` |
+| Convert JSON template to Markdown | `gobbi docs json2md <path>` |
+| Migrate existing Markdown to JSON | `gobbi docs md2json <path>` |
+| Validate a JSON template against schema | `gobbi docs validate <path>` |
+| Inspect template metadata or section | `gobbi docs read <path> [--section <name>]` |
+| View the gobbi-docs JSON schema | `gobbi docs spec` |
+
+The `docs init` types are: `skill`, `agent`, `rule`, `root`, `child`, `gotcha`. Use `--out <path>` to write directly to a file instead of stdout.
+
+Cross-reference: `_claude` for the documentation standard and writing guidelines.
+
+---
+
+## Explore Documentation
+
+Commands for navigating and analyzing the documentation corpus. All default to the `.claude/` directory in the current repository.
+
+| Intent | Command |
+|---|---|
+| List all templates with metadata | `gobbi docs list [directory]` |
+| Show navigation hierarchy as tree | `gobbi docs tree [directory]` |
+| Search content across templates | `gobbi docs search <pattern> [directory]` |
+| Extract content by dot-path query | `gobbi docs extract <path> <query>` |
+| Show aggregate corpus statistics | `gobbi docs stats [directory]` |
+| Run cross-document health checks | `gobbi docs health [directory]` |
+
+Filtering options: `docs list` and `docs search` accept `--type <type>` to filter by doc type. `docs search` also accepts `--block <type>` to filter by block type. Most exploration commands support `--format json` for programmatic consumption.
+
+Cross-reference: `_doctor` for interpreting health check results.
+
+---
+
+## Check and Fix Health
+
+Unified documentation health checking with optional auto-remediation. Doctor consolidates reference checking, structural health, schema validation, JSON/MD sync, and completeness scoring into one command.
+
+| Intent | Command |
+|---|---|
+| Run full health check (human-readable) | `gobbi doctor` |
+| Run full health check (machine-readable) | `gobbi doctor --format json` |
+| Preview what auto-fix would change | `gobbi doctor --plan` |
+| Auto-apply safe fixes and re-check | `gobbi doctor --fix` |
+| Validate an agent definition | `gobbi validate agent <file.md>` |
+| Validate a skill definition | `gobbi validate skill <SKILL.md>` |
+| Validate gotcha entries | `gobbi validate gotcha <file.md>` |
+| Lint for documentation anti-patterns | `gobbi validate lint <file.md>` |
+
+Cross-reference: `_doctor` for the full maturity model, check categories, and remediation strategy.
+
+---
+
+## Send Notifications
+
+Commands for sending messages through configured notification channels (Slack, Telegram, Desktop). Most notification commands are invoked by hooks, not directly by agents.
+
+| Intent | Command |
+|---|---|
+| Send a plain-text message | `gobbi notify send [--title "Title"]` |
+| Send attention-needed notification | `gobbi notify attention` |
+| Send error notification | `gobbi notify error` |
+| Send completion notification | `gobbi notify completion` |
+| Send session lifecycle notification | `gobbi notify session` |
+| Send subagent completion notification | `gobbi notify subagent` |
+
+`gobbi notify send` reads message body from stdin. The event-specific commands (`attention`, `error`, `completion`, `session`, `subagent`) read hook event payloads from stdin and map them to formatted messages.
+
+Cross-reference: `_notification` for channel configuration and credentials setup.
+
+---
+
+## Analyze Media
+
+Commands for image analysis, video frame extraction, and web page capture. These are standalone utilities without a dedicated domain skill.
+
+| Intent | Command |
+|---|---|
+| Analyze an image (metadata + resize) | `gobbi image analyze <path>` |
+| Compare images side-by-side | `gobbi image compare <paths...>` |
+| Analyze a video (extract frames) | `gobbi video analyze <path>` |
+| Take a screenshot of a web page | `gobbi web screenshot <url>` |
+| Download images from a web page | `gobbi web capture <url>` |
+
+---
+
+## Common Mistakes
+
+- Editing `.md` directly instead of editing `.json` and running `gobbi docs json2md` -- the `.md` file will be overwritten on next generation, losing all manual edits
+- Not running `gobbi note collect` after a subagent completes -- directory existence is not collection, only the command parses the transcript and populates subtask files
+- Using `mkdir` to create note directories instead of `gobbi note init` -- manual creation misses `metadata.json`, session ID embedding, and the full subdirectory structure
+- Checking whether a directory exists as proof that collection happened -- the directory is created by `gobbi note init`, but the subtask files inside it are only created by `gobbi note collect`
+- Using `gobbi audit` instead of `gobbi doctor` -- `audit` is deprecated and prints a deprecation warning before forwarding to `doctor`
+
+---
+
+## Constraints
+
+- `gobbi audit` is deprecated -- use `gobbi doctor` instead
+- This skill documents what commands exist and when to use them; domain skills (`_claude`, `_note`, `_doctor`, `_notification`) teach the full workflow context
+- Installation and troubleshooting are in `gobbi/cli-setup.md`, not here
+- Run `gobbi <command> --help` for the most current synopsis if this reference and the CLI disagree -- the CLI is the source of truth

--- a/.claude/skills/_gobbi-cli/SKILL.md
+++ b/.claude/skills/_gobbi-cli/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Read, Bash
 
 # Gobbi CLI
 
-Intent-first reference for the `gobbi` CLI. Start from what you need to accomplish, find the command, then follow the cross-reference to the domain skill that teaches the full workflow context.
+Intent-first reference for the `gobbi` CLI. Start from what you need to accomplish, find the command, then follow the cross-reference to the domain skill that teaches the full workflow context. This skill is loaded on-demand when agents need CLI command guidance, not proactively at session start.
 
 This skill answers "which command?" — domain skills answer "when and why?"
 
@@ -15,6 +15,7 @@ This skill answers "which command?" — domain skills answer "when and why?"
 | Document | Covers |
 |----------|--------|
 | [commands.md](commands.md) | Complete CLI syntax reference by command group |
+| [gotchas.md](gotchas.md) | Known CLI usage mistakes and corrections |
 
 ---
 
@@ -44,6 +45,7 @@ Commands for initializing a work session: creating note directories, loading con
 | Read a session config value | `gobbi config get <session-id> [key]` |
 | Write a session config value | `gobbi config set <session-id> <key> <val>` |
 | Create or migrate config file | `gobbi config init` |
+| Output session metadata to stdout | `gobbi note metadata` |
 | Load session metadata into env | `gobbi session metadata` |
 | Load `.claude/.env` into session | `gobbi session load-env` |
 | Check documentation health | `gobbi doctor` |
@@ -58,7 +60,7 @@ After every subagent completes, extract its delegation prompt and final result f
 
 | Intent | Command |
 |---|---|
-| Extract subagent result to note | `gobbi note collect <agent-id> <n> <slug> <note-dir> --phase <phase>` |
+| Extract subagent result to note | `gobbi note collect <agent-id> <n> <slug> <note-dir> [--phase <phase>]` |
 | Extract plan from session transcript | `gobbi note plan <note-dir>` |
 
 Preconditions for `gobbi note collect`: you must have the `agent-id` from the Agent tool result, the subtask number (`n`) for ordering, a descriptive slug, the note directory path from `gobbi note init`, and the `--phase` flag (`ideation`, `plan`, `research`, `execution`, or `review`) to route output to the correct step's `subtasks/` subdirectory.
@@ -100,6 +102,8 @@ Commands for navigating and analyzing the documentation corpus. All default to t
 | Run cross-document health checks | `gobbi docs health [directory]` |
 
 Filtering options: `docs list` and `docs search` accept `--type <type>` to filter by doc type. `docs search` also accepts `--block <type>` to filter by block type. Most exploration commands support `--format json` for programmatic consumption.
+
+`gobbi docs health` checks cross-document consistency only. For the full health check (references, schema, sync, maturity), use `gobbi doctor`.
 
 Cross-reference: `_doctor` for interpreting health check results.
 
@@ -155,6 +159,8 @@ Commands for image analysis, video frame extraction, and web page capture. These
 | Take a screenshot of a web page | `gobbi web screenshot <url>` |
 | Download images from a web page | `gobbi web capture <url>` |
 
+No dedicated domain skill — run `gobbi <command> --help` for detailed options.
+
 ---
 
 ## Common Mistakes
@@ -171,5 +177,5 @@ Commands for image analysis, video frame extraction, and web page capture. These
 
 - `gobbi audit` is deprecated -- use `gobbi doctor` instead
 - This skill documents what commands exist and when to use them; domain skills (`_claude`, `_note`, `_doctor`, `_notification`) teach the full workflow context
-- Installation and troubleshooting are in `gobbi/cli-setup.md`, not here
+- Installation and troubleshooting are in `skills/gobbi/cli-setup.md`, not here
 - Run `gobbi <command> --help` for the most current synopsis if this reference and the CLI disagree -- the CLI is the source of truth

--- a/.claude/skills/_gobbi-cli/commands.json
+++ b/.claude/skills/_gobbi-cli/commands.json
@@ -1,0 +1,282 @@
+{
+  "$schema": "gobbi-docs/child",
+  "parent": "_gobbi-cli",
+  "title": "CLI Commands",
+  "opening": "Complete syntax reference for all `gobbi` CLI commands, organized by command group. For intent-based lookup (\"which command do I need?\"), see the parent SKILL.md.",
+  "sections": [
+    {
+      "heading": "note",
+      "content": [
+        {
+          "type": "text",
+          "value": "Workflow note management and transcript extraction. Every task gets a note directory; every subagent's output gets collected into it."
+        },
+        {
+          "type": "table",
+          "headers": ["Command", "Synopsis", "Description"],
+          "rows": [
+            ["`gobbi note metadata`", "`gobbi note metadata`", "Output session metadata as key=value pairs to stdout"],
+            ["`gobbi note init`", "`gobbi note init <project-name> <task-slug>`", "Create note directory structure with all step subdirectories and `metadata.json`"],
+            ["`gobbi note collect`", "`gobbi note collect <agent-id> <n> <slug> <note-dir> [--phase <phase>]`", "Extract subagent delegation prompt and final result from JSONL transcript into `{phase}/subtasks/{n}-{slug}.json`"],
+            ["`gobbi note plan`", "`gobbi note plan <note-dir>`", "Extract plan from session transcript and write `plan.json`"]
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "note collect options",
+          "content": [
+            {
+              "type": "table",
+              "headers": ["Option", "Values", "Description"],
+              "rows": [
+                ["`--phase`", "`ideation`, `plan`, `research`, `execution`, `review`", "Route output to the correct step's `subtasks/` subdirectory. Determines where the extracted JSON file is written."]
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "value": "Cross-reference: `_note` for note directory structure, subtask JSON format, and when to write at each workflow step."
+        }
+      ]
+    },
+    {
+      "heading": "config",
+      "content": [
+        {
+          "type": "text",
+          "value": "Manage per-session workflow configuration stored in `gobbi.json`. Sessions are identified by session ID and store workflow state such as base branch, notification preferences, and project name."
+        },
+        {
+          "type": "table",
+          "headers": ["Command", "Synopsis", "Description"],
+          "rows": [
+            ["`gobbi config init`", "`gobbi config init`", "Create `gobbi.json` or migrate existing file to current schema version"],
+            ["`gobbi config get`", "`gobbi config get <session-id> [key]`", "Read entire session object or a specific field using dot-path notation"],
+            ["`gobbi config set`", "`gobbi config set <session-id> <key> <val>`", "Write a field using dot-path notation"],
+            ["`gobbi config delete`", "`gobbi config delete <session-id>`", "Remove a session entry"],
+            ["`gobbi config list`", "`gobbi config list`", "List all sessions as tab-separated `id\\tcreatedAt` pairs"],
+            ["`gobbi config cleanup`", "`gobbi config cleanup`", "Run TTL and max-entries cleanup to remove stale sessions"]
+          ]
+        },
+        {
+          "type": "text",
+          "value": "Cross-reference: `gobbi` skill for session setup questions and configuration keys."
+        }
+      ]
+    },
+    {
+      "heading": "docs",
+      "content": [
+        {
+          "type": "text",
+          "value": "Manage gobbi-docs JSON templates and their Markdown output. The JSON-first workflow: edit `.json` source, run `json2md` to generate `.md`, run `validate` to check schema compliance. Never edit `.md` directly."
+        },
+        {
+          "type": "subsection",
+          "heading": "Authoring Commands",
+          "content": [
+            {
+              "type": "table",
+              "headers": ["Command", "Synopsis", "Description"],
+              "rows": [
+                ["`gobbi docs init`", "`gobbi docs init <type> [name] [--out <path>]`", "Scaffold a new JSON template. Types: `skill`, `agent`, `rule`, `root`, `child`, `gotcha`. Writes to stdout by default; use `--out` for file output."],
+                ["`gobbi docs json2md`", "`gobbi docs json2md <path>`", "Convert JSON template to Markdown. Writes the `.md` file alongside the `.json` source."],
+                ["`gobbi docs md2json`", "`gobbi docs md2json <path> [--stdout]`", "Migrate existing Markdown to JSON template. Writes `.json` alongside `.md` by default; use `--stdout` for stdout output."],
+                ["`gobbi docs validate`", "`gobbi docs validate <path>`", "Validate a JSON template against the gobbi-docs schema. Reports schema violations."],
+                ["`gobbi docs read`", "`gobbi docs read <path> [--section <name>]`", "Pretty-print JSON template metadata or a specific section."],
+                ["`gobbi docs spec`", "`gobbi docs spec`", "Show the full gobbi-docs JSON schema specification."]
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "Exploration Commands",
+          "content": [
+            {
+              "type": "table",
+              "headers": ["Command", "Synopsis", "Description"],
+              "rows": [
+                ["`gobbi docs list`", "`gobbi docs list [directory] [--type <type>] [--format <fmt>]`", "List all JSON templates with type, title, and content count. Formats: `table` (default), `json`."],
+                ["`gobbi docs tree`", "`gobbi docs tree [directory] [--format <fmt>]`", "Show navigation hierarchy as a tree. Formats: `text` (default), `json`."],
+                ["`gobbi docs search`", "`gobbi docs search <pattern> [directory] [--type <type>] [--block <type>] [--format <fmt>]`", "Search content across templates using regex. Filter by doc type or block type. Formats: `text` (default), `json`."],
+                ["`gobbi docs extract`", "`gobbi docs extract <path> <query> [--format <fmt>]`", "Extract content by dot-path query (e.g., `title`, `frontmatter.name`, `sections.Setup`). Formats: `json` (default), `md`, `text`."],
+                ["`gobbi docs stats`", "`gobbi docs stats [directory] [--format <fmt>]`", "Show aggregate corpus statistics. Formats: `text` (default), `json`."],
+                ["`gobbi docs health`", "`gobbi docs health [directory] [--format <fmt>]`", "Run cross-document health checks: orphans, broken links, empty sections, missing parents, bidirectional consistency. Exits with code 1 if errors found. Formats: `text` (default), `json`."]
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "value": "Cross-reference: `_claude` for the documentation standard, writing guidelines, and block type reference."
+        }
+      ]
+    },
+    {
+      "heading": "doctor",
+      "content": [
+        {
+          "type": "text",
+          "value": "Unified health check for `.claude/` documentation. Consolidates reference checking, structural health, schema validation, JSON/MD sync, and completeness scoring into a single pass."
+        },
+        {
+          "type": "table",
+          "headers": ["Command", "Synopsis", "Description"],
+          "rows": [
+            ["`gobbi doctor`", "`gobbi doctor [--format <fmt>] [--plan] [--fix]`", "Run unified health check. Default output is human-readable text."]
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "doctor options",
+          "content": [
+            {
+              "type": "table",
+              "headers": ["Option", "Description"],
+              "rows": [
+                ["`--format <fmt>`", "Output format: `text` (default), `json` for structured output"],
+                ["`--plan`", "Terraform-plan-style preview of remediations. Shows auto-fixable, suggested, and skipped counts without changing anything. Exits with code 2 if auto-fixes are available."],
+                ["`--fix`", "Auto-apply deterministic fixes (sync-out-of-date, bidirectional-consistency, naming-mismatch), then re-run doctor to show new state."]
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "value": "Cross-reference: `_doctor` for the maturity model (levels 0-4), check categories, auto-fixable versus suggested categories, and exit codes."
+        }
+      ]
+    },
+    {
+      "heading": "validate",
+      "content": [
+        {
+          "type": "text",
+          "value": "Validate individual documentation files against their expected structure. Unlike `gobbi doctor` which checks the entire corpus, `validate` checks one file at a time."
+        },
+        {
+          "type": "table",
+          "headers": ["Command", "Synopsis", "Description"],
+          "rows": [
+            ["`gobbi validate agent`", "`gobbi validate agent <file.md>`", "Validate an agent definition file"],
+            ["`gobbi validate skill`", "`gobbi validate skill <SKILL.md>`", "Validate a skill definition file"],
+            ["`gobbi validate gotcha`", "`gobbi validate gotcha <file.md>`", "Validate gotcha entries"],
+            ["`gobbi validate lint`", "`gobbi validate lint <file.md>`", "Lint a documentation file for anti-patterns"]
+          ]
+        },
+        {
+          "type": "text",
+          "value": "Cross-reference: `_skills` for skill structure requirements, `_agents` for agent definition requirements, `_gotcha` for gotcha entry format."
+        }
+      ]
+    },
+    {
+      "heading": "notify",
+      "content": [
+        {
+          "type": "text",
+          "value": "Send notifications through configured channels (Slack, Telegram, Desktop). The `send` command is for direct use; the event-specific commands are designed for hook payloads."
+        },
+        {
+          "type": "table",
+          "headers": ["Command", "Synopsis", "Description"],
+          "rows": [
+            ["`gobbi notify send`", "`gobbi notify send [--title \"Title\"]`", "Send a plain-text message. Reads message body from stdin."],
+            ["`gobbi notify attention`", "`gobbi notify attention`", "Map NotificationEvent hook payload (stdin) to an attention message"],
+            ["`gobbi notify error`", "`gobbi notify error`", "Map StopFailure hook payload (stdin) to an error message"],
+            ["`gobbi notify completion`", "`gobbi notify completion`", "Map Stop hook payload (stdin) to a completion message (with loop guard)"],
+            ["`gobbi notify session`", "`gobbi notify session`", "Map SessionStart/SessionEnd hook payload (stdin) to a lifecycle message"],
+            ["`gobbi notify subagent`", "`gobbi notify subagent`", "Map SubagentStop hook payload (stdin) to a subagent completion message"]
+          ]
+        },
+        {
+          "type": "text",
+          "value": "Cross-reference: `_notification` for channel configuration, credentials setup in `.claude/.env`, and hook integration."
+        }
+      ]
+    },
+    {
+      "heading": "session",
+      "content": [
+        {
+          "type": "text",
+          "value": "Session environment setup commands invoked by hooks at session start. These populate `CLAUDE_ENV_FILE` with session metadata and project environment variables."
+        },
+        {
+          "type": "table",
+          "headers": ["Command", "Synopsis", "Description"],
+          "rows": [
+            ["`gobbi session metadata`", "`gobbi session metadata`", "Extract session metadata from stdin JSON and write key=value pairs to `CLAUDE_ENV_FILE`"],
+            ["`gobbi session load-env`", "`gobbi session load-env`", "Load `.claude/.env` file and write exports to `CLAUDE_ENV_FILE`"]
+          ]
+        },
+        {
+          "type": "text",
+          "value": "Cross-reference: `gobbi` skill for session setup questions and the SessionStart hook configuration."
+        }
+      ]
+    },
+    {
+      "heading": "Media Commands",
+      "content": [
+        {
+          "type": "text",
+          "value": "Image analysis, video frame extraction, and web page capture. Standalone utilities without a dedicated domain skill."
+        },
+        {
+          "type": "subsection",
+          "heading": "image",
+          "content": [
+            {
+              "type": "table",
+              "headers": ["Command", "Synopsis", "Description"],
+              "rows": [
+                ["`gobbi image analyze`", "`gobbi image analyze <path>`", "Analyze an image: extract metadata and resize for inspection"],
+                ["`gobbi image compare`", "`gobbi image compare <paths...>`", "Compare multiple images side-by-side via contact sheet"]
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "video",
+          "content": [
+            {
+              "type": "table",
+              "headers": ["Command", "Synopsis", "Description"],
+              "rows": [
+                ["`gobbi video analyze`", "`gobbi video analyze <path>`", "Analyze a video: extract frames and generate contact sheet"]
+              ]
+            }
+          ]
+        },
+        {
+          "type": "subsection",
+          "heading": "web",
+          "content": [
+            {
+              "type": "table",
+              "headers": ["Command", "Synopsis", "Description"],
+              "rows": [
+                ["`gobbi web screenshot`", "`gobbi web screenshot <url>`", "Take a screenshot of a web page"],
+                ["`gobbi web capture`", "`gobbi web capture <url>`", "Download images from a web page"]
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "heading": "audit (Deprecated)",
+      "content": [
+        {
+          "type": "text",
+          "value": "`gobbi audit` is deprecated. It prints a deprecation warning and forwards all subcommands to `gobbi doctor`. Use `gobbi doctor` directly instead.\n\nThe former `audit` subcommands (`references`, `conventions`, `commands`) are now internal check categories within doctor's unified report."
+        }
+      ]
+    }
+  ],
+  "navigation": {}
+}

--- a/.claude/skills/_gobbi-cli/commands.md
+++ b/.claude/skills/_gobbi-cli/commands.md
@@ -1,0 +1,172 @@
+# CLI Commands
+
+Complete syntax reference for all `gobbi` CLI commands, organized by command group. For intent-based lookup ("which command do I need?"), see the parent SKILL.md.
+
+
+
+---
+
+## note
+
+Workflow note management and transcript extraction. Every task gets a note directory; every subagent's output gets collected into it.
+
+| Command | Synopsis | Description |
+|---|---|---|
+| `gobbi note metadata` | `gobbi note metadata` | Output session metadata as key=value pairs to stdout |
+| `gobbi note init` | `gobbi note init <project-name> <task-slug>` | Create note directory structure with all step subdirectories and `metadata.json` |
+| `gobbi note collect` | `gobbi note collect <agent-id> <n> <slug> <note-dir> [--phase <phase>]` | Extract subagent delegation prompt and final result from JSONL transcript into `{phase}/subtasks/{n}-{slug}.json` |
+| `gobbi note plan` | `gobbi note plan <note-dir>` | Extract plan from session transcript and write `plan.json` |
+
+### note collect options
+
+| Option | Values | Description |
+|---|---|---|
+| `--phase` | `ideation`, `plan`, `research`, `execution`, `review` | Route output to the correct step's `subtasks/` subdirectory. Determines where the extracted JSON file is written. |
+
+Cross-reference: `_note` for note directory structure, subtask JSON format, and when to write at each workflow step.
+
+---
+
+## config
+
+Manage per-session workflow configuration stored in `gobbi.json`. Sessions are identified by session ID and store workflow state such as base branch, notification preferences, and project name.
+
+| Command | Synopsis | Description |
+|---|---|---|
+| `gobbi config init` | `gobbi config init` | Create `gobbi.json` or migrate existing file to current schema version |
+| `gobbi config get` | `gobbi config get <session-id> [key]` | Read entire session object or a specific field using dot-path notation |
+| `gobbi config set` | `gobbi config set <session-id> <key> <val>` | Write a field using dot-path notation |
+| `gobbi config delete` | `gobbi config delete <session-id>` | Remove a session entry |
+| `gobbi config list` | `gobbi config list` | List all sessions as tab-separated `id\tcreatedAt` pairs |
+| `gobbi config cleanup` | `gobbi config cleanup` | Run TTL and max-entries cleanup to remove stale sessions |
+
+Cross-reference: `gobbi` skill for session setup questions and configuration keys.
+
+---
+
+## docs
+
+Manage gobbi-docs JSON templates and their Markdown output. The JSON-first workflow: edit `.json` source, run `json2md` to generate `.md`, run `validate` to check schema compliance. Never edit `.md` directly.
+
+### Authoring Commands
+
+| Command | Synopsis | Description |
+|---|---|---|
+| `gobbi docs init` | `gobbi docs init <type> [name] [--out <path>]` | Scaffold a new JSON template. Types: `skill`, `agent`, `rule`, `root`, `child`, `gotcha`. Writes to stdout by default; use `--out` for file output. |
+| `gobbi docs json2md` | `gobbi docs json2md <path>` | Convert JSON template to Markdown. Writes the `.md` file alongside the `.json` source. |
+| `gobbi docs md2json` | `gobbi docs md2json <path> [--stdout]` | Migrate existing Markdown to JSON template. Writes `.json` alongside `.md` by default; use `--stdout` for stdout output. |
+| `gobbi docs validate` | `gobbi docs validate <path>` | Validate a JSON template against the gobbi-docs schema. Reports schema violations. |
+| `gobbi docs read` | `gobbi docs read <path> [--section <name>]` | Pretty-print JSON template metadata or a specific section. |
+| `gobbi docs spec` | `gobbi docs spec` | Show the full gobbi-docs JSON schema specification. |
+
+### Exploration Commands
+
+| Command | Synopsis | Description |
+|---|---|---|
+| `gobbi docs list` | `gobbi docs list [directory] [--type <type>] [--format <fmt>]` | List all JSON templates with type, title, and content count. Formats: `table` (default), `json`. |
+| `gobbi docs tree` | `gobbi docs tree [directory] [--format <fmt>]` | Show navigation hierarchy as a tree. Formats: `text` (default), `json`. |
+| `gobbi docs search` | `gobbi docs search <pattern> [directory] [--type <type>] [--block <type>] [--format <fmt>]` | Search content across templates using regex. Filter by doc type or block type. Formats: `text` (default), `json`. |
+| `gobbi docs extract` | `gobbi docs extract <path> <query> [--format <fmt>]` | Extract content by dot-path query (e.g., `title`, `frontmatter.name`, `sections.Setup`). Formats: `json` (default), `md`, `text`. |
+| `gobbi docs stats` | `gobbi docs stats [directory] [--format <fmt>]` | Show aggregate corpus statistics. Formats: `text` (default), `json`. |
+| `gobbi docs health` | `gobbi docs health [directory] [--format <fmt>]` | Run cross-document health checks: orphans, broken links, empty sections, missing parents, bidirectional consistency. Exits with code 1 if errors found. Formats: `text` (default), `json`. |
+
+Cross-reference: `_claude` for the documentation standard, writing guidelines, and block type reference.
+
+---
+
+## doctor
+
+Unified health check for `.claude/` documentation. Consolidates reference checking, structural health, schema validation, JSON/MD sync, and completeness scoring into a single pass.
+
+| Command | Synopsis | Description |
+|---|---|---|
+| `gobbi doctor` | `gobbi doctor [--format <fmt>] [--plan] [--fix]` | Run unified health check. Default output is human-readable text. |
+
+### doctor options
+
+| Option | Description |
+|---|---|
+| `--format <fmt>` | Output format: `text` (default), `json` for structured output |
+| `--plan` | Terraform-plan-style preview of remediations. Shows auto-fixable, suggested, and skipped counts without changing anything. Exits with code 2 if auto-fixes are available. |
+| `--fix` | Auto-apply deterministic fixes (sync-out-of-date, bidirectional-consistency, naming-mismatch), then re-run doctor to show new state. |
+
+Cross-reference: `_doctor` for the maturity model (levels 0-4), check categories, auto-fixable versus suggested categories, and exit codes.
+
+---
+
+## validate
+
+Validate individual documentation files against their expected structure. Unlike `gobbi doctor` which checks the entire corpus, `validate` checks one file at a time.
+
+| Command | Synopsis | Description |
+|---|---|---|
+| `gobbi validate agent` | `gobbi validate agent <file.md>` | Validate an agent definition file |
+| `gobbi validate skill` | `gobbi validate skill <SKILL.md>` | Validate a skill definition file |
+| `gobbi validate gotcha` | `gobbi validate gotcha <file.md>` | Validate gotcha entries |
+| `gobbi validate lint` | `gobbi validate lint <file.md>` | Lint a documentation file for anti-patterns |
+
+Cross-reference: `_skills` for skill structure requirements, `_agents` for agent definition requirements, `_gotcha` for gotcha entry format.
+
+---
+
+## notify
+
+Send notifications through configured channels (Slack, Telegram, Desktop). The `send` command is for direct use; the event-specific commands are designed for hook payloads.
+
+| Command | Synopsis | Description |
+|---|---|---|
+| `gobbi notify send` | `gobbi notify send [--title "Title"]` | Send a plain-text message. Reads message body from stdin. |
+| `gobbi notify attention` | `gobbi notify attention` | Map NotificationEvent hook payload (stdin) to an attention message |
+| `gobbi notify error` | `gobbi notify error` | Map StopFailure hook payload (stdin) to an error message |
+| `gobbi notify completion` | `gobbi notify completion` | Map Stop hook payload (stdin) to a completion message (with loop guard) |
+| `gobbi notify session` | `gobbi notify session` | Map SessionStart/SessionEnd hook payload (stdin) to a lifecycle message |
+| `gobbi notify subagent` | `gobbi notify subagent` | Map SubagentStop hook payload (stdin) to a subagent completion message |
+
+Cross-reference: `_notification` for channel configuration, credentials setup in `.claude/.env`, and hook integration.
+
+---
+
+## session
+
+Session environment setup commands invoked by hooks at session start. These populate `CLAUDE_ENV_FILE` with session metadata and project environment variables.
+
+| Command | Synopsis | Description |
+|---|---|---|
+| `gobbi session metadata` | `gobbi session metadata` | Extract session metadata from stdin JSON and write key=value pairs to `CLAUDE_ENV_FILE` |
+| `gobbi session load-env` | `gobbi session load-env` | Load `.claude/.env` file and write exports to `CLAUDE_ENV_FILE` |
+
+Cross-reference: `gobbi` skill for session setup questions and the SessionStart hook configuration.
+
+---
+
+## Media Commands
+
+Image analysis, video frame extraction, and web page capture. Standalone utilities without a dedicated domain skill.
+
+### image
+
+| Command | Synopsis | Description |
+|---|---|---|
+| `gobbi image analyze` | `gobbi image analyze <path>` | Analyze an image: extract metadata and resize for inspection |
+| `gobbi image compare` | `gobbi image compare <paths...>` | Compare multiple images side-by-side via contact sheet |
+
+### video
+
+| Command | Synopsis | Description |
+|---|---|---|
+| `gobbi video analyze` | `gobbi video analyze <path>` | Analyze a video: extract frames and generate contact sheet |
+
+### web
+
+| Command | Synopsis | Description |
+|---|---|---|
+| `gobbi web screenshot` | `gobbi web screenshot <url>` | Take a screenshot of a web page |
+| `gobbi web capture` | `gobbi web capture <url>` | Download images from a web page |
+
+---
+
+## audit (Deprecated)
+
+`gobbi audit` is deprecated. It prints a deprecation warning and forwards all subcommands to `gobbi doctor`. Use `gobbi doctor` directly instead.
+
+The former `audit` subcommands (`references`, `conventions`, `commands`) are now internal check categories within doctor's unified report.

--- a/.claude/skills/_gobbi-cli/gotchas.json
+++ b/.claude/skills/_gobbi-cli/gotchas.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "gobbi-docs/gotcha",
+  "parent": "_gobbi-cli",
+  "title": "Gotcha: _gobbi-cli",
+  "entries": [
+    {
+      "title": "Editing .md directly instead of .json + json2md",
+      "body": {
+        "priority": "High",
+        "what-happened": "Agent edited the generated `.md` file directly instead of editing the `.json` source and running `gobbi docs json2md`. On the next `json2md` run, all manual edits were overwritten.",
+        "user-feedback": "Edit `.json` source and generate `.md` via `gobbi docs json2md` — never edit `.md` directly.",
+        "correct-approach": "Always edit the `.json` template file. Run `gobbi docs json2md <path>` to regenerate the `.md` output. The `.md` file is a generated artifact — it will be overwritten on every generation cycle. Manual edits to `.md` files are guaranteed to be lost."
+      },
+      "metadata": {
+        "priority": "high"
+      }
+    },
+    {
+      "title": "Not running gobbi note collect after subagent completes",
+      "body": {
+        "priority": "Critical",
+        "what-happened": "After subagents completed, the orchestrator moved on without running `gobbi note collect`. The `subtasks/` directories remained empty. Downstream agents (synthesis, evaluation) found nothing on disk.",
+        "user-feedback": "Subtask collection must happen after each subagent returns, before any downstream agent runs.",
+        "correct-approach": "After each subagent completes, run `gobbi note collect <agent-id> <n> <slug> <note-dir> [--phase <phase>]` to extract the delegation prompt and final result from the JSONL transcript. Verify the JSON file exists before launching any downstream agent that depends on it. Directory existence proves nothing — only the collect command populates subtask files."
+      },
+      "metadata": {
+        "priority": "critical"
+      }
+    },
+    {
+      "title": "Using mkdir instead of gobbi note init",
+      "body": {
+        "priority": "Critical",
+        "what-happened": "Agent created note directories manually with `mkdir -p` instead of using `gobbi note init`. The resulting directory was missing `metadata.json`, had no session ID embedding, and lacked the full subdirectory structure (step directories with `subtasks/` subdirs).",
+        "user-feedback": "Always use `gobbi note init` to create note directories.",
+        "correct-approach": "Run `gobbi note init <project-name> <task-slug>` to create the note directory. The command generates `metadata.json`, embeds the session ID in the directory name, and creates all step subdirectories (`ideation/`, `plan/`, `research/`, `execution/`, `review/`) with their `subtasks/` subdirs. Manual `mkdir` bypasses all of this."
+      },
+      "metadata": {
+        "priority": "critical"
+      }
+    },
+    {
+      "title": "Checking directory existence instead of running gobbi note collect",
+      "body": {
+        "priority": "Critical",
+        "what-happened": "The orchestrator checked whether step subdirectories existed (via `ls` or `glob`) and treated directory existence as proof that collection had happened. The directories were empty — they are created at init time by `gobbi note init`, not by `gobbi note collect`.",
+        "user-feedback": "The orchestrator just checks directory existence without real collecting.",
+        "correct-approach": "After every subagent returns, run `gobbi note collect` and then verify the subtask JSON file was created by reading it. `gobbi note init` creates empty directories at workflow start. Only `gobbi note collect` populates them with extracted transcript content. The sequence is: subagent completes, run collect, verify JSON file exists, then proceed."
+      },
+      "metadata": {
+        "priority": "critical"
+      }
+    },
+    {
+      "title": "Using gobbi audit instead of gobbi doctor",
+      "body": {
+        "priority": "Medium",
+        "what-happened": "Agent invoked `gobbi audit` for documentation health checking. The command printed a deprecation warning and forwarded to `gobbi doctor`, adding unnecessary noise to the output.",
+        "user-feedback": "Use `gobbi doctor` directly — `audit` is deprecated.",
+        "correct-approach": "Always use `gobbi doctor` for documentation health checks. The `gobbi audit` command is deprecated — it still works by forwarding to `doctor`, but it prints a deprecation warning. Using `doctor` directly avoids the warning and uses the current command name."
+      },
+      "metadata": {
+        "priority": "medium"
+      }
+    }
+  ],
+  "opening": "Common CLI usage mistakes that agents make when interacting with the gobbi CLI.",
+  "navigation": {}
+}

--- a/.claude/skills/_gobbi-cli/gotchas.md
+++ b/.claude/skills/_gobbi-cli/gotchas.md
@@ -1,0 +1,80 @@
+# Gotcha: _gobbi-cli
+
+Common CLI usage mistakes that agents make when interacting with the gobbi CLI.
+
+
+
+---
+
+### Editing .md directly instead of .json + json2md
+---
+priority: high
+---
+
+**Priority:** High
+
+**What happened:** Agent edited the generated `.md` file directly instead of editing the `.json` source and running `gobbi docs json2md`. On the next `json2md` run, all manual edits were overwritten.
+
+**User feedback:** Edit `.json` source and generate `.md` via `gobbi docs json2md` — never edit `.md` directly.
+
+**Correct approach:** Always edit the `.json` template file. Run `gobbi docs json2md <path>` to regenerate the `.md` output. The `.md` file is a generated artifact — it will be overwritten on every generation cycle. Manual edits to `.md` files are guaranteed to be lost.
+
+---
+
+### Not running gobbi note collect after subagent completes
+---
+priority: critical
+---
+
+**Priority:** Critical
+
+**What happened:** After subagents completed, the orchestrator moved on without running `gobbi note collect`. The `subtasks/` directories remained empty. Downstream agents (synthesis, evaluation) found nothing on disk.
+
+**User feedback:** Subtask collection must happen after each subagent returns, before any downstream agent runs.
+
+**Correct approach:** After each subagent completes, run `gobbi note collect <agent-id> <n> <slug> <note-dir> [--phase <phase>]` to extract the delegation prompt and final result from the JSONL transcript. Verify the JSON file exists before launching any downstream agent that depends on it. Directory existence proves nothing — only the collect command populates subtask files.
+
+---
+
+### Using mkdir instead of gobbi note init
+---
+priority: critical
+---
+
+**Priority:** Critical
+
+**What happened:** Agent created note directories manually with `mkdir -p` instead of using `gobbi note init`. The resulting directory was missing `metadata.json`, had no session ID embedding, and lacked the full subdirectory structure (step directories with `subtasks/` subdirs).
+
+**User feedback:** Always use `gobbi note init` to create note directories.
+
+**Correct approach:** Run `gobbi note init <project-name> <task-slug>` to create the note directory. The command generates `metadata.json`, embeds the session ID in the directory name, and creates all step subdirectories (`ideation/`, `plan/`, `research/`, `execution/`, `review/`) with their `subtasks/` subdirs. Manual `mkdir` bypasses all of this.
+
+---
+
+### Checking directory existence instead of running gobbi note collect
+---
+priority: critical
+---
+
+**Priority:** Critical
+
+**What happened:** The orchestrator checked whether step subdirectories existed (via `ls` or `glob`) and treated directory existence as proof that collection had happened. The directories were empty — they are created at init time by `gobbi note init`, not by `gobbi note collect`.
+
+**User feedback:** The orchestrator just checks directory existence without real collecting.
+
+**Correct approach:** After every subagent returns, run `gobbi note collect` and then verify the subtask JSON file was created by reading it. `gobbi note init` creates empty directories at workflow start. Only `gobbi note collect` populates them with extracted transcript content. The sequence is: subagent completes, run collect, verify JSON file exists, then proceed.
+
+---
+
+### Using gobbi audit instead of gobbi doctor
+---
+priority: medium
+---
+
+**Priority:** Medium
+
+**What happened:** Agent invoked `gobbi audit` for documentation health checking. The command printed a deprecation warning and forwarded to `gobbi doctor`, adding unnecessary noise to the output.
+
+**User feedback:** Use `gobbi doctor` directly — `audit` is deprecated.
+
+**Correct approach:** Always use `gobbi doctor` for documentation health checks. The `gobbi audit` command is deprecated — it still works by forwarding to `doctor`, but it prints a deprecation warning. Using `doctor` directly avoids the warning and uses the current command name.

--- a/.claude/skills/gobbi/SKILL.json
+++ b/.claude/skills/gobbi/SKILL.json
@@ -333,6 +333,10 @@
               ],
               "rows": [
                 [
+                  "**_gobbi-cli**",
+                  "Intent-first CLI reference. Maps agent tasks to gobbi commands and cross-references domain skills for workflow context."
+                ],
+                [
                   "**_doctor**",
                   "Unified health check. Verify .claude/ docs match codebase reality, assess maturity, and check completeness."
                 ],

--- a/.claude/skills/gobbi/SKILL.md
+++ b/.claude/skills/gobbi/SKILL.md
@@ -178,6 +178,7 @@ Utility and maintenance tooling.
 
 | Skill | Purpose |
 |---|---|
+| **_gobbi-cli** | Intent-first CLI reference. Maps agent tasks to gobbi commands and cross-references domain skills for workflow context. |
 | **_doctor** | Unified health check. Verify .claude/ docs match codebase reality, assess maturity, and check completeness. |
 | **_gobbi-rule-container** | Container for `_gobbi-rule` behavioral rule. Source files symlinked into `.claude/rules/` at session start for auto-update with plugin. |
 


### PR DESCRIPTION
## Summary
- Create new `_gobbi-cli` skill (Tool category) — intent-first guide mapping agent tasks to gobbi CLI commands
- Add `commands.md` child doc — complete syntax reference for all 37 CLI commands
- Add `gotchas.md` — 5 CLI usage gotchas (3 critical, 1 high, 1 medium)
- Update gobbi SKILL.md to register `_gobbi-cli` in the Tool skill table

## Design
Two-layer architecture:
- **SKILL.md** — "Which command do I need?" (intent → command routing)
- **commands.md** — "How do I call it?" (full syntax reference)
- **Domain skills** — "When and why?" (workflow context, unchanged)

Closes #58

## Test plan
- [ ] `gobbi docs validate .claude/skills/_gobbi-cli/SKILL.json` passes
- [ ] `gobbi docs validate .claude/skills/_gobbi-cli/commands.json` passes
- [ ] `gobbi docs validate .claude/skills/_gobbi-cli/gotchas.json` passes
- [ ] `gobbi validate skill .claude/skills/_gobbi-cli/SKILL.md` passes
- [ ] Both MD files under 400 lines
- [ ] All CLI commands represented in commands.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)