### PR TITLE
feat: gobbi prompt architecture — chain-of-prompts for v0.5.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "tsc && node --test dist/test/doctor.test.js dist/test/remediation.test.js"
+    "test": "tsc && node --test dist/test/doctor.test.js dist/test/remediation.test.js dist/test/prompt.test.js"
   },
   "dependencies": {
     "proper-lockfile": "^4.1.2"

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -17,6 +17,7 @@ Commands:
   image      Analyze images or create comparison sheets
   video      Analyze video files and extract frames
   web        Take screenshots or capture images from web pages
+  prompt     Deliver phase-specific orchestrator prompts
 
 Options:
   --help              Show this help message
@@ -26,7 +27,7 @@ export async function run(): Promise<void> {
   const command = process.argv[2];
 
   // Early routing for commands (they have their own parseArgs)
-  const COMMANDS = ['docs', 'config', 'session', 'notify', 'note', 'validate', 'audit', 'doctor', 'image', 'video', 'web'] as const;
+  const COMMANDS = ['docs', 'config', 'session', 'notify', 'note', 'validate', 'audit', 'doctor', 'image', 'video', 'web', 'prompt'] as const;
   if (command !== undefined && (COMMANDS as readonly string[]).includes(command)) {
     const commandArgs = process.argv.slice(3);
     switch (command) {
@@ -83,6 +84,11 @@ export async function run(): Promise<void> {
       case 'web': {
         const { runWeb } = await import('./commands/web.js');
         await runWeb(commandArgs);
+        return;
+      }
+      case 'prompt': {
+        const { runPrompt } = await import('./commands/prompt.js');
+        await runPrompt(commandArgs);
         return;
       }
     }

--- a/packages/cli/src/commands/prompt.ts
+++ b/packages/cli/src/commands/prompt.ts
@@ -1,0 +1,382 @@
+/**
+ * gobbi prompt — render phase-specific orchestrator prompts.
+ *
+ * Subcommands:
+ *   <phase>        Render the prompt for the given phase
+ *   validate       Validate all registered prompt templates
+ *   status         Show current prompt state and consistency
+ *
+ * Options:
+ *   --markdown     Output in markdown format (default: plain text)
+ *   --help         Show this help message
+ */
+
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { parseArgs } from 'node:util';
+
+import { error, ok, header, dim, formatTable } from '../lib/style.js';
+import { isPromptPhase, isPromptTemplate, VALID_PROMPT_PHASES } from '../lib/prompt/types.js';
+import type { PromptPhase } from '../lib/prompt/types.js';
+import { readPromptState, resolvePromptStatePath, writePromptStateAtomic, updatePromptHistory, emptyPromptState } from '../lib/prompt/state.js';
+import { resolveAllVariables, PromptResolutionError } from '../lib/prompt/variables.js';
+import { renderPrompt } from '../lib/prompt/renderer.js';
+import { getTemplate } from '../lib/prompt/templates/index.js';
+import { withLock } from '../lib/lockfile.js';
+
+// ---------------------------------------------------------------------------
+// Usage
+// ---------------------------------------------------------------------------
+
+const USAGE = `Usage: gobbi prompt <phase> [options]
+
+Phases:
+  session-start      Initialize session (settings, project detection)
+  workflow-start     Classify task and start workflow
+
+Subcommands:
+  validate           Validate all registered prompt templates
+  status             Show current prompt state and consistency
+
+Options:
+  --markdown         Output in markdown format (default: plain text)
+  --help             Show this help message`;
+
+// ---------------------------------------------------------------------------
+// Implemented Phases
+// ---------------------------------------------------------------------------
+
+const IMPLEMENTED_PHASES: readonly PromptPhase[] = ['session-start', 'workflow-start'];
+
+// ---------------------------------------------------------------------------
+// Top-Level Router
+// ---------------------------------------------------------------------------
+
+/**
+ * Top-level handler for `gobbi prompt`. Dispatches to subcommands.
+ * Called from cli.ts with process.argv.slice(3).
+ */
+export async function runPrompt(args: string[]): Promise<void> {
+  const subcommand = args[0];
+
+  switch (subcommand) {
+    case '--help':
+    case undefined:
+      console.log(USAGE);
+      return;
+    case 'validate':
+      await runPromptValidate();
+      return;
+    case 'status':
+      await runPromptStatus();
+      return;
+    default:
+      await runPromptRender(args);
+      return;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+async function runPromptRender(args: string[]): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args,
+    allowPositionals: true,
+    options: {
+      markdown: { type: 'boolean', default: false },
+    },
+  });
+
+  const phaseArg = positionals[0];
+  if (phaseArg === undefined) {
+    console.error(error('No phase specified'));
+    console.log(USAGE);
+    process.exit(1);
+  }
+
+  if (!isPromptPhase(phaseArg)) {
+    console.error(error(`"${phaseArg}" is not a valid prompt phase`));
+    console.error(dim(`  Valid phases: ${VALID_PROMPT_PHASES.join(', ')}`));
+    process.exit(1);
+  }
+
+  const template = getTemplate(phaseArg);
+  if (template === undefined) {
+    console.error(error(`Phase "${phaseArg}" is not yet implemented. Available: ${IMPLEMENTED_PHASES.join(', ')}`));
+    process.exit(1);
+  }
+
+  // Build runtime values
+  const runtimeValues: Record<string, string> = {};
+
+  if (phaseArg === 'workflow-start') {
+    // Read project name from prompt state or use default
+    const statePath = resolvePromptStatePath();
+    if (statePath !== null) {
+      const state = await readPromptState(statePath);
+      if (state !== null && state.project.name !== '') {
+        runtimeValues['projectName'] = state.project.name;
+      } else {
+        runtimeValues['projectName'] = 'default';
+      }
+    } else {
+      runtimeValues['projectName'] = 'default';
+    }
+
+    // Read orchestration gotchas file
+    const projectDir = process.env['CLAUDE_PROJECT_DIR'];
+    if (projectDir !== undefined) {
+      const gotchasPath = join(projectDir, '.claude', 'skills', '_orchestration', 'gotchas.md');
+      try {
+        const gotchasContent = await readFile(gotchasPath, 'utf8');
+        runtimeValues['orchestrationGotchas'] = gotchasContent;
+      } catch {
+        runtimeValues['orchestrationGotchas'] = 'No gotchas loaded.';
+      }
+    } else {
+      runtimeValues['orchestrationGotchas'] = 'No gotchas loaded.';
+    }
+  }
+
+  // Resolve variables
+  let resolved: Record<string, string>;
+  try {
+    resolved = await resolveAllVariables(template.variables, runtimeValues);
+  } catch (err) {
+    if (err instanceof PromptResolutionError) {
+      console.error(error(`Variable resolution failed: ${err.message}`));
+      process.exit(1);
+    }
+    throw err;
+  }
+
+  // Render
+  const markdown = values.markdown === true;
+  const output = renderPrompt(template, resolved, { markdown });
+  console.log(output);
+
+  // Update prompt state
+  const statePath = resolvePromptStatePath();
+  if (statePath !== null) {
+    try {
+      await withLock(statePath, async () => {
+        const current = await readPromptState(statePath) ?? emptyPromptState();
+        const updated = updatePromptHistory(current, phaseArg, 'rendered');
+        const withPhase = {
+          ...updated,
+          workflow: {
+            ...updated.workflow,
+            currentPhase: phaseArg,
+          },
+        };
+        await writePromptStateAtomic(statePath, withPhase);
+      });
+    } catch {
+      // State update is best-effort — do not fail the render
+      console.error(dim('  (Could not update prompt state)'));
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Validate
+// ---------------------------------------------------------------------------
+
+async function runPromptValidate(): Promise<void> {
+  console.log(header('Prompt Template Validation'));
+  console.log('');
+
+  let allPassed = true;
+
+  for (const phase of VALID_PROMPT_PHASES) {
+    const template = getTemplate(phase);
+
+    if (template === undefined) {
+      console.log(dim(`  - ${phase}: not yet implemented`));
+      continue;
+    }
+
+    // Structural validation via type guard
+    if (!isPromptTemplate(template)) {
+      console.log(error(`${phase}: fails structural validation`));
+      allPassed = false;
+      continue;
+    }
+
+    // Check schema matches phase
+    const expectedSchema = `gobbi-prompt/${phase}`;
+    if (template.$schema !== expectedSchema) {
+      console.log(error(`${phase}: schema mismatch (expected "${expectedSchema}", got "${template.$schema}")`));
+      allPassed = false;
+      continue;
+    }
+
+    // Check phase field
+    if (template.phase !== phase) {
+      console.log(error(`${phase}: phase field mismatch (expected "${phase}", got "${template.phase}")`));
+      allPassed = false;
+      continue;
+    }
+
+    // Try resolving variables with mock runtime values
+    const mockRuntime: Record<string, string> = {};
+    for (const [name, decl] of Object.entries(template.variables)) {
+      if (decl.source === 'runtime') {
+        mockRuntime[decl.path] = `<mock-${name}>`;
+      }
+    }
+
+    let resolved: Record<string, string>;
+    try {
+      // For validation, override required env/config/file variables with fallbacks
+      // by creating a permissive resolution that catches errors
+      resolved = await resolveAllVariablesPermissive(template.variables, mockRuntime);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.log(error(`${phase}: variable resolution failed: ${msg}`));
+      allPassed = false;
+      continue;
+    }
+
+    // Try rendering
+    try {
+      const output = renderPrompt(template, resolved, { markdown: false });
+      const lineCount = output.split('\n').length;
+      console.log(ok(`${phase}: valid (${Object.keys(template.variables).length} variables, ${template.layers.length} layers, ${lineCount} lines)`));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.log(error(`${phase}: render failed: ${msg}`));
+      allPassed = false;
+    }
+  }
+
+  console.log('');
+  if (allPassed) {
+    console.log(ok('All implemented templates pass validation'));
+  } else {
+    console.log(error('Some templates failed validation'));
+    process.exit(1);
+  }
+}
+
+/**
+ * Permissive variable resolution for validation purposes.
+ * Fills in mock values for required variables that cannot be resolved
+ * from the environment (env, config, file, command, state, git sources).
+ */
+async function resolveAllVariablesPermissive(
+  variables: Record<string, import('../lib/prompt/types.js').VariableDeclaration>,
+  runtimeValues: Record<string, string>,
+): Promise<Record<string, string>> {
+  const resolved: Record<string, string> = {};
+
+  for (const [name, declaration] of Object.entries(variables)) {
+    // For runtime variables, use the provided mock values
+    if (declaration.source === 'runtime') {
+      const value = runtimeValues[declaration.path];
+      resolved[name] = value ?? declaration.fallback ?? `<${name}>`;
+      continue;
+    }
+
+    // For other sources, try real resolution but fall back gracefully
+    try {
+      const { resolveVariable } = await import('../lib/prompt/variables.js');
+      const value = await resolveVariable(name, declaration, runtimeValues);
+      resolved[name] = value ?? declaration.fallback ?? `<${name}>`;
+    } catch {
+      resolved[name] = declaration.fallback ?? `<${name}>`;
+    }
+  }
+
+  return resolved;
+}
+
+// ---------------------------------------------------------------------------
+// Status
+// ---------------------------------------------------------------------------
+
+async function runPromptStatus(): Promise<void> {
+  const statePath = resolvePromptStatePath();
+
+  if (statePath === null) {
+    console.log(dim('No prompt state found. CLAUDE_PROJECT_DIR is not set.'));
+    console.log(dim('Run `gobbi prompt session-start` inside a Claude Code session to initialize.'));
+    return;
+  }
+
+  const state = await readPromptState(statePath);
+
+  if (state === null) {
+    console.log(dim('No prompt state found. Run `gobbi prompt session-start` to initialize.'));
+    return;
+  }
+
+  // Display current state
+  console.log(header('Prompt State'));
+  console.log('');
+
+  // Session settings
+  console.log(header('Session'));
+  const sessionRows: string[][] = [
+    ['trivialRange', state.session.trivialRange],
+    ['evaluationMode', state.session.evaluationMode],
+    ['gitWorkflow', state.session.gitWorkflow],
+    ['notify.slack', String(state.session.notify.slack)],
+    ['notify.telegram', String(state.session.notify.telegram)],
+    ['notify.discord', String(state.session.notify.discord)],
+  ];
+  console.log(formatTable(['Setting', 'Value'], sessionRows));
+  console.log('');
+
+  // Project context
+  console.log(header('Project'));
+  const projectRows: string[][] = [
+    ['name', state.project.name || dim('(not set)')],
+    ['noteDir', state.project.noteDir ?? dim('(none)')],
+    ['projectDir', state.project.projectDir || dim('(not set)')],
+    ['baseBranch', state.project.baseBranch ?? dim('(none)')],
+  ];
+  console.log(formatTable(['Field', 'Value'], projectRows));
+  console.log('');
+
+  // Workflow state
+  console.log(header('Workflow'));
+  const workflowRows: string[][] = [
+    ['currentPhase', state.workflow.currentPhase ?? dim('(none)')],
+    ['taskSlug', state.workflow.taskSlug ?? dim('(none)')],
+    ['taskTier', state.workflow.taskTier ?? dim('(none)')],
+    ['feedbackRound', String(state.workflow.feedbackRound)],
+  ];
+  console.log(formatTable(['Field', 'Value'], workflowRows));
+  console.log('');
+
+  // History
+  if (state.history.length > 0) {
+    console.log(header('History'));
+    const historyRows: string[][] = state.history.map((entry) => [
+      entry.phase,
+      entry.outcome,
+      entry.timestamp,
+    ]);
+    console.log(formatTable(['Phase', 'Outcome', 'Timestamp'], historyRows));
+  } else {
+    console.log(dim('No history entries.'));
+  }
+
+  // Consistency check
+  console.log('');
+  console.log(header('Consistency'));
+  const currentPhase = state.workflow.currentPhase;
+  if (currentPhase === null) {
+    console.log(dim('  No active workflow phase.'));
+  } else {
+    const noteDir = state.project.noteDir;
+    if (noteDir !== null) {
+      console.log(ok(`Active phase: ${currentPhase}, note directory: ${noteDir}`));
+    } else {
+      console.log(dim(`  Active phase: ${currentPhase}, but no note directory set.`));
+    }
+  }
+}

--- a/packages/cli/src/commands/prompt.ts
+++ b/packages/cli/src/commands/prompt.ts
@@ -2,13 +2,14 @@
  * gobbi prompt — render phase-specific orchestrator prompts.
  *
  * Subcommands:
- *   <phase>        Render the prompt for the given phase
- *   validate       Validate all registered prompt templates
- *   status         Show current prompt state and consistency
+ *   <phase>           Render the prompt for the given phase
+ *   validate          Validate all registered prompt templates
+ *   status            Show current prompt state and consistency
+ *   record-outcome    Record a phase outcome and print the next command
  *
  * Options:
- *   --markdown     Output in markdown format (default: plain text)
- *   --help         Show this help message
+ *   --markdown        Output in markdown format (default: plain text)
+ *   --help            Show this help message
  */
 
 import { readFile } from 'node:fs/promises';
@@ -22,6 +23,7 @@ import { readPromptState, resolvePromptStatePath, writePromptStateAtomic, update
 import { resolveAllVariables, PromptResolutionError } from '../lib/prompt/variables.js';
 import { renderPrompt } from '../lib/prompt/renderer.js';
 import { getTemplate } from '../lib/prompt/templates/index.js';
+import { getTransitionNode, getNextPhase } from '../lib/prompt/graph.js';
 import { withLock } from '../lib/lockfile.js';
 
 // ---------------------------------------------------------------------------
@@ -35,8 +37,9 @@ Phases:
   workflow-start     Classify task and start workflow
 
 Subcommands:
-  validate           Validate all registered prompt templates
-  status             Show current prompt state and consistency
+  validate                          Validate all registered prompt templates
+  status                            Show current prompt state and consistency
+  record-outcome <phase> <outcome>  Record a phase outcome and print next command
 
 Options:
   --markdown         Output in markdown format (default: plain text)
@@ -69,6 +72,9 @@ export async function runPrompt(args: string[]): Promise<void> {
       return;
     case 'status':
       await runPromptStatus();
+      return;
+    case 'record-outcome':
+      await runPromptRecordOutcome(args.slice(1));
       return;
     default:
       await runPromptRender(args);
@@ -177,6 +183,70 @@ async function runPromptRender(args: string[]): Promise<void> {
       // State update is best-effort — do not fail the render
       console.error(dim('  (Could not update prompt state)'));
     }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Record Outcome
+// ---------------------------------------------------------------------------
+
+async function runPromptRecordOutcome(args: string[]): Promise<void> {
+  const phaseArg = args[0];
+  const outcomeArg = args[1];
+
+  if (phaseArg === undefined || outcomeArg === undefined) {
+    console.error(error('Usage: gobbi prompt record-outcome <phase> <outcome-id>'));
+    process.exit(1);
+  }
+
+  // Validate phase
+  if (!isPromptPhase(phaseArg)) {
+    console.error(error(`"${phaseArg}" is not a valid prompt phase`));
+    console.error(dim(`  Valid phases: ${VALID_PROMPT_PHASES.join(', ')}`));
+    process.exit(1);
+  }
+
+  // Validate outcome against the transition graph node's completion outcomes
+  const node = getTransitionNode(phaseArg);
+  if (node === undefined) {
+    console.error(error(`No transition graph node for phase "${phaseArg}"`));
+    process.exit(1);
+  }
+
+  const validOutcomeIds = node.completion.outcomes.map((o) => o.id);
+  if (!validOutcomeIds.includes(outcomeArg)) {
+    console.error(error(`"${outcomeArg}" is not a valid outcome for phase "${phaseArg}"`));
+    console.error(dim(`  Valid outcomes: ${validOutcomeIds.join(', ')}`));
+    process.exit(1);
+  }
+
+  // Update prompt state
+  const statePath = resolvePromptStatePath();
+  if (statePath === null) {
+    console.error(error('CLAUDE_PROJECT_DIR is not set — cannot update prompt state'));
+    process.exit(1);
+  }
+
+  await withLock(statePath, async () => {
+    const current = await readPromptState(statePath) ?? emptyPromptState();
+    const withHistory = updatePromptHistory(current, phaseArg, outcomeArg);
+    const updated = {
+      ...withHistory,
+      workflow: {
+        ...withHistory.workflow,
+        currentPhase: phaseArg,
+      },
+    };
+    await writePromptStateAtomic(statePath, updated);
+  });
+
+  // Resolve and print next phase
+  const nextPhase = getNextPhase(phaseArg, { outcome: outcomeArg });
+
+  if (nextPhase === null) {
+    console.log('Terminal — no next phase');
+  } else {
+    console.log(`gobbi prompt ${nextPhase}`);
   }
 }
 

--- a/packages/cli/src/lib/prompt/graph.ts
+++ b/packages/cli/src/lib/prompt/graph.ts
@@ -1,0 +1,355 @@
+/**
+ * Prompt transition graph — complete routing map for all 14 phases.
+ *
+ * Each node declares its completion outcomes and ASL Choice-style transitions.
+ * The graph is a static data structure; `getNextPhase()` resolves transitions
+ * by evaluating conditions against the provided outcome.
+ */
+
+import type { PromptPhase, PromptSchema, Completion, Transitions } from './types.js';
+import { PROMPT_PHASE_TO_SCHEMA, isPromptPhase } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Graph Node
+// ---------------------------------------------------------------------------
+
+/** A single node in the transition graph. */
+export interface TransitionGraphNode {
+  phase: PromptPhase;
+  schema: PromptSchema;
+  description: string;
+  completion: Completion;
+  transitions: Transitions;
+}
+
+// ---------------------------------------------------------------------------
+// Transition Graph
+// ---------------------------------------------------------------------------
+
+/**
+ * Complete routing map for all 14 prompt phases.
+ *
+ * Terminal states use `default: '__terminal__'` to indicate no next phase.
+ * Return-to-parent states use `default: '__parent__'` to indicate the
+ * orchestrator should resume the calling context.
+ */
+export const TRANSITION_GRAPH: Readonly<Record<PromptPhase, TransitionGraphNode>> = {
+  'session-start': {
+    phase: 'session-start',
+    schema: PROMPT_PHASE_TO_SCHEMA['session-start'],
+    description: 'Initialize session — gather user preferences and environment',
+    completion: {
+      type: 'select-outcome',
+      outcomes: [
+        { id: 'configured', description: 'Session configured successfully' },
+      ],
+    },
+    transitions: {
+      type: 'choice',
+      choices: [
+        { condition: { variable: 'outcome', equals: 'configured' }, next: 'workflow-start' },
+      ],
+      default: 'workflow-start',
+    },
+  },
+
+  'project-setup': {
+    phase: 'project-setup',
+    schema: PROMPT_PHASE_TO_SCHEMA['project-setup'],
+    description: 'Configure project context — name, directories, base branch',
+    completion: {
+      type: 'select-outcome',
+      outcomes: [
+        { id: 'configured', description: 'Project configured successfully' },
+      ],
+    },
+    transitions: {
+      type: 'choice',
+      choices: [
+        { condition: { variable: 'outcome', equals: 'configured' }, next: 'workflow-start' },
+      ],
+      default: 'workflow-start',
+    },
+  },
+
+  'workflow-start': {
+    phase: 'workflow-start',
+    schema: PROMPT_PHASE_TO_SCHEMA['workflow-start'],
+    description: 'Classify task tier and route to appropriate workflow',
+    completion: {
+      type: 'select-outcome',
+      outcomes: [
+        { id: 'trivial', description: 'Trivial task — execute directly, no workflow' },
+        { id: 'structured-routine', description: 'Structured routine — skip ideation, go to execution' },
+        { id: 'non-trivial', description: 'Non-trivial — full workflow starting with ideation' },
+      ],
+    },
+    transitions: {
+      type: 'choice',
+      choices: [
+        { condition: { variable: 'outcome', equals: 'trivial' }, next: '__terminal__' },
+        { condition: { variable: 'outcome', equals: 'structured-routine' }, next: 'workflow-execution' },
+        { condition: { variable: 'outcome', equals: 'non-trivial' }, next: 'workflow-ideation' },
+      ],
+      default: 'workflow-ideation',
+    },
+  },
+
+  'workflow-ideation': {
+    phase: 'workflow-ideation',
+    schema: PROMPT_PHASE_TO_SCHEMA['workflow-ideation'],
+    description: 'PI agents explore what to do — innovative and best-practice stances',
+    completion: {
+      type: 'select-outcome',
+      outcomes: [
+        { id: 'ideas-ready', description: 'Ideation complete, proceed to planning' },
+      ],
+    },
+    transitions: {
+      type: 'choice',
+      choices: [
+        { condition: { variable: 'outcome', equals: 'ideas-ready' }, next: 'workflow-plan' },
+      ],
+      default: 'workflow-plan',
+    },
+  },
+
+  'workflow-plan': {
+    phase: 'workflow-plan',
+    schema: PROMPT_PHASE_TO_SCHEMA['workflow-plan'],
+    description: 'Decompose chosen idea into narrow, ordered tasks',
+    completion: {
+      type: 'select-outcome',
+      outcomes: [
+        { id: 'plan-approved', description: 'Plan approved, proceed to research' },
+      ],
+    },
+    transitions: {
+      type: 'choice',
+      choices: [
+        { condition: { variable: 'outcome', equals: 'plan-approved' }, next: 'workflow-research' },
+      ],
+      default: 'workflow-research',
+    },
+  },
+
+  'workflow-research': {
+    phase: 'workflow-research',
+    schema: PROMPT_PHASE_TO_SCHEMA['workflow-research'],
+    description: 'Research agents investigate how to implement the plan',
+    completion: {
+      type: 'select-outcome',
+      outcomes: [
+        { id: 'research-complete', description: 'Research complete, proceed to execution' },
+      ],
+    },
+    transitions: {
+      type: 'choice',
+      choices: [
+        { condition: { variable: 'outcome', equals: 'research-complete' }, next: 'workflow-execution' },
+      ],
+      default: 'workflow-execution',
+    },
+  },
+
+  'workflow-execution': {
+    phase: 'workflow-execution',
+    schema: PROMPT_PHASE_TO_SCHEMA['workflow-execution'],
+    description: 'Execute tasks one at a time — implement, verify, proceed',
+    completion: {
+      type: 'select-outcome',
+      outcomes: [
+        { id: 'execution-complete', description: 'All tasks executed, proceed to collection' },
+      ],
+    },
+    transitions: {
+      type: 'choice',
+      choices: [
+        { condition: { variable: 'outcome', equals: 'execution-complete' }, next: 'workflow-collection' },
+      ],
+      default: 'workflow-collection',
+    },
+  },
+
+  'workflow-collection': {
+    phase: 'workflow-collection',
+    schema: PROMPT_PHASE_TO_SCHEMA['workflow-collection'],
+    description: 'Verify notes, write README, record gotchas',
+    completion: {
+      type: 'select-outcome',
+      outcomes: [
+        { id: 'collected', description: 'Collection complete, proceed to memorization' },
+      ],
+    },
+    transitions: {
+      type: 'choice',
+      choices: [
+        { condition: { variable: 'outcome', equals: 'collected' }, next: 'workflow-memorization' },
+      ],
+      default: 'workflow-memorization',
+    },
+  },
+
+  'workflow-memorization': {
+    phase: 'workflow-memorization',
+    schema: PROMPT_PHASE_TO_SCHEMA['workflow-memorization'],
+    description: 'Save context for session continuity — decisions, state, open questions',
+    completion: {
+      type: 'select-outcome',
+      outcomes: [
+        { id: 'memorized', description: 'Context saved, proceed to review' },
+      ],
+    },
+    transitions: {
+      type: 'choice',
+      choices: [
+        { condition: { variable: 'outcome', equals: 'memorized' }, next: 'workflow-review' },
+      ],
+      default: 'workflow-review',
+    },
+  },
+
+  'workflow-review': {
+    phase: 'workflow-review',
+    schema: PROMPT_PHASE_TO_SCHEMA['workflow-review'],
+    description: 'PI agents assess the work — verdict and documentation',
+    completion: {
+      type: 'select-outcome',
+      outcomes: [
+        { id: 'pass', description: 'Review passed, finish workflow' },
+        { id: 'needs-work', description: 'Needs improvements, enter feedback loop' },
+        { id: 'fail', description: 'Significant issues, enter feedback loop' },
+      ],
+    },
+    transitions: {
+      type: 'choice',
+      choices: [
+        { condition: { variable: 'outcome', equals: 'pass' }, next: 'workflow-finish' },
+        { condition: { variable: 'outcome', equals: 'needs-work' }, next: 'workflow-feedback' },
+        { condition: { variable: 'outcome', equals: 'fail' }, next: 'workflow-feedback' },
+      ],
+      default: 'workflow-feedback',
+    },
+  },
+
+  'workflow-feedback': {
+    phase: 'workflow-feedback',
+    schema: PROMPT_PHASE_TO_SCHEMA['workflow-feedback'],
+    description: 'Address review findings — user decides what to fix, defer, or disagree with',
+    completion: {
+      type: 'select-outcome',
+      outcomes: [
+        { id: 'feedback-applied', description: 'Feedback addressed, return to review' },
+      ],
+    },
+    transitions: {
+      type: 'choice',
+      choices: [
+        { condition: { variable: 'outcome', equals: 'feedback-applied' }, next: 'workflow-review' },
+      ],
+      default: 'workflow-review',
+    },
+  },
+
+  'workflow-finish': {
+    phase: 'workflow-finish',
+    schema: PROMPT_PHASE_TO_SCHEMA['workflow-finish'],
+    description: 'Workflow complete — final summary and cleanup',
+    completion: {
+      type: 'select-outcome',
+      outcomes: [
+        { id: 'finished', description: 'Workflow finished' },
+      ],
+    },
+    transitions: {
+      type: 'choice',
+      choices: [],
+      default: '__terminal__',
+    },
+  },
+
+  'evaluation-ask': {
+    phase: 'evaluation-ask',
+    schema: PROMPT_PHASE_TO_SCHEMA['evaluation-ask'],
+    description: 'Ask user whether to run evaluation at this point',
+    completion: {
+      type: 'select-outcome',
+      outcomes: [
+        { id: 'evaluate', description: 'User wants evaluation — spawn evaluators' },
+        { id: 'skip', description: 'User skips evaluation — return to parent phase' },
+      ],
+    },
+    transitions: {
+      type: 'choice',
+      choices: [
+        { condition: { variable: 'outcome', equals: 'evaluate' }, next: 'evaluation-spawn' },
+        { condition: { variable: 'outcome', equals: 'skip' }, next: '__parent__' },
+      ],
+      default: '__parent__',
+    },
+  },
+
+  'evaluation-spawn': {
+    phase: 'evaluation-spawn',
+    schema: PROMPT_PHASE_TO_SCHEMA['evaluation-spawn'],
+    description: 'Spawn evaluator agents and collect findings',
+    completion: {
+      type: 'select-outcome',
+      outcomes: [
+        { id: 'evaluated', description: 'Evaluation complete — return to parent phase' },
+      ],
+    },
+    transitions: {
+      type: 'choice',
+      choices: [
+        { condition: { variable: 'outcome', equals: 'evaluated' }, next: '__parent__' },
+      ],
+      default: '__parent__',
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Lookup Functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the transition graph node for a phase.
+ * Returns undefined if the phase is not in the graph.
+ */
+export function getTransitionNode(phase: PromptPhase): TransitionGraphNode | undefined {
+  return TRANSITION_GRAPH[phase];
+}
+
+/**
+ * Resolve the next phase given a current phase and outcome.
+ *
+ * Evaluates each transition choice in order: if the outcome matches a
+ * choice's condition, returns that choice's `next` value. Falls back to
+ * the node's default transition.
+ *
+ * Returns null for terminal states (`__terminal__`) and parent returns
+ * (`__parent__`). Returns null if the phase is not in the graph.
+ */
+export function getNextPhase(
+  phase: PromptPhase,
+  outcome: string,
+): string | null {
+  const node = TRANSITION_GRAPH[phase];
+  if (!node) return null;
+
+  const { transitions } = node;
+
+  for (const choice of transitions.choices) {
+    if (choice.condition.variable === 'outcome' && choice.condition.equals === outcome) {
+      const next = choice.next;
+      if (next === '__terminal__' || next === '__parent__') return null;
+      return isPromptPhase(next) ? next : null;
+    }
+  }
+
+  // Fall back to default
+  const defaultNext = transitions.default;
+  if (defaultNext === '__terminal__' || defaultNext === '__parent__') return null;
+  return isPromptPhase(defaultNext) ? defaultNext : null;
+}

--- a/packages/cli/src/lib/prompt/graph.ts
+++ b/packages/cli/src/lib/prompt/graph.ts
@@ -322,18 +322,21 @@ export function getTransitionNode(phase: PromptPhase): TransitionGraphNode | und
 }
 
 /**
- * Resolve the next phase given a current phase and outcome.
+ * Resolve the next phase given a current phase and a context of variable values.
  *
- * Evaluates each transition choice in order: if the outcome matches a
- * choice's condition, returns that choice's `next` value. Falls back to
- * the node's default transition.
+ * Evaluates each transition choice in order (ASL Choice pattern): for each
+ * choice, checks whether `context[condition.variable] === condition.equals`.
+ * First match wins. Falls back to the node's default transition when no
+ * choice matches.
+ *
+ * The `outcome` value should be passed as `context.outcome`.
  *
  * Returns null for terminal states (`__terminal__`) and parent returns
  * (`__parent__`). Returns null if the phase is not in the graph.
  */
 export function getNextPhase(
   phase: PromptPhase,
-  outcome: string,
+  context: Record<string, string>,
 ): string | null {
   const node = TRANSITION_GRAPH[phase];
   if (!node) return null;
@@ -341,7 +344,8 @@ export function getNextPhase(
   const { transitions } = node;
 
   for (const choice of transitions.choices) {
-    if (choice.condition.variable === 'outcome' && choice.condition.equals === outcome) {
+    const contextValue = context[choice.condition.variable];
+    if (contextValue !== undefined && contextValue === choice.condition.equals) {
       const next = choice.next;
       if (next === '__terminal__' || next === '__parent__') return null;
       return isPromptPhase(next) ? next : null;

--- a/packages/cli/src/lib/prompt/renderer.ts
+++ b/packages/cli/src/lib/prompt/renderer.ts
@@ -1,0 +1,245 @@
+/**
+ * Prompt renderer — takes a PromptTemplate and ResolvedVariables,
+ * produces formatted plain text or markdown output.
+ *
+ * Supports two output formats:
+ * - Plain text (default): structured with `---` delimiters and bracket headers
+ * - Markdown: uses heading levels, tables, and inline code formatting
+ *
+ * Emits a stderr warning if the rendered output exceeds 200 lines.
+ */
+
+import type { PromptTemplate, PromptLayer, AskUserQuestion, Completion, Transitions } from './types.js';
+import type { ResolvedVariables } from './variables.js';
+import { interpolate } from './variables.js';
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface RenderOptions {
+  markdown: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Line Limit
+// ---------------------------------------------------------------------------
+
+const LINE_LIMIT = 200;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a prompt template with resolved variables into formatted output.
+ *
+ * @param template - The prompt template to render
+ * @param resolved - Map of variable name to resolved string value
+ * @param options  - Rendering options (markdown vs plain text)
+ * @returns Formatted prompt string
+ */
+export function renderPrompt(
+  template: PromptTemplate,
+  resolved: ResolvedVariables,
+  options: RenderOptions,
+): string {
+  const output = options.markdown
+    ? renderMarkdown(template, resolved)
+    : renderPlainText(template, resolved);
+
+  const lineCount = countLines(output);
+  if (lineCount > LINE_LIMIT) {
+    console.error(`Warning: rendered prompt exceeds 200 lines (${lineCount} lines)`);
+  }
+
+  return output;
+}
+
+// ---------------------------------------------------------------------------
+// Plain Text Renderer
+// ---------------------------------------------------------------------------
+
+function renderPlainText(template: PromptTemplate, resolved: ResolvedVariables): string {
+  const sections: string[] = [];
+
+  // Phase header
+  sections.push(`[PHASE: ${template.phase}]`);
+
+  // Layers
+  for (const layer of template.layers) {
+    sections.push(renderPlainLayer(layer, resolved));
+  }
+
+  // Ask User
+  if (template.askUser !== undefined && template.askUser.length > 0) {
+    sections.push(renderPlainAskUser(template.askUser));
+  }
+
+  // Completion
+  sections.push(renderPlainCompletion(template.completion));
+
+  // Transitions
+  sections.push(renderPlainTransitions(template.transitions));
+
+  return sections.join('\n\n') + '\n';
+}
+
+function renderPlainLayer(layer: PromptLayer, resolved: ResolvedVariables): string {
+  const label = layer.role.toUpperCase();
+  const content = interpolate(layer.content, resolved);
+  return `--- ${label} ---\n${content}`;
+}
+
+function renderPlainAskUser(questions: AskUserQuestion[]): string {
+  const lines: string[] = ['[ASK USER]'];
+
+  for (let i = 0; i < questions.length; i++) {
+    const q = questions[i];
+    if (q === undefined) continue;
+
+    const num = i + 1;
+    const multiTag = q.multiSelect === true ? ' [multi-select]' : '';
+    lines.push(`Q${num}: ${q.question}${multiTag}`);
+
+    for (let j = 0; j < q.options.length; j++) {
+      const opt = q.options[j];
+      if (opt === undefined) continue;
+
+      const letter = String.fromCharCode(97 + j); // a, b, c, d...
+      const desc = opt.description !== undefined ? ` \u2014 ${opt.description}` : '';
+      lines.push(`  ${letter}) ${opt.label}${desc}`);
+    }
+
+    // Blank line between questions, but not after the last one
+    if (i < questions.length - 1) {
+      lines.push('');
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function renderPlainCompletion(completion: Completion): string {
+  const lines: string[] = ['[COMPLETION: select one outcome]'];
+
+  for (const outcome of completion.outcomes) {
+    const desc = outcome.description !== undefined ? `: ${outcome.description}` : '';
+    lines.push(`  - ${outcome.id}${desc}`);
+  }
+
+  return lines.join('\n');
+}
+
+function renderPlainTransitions(transitions: Transitions): string {
+  const lines: string[] = ['[NEXT STEPS]'];
+
+  if (transitions.choices.length > 0) {
+    lines.push('Conditions:');
+    for (const choice of transitions.choices) {
+      lines.push(`  If ${choice.condition.variable} equals "${choice.condition.equals}" \u2192 run: gobbi prompt ${choice.next}`);
+    }
+  }
+
+  lines.push(`Default: run gobbi prompt ${transitions.default}`);
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Markdown Renderer
+// ---------------------------------------------------------------------------
+
+function renderMarkdown(template: PromptTemplate, resolved: ResolvedVariables): string {
+  const sections: string[] = [];
+
+  // Phase header
+  sections.push(`# Phase: ${template.phase}`);
+
+  // Layers
+  for (const layer of template.layers) {
+    sections.push(renderMarkdownLayer(layer, resolved));
+  }
+
+  // Ask User
+  if (template.askUser !== undefined && template.askUser.length > 0) {
+    sections.push(renderMarkdownAskUser(template.askUser));
+  }
+
+  // Completion
+  sections.push(renderMarkdownCompletion(template.completion));
+
+  // Transitions
+  sections.push(renderMarkdownTransitions(template.transitions));
+
+  return sections.join('\n\n') + '\n';
+}
+
+function renderMarkdownLayer(layer: PromptLayer, resolved: ResolvedVariables): string {
+  const label = layer.role.charAt(0).toUpperCase() + layer.role.slice(1);
+  const content = interpolate(layer.content, resolved);
+  return `## ${label}\n${content}`;
+}
+
+function renderMarkdownAskUser(questions: AskUserQuestion[]): string {
+  const lines: string[] = ['## Ask User'];
+
+  for (let i = 0; i < questions.length; i++) {
+    const q = questions[i];
+    if (q === undefined) continue;
+
+    const num = i + 1;
+    const multiTag = q.multiSelect === true ? ' [multi-select]' : '';
+    lines.push(`### Q${num}: ${q.question}${multiTag}`);
+    lines.push('| Option | Description |');
+    lines.push('|--------|-------------|');
+
+    for (const opt of q.options) {
+      const desc = opt.description !== undefined ? opt.description : '';
+      lines.push(`| ${opt.label} | ${desc} |`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function renderMarkdownCompletion(completion: Completion): string {
+  const lines: string[] = [
+    '## Completion',
+    'Select one outcome:',
+    '| Outcome | Description |',
+    '|---------|-------------|',
+  ];
+
+  for (const outcome of completion.outcomes) {
+    const desc = outcome.description !== undefined ? outcome.description : '';
+    lines.push(`| ${outcome.id} | ${desc} |`);
+  }
+
+  return lines.join('\n');
+}
+
+function renderMarkdownTransitions(transitions: Transitions): string {
+  const lines: string[] = ['## Next Steps'];
+
+  for (const choice of transitions.choices) {
+    lines.push(`- If \`${choice.condition.variable}\` equals \`"${choice.condition.equals}"\` \u2192 \`gobbi prompt ${choice.next}\``);
+  }
+
+  lines.push(`- Default: \`gobbi prompt ${transitions.default}\``);
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function countLines(text: string): number {
+  if (text.length === 0) return 0;
+  let count = 1;
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] === '\n') count++;
+  }
+  return count;
+}

--- a/packages/cli/src/lib/prompt/state.ts
+++ b/packages/cli/src/lib/prompt/state.ts
@@ -1,0 +1,268 @@
+/**
+ * Prompt state management — read, write, and update prompt-state.json.
+ *
+ * Independent state system for the prompt architecture. Tracks session
+ * configuration, project context, workflow progress, and phase history.
+ *
+ * This module is the pure data layer. It has no locking — callers are
+ * responsible for coordination. Follows the same patterns as config.ts:
+ * pure data, atomic writes, type guards for safe narrowing.
+ */
+
+import { readFile, rename, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+import { isRecord, isString, isBoolean, isArray } from '../guards.js';
+import { nowIso } from '../config.js';
+import { isPromptPhase } from './types.js';
+import type { PromptPhase } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const PROMPT_STATE_VERSION = '0.5.0';
+export const PROMPT_STATE_FILENAME = 'prompt-state.json';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PromptNotifyConfig {
+  slack: boolean;
+  telegram: boolean;
+  discord: boolean;
+}
+
+export interface PromptSessionState {
+  trivialRange: string;
+  evaluationMode: string;
+  gitWorkflow: string;
+  notify: PromptNotifyConfig;
+}
+
+export interface PromptProjectState {
+  name: string;
+  noteDir: string | null;
+  projectDir: string;
+  baseBranch: string | null;
+}
+
+export type TaskTier = 'trivial' | 'structured-routine' | 'non-trivial';
+
+export interface PromptWorkflowState {
+  currentPhase: PromptPhase | null;
+  taskSlug: string | null;
+  taskTier: TaskTier | null;
+  feedbackRound: number;
+}
+
+export interface PromptHistoryEntry {
+  phase: PromptPhase;
+  outcome: string;
+  timestamp: string;
+}
+
+export interface PromptState {
+  version: string;
+  session: PromptSessionState;
+  project: PromptProjectState;
+  workflow: PromptWorkflowState;
+  history: PromptHistoryEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// Type Guards
+// ---------------------------------------------------------------------------
+
+function isPromptNotifyConfig(value: unknown): value is PromptNotifyConfig {
+  if (!isRecord(value)) return false;
+  return (
+    isBoolean(value['slack']) &&
+    isBoolean(value['telegram']) &&
+    isBoolean(value['discord'])
+  );
+}
+
+function isPromptSessionState(value: unknown): value is PromptSessionState {
+  if (!isRecord(value)) return false;
+  return (
+    isString(value['trivialRange']) &&
+    isString(value['evaluationMode']) &&
+    isString(value['gitWorkflow']) &&
+    isPromptNotifyConfig(value['notify'])
+  );
+}
+
+function isPromptProjectState(value: unknown): value is PromptProjectState {
+  if (!isRecord(value)) return false;
+  return (
+    isString(value['name']) &&
+    (value['noteDir'] === null || isString(value['noteDir'])) &&
+    isString(value['projectDir']) &&
+    (value['baseBranch'] === null || isString(value['baseBranch']))
+  );
+}
+
+function isTaskTier(value: unknown): value is TaskTier {
+  return value === 'trivial' || value === 'structured-routine' || value === 'non-trivial';
+}
+
+function isPromptWorkflowState(value: unknown): value is PromptWorkflowState {
+  if (!isRecord(value)) return false;
+  const phase = value['currentPhase'];
+  if (phase !== null && !(isString(phase) && isPromptPhase(phase))) return false;
+  const slug = value['taskSlug'];
+  if (slug !== null && !isString(slug)) return false;
+  const tier = value['taskTier'];
+  if (tier !== null && !isTaskTier(tier)) return false;
+  if (typeof value['feedbackRound'] !== 'number') return false;
+  return true;
+}
+
+function isPromptHistoryEntry(value: unknown): value is PromptHistoryEntry {
+  if (!isRecord(value)) return false;
+  if (!isString(value['phase']) || !isPromptPhase(value['phase'])) return false;
+  if (!isString(value['outcome'])) return false;
+  return isString(value['timestamp']);
+}
+
+function isPromptState(value: unknown): value is PromptState {
+  if (!isRecord(value)) return false;
+  if (!isString(value['version'])) return false;
+  if (!isPromptSessionState(value['session'])) return false;
+  if (!isPromptProjectState(value['project'])) return false;
+  if (!isPromptWorkflowState(value['workflow'])) return false;
+  if (!isArray(value['history'])) return false;
+  return value['history'].every(isPromptHistoryEntry);
+}
+
+// ---------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a fresh prompt state with default values.
+ */
+export function emptyPromptState(): PromptState {
+  return {
+    version: PROMPT_STATE_VERSION,
+    session: {
+      trivialRange: 'read-only',
+      evaluationMode: 'ask-each-time',
+      gitWorkflow: 'direct-commit',
+      notify: { slack: false, telegram: false, discord: false },
+    },
+    project: {
+      name: '',
+      noteDir: null,
+      projectDir: '',
+      baseBranch: null,
+    },
+    workflow: {
+      currentPhase: null,
+      taskSlug: null,
+      taskTier: null,
+      feedbackRound: 0,
+    },
+    history: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Read / Write
+// ---------------------------------------------------------------------------
+
+/**
+ * Read and parse prompt-state.json from disk.
+ * Returns null if the file is missing or contains invalid JSON / unexpected shape.
+ */
+export async function readPromptState(filePath: string): Promise<PromptState | null> {
+  let raw: string;
+  try {
+    raw = await readFile(filePath, 'utf8');
+  } catch (err: unknown) {
+    if (isNodeErrnoException(err) && err.code === 'ENOENT') {
+      return null;
+    }
+    throw err;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+
+  if (!isPromptState(parsed)) {
+    return null;
+  }
+
+  return parsed;
+}
+
+/**
+ * Write prompt-state.json atomically: write to a temp file in the same
+ * directory, then rename to the target path. The rename is atomic on
+ * same-filesystem writes.
+ */
+export async function writePromptStateAtomic(filePath: string, data: PromptState): Promise<void> {
+  const dir = dirname(filePath);
+  const tmpPath = join(dir, `${PROMPT_STATE_FILENAME}.${randomUUID()}.tmp`);
+  const serialized = JSON.stringify(data, null, 2);
+
+  await writeFile(tmpPath, serialized, 'utf8');
+  await rename(tmpPath, filePath);
+}
+
+// ---------------------------------------------------------------------------
+// Path Resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the path to prompt-state.json using CLAUDE_PROJECT_DIR.
+ * Returns null if CLAUDE_PROJECT_DIR is not set.
+ */
+export function resolvePromptStatePath(): string | null {
+  const projectDir = process.env['CLAUDE_PROJECT_DIR'];
+  if (!projectDir) return null;
+  return join(projectDir, '.claude', PROMPT_STATE_FILENAME);
+}
+
+// ---------------------------------------------------------------------------
+// State Updates
+// ---------------------------------------------------------------------------
+
+/**
+ * Append a history entry to the state. Returns a new state — does not mutate input.
+ */
+export function updatePromptHistory(
+  state: PromptState,
+  phase: PromptPhase,
+  outcome: string,
+): PromptState {
+  const entry: PromptHistoryEntry = {
+    phase,
+    outcome,
+    timestamp: nowIso(),
+  };
+
+  return {
+    ...state,
+    history: [...state.history, entry],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal utilities
+// ---------------------------------------------------------------------------
+
+interface NodeErrnoException extends Error {
+  code?: string;
+}
+
+function isNodeErrnoException(err: unknown): err is NodeErrnoException {
+  return err instanceof Error && 'code' in err;
+}

--- a/packages/cli/src/lib/prompt/templates/index.ts
+++ b/packages/cli/src/lib/prompt/templates/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Prompt template registry.
+ *
+ * Maps prompt phase names to their template definitions. New templates
+ * are registered here as they are implemented across v0.5.x releases.
+ */
+
+import type { PromptPhase, PromptTemplate } from '../types.js';
+import { SESSION_START_TEMPLATE } from './session-start.js';
+import { WORKFLOW_START_TEMPLATE } from './workflow-start.js';
+
+/**
+ * Look up the prompt template for a given phase.
+ * Returns undefined if the phase has no template registered yet.
+ */
+export function getTemplate(phase: PromptPhase): PromptTemplate | undefined {
+  switch (phase) {
+    case 'session-start': return SESSION_START_TEMPLATE;
+    case 'workflow-start': return WORKFLOW_START_TEMPLATE;
+    default: return undefined;
+  }
+}

--- a/packages/cli/src/lib/prompt/templates/session-start.ts
+++ b/packages/cli/src/lib/prompt/templates/session-start.ts
@@ -1,0 +1,151 @@
+/**
+ * Session-start prompt template.
+ *
+ * Replaces the gobbi SKILL.md session setup: symlink verification,
+ * existing config detection, setup questions, and project context.
+ *
+ * Variables resolved from env (session ID, project dir), command
+ * (CLI version, existing config), and runtime (none required).
+ */
+
+import type { PromptTemplate } from '../types.js';
+
+export const SESSION_START_TEMPLATE: PromptTemplate = {
+  $schema: 'gobbi-prompt/session-start',
+  version: '0.5.0',
+  phase: 'session-start',
+
+  layers: [
+    {
+      role: 'system',
+      content: [
+        'You are an orchestrator based on gobbi. You must delegate everything to specialist subagents except trivial cases.',
+        '',
+        'You are receiving this prompt via the gobbi prompt architecture. Follow the instructions below precisely. At the end, you will find completion outcomes and next steps.',
+      ].join('\n'),
+    },
+    {
+      role: 'context',
+      content: [
+        'Session ID: {{sessionId}}',
+        'Project directory: {{projectDir}}',
+        'CLI version: {{cliVersion}}',
+        'Current session config: {{existingConfig}}',
+      ].join('\n'),
+    },
+    {
+      role: 'task',
+      content: [
+        'STEP 1: Ensure _gobbi-rule symlinks exist.',
+        'Check whether {{projectDir}}/.claude/rules/_gobbi-rule.json and _gobbi-rule.md exist.',
+        'If either is missing, create symlinks from .claude/rules/ pointing to the corresponding files in .claude/skills/_gobbi-rule-container/.',
+        '',
+        'STEP 2: Check for existing session settings.',
+        'If the "Current session config" above is not empty, present the saved settings to the user using AskUserQuestion. Ask whether to reuse them or reconfigure.',
+        'If the user chooses to reuse, report outcome "reused-existing".',
+        'If no settings exist or user wants to reconfigure, continue to STEP 3.',
+        '',
+        'STEP 3: Ask setup questions.',
+        'Use the AskUserQuestion tool with the exact parameters provided in the ASK USER section below.',
+        'After receiving answers, persist all choices:',
+        '  gobbi config set {{sessionId}} trivialRange <value>',
+        '  gobbi config set {{sessionId}} evaluationMode <value>',
+        '  gobbi config set {{sessionId}} gitWorkflow <value>',
+        '  gobbi config set {{sessionId}} baseBranch <value> (if worktree-pr selected)',
+        '  gobbi config set {{sessionId}} notify.slack true/false',
+        '  gobbi config set {{sessionId}} notify.telegram true/false',
+        '',
+        'If git workflow (worktree + PR) is selected, ask for the base branch as a follow-up question.',
+        'If notification channels are selected, check {{projectDir}}/.claude/.env for credentials.',
+        '',
+        'STEP 4: Detect project context.',
+        'Check for {{projectDir}}/.claude/project/ directory.',
+        'If a project subdirectory exists, read only README.md, design/, and gotchas/ for context.',
+        'If no project directory exists, ask the user for a project name and create the standard structure.',
+        '',
+        'After completing all steps, report your completion outcome.',
+      ].join('\n'),
+    },
+  ],
+
+  variables: {
+    sessionId: { source: 'env', path: 'CLAUDE_SESSION_ID', required: true },
+    projectDir: { source: 'env', path: 'CLAUDE_PROJECT_DIR', required: true },
+    cliVersion: { source: 'command', path: 'gobbi --version', required: false, fallback: 'unknown' },
+    existingConfig: { source: 'command', path: 'gobbi config get $CLAUDE_SESSION_ID', required: false, fallback: '' },
+  },
+
+  askUser: [
+    {
+      question: 'What is the trivial case range for this session?',
+      header: 'Trivial Case Range',
+      options: [
+        {
+          label: 'Read-only (no code changes)',
+          description: 'Reading files, explaining code, running status commands, searching codebase. Any code change must be delegated.',
+        },
+        {
+          label: 'Simple code edits included',
+          description: 'The above, plus single-file obvious changes (fix a typo, rename a variable, toggle a config value). Anything beyond must be delegated.',
+        },
+      ],
+    },
+    {
+      question: 'What evaluation mode should this session use?',
+      header: 'Evaluation Mode',
+      options: [
+        {
+          label: 'Ask each time (Recommended)',
+          description: 'Before each evaluation stage, the orchestrator asks whether to spawn evaluators.',
+        },
+        {
+          label: 'Always evaluate',
+          description: 'Skip the evaluation question, always spawn evaluators at every stage.',
+        },
+        {
+          label: 'Skip evaluation',
+          description: 'Never spawn evaluators unless you explicitly request one.',
+        },
+      ],
+    },
+    {
+      question: 'What git workflow should this session use?',
+      header: 'Git Workflow',
+      options: [
+        {
+          label: 'Direct commit (default)',
+          description: 'Work happens in the main working tree. Commits are created at FINISH.',
+        },
+        {
+          label: 'Git workflow (worktree + PR)',
+          description: 'Each task gets its own worktree and branch. Work is integrated via pull request.',
+        },
+      ],
+    },
+    {
+      question: 'Which notification channels should be active?',
+      header: 'Notification Channels',
+      options: [
+        { label: 'Slack', description: 'Notify via Slack bot message.' },
+        { label: 'Telegram', description: 'Notify via Telegram bot message.' },
+        { label: 'Discord', description: 'Notify via Discord webhook.' },
+        { label: 'Skip notifications', description: 'No notifications this session.' },
+      ],
+      multiSelect: true,
+    },
+  ],
+
+  completion: {
+    type: 'select-outcome',
+    outcomes: [
+      { id: 'configured', description: 'New session configured from scratch' },
+      { id: 'reused-existing', description: 'Reused existing session settings' },
+    ],
+  },
+
+  transitions: {
+    type: 'choice',
+    choices: [],
+    default: 'gobbi prompt workflow-start',
+  },
+};

--- a/packages/cli/src/lib/prompt/templates/workflow-start.ts
+++ b/packages/cli/src/lib/prompt/templates/workflow-start.ts
@@ -1,0 +1,103 @@
+/**
+ * Workflow-start prompt template.
+ *
+ * Replaces the _orchestration SKILL.md task routing: classify the
+ * incoming task into a tier (trivial, structured-routine, non-trivial),
+ * initialize notes, create the workflow checklist, and verify git
+ * prerequisites when the worktree+PR workflow is active.
+ *
+ * Variables resolved from config (session settings), runtime
+ * (project name, orchestration gotchas), and env (project dir).
+ */
+
+import type { PromptTemplate } from '../types.js';
+
+export const WORKFLOW_START_TEMPLATE: PromptTemplate = {
+  $schema: 'gobbi-prompt/workflow-start',
+  version: '0.5.0',
+  phase: 'workflow-start',
+
+  layers: [
+    {
+      role: 'system',
+      content: [
+        'You are an orchestrator receiving workflow initialization instructions. Classify the user\'s task, initialize notes, and create a workflow checklist.',
+      ].join('\n'),
+    },
+    {
+      role: 'context',
+      content: [
+        'Trivial case range: {{trivialRange}}',
+        'Evaluation mode: {{evaluationMode}}',
+        'Git workflow: {{gitWorkflow}}',
+        'Base branch: {{baseBranch}}',
+        'Project name: {{projectName}}',
+        '',
+        'Orchestration gotchas:',
+        '{{orchestrationGotchas}}',
+      ].join('\n'),
+    },
+    {
+      role: 'task',
+      content: [
+        'STEP 1: Classify the incoming task.',
+        'The user has described a task. Classify it into one of three tiers:',
+        '- Trivial: Within the trivial case range ({{trivialRange}}). Handle directly without delegation.',
+        '- Structured routine: Can be fully specified without discussion. Has a known execution pattern. Skip Ideation, Planning, and Research.',
+        '- Non-trivial: Requires exploration, trade-offs, or creative decomposition. Full 7-step workflow.',
+        'When uncertain, default to non-trivial.',
+        '',
+        'STEP 2: For non-trivial or structured-routine tasks, initialize notes.',
+        'Run: gobbi note init {{projectName}} <task-slug>',
+        'The returned path is the note directory \u2014 pass it to every subagent.',
+        '',
+        'STEP 3: Create workflow task checklist.',
+        'Use TaskCreate to create these tasks:',
+        '  Step 1: Ideation \u2014 discuss, spawn PI agents (innovative + best), synthesize',
+        '  Step 2: Planning \u2014 plan, discuss, evaluate, improve',
+        '  Step 3: Research \u2014 spawn researchers (innovative + best), synthesize',
+        '  Step 4: Execution \u2014 delegate subtasks to executors',
+        '  Step 5: Collection \u2014 write notes, verify, record gotchas',
+        '  Step 6: Memorization \u2014 save context for session continuity',
+        '  Step 7: Review \u2014 spawn PI agents (innovative + best), verdict + docs',
+        '  Phase transition \u2014 Ask user: FEEDBACK or FINISH?',
+        '',
+        'STEP 4: If git workflow is active ({{gitWorkflow}} = worktree-pr):',
+        '- Verify gh CLI is authenticated: gh auth status',
+        '- Verify base branch exists on remote: git ls-remote --heads origin {{baseBranch}}',
+        '- Check for orphaned worktrees in {{projectDir}}/.claude/worktrees/',
+        '- Create issue, worktree, and branch before first delegation',
+        '',
+        'Report your classification outcome.',
+      ].join('\n'),
+    },
+  ],
+
+  variables: {
+    trivialRange: { source: 'config', path: 'trivialRange', required: true },
+    evaluationMode: { source: 'config', path: 'evaluationMode', required: true },
+    gitWorkflow: { source: 'config', path: 'gitWorkflow', required: true },
+    baseBranch: { source: 'config', path: 'baseBranch', required: false, fallback: 'main' },
+    projectName: { source: 'runtime', path: 'projectName', required: true },
+    orchestrationGotchas: { source: 'runtime', path: 'orchestrationGotchas', required: false, fallback: 'No gotchas loaded.' },
+    projectDir: { source: 'env', path: 'CLAUDE_PROJECT_DIR', required: true },
+  },
+
+  completion: {
+    type: 'select-outcome',
+    outcomes: [
+      { id: 'trivial', description: 'Task is within trivial range \u2014 handle directly' },
+      { id: 'structured-routine', description: 'Task follows a known pattern \u2014 skip ideation/plan/research' },
+      { id: 'non-trivial', description: 'Task requires full 7-step workflow' },
+    ],
+  },
+
+  transitions: {
+    type: 'choice',
+    choices: [
+      { condition: { variable: 'taskTier', equals: 'trivial' }, next: '__terminal__' },
+      { condition: { variable: 'taskTier', equals: 'structured-routine' }, next: 'gobbi prompt workflow-execution' },
+    ],
+    default: 'gobbi prompt workflow-ideation',
+  },
+};

--- a/packages/cli/src/lib/prompt/types.ts
+++ b/packages/cli/src/lib/prompt/types.ts
@@ -1,0 +1,323 @@
+/**
+ * gobbi-prompt JSON schema types.
+ *
+ * Independent type family for the prompt architecture (14 phases).
+ * Discriminated unions on `$schema` (prompt schemas).
+ * Strict mode compliance: no `any`, no `as` assertions.
+ */
+
+import { isRecord, isString, isBoolean, isArray } from '../guards.js';
+
+// ---------------------------------------------------------------------------
+// Prompt Schema Discriminator
+// ---------------------------------------------------------------------------
+
+/** All valid prompt schema identifiers. */
+export type PromptSchema =
+  | 'gobbi-prompt/session-start'
+  | 'gobbi-prompt/project-setup'
+  | 'gobbi-prompt/workflow-start'
+  | 'gobbi-prompt/workflow-ideation'
+  | 'gobbi-prompt/workflow-plan'
+  | 'gobbi-prompt/workflow-research'
+  | 'gobbi-prompt/workflow-execution'
+  | 'gobbi-prompt/workflow-collection'
+  | 'gobbi-prompt/workflow-memorization'
+  | 'gobbi-prompt/workflow-review'
+  | 'gobbi-prompt/workflow-feedback'
+  | 'gobbi-prompt/workflow-finish'
+  | 'gobbi-prompt/evaluation-ask'
+  | 'gobbi-prompt/evaluation-spawn';
+
+/** Short names used as CLI arguments and state references. */
+export type PromptPhase =
+  | 'session-start'
+  | 'project-setup'
+  | 'workflow-start'
+  | 'workflow-ideation'
+  | 'workflow-plan'
+  | 'workflow-research'
+  | 'workflow-execution'
+  | 'workflow-collection'
+  | 'workflow-memorization'
+  | 'workflow-review'
+  | 'workflow-feedback'
+  | 'workflow-finish'
+  | 'evaluation-ask'
+  | 'evaluation-spawn';
+
+/** Map from short phase name to full schema identifier. */
+export const PROMPT_PHASE_TO_SCHEMA: Readonly<Record<PromptPhase, PromptSchema>> = {
+  'session-start': 'gobbi-prompt/session-start',
+  'project-setup': 'gobbi-prompt/project-setup',
+  'workflow-start': 'gobbi-prompt/workflow-start',
+  'workflow-ideation': 'gobbi-prompt/workflow-ideation',
+  'workflow-plan': 'gobbi-prompt/workflow-plan',
+  'workflow-research': 'gobbi-prompt/workflow-research',
+  'workflow-execution': 'gobbi-prompt/workflow-execution',
+  'workflow-collection': 'gobbi-prompt/workflow-collection',
+  'workflow-memorization': 'gobbi-prompt/workflow-memorization',
+  'workflow-review': 'gobbi-prompt/workflow-review',
+  'workflow-feedback': 'gobbi-prompt/workflow-feedback',
+  'workflow-finish': 'gobbi-prompt/workflow-finish',
+  'evaluation-ask': 'gobbi-prompt/evaluation-ask',
+  'evaluation-spawn': 'gobbi-prompt/evaluation-spawn',
+};
+
+export const VALID_PROMPT_PHASES: readonly PromptPhase[] = [
+  'session-start',
+  'project-setup',
+  'workflow-start',
+  'workflow-ideation',
+  'workflow-plan',
+  'workflow-research',
+  'workflow-execution',
+  'workflow-collection',
+  'workflow-memorization',
+  'workflow-review',
+  'workflow-feedback',
+  'workflow-finish',
+  'evaluation-ask',
+  'evaluation-spawn',
+];
+
+// ---------------------------------------------------------------------------
+// Variable Types
+// ---------------------------------------------------------------------------
+
+/** Sources from which a variable can be resolved. */
+export type VariableSource = 'env' | 'config' | 'file' | 'glob' | 'command' | 'state' | 'git' | 'runtime';
+
+const VALID_VARIABLE_SOURCES: readonly VariableSource[] = [
+  'env', 'config', 'file', 'glob', 'command', 'state', 'git', 'runtime',
+];
+
+/** Declaration of a single variable and how to resolve it. */
+export interface VariableDeclaration {
+  source: VariableSource;
+  path: string;
+  required: boolean;
+  fallback?: string;
+  description?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Layer Types
+// ---------------------------------------------------------------------------
+
+/** A single layer of prompt content with a role. */
+export interface PromptLayer {
+  role: 'system' | 'context' | 'task';
+  content: string;
+}
+
+// ---------------------------------------------------------------------------
+// Completion Types
+// ---------------------------------------------------------------------------
+
+/** A possible outcome from completing a phase. */
+export interface CompletionOutcome {
+  id: string;
+  description?: string;
+}
+
+/** How the phase is completed — currently only select-outcome. */
+export interface Completion {
+  type: 'select-outcome';
+  outcomes: CompletionOutcome[];
+}
+
+// ---------------------------------------------------------------------------
+// Transition Types
+// ---------------------------------------------------------------------------
+
+/** A condition that checks a variable against an expected value. */
+export interface TransitionCondition {
+  variable: string;
+  equals: string;
+}
+
+/** A single transition choice — if condition matches, go to `next`. */
+export interface TransitionChoice {
+  condition: TransitionCondition;
+  next: string;
+}
+
+/** ASL Choice-style transition routing. */
+export interface Transitions {
+  type: 'choice';
+  choices: TransitionChoice[];
+  default: string;
+}
+
+// ---------------------------------------------------------------------------
+// Agent Spec Types
+// ---------------------------------------------------------------------------
+
+/** Specification for an agent to spawn during a phase. */
+export interface AgentSpec {
+  id: string;
+  model: 'sonnet' | 'opus' | 'haiku';
+  stance?: 'innovative' | 'best-practice';
+  skills: string[];
+  outputPath?: string;
+  brief?: string;
+}
+
+// ---------------------------------------------------------------------------
+// AskUser Types
+// ---------------------------------------------------------------------------
+
+/** A single option in an AskUser question. */
+export interface AskUserOption {
+  label: string;
+  description?: string;
+}
+
+/** An interactive question to present to the user. */
+export interface AskUserQuestion {
+  question: string;
+  header?: string;
+  options: AskUserOption[];
+  multiSelect?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Prompt Template
+// ---------------------------------------------------------------------------
+
+/** Complete prompt template for a single phase. */
+export interface PromptTemplate {
+  $schema: PromptSchema;
+  version: string;
+  phase: string;
+  layers: PromptLayer[];
+  variables: Record<string, VariableDeclaration>;
+  completion: Completion;
+  transitions: Transitions;
+  agents?: AgentSpec[];
+  askUser?: AskUserQuestion[];
+}
+
+// ---------------------------------------------------------------------------
+// Type Guards
+// ---------------------------------------------------------------------------
+
+/** Check whether a string is a valid prompt phase. */
+export function isPromptPhase(value: string): value is PromptPhase {
+  return (VALID_PROMPT_PHASES as readonly string[]).includes(value);
+}
+
+/** Check whether a string is a valid prompt schema identifier. */
+export function isPromptSchema(value: string): value is PromptSchema {
+  return value.startsWith('gobbi-prompt/') && isPromptPhase(value.slice('gobbi-prompt/'.length));
+}
+
+/** Check whether a string is a valid variable source. */
+export function isVariableSource(value: string): value is VariableSource {
+  return (VALID_VARIABLE_SOURCES as readonly string[]).includes(value);
+}
+
+function isVariableDeclaration(value: unknown): value is VariableDeclaration {
+  if (!isRecord(value)) return false;
+  if (!isString(value['source']) || !isVariableSource(value['source'])) return false;
+  if (!isString(value['path'])) return false;
+  if (!isBoolean(value['required'])) return false;
+  if ('fallback' in value && value['fallback'] !== undefined && !isString(value['fallback'])) return false;
+  if ('description' in value && value['description'] !== undefined && !isString(value['description'])) return false;
+  return true;
+}
+
+function isVariableRecord(value: unknown): value is Record<string, VariableDeclaration> {
+  if (!isRecord(value)) return false;
+  return Object.values(value).every(isVariableDeclaration);
+}
+
+function isPromptLayer(value: unknown): value is PromptLayer {
+  if (!isRecord(value)) return false;
+  if (!isString(value['role'])) return false;
+  if (value['role'] !== 'system' && value['role'] !== 'context' && value['role'] !== 'task') return false;
+  return isString(value['content']);
+}
+
+function isCompletionOutcome(value: unknown): value is CompletionOutcome {
+  if (!isRecord(value)) return false;
+  if (!isString(value['id'])) return false;
+  if ('description' in value && value['description'] !== undefined && !isString(value['description'])) return false;
+  return true;
+}
+
+function isCompletion(value: unknown): value is Completion {
+  if (!isRecord(value)) return false;
+  if (value['type'] !== 'select-outcome') return false;
+  if (!isArray(value['outcomes'])) return false;
+  return value['outcomes'].every(isCompletionOutcome);
+}
+
+function isTransitionCondition(value: unknown): value is TransitionCondition {
+  if (!isRecord(value)) return false;
+  return isString(value['variable']) && isString(value['equals']);
+}
+
+function isTransitionChoice(value: unknown): value is TransitionChoice {
+  if (!isRecord(value)) return false;
+  if (!isTransitionCondition(value['condition'])) return false;
+  return isString(value['next']);
+}
+
+function isTransitions(value: unknown): value is Transitions {
+  if (!isRecord(value)) return false;
+  if (value['type'] !== 'choice') return false;
+  if (!isArray(value['choices'])) return false;
+  if (!value['choices'].every(isTransitionChoice)) return false;
+  return isString(value['default']);
+}
+
+function isAgentSpec(value: unknown): value is AgentSpec {
+  if (!isRecord(value)) return false;
+  if (!isString(value['id'])) return false;
+  const model = value['model'];
+  if (model !== 'sonnet' && model !== 'opus' && model !== 'haiku') return false;
+  if ('stance' in value && value['stance'] !== undefined) {
+    if (value['stance'] !== 'innovative' && value['stance'] !== 'best-practice') return false;
+  }
+  if (!isArray(value['skills']) || !value['skills'].every(isString)) return false;
+  if ('outputPath' in value && value['outputPath'] !== undefined && !isString(value['outputPath'])) return false;
+  if ('brief' in value && value['brief'] !== undefined && !isString(value['brief'])) return false;
+  return true;
+}
+
+function isAskUserOption(value: unknown): value is AskUserOption {
+  if (!isRecord(value)) return false;
+  if (!isString(value['label'])) return false;
+  if ('description' in value && value['description'] !== undefined && !isString(value['description'])) return false;
+  return true;
+}
+
+function isAskUserQuestion(value: unknown): value is AskUserQuestion {
+  if (!isRecord(value)) return false;
+  if (!isString(value['question'])) return false;
+  if ('header' in value && value['header'] !== undefined && !isString(value['header'])) return false;
+  if (!isArray(value['options']) || !value['options'].every(isAskUserOption)) return false;
+  if ('multiSelect' in value && value['multiSelect'] !== undefined && !isBoolean(value['multiSelect'])) return false;
+  return true;
+}
+
+/** Check whether an unknown value is a valid PromptTemplate. */
+export function isPromptTemplate(value: unknown): value is PromptTemplate {
+  if (!isRecord(value)) return false;
+  if (!isString(value['$schema']) || !isPromptSchema(value['$schema'])) return false;
+  if (!isString(value['version'])) return false;
+  if (!isString(value['phase'])) return false;
+  if (!isArray(value['layers']) || !value['layers'].every(isPromptLayer)) return false;
+  if (!isVariableRecord(value['variables'])) return false;
+  if (!isCompletion(value['completion'])) return false;
+  if (!isTransitions(value['transitions'])) return false;
+  if ('agents' in value && value['agents'] !== undefined) {
+    if (!isArray(value['agents']) || !value['agents'].every(isAgentSpec)) return false;
+  }
+  if ('askUser' in value && value['askUser'] !== undefined) {
+    if (!isArray(value['askUser']) || !value['askUser'].every(isAskUserQuestion)) return false;
+  }
+  return true;
+}

--- a/packages/cli/src/lib/prompt/variables.ts
+++ b/packages/cli/src/lib/prompt/variables.ts
@@ -17,6 +17,7 @@ import { dirname, basename, join } from 'node:path';
 import { isRecord, isString } from '../guards.js';
 import { readGobbiJson, getNestedValue } from '../config.js';
 import { readPromptState, resolvePromptStatePath } from './state.js';
+import type { PromptState } from './state.js';
 import type { VariableDeclaration, VariableSource } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -163,6 +164,26 @@ function resolveCommand(declaration: VariableDeclaration): string | null {
 }
 
 /**
+ * Walk a dot-separated path into a PromptState without type assertions.
+ *
+ * At each step the current value is narrowed through `isRecord` before
+ * indexing, so the traversal is type-safe from `unknown` downward.
+ * Returns `undefined` when any segment fails to resolve.
+ */
+function getPromptStateValue(state: PromptState, dotPath: string): unknown {
+  const parts = dotPath.split('.');
+  // PromptState is a well-known shape — convert to unknown to walk generically
+  let current: unknown = state;
+
+  for (const part of parts) {
+    if (!isRecord(current)) return undefined;
+    current = current[part];
+  }
+
+  return current;
+}
+
+/**
  * Resolve a variable from the `state` source.
  * Reads prompt-state.json and accesses the nested path.
  */
@@ -173,8 +194,7 @@ async function resolveState(declaration: VariableDeclaration): Promise<string | 
   const state = await readPromptState(filePath);
   if (state === null) return null;
 
-  const stateAsRecord = state as unknown as Record<string, unknown>;
-  const value = getNestedValue(stateAsRecord, declaration.path);
+  const value = getPromptStateValue(state, declaration.path);
   if (value === undefined || value === null) return null;
 
   return isString(value) ? value : JSON.stringify(value);

--- a/packages/cli/src/lib/prompt/variables.ts
+++ b/packages/cli/src/lib/prompt/variables.ts
@@ -1,0 +1,283 @@
+/**
+ * Variable resolution pipeline for prompt templates.
+ *
+ * Resolves {{variable}} references from 8 source types: env, config, file,
+ * glob, command, state, git, runtime. Each variable declaration specifies
+ * its source and path; this module dispatches to the correct resolver.
+ *
+ * Follows the same patterns as config.ts and state.ts: pure data operations,
+ * type-safe narrowing, no `as` casts, strict mode compliance.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { readdirSync, readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { dirname, basename, join } from 'node:path';
+
+import { isRecord, isString } from '../guards.js';
+import { readGobbiJson, getNestedValue } from '../config.js';
+import { readPromptState, resolvePromptStatePath } from './state.js';
+import type { VariableDeclaration, VariableSource } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Resolved variables — key/value map ready for interpolation. */
+export type ResolvedVariables = Record<string, string>;
+
+/** Error thrown when a required variable fails resolution. */
+export class PromptResolutionError extends Error {
+  readonly variableName: string;
+  readonly source: VariableSource;
+
+  constructor(variableName: string, source: VariableSource, message: string) {
+    super(message);
+    this.name = 'PromptResolutionError';
+    this.variableName = variableName;
+    this.source = source;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Path Resolution Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the path to gobbi.json using CLAUDE_PROJECT_DIR.
+ * Returns null if CLAUDE_PROJECT_DIR is not set.
+ */
+function resolveGobbiJsonPath(): string | null {
+  const projectDir = process.env['CLAUDE_PROJECT_DIR'];
+  if (!projectDir) return null;
+  return join(projectDir, '.claude', 'gobbi.json');
+}
+
+// ---------------------------------------------------------------------------
+// Source Resolvers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a variable from the `env` source.
+ * Returns the environment variable value, or null if not set.
+ */
+function resolveEnv(declaration: VariableDeclaration): string | null {
+  const value = process.env[declaration.path];
+  return value !== undefined ? value : null;
+}
+
+/**
+ * Resolve a variable from the `config` source.
+ * Reads gobbi.json, finds the current session by CLAUDE_SESSION_ID,
+ * then accesses the nested path within that session.
+ */
+async function resolveConfig(declaration: VariableDeclaration): Promise<string | null> {
+  const filePath = resolveGobbiJsonPath();
+  if (filePath === null) return null;
+
+  const data = await readGobbiJson(filePath);
+  if (data === null) return null;
+
+  const sessionId = process.env['CLAUDE_SESSION_ID'];
+  if (!sessionId) return null;
+
+  const session: unknown = data.sessions[sessionId];
+  if (!isRecord(session)) return null;
+
+  const value = getNestedValue(session, declaration.path);
+  if (value === undefined || value === null) return null;
+
+  return isString(value) ? value : JSON.stringify(value);
+}
+
+/**
+ * Resolve a variable from the `file` source.
+ * Reads the file at the declared path. Returns null on ENOENT.
+ */
+async function resolveFile(declaration: VariableDeclaration): Promise<string | null> {
+  try {
+    return await readFile(declaration.path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve a variable from the `glob` source.
+ * Splits the path into directory + pattern, lists matching files,
+ * and concatenates their contents separated by `\n---\n`.
+ *
+ * Uses simple glob matching: `*` matches any sequence of non-separator
+ * characters, `?` matches a single character. No external library.
+ */
+function resolveGlob(declaration: VariableDeclaration): string | null {
+  const dir = dirname(declaration.path);
+  const pattern = basename(declaration.path);
+
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return null;
+  }
+
+  // Convert simple glob pattern to regex
+  const regexStr = '^' + pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*/g, '.*')
+    .replace(/\?/g, '.') + '$';
+  const regex = new RegExp(regexStr);
+
+  const matched = entries
+    .filter((entry) => regex.test(entry))
+    .sort();
+
+  if (matched.length === 0) return null;
+
+  const contents: string[] = [];
+  for (const entry of matched) {
+    try {
+      const content = readFileSync(join(dir, entry), 'utf8');
+      contents.push(content);
+    } catch {
+      // Skip unreadable files
+    }
+  }
+
+  return contents.length > 0 ? contents.join('\n---\n') : null;
+}
+
+/**
+ * Resolve a variable from the `command` source.
+ * Executes the command and returns trimmed stdout. Returns null on error.
+ */
+function resolveCommand(declaration: VariableDeclaration): string | null {
+  try {
+    return execSync(declaration.path, {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve a variable from the `state` source.
+ * Reads prompt-state.json and accesses the nested path.
+ */
+async function resolveState(declaration: VariableDeclaration): Promise<string | null> {
+  const filePath = resolvePromptStatePath();
+  if (filePath === null) return null;
+
+  const state = await readPromptState(filePath);
+  if (state === null) return null;
+
+  const stateAsRecord = state as unknown as Record<string, unknown>;
+  const value = getNestedValue(stateAsRecord, declaration.path);
+  if (value === undefined || value === null) return null;
+
+  return isString(value) ? value : JSON.stringify(value);
+}
+
+/**
+ * Resolve a variable from the `git` source.
+ * Executes `git <path>` and returns trimmed stdout. Returns null on error.
+ */
+function resolveGit(declaration: VariableDeclaration): string | null {
+  try {
+    return execSync('git ' + declaration.path, {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve a variable from the `runtime` source.
+ * Simple lookup in the runtime values map.
+ */
+function resolveRuntime(
+  declaration: VariableDeclaration,
+  runtimeValues: Record<string, string>,
+): string | null {
+  const value = runtimeValues[declaration.path];
+  return value !== undefined ? value : null;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a single variable from its declared source.
+ * Returns the resolved string value, or null if resolution fails.
+ */
+export async function resolveVariable(
+  name: string,
+  declaration: VariableDeclaration,
+  runtimeValues: Record<string, string>,
+): Promise<string | null> {
+  // Suppress unused parameter lint — name is part of the public API signature
+  void name;
+
+  switch (declaration.source) {
+    case 'env':
+      return resolveEnv(declaration);
+    case 'config':
+      return resolveConfig(declaration);
+    case 'file':
+      return resolveFile(declaration);
+    case 'glob':
+      return resolveGlob(declaration);
+    case 'command':
+      return resolveCommand(declaration);
+    case 'state':
+      return resolveState(declaration);
+    case 'git':
+      return resolveGit(declaration);
+    case 'runtime':
+      return resolveRuntime(declaration, runtimeValues);
+  }
+}
+
+/**
+ * Resolve all variables in a template.
+ * Throws PromptResolutionError for any required variable that fails.
+ * Returns a ResolvedVariables map.
+ */
+export async function resolveAllVariables(
+  variables: Record<string, VariableDeclaration>,
+  runtimeValues: Record<string, string>,
+): Promise<ResolvedVariables> {
+  const resolved: ResolvedVariables = {};
+
+  for (const [name, declaration] of Object.entries(variables)) {
+    const value = await resolveVariable(name, declaration, runtimeValues);
+
+    if (value === null) {
+      if (declaration.required) {
+        throw new PromptResolutionError(
+          name,
+          declaration.source,
+          `Required variable "${name}" could not be resolved from source "${declaration.source}" (path: "${declaration.path}")`,
+        );
+      }
+      resolved[name] = declaration.fallback ?? '';
+    } else {
+      resolved[name] = value;
+    }
+  }
+
+  return resolved;
+}
+
+/**
+ * Replace all {{key}} references in a template string with resolved values.
+ * Unresolved references (not in resolved map) become empty string.
+ */
+export function interpolate(template: string, resolved: ResolvedVariables): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (_, key: string) => resolved[key] ?? '');
+}

--- a/packages/cli/src/test/prompt.test.ts
+++ b/packages/cli/src/test/prompt.test.ts
@@ -514,12 +514,114 @@ describe('transition graph', () => {
   });
 
   it('getNextPhase session-start configured returns workflow-start', () => {
-    const next = getNextPhase('session-start', 'configured');
+    const next = getNextPhase('session-start', { outcome: 'configured' });
     assert.equal(next, 'workflow-start');
   });
 
   it('getNextPhase workflow-start non-trivial returns workflow-ideation', () => {
-    const next = getNextPhase('workflow-start', 'non-trivial');
+    const next = getNextPhase('workflow-start', { outcome: 'non-trivial' });
     assert.equal(next, 'workflow-ideation');
+  });
+
+  it('getNextPhase evaluates non-outcome conditions', () => {
+    // workflow-start with trivial outcome should return null (terminal)
+    const next = getNextPhase('workflow-start', { outcome: 'trivial' });
+    assert.equal(next, null);
+  });
+
+  it('getNextPhase falls back to default when no choice matches', () => {
+    const next = getNextPhase('workflow-start', { outcome: 'unknown-outcome' });
+    // default for workflow-start is workflow-ideation
+    assert.equal(next, 'workflow-ideation');
+  });
+
+  it('getNextPhase returns null for terminal default', () => {
+    const next = getNextPhase('workflow-finish', { outcome: 'finished' });
+    // workflow-finish default is __terminal__, and there are no matching choices
+    assert.equal(next, null);
+  });
+
+  it('getNextPhase context can match on any variable, not just outcome', () => {
+    // All current graph nodes use variable: 'outcome', but the API supports
+    // arbitrary variables. Verify the mechanism works by confirming that a
+    // non-matching variable name does not accidentally match.
+    const next = getNextPhase('session-start', { notOutcome: 'configured' });
+    // No choice matches — falls back to default (workflow-start)
+    assert.equal(next, 'workflow-start');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Record Outcome (logic-level tests)
+// ---------------------------------------------------------------------------
+
+describe('record-outcome logic', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      removeTempDir(dir);
+    }
+    tempDirs.length = 0;
+  });
+
+  function track(dir: string): string {
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  it('valid phase + outcome records to history and resolves next phase', async () => {
+    const dir = track(createTempDir());
+    const filePath = path.join(dir, 'prompt-state.json');
+
+    // Write initial state
+    const initial = emptyPromptState();
+    await writePromptStateAtomic(filePath, initial);
+
+    // Simulate record-outcome: validate, update state, resolve next
+    const phase = 'session-start' as const;
+    const outcomeId = 'configured';
+
+    const node = getTransitionNode(phase);
+    assert.ok(node !== undefined, 'phase should have a transition node');
+    const validOutcomeIds = node.completion.outcomes.map((o) => o.id);
+    assert.ok(validOutcomeIds.includes(outcomeId), 'outcome should be valid');
+
+    // Update state
+    const current = await readPromptState(filePath) ?? emptyPromptState();
+    const withHistory = updatePromptHistory(current, phase, outcomeId);
+    const updated = {
+      ...withHistory,
+      workflow: {
+        ...withHistory.workflow,
+        currentPhase: phase,
+      },
+    };
+    await writePromptStateAtomic(filePath, updated);
+
+    // Verify state was written
+    const reloaded = await readPromptState(filePath);
+    assert.ok(reloaded !== null);
+    assert.equal(reloaded.workflow.currentPhase, 'session-start');
+    assert.equal(reloaded.history.length, 1);
+    const entry = reloaded.history[0];
+    assert.ok(entry !== undefined);
+    assert.equal(entry.phase, 'session-start');
+    assert.equal(entry.outcome, 'configured');
+
+    // Verify next phase
+    const nextPhase = getNextPhase(phase, { outcome: outcomeId });
+    assert.equal(nextPhase, 'workflow-start');
+  });
+
+  it('invalid phase is detected by isPromptPhase', () => {
+    assert.equal(isPromptPhase('not-a-real-phase'), false);
+  });
+
+  it('invalid outcome for a phase is detected by checking completion outcomes', () => {
+    const node = getTransitionNode('session-start');
+    assert.ok(node !== undefined);
+    const validOutcomeIds = node.completion.outcomes.map((o) => o.id);
+    assert.equal(validOutcomeIds.includes('nonexistent-outcome'), false);
   });
 });

--- a/packages/cli/src/test/prompt.test.ts
+++ b/packages/cli/src/test/prompt.test.ts
@@ -1,0 +1,525 @@
+/**
+ * Tests for the prompt architecture library.
+ *
+ * Covers type guards, state management, variable resolution,
+ * renderer, template registry, and transition graph.
+ *
+ * Uses Node's built-in test runner (`node:test`) and strict assertions.
+ * Run via: npm test (which compiles first, then runs the compiled JS).
+ */
+
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  isPromptPhase,
+  isPromptSchema,
+  isVariableSource,
+  isPromptTemplate,
+  VALID_PROMPT_PHASES,
+} from '../lib/prompt/types.js';
+import type { PromptTemplate } from '../lib/prompt/types.js';
+import {
+  emptyPromptState,
+  readPromptState,
+  writePromptStateAtomic,
+  updatePromptHistory,
+} from '../lib/prompt/state.js';
+import {
+  interpolate,
+  resolveVariable,
+  resolveAllVariables,
+  PromptResolutionError,
+} from '../lib/prompt/variables.js';
+import { renderPrompt } from '../lib/prompt/renderer.js';
+import { getTemplate } from '../lib/prompt/templates/index.js';
+import { SESSION_START_TEMPLATE } from '../lib/prompt/templates/session-start.js';
+import { WORKFLOW_START_TEMPLATE } from '../lib/prompt/templates/workflow-start.js';
+import {
+  TRANSITION_GRAPH,
+  getTransitionNode,
+  getNextPhase,
+} from '../lib/prompt/graph.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'gobbi-prompt-test-'));
+}
+
+function removeTempDir(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+/**
+ * Construct a minimal valid PromptTemplate for renderer tests.
+ * Kept separate from real templates to test the renderer independently.
+ */
+function minimalTemplate(): PromptTemplate {
+  return {
+    $schema: 'gobbi-prompt/session-start',
+    version: '0.1.0',
+    phase: 'session-start',
+    layers: [
+      { role: 'system', content: 'System instructions for {{mode}}.' },
+      { role: 'context', content: 'Context: project={{project}}.' },
+      { role: 'task', content: 'Do the {{action}} now.' },
+    ],
+    variables: {},
+    completion: {
+      type: 'select-outcome',
+      outcomes: [
+        { id: 'done', description: 'Task complete' },
+        { id: 'retry', description: 'Need another attempt' },
+      ],
+    },
+    transitions: {
+      type: 'choice',
+      choices: [
+        { condition: { variable: 'outcome', equals: 'done' }, next: 'workflow-start' },
+      ],
+      default: 'workflow-start',
+    },
+    askUser: [
+      {
+        question: 'Pick a color',
+        options: [
+          { label: 'Red', description: 'A warm color' },
+          { label: 'Blue', description: 'A cool color' },
+        ],
+      },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Type Guards
+// ---------------------------------------------------------------------------
+
+describe('type guards', () => {
+  it('isPromptPhase accepts valid phases', () => {
+    assert.equal(isPromptPhase('session-start'), true);
+    assert.equal(isPromptPhase('workflow-start'), true);
+    assert.equal(isPromptPhase('workflow-ideation'), true);
+  });
+
+  it('isPromptPhase rejects invalid strings', () => {
+    assert.equal(isPromptPhase('invalid'), false);
+    assert.equal(isPromptPhase(''), false);
+    assert.equal(isPromptPhase('session_start'), false);
+  });
+
+  it('isPromptSchema accepts valid schema identifiers', () => {
+    assert.equal(isPromptSchema('gobbi-prompt/session-start'), true);
+  });
+
+  it('isPromptSchema rejects invalid schema identifiers', () => {
+    assert.equal(isPromptSchema('gobbi-docs/skill'), false);
+    assert.equal(isPromptSchema('gobbi-prompt/invalid'), false);
+  });
+
+  it('isVariableSource accepts valid sources', () => {
+    assert.equal(isVariableSource('env'), true);
+    assert.equal(isVariableSource('config'), true);
+    assert.equal(isVariableSource('file'), true);
+    assert.equal(isVariableSource('runtime'), true);
+  });
+
+  it('isVariableSource rejects invalid sources', () => {
+    assert.equal(isVariableSource('database'), false);
+    assert.equal(isVariableSource(''), false);
+  });
+
+  it('isPromptTemplate accepts a well-formed template', () => {
+    const template = minimalTemplate();
+    assert.equal(isPromptTemplate(template), true);
+  });
+
+  it('isPromptTemplate rejects objects missing required fields', () => {
+    // Missing $schema
+    assert.equal(
+      isPromptTemplate({ version: '0.1.0', phase: 'session-start', layers: [], variables: {} }),
+      false,
+    );
+
+    // Missing version
+    assert.equal(
+      isPromptTemplate({ $schema: 'gobbi-prompt/session-start', phase: 'session-start', layers: [], variables: {} }),
+      false,
+    );
+
+    // Not an object at all
+    assert.equal(isPromptTemplate('not-an-object'), false);
+    assert.equal(isPromptTemplate(null), false);
+    assert.equal(isPromptTemplate(42), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Prompt State
+// ---------------------------------------------------------------------------
+
+describe('prompt state', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      removeTempDir(dir);
+    }
+    tempDirs.length = 0;
+  });
+
+  function track(dir: string): string {
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  it('emptyPromptState returns correct shape', () => {
+    const state = emptyPromptState();
+    assert.ok(typeof state.version === 'string');
+    assert.ok(typeof state.session === 'object');
+    assert.ok(typeof state.project === 'object');
+    assert.ok(typeof state.workflow === 'object');
+    assert.ok(Array.isArray(state.history));
+  });
+
+  it('emptyPromptState history is empty array', () => {
+    const state = emptyPromptState();
+    assert.equal(state.history.length, 0);
+  });
+
+  it('emptyPromptState workflow.currentPhase is null', () => {
+    const state = emptyPromptState();
+    assert.equal(state.workflow.currentPhase, null);
+  });
+
+  it('write + read round-trip returns deep-equal state', async () => {
+    const dir = track(createTempDir());
+    const filePath = path.join(dir, 'prompt-state.json');
+    const original = emptyPromptState();
+
+    await writePromptStateAtomic(filePath, original);
+    const loaded = await readPromptState(filePath);
+
+    assert.deepEqual(loaded, original);
+  });
+
+  it('readPromptState returns null for missing file', async () => {
+    const dir = track(createTempDir());
+    const filePath = path.join(dir, 'does-not-exist.json');
+    const result = await readPromptState(filePath);
+    assert.equal(result, null);
+  });
+
+  it('readPromptState returns null for invalid JSON', async () => {
+    const dir = track(createTempDir());
+    const filePath = path.join(dir, 'bad.json');
+    fs.writeFileSync(filePath, '{{not json at all}}', 'utf8');
+    const result = await readPromptState(filePath);
+    assert.equal(result, null);
+  });
+
+  it('updatePromptHistory appends entry with correct phase and outcome', () => {
+    const state = emptyPromptState();
+    const updated = updatePromptHistory(state, 'session-start', 'configured');
+
+    assert.equal(updated.history.length, 1);
+    const entry = updated.history[0];
+    assert.ok(entry !== undefined);
+    assert.equal(entry.phase, 'session-start');
+    assert.equal(entry.outcome, 'configured');
+    assert.ok(typeof entry.timestamp === 'string');
+  });
+
+  it('updatePromptHistory does not mutate input state', () => {
+    const state = emptyPromptState();
+    const historyLengthBefore = state.history.length;
+
+    updatePromptHistory(state, 'session-start', 'configured');
+
+    assert.equal(state.history.length, historyLengthBefore);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Variable Resolution
+// ---------------------------------------------------------------------------
+
+describe('variable resolution', () => {
+  const tempDirs: string[] = [];
+  const savedEnvVars: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      removeTempDir(dir);
+    }
+    tempDirs.length = 0;
+    for (const key of savedEnvVars) {
+      delete process.env[key];
+    }
+    savedEnvVars.length = 0;
+  });
+
+  function track(dir: string): string {
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  function setEnv(key: string, value: string): void {
+    process.env[key] = value;
+    savedEnvVars.push(key);
+  }
+
+  it('interpolate replaces {{key}} with value from resolved map', () => {
+    const result = interpolate('Hello {{name}}!', { name: 'world' });
+    assert.equal(result, 'Hello world!');
+  });
+
+  it('interpolate handles multiple variables in one string', () => {
+    const result = interpolate('{{a}} and {{b}}', { a: 'X', b: 'Y' });
+    assert.equal(result, 'X and Y');
+  });
+
+  it('interpolate replaces unresolved references with empty string', () => {
+    const result = interpolate('Hello {{missing}}!', {});
+    assert.equal(result, 'Hello !');
+  });
+
+  it('interpolate leaves strings without {{}} unchanged', () => {
+    const result = interpolate('no variables here', { key: 'value' });
+    assert.equal(result, 'no variables here');
+  });
+
+  it('resolveVariable with env source reads from process.env', async () => {
+    setEnv('GOBBI_TEST_VAR', 'test-value');
+
+    const result = await resolveVariable(
+      'testVar',
+      { source: 'env', path: 'GOBBI_TEST_VAR', required: true },
+      {},
+    );
+
+    assert.equal(result, 'test-value');
+  });
+
+  it('resolveVariable with runtime source reads from runtime values map', async () => {
+    const result = await resolveVariable(
+      'myRuntime',
+      { source: 'runtime', path: 'myKey', required: true },
+      { myKey: 'runtime-value' },
+    );
+
+    assert.equal(result, 'runtime-value');
+  });
+
+  it('resolveVariable with file source reads file content', async () => {
+    const dir = track(createTempDir());
+    const filePath = path.join(dir, 'test-content.txt');
+    fs.writeFileSync(filePath, 'file-content-here', 'utf8');
+
+    const result = await resolveVariable(
+      'fileVar',
+      { source: 'file', path: filePath, required: true },
+      {},
+    );
+
+    assert.equal(result, 'file-content-here');
+  });
+
+  it('resolveVariable returns null for missing env var', async () => {
+    // Ensure the env var does not exist
+    delete process.env['GOBBI_NONEXISTENT_VAR_12345'];
+
+    const result = await resolveVariable(
+      'missingVar',
+      { source: 'env', path: 'GOBBI_NONEXISTENT_VAR_12345', required: true },
+      {},
+    );
+
+    assert.equal(result, null);
+  });
+
+  it('resolveAllVariables throws PromptResolutionError for required variable that fails', async () => {
+    // Ensure the env var does not exist
+    delete process.env['GOBBI_REQUIRED_MISSING'];
+
+    await assert.rejects(
+      () => resolveAllVariables(
+        {
+          missing: { source: 'env', path: 'GOBBI_REQUIRED_MISSING', required: true },
+        },
+        {},
+      ),
+      (err: unknown) => {
+        assert.ok(err instanceof PromptResolutionError);
+        assert.equal(err.variableName, 'missing');
+        assert.equal(err.source, 'env');
+        return true;
+      },
+    );
+  });
+
+  it('resolveAllVariables uses fallback for optional variable that fails', async () => {
+    delete process.env['GOBBI_OPTIONAL_MISSING'];
+
+    const resolved = await resolveAllVariables(
+      {
+        optional: {
+          source: 'env',
+          path: 'GOBBI_OPTIONAL_MISSING',
+          required: false,
+          fallback: 'default-value',
+        },
+      },
+      {},
+    );
+
+    assert.equal(resolved['optional'], 'default-value');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Prompt Renderer
+// ---------------------------------------------------------------------------
+
+describe('prompt renderer', () => {
+  const template = minimalTemplate();
+  const resolved = { mode: 'test', project: 'gobbi', action: 'build' };
+
+  it('plain text output contains [PHASE: header', () => {
+    const output = renderPrompt(template, resolved, { markdown: false });
+    assert.ok(output.includes('[PHASE:'));
+  });
+
+  it('plain text output contains --- SYSTEM ---, --- CONTEXT ---, --- TASK --- layer headers', () => {
+    const output = renderPrompt(template, resolved, { markdown: false });
+    assert.ok(output.includes('--- SYSTEM ---'));
+    assert.ok(output.includes('--- CONTEXT ---'));
+    assert.ok(output.includes('--- TASK ---'));
+  });
+
+  it('plain text output contains [COMPLETION: section', () => {
+    const output = renderPrompt(template, resolved, { markdown: false });
+    assert.ok(output.includes('[COMPLETION:'));
+  });
+
+  it('plain text output contains [NEXT STEPS] section', () => {
+    const output = renderPrompt(template, resolved, { markdown: false });
+    assert.ok(output.includes('[NEXT STEPS]'));
+  });
+
+  it('markdown output contains # Phase: header', () => {
+    const output = renderPrompt(template, resolved, { markdown: true });
+    assert.ok(output.includes('# Phase:'));
+  });
+
+  it('markdown output contains ## System, ## Context, ## Task headers', () => {
+    const output = renderPrompt(template, resolved, { markdown: true });
+    assert.ok(output.includes('## System'));
+    assert.ok(output.includes('## Context'));
+    assert.ok(output.includes('## Task'));
+  });
+
+  it('{{variables}} are replaced in rendered output', () => {
+    const output = renderPrompt(template, resolved, { markdown: false });
+    // Variables should be resolved — no raw {{}} in output
+    assert.ok(!output.includes('{{mode}}'));
+    assert.ok(!output.includes('{{project}}'));
+    assert.ok(!output.includes('{{action}}'));
+    // Resolved values should be present
+    assert.ok(output.includes('test'));
+    assert.ok(output.includes('gobbi'));
+    assert.ok(output.includes('build'));
+  });
+
+  it('AskUser section renders question text and option labels', () => {
+    const output = renderPrompt(template, resolved, { markdown: false });
+    assert.ok(output.includes('Pick a color'));
+    assert.ok(output.includes('Red'));
+    assert.ok(output.includes('Blue'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Prompt Templates
+// ---------------------------------------------------------------------------
+
+describe('prompt templates', () => {
+  it('session-start template passes isPromptTemplate guard', () => {
+    assert.equal(isPromptTemplate(SESSION_START_TEMPLATE), true);
+  });
+
+  it('workflow-start template passes isPromptTemplate guard', () => {
+    assert.equal(isPromptTemplate(WORKFLOW_START_TEMPLATE), true);
+  });
+
+  it('getTemplate session-start returns a template', () => {
+    const template = getTemplate('session-start');
+    assert.ok(template !== undefined);
+  });
+
+  it('getTemplate workflow-start returns a template', () => {
+    const template = getTemplate('workflow-start');
+    assert.ok(template !== undefined);
+  });
+
+  it('getTemplate workflow-ideation returns undefined (not implemented)', () => {
+    const template = getTemplate('workflow-ideation');
+    assert.equal(template, undefined);
+  });
+
+  it('session-start template has 3 layers', () => {
+    assert.equal(SESSION_START_TEMPLATE.layers.length, 3);
+  });
+
+  it('session-start template has askUser field with 4 questions', () => {
+    assert.ok(SESSION_START_TEMPLATE.askUser !== undefined);
+    assert.equal(SESSION_START_TEMPLATE.askUser.length, 4);
+  });
+
+  it('workflow-start template has 3 completion outcomes', () => {
+    assert.equal(WORKFLOW_START_TEMPLATE.completion.outcomes.length, 3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transition Graph
+// ---------------------------------------------------------------------------
+
+describe('transition graph', () => {
+  it('every phase in VALID_PROMPT_PHASES has a node in the graph', () => {
+    for (const phase of VALID_PROMPT_PHASES) {
+      assert.ok(
+        phase in TRANSITION_GRAPH,
+        `Missing graph node for phase: ${phase}`,
+      );
+    }
+  });
+
+  it('getTransitionNode session-start returns a node', () => {
+    const node = getTransitionNode('session-start');
+    assert.ok(node !== undefined);
+    assert.equal(node.phase, 'session-start');
+  });
+
+  it('getTransitionNode returns undefined for invalid phase', () => {
+    // Cast to satisfy TypeScript — testing runtime behavior for bad input
+    const node = getTransitionNode('not-a-phase' as 'session-start');
+    assert.equal(node, undefined);
+  });
+
+  it('getNextPhase session-start configured returns workflow-start', () => {
+    const next = getNextPhase('session-start', 'configured');
+    assert.equal(next, 'workflow-start');
+  });
+
+  it('getNextPhase workflow-start non-trivial returns workflow-ideation', () => {
+    const next = getNextPhase('workflow-start', 'non-trivial');
+    assert.equal(next, 'workflow-ideation');
+  });
+});


### PR DESCRIPTION
## Summary

Replaces skill-based instruction delivery with `gobbi prompt <phase>` — a CLI command that delivers right-sized, phase-specific prompts on demand. Each prompt is a micro-contract: what to do now, what context is needed, how to signal completion, and where to go next.

- New `gobbi-prompt/*` type family (14 phases, independent of gobbi-docs)
- Prompt state management (`prompt-state.json`, independent of Session type)
- Complete transition graph with ASL-style Choice routing
- Variable resolution system (8 source types, `{{variable}}` interpolation)
- Prompt renderer (plain text + markdown)
- Two implemented prompts: `session-start` and `workflow-start`
- CLI: `gobbi prompt <phase>`, `validate`, `status`
- 40 new tests (85 total, all passing)

## Test plan

- [x] `tsc --noEmit` compiles clean under strict mode
- [x] `npm test` passes (85/85, 0 failures)
- [x] `gobbi prompt --help` shows usage
- [x] `gobbi prompt validate` reports both templates valid
- [x] `gobbi prompt status` shows state
- [x] `gobbi prompt workflow-ideation` exits 1 (unimplemented phase)

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)