### PR TITLE
docs: v0.5.0 specification documents

### DIFF
--- a/.claude/project/gobbi/design/v050-cli.md
+++ b/.claude/project/gobbi/design/v050-cli.md
@@ -77,9 +77,15 @@ The CLI expands from its current eight-command surface to add a `workflow` subco
 
 **`gobbi workflow init`** — Creates the session directory under `.gobbi/sessions/{session-id}/`, writes `metadata.json`, initializes `gobbi.db` with the events table schema, and appends the first `workflow.start` event. Called by the SessionStart hook. Idempotent — if the session directory already exists, it verifies structure and exits cleanly.
 
+During initialization, `gobbi workflow init` asks the user four setup questions: the task description, whether to evaluate after Ideation, whether to evaluate after Plan, and any additional context. The evaluation answers (Ideation and Plan eval on/off) are stored immediately as a `workflow.eval.decide` event in `gobbi.db`, populating `evalConfig` in `state.json`. The prompt template generated for the first step (Ideation) includes the eval decision in its session section so the orchestrator knows the evaluation configuration from the start without needing to ask mid-workflow.
+
 **`gobbi workflow next`** — The core command. Reads `state.json` (or replays `gobbi.db` if absent), determines the active step, selects the appropriate prompt template, loads relevant skills and artifacts, evaluates token budget, and writes the compiled prompt to stdout. This is what the orchestrator receives at the start of each step. Every other `workflow` command supports this one.
 
 **`gobbi workflow transition <event>`** — Advances the state machine by appending a typed event to `gobbi.db` and updating `state.json`. Validates that the event produces a valid transition from the current step before writing. Returns the new state summary on stdout. Invalid transitions produce an error with the reason — useful for diagnosing stalls.
+
+The orchestrator calls this command via Bash, instructed by the prompt template. Each step's generated prompt ends with an explicit instruction: when this step is complete, run `gobbi workflow transition COMPLETE`. The CLI validates the transition against the state machine and advances state — the orchestrator does not decide when to transition, the prompt template instructs it.
+
+The Stop hook can also trigger implicit transitions: after each turn, the Stop hook analyzes the conversation to detect whether the orchestrator's response completed a step. If the response contains a recognized completion signal and no explicit transition was already written, the Stop hook writes the transition event. This handles cases where the orchestrator completed the step work but did not execute the transition command.
 
 **`gobbi workflow guard`** — Invoked by the PreToolUse hook. Reads the full hook stdin payload, loads `state.json`, evaluates guard conditions using the JsonLogic engine, and writes the appropriate JSON response to stdout. If the call violates a guard, appends a `guard.violation` event and returns `permissionDecision: "deny"`. If the call is valid, returns `permissionDecision: "allow"` or defers to the next hook. Guard evaluation is the hottest code path in the CLI — it must complete in single-digit milliseconds.
 
@@ -93,11 +99,17 @@ The CLI expands from its current eight-command surface to add a `workflow` subco
 
 **`gobbi workflow status`** — Reads `state.json` and prints the current workflow step, completed steps, active subagent count, evaluation configuration, and feedback round count. Human-readable output. Useful for diagnosing where a session is in the workflow without reading raw JSON.
 
+### New: `gobbi session` commands
+
+**`gobbi session events`** — Formats the `events.jsonl` log for human consumption. New in v0.5.0. Provides a readable audit trail of every event in a session without requiring a SQLite client.
+
+### New: `gobbi gotcha` commands
+
+**`gobbi gotcha promote`** — Moves gotchas from `.gobbi/project/gotchas/` to the permanent store in `.claude/skills/_gotcha/`. This command runs outside active sessions only — it checks that no session is active (no `workflow.start` event without a corresponding `workflow.finish` in any session directory) before proceeding. Gotchas recorded during a session live in `.gobbi/project/gotchas/` until this promotion step runs. The promotion is the mechanism that turns mid-session learnings into permanent `.claude/` knowledge without causing context reload during the session itself.
+
 ### Existing commands (unchanged)
 
 **`gobbi session list`** — Lists sessions with their IDs, creation timestamps, and current steps. Unchanged in v0.5.0 except the session source moves from the v0.4.x session files to `.gobbi/sessions/`.
-
-**`gobbi session events`** — Formats the `events.jsonl` log for human consumption. New in v0.5.0. Provides a readable audit trail of every event in a session without requiring a SQLite client.
 
 **`gobbi config`** — Session configuration management. Unchanged.
 

--- a/.claude/project/gobbi/design/v050-cli.md
+++ b/.claude/project/gobbi/design/v050-cli.md
@@ -1,0 +1,197 @@
+# v0.5.0 CLI — Integration Point
+
+CLI architecture reference for v0.5.0. Read this when implementing or reasoning about command structure, runtime choices, distribution, or the relationship between the plugin and the CLI. This document treats the CLI as a container — how it binds the event store, state machine, prompt templates, and hook system into a single executable. For the internals of each subsystem, see the respective doc.
+
+---
+
+## The CLI's Role
+
+The CLI is where all v0.5.0 subsystems converge. It is the only component that has read access to every part of the system simultaneously: workflow state from the event store, domain knowledge from `.claude/skills/`, guard specifications, prompt templates, and project configuration.
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         CLI as Integration Hub                       │
+└─────────────────────────────────────────────────────────────────────┘
+
+   .claude/                      .gobbi/
+   ────────────────              ─────────────────────────────────
+   skills/          ──read──▶   sessions/{id}/gobbi.db
+   rules/           ──read──▶   sessions/{id}/state.json
+   CLAUDE.md        ──read──▶   sessions/{id}/{step}/
+   agents/          ──read──▶   project/gotchas/
+                                                  │
+                                                  │
+                    ┌─────────────────────────────┘
+                    │
+                    ▼
+          ┌─────────────────────┐
+          │        CLI          │
+          │                     │
+          │  Event store reads  │
+          │  State derivation   │
+          │  Guard evaluation   │
+          │  Prompt compilation │
+          │  Event writes       │
+          └──────────┬──────────┘
+                     │
+          ┌──────────▼──────────┐
+          │   Hook scripts      │──▶  Claude Code (hook delegation)
+          └─────────────────────┘
+                     │
+          ┌──────────▼──────────┐
+          │   Orchestrator      │──▶  receives bounded prompt
+          └─────────────────────┘
+```
+
+> **The CLI is the prompt factory and the guard enforcer. Hooks are thin wrappers that delegate to it.**
+
+Hook scripts registered in `hooks/hooks.json` contain no logic. Each hook reads stdin and calls the appropriate `gobbi workflow *` command. Guard logic, event schemas, and capture behavior all live in the CLI — not in the hooks. This means updating workflow behavior means updating the CLI package, not touching the hook scripts.
+
+---
+
+## Runtime: Bun + TypeScript
+
+V0.5.0 migrates the CLI from Node.js to Bun. The current `package.json` declares `"engines": { "node": ">=18.0.0" }` and uses `tsc` for compilation. V0.5.0 replaces both.
+
+> **Bun matches Claude Code's own runtime, eliminates the build step, and brings native SQLite — three wins with one dependency choice.**
+
+**Native TypeScript execution** — Bun runs `.ts` files directly. No `tsc` build step during development. `bun run src/cli.ts` executes immediately. The build step for distribution still exists (`bun build`), but the development loop no longer requires it.
+
+**`bun:sqlite`** — The event store in `v050-session.md` requires SQLite with WAL mode and atomic write semantics. `bun:sqlite` is native to the runtime — zero additional dependencies, no `better-sqlite3` binding to compile, and 3–6x faster than equivalent Node.js SQLite solutions. This is the primary technical reason for the Bun migration: the event store architecture depends on SQLite, and Bun makes SQLite a first-class runtime capability.
+
+**`bun:test`** — Jest-compatible test runner built into the runtime. Zero configuration, built-in mocking, snapshot testing support. The testing strategy for prompt templates relies on snapshots to catch unintended changes — `bun:test` supports this natively without additional tooling.
+
+**File I/O** — `Bun.file()` and `Bun.write()` replace `node:fs/promises` for the common case. State file writes use the temp+rename pattern: the CLI writes to a `.tmp` file, then renames it atomically over the target. This prevents a partial write from corrupting `state.json` — the rename is atomic at the OS level.
+
+**Startup time** — Hook scripts are invoked on every tool call. A PreToolUse guard fires before every `Write`, `Edit`, or `Task` tool call during a workflow session. Guard evaluation must be fast — slow hooks stall the session. Bun's startup time (sub-10ms for a simple script) makes per-call invocation practical in a way that a Node.js + tsc compiled CLI struggles to match.
+
+The `package.json` `name` (`@gobbitools/cli`) and `bin` configuration remain unchanged. The migration is internal — callers invoke `gobbi` the same way.
+
+---
+
+## Command Structure
+
+The CLI expands from its current eight-command surface to add a `workflow` subcommand group. All new commands live under `gobbi workflow`. Existing commands are unchanged.
+
+### New: `gobbi workflow` commands
+
+**`gobbi workflow init`** — Creates the session directory under `.gobbi/sessions/{session-id}/`, writes `metadata.json`, initializes `gobbi.db` with the events table schema, and appends the first `workflow.start` event. Called by the SessionStart hook. Idempotent — if the session directory already exists, it verifies structure and exits cleanly.
+
+**`gobbi workflow next`** — The core command. Reads `state.json` (or replays `gobbi.db` if absent), determines the active step, selects the appropriate prompt template, loads relevant skills and artifacts, evaluates token budget, and writes the compiled prompt to stdout. This is what the orchestrator receives at the start of each step. Every other `workflow` command supports this one.
+
+**`gobbi workflow transition <event>`** — Advances the state machine by appending a typed event to `gobbi.db` and updating `state.json`. Validates that the event produces a valid transition from the current step before writing. Returns the new state summary on stdout. Invalid transitions produce an error with the reason — useful for diagnosing stalls.
+
+**`gobbi workflow guard`** — Invoked by the PreToolUse hook. Reads the full hook stdin payload, loads `state.json`, evaluates guard conditions using the JsonLogic engine, and writes the appropriate JSON response to stdout. If the call violates a guard, appends a `guard.violation` event and returns `permissionDecision: "deny"`. If the call is valid, returns `permissionDecision: "allow"` or defers to the next hook. Guard evaluation is the hottest code path in the CLI — it must complete in single-digit milliseconds.
+
+**`gobbi workflow capture-subagent`** — Invoked by the SubagentStop hook. Reads the hook stdin payload, extracts the subagent's transcript from `agent_transcript_path`, writes an artifact to the current step directory, and appends a `delegation.complete` event linked to the originating `delegation.spawn` event via `parent_seq`. This replaces manual `gobbi note collect`.
+
+**`gobbi workflow capture-plan`** — Invoked by the PostToolUse hook on ExitPlanMode. Reads the plan content from the hook stdin payload, writes a plan artifact to `.gobbi/sessions/{id}/plan/`, and appends an `artifact.write` event. The orchestrator does not need to explicitly save the plan — this capture is automatic.
+
+**`gobbi workflow flush-state`** — Invoked by the Stop hook. Checks for pending state changes that were not flushed during the turn and applies them. Respects `stop_hook_active` — exits immediately if true to prevent reentrance loops. This is a safety net, not the primary persistence path.
+
+**`gobbi workflow resume`** — User-facing recovery command. Replays `gobbi.db` through the reducer, writes a fresh `state.json`, and outputs a resume prompt that re-orients the orchestrator to the current step. Used after crash recovery and after context compaction — both cases use the same rebuild path.
+
+**`gobbi workflow status`** — Reads `state.json` and prints the current workflow step, completed steps, active subagent count, evaluation configuration, and feedback round count. Human-readable output. Useful for diagnosing where a session is in the workflow without reading raw JSON.
+
+### Existing commands (unchanged)
+
+**`gobbi session list`** — Lists sessions with their IDs, creation timestamps, and current steps. Unchanged in v0.5.0 except the session source moves from the v0.4.x session files to `.gobbi/sessions/`.
+
+**`gobbi session events`** — Formats the `events.jsonl` log for human consumption. New in v0.5.0. Provides a readable audit trail of every event in a session without requiring a SQLite client.
+
+**`gobbi config`** — Session configuration management. Unchanged.
+
+**`gobbi notify`** — Notification commands (Slack, Telegram, Desktop). Unchanged.
+
+**`gobbi image`, `gobbi video`, `gobbi web`** — Media analysis commands. Unchanged.
+
+**`gobbi validate`**, **`gobbi note`** — Unchanged in function; `note collect` behavior is superseded by automatic SubagentStop capture in v0.5.0, but the command remains for manual use.
+
+---
+
+## Argument Parsing
+
+The current CLI uses `node:util` `parseArgs` with manual command routing — the `switch` on `command` in `cli.ts`. This pattern is kept for v0.5.0. It has a manageable cost at the current command count and adding a `workflow` subcommand group is straightforward.
+
+> **The parsing layer is isolated. Migration to a typed routing library is a contained refactor, not an architectural change.**
+
+The `gobbi workflow <subcommand>` routing follows the same pattern as the existing top-level commands: `process.argv[2]` routes to `workflow`, and `process.argv[3]` routes to the subcommand. The workflow subcommand handler lives in `src/commands/workflow.ts`.
+
+When the command count grows significantly — particularly when workflow subcommands multiply for domain-specific variants — the CLI can migrate the parsing layer to a typed subcommand router without touching the handler implementations. The handlers are isolated from the parsing surface.
+
+---
+
+## Plugin-CLI Relationship
+
+> **The plugin distributes. The CLI runs. These are separate responsibilities with a clean boundary.**
+
+The gobbi plugin is the Claude Code integration artifact — it is what users install, what registers hooks with Claude Code, and what declares the rules that load into every session. The CLI is the runtime engine that the plugin delegates to.
+
+```
+  Plugin (distribution layer)          CLI (runtime layer)
+  ──────────────────────────           ─────────────────────────────
+  hooks/hooks.json         ──calls──▶  gobbi workflow guard
+  hooks/hooks.json         ──calls──▶  gobbi workflow capture-subagent
+  hooks/hooks.json         ──calls──▶  gobbi workflow capture-plan
+  hooks/hooks.json         ──calls──▶  gobbi workflow flush-state
+  rules/                   ──reads──▶  (loaded by Claude Code directly)
+  agents/                  ──reads──▶  (loaded by Claude Code directly)
+  skills/ (domain only)    ──reads──▶  CLI inlines into generated prompts
+  settings.json            ──declares──▶  hook registration, permissions
+```
+
+**Plugin responsibilities:**
+- Hook registration via `hooks/hooks.json`
+- Always-active behavioral rules in `rules/`
+- Agent definitions for the workflow agents
+- Domain knowledge skills (`_gotcha`, `_claude`, `_git`, and others that survive as materials per `v050-prompts.md`)
+- `settings.json` declaring permissions and hook timeouts
+
+**CLI responsibilities:**
+- Workflow engine: event store, state machine, reducer
+- Prompt templates for all five workflow steps plus their variants
+- Guard specification and JsonLogic evaluation
+- Prompt compilation: selecting artifacts, loading skill materials, applying cache ordering, enforcing token budget
+- Session lifecycle management
+
+The plugin does not contain orchestration logic. It contains wiring. When guard behavior changes, the CLI package is updated. The hook scripts in `hooks/hooks.json` remain stable across releases because they contain no logic to change — they only invoke `gobbi workflow *` commands.
+
+**Installation path** — The plugin declares `@gobbitools/cli` as a dependency in its `package.json`. When the plugin is installed, the CLI installs with it. The `gobbi` binary is available as a project-local command, invokable from hook scripts via the standard node_modules path or a resolved absolute path stored in plugin configuration.
+
+---
+
+## Distribution Strategy
+
+> **npm is primary. Single-binary is secondary for environments where npm is unavailable.**
+
+**Primary: npm package** — `@gobbitools/cli` published to the npm registry. This is the current distribution mechanism and it remains correct for v0.5.0. Plugin installation pulls the CLI as a dependency. Users with a standard Node.js or Bun environment install once and update via `npm update` or `bun update`.
+
+**Secondary: `bun --compile` binary** — Bun can compile a TypeScript project into a self-contained binary with no runtime dependency. This is the distribution path for users in environments where npm is unavailable — CI systems, restricted corporate environments, or setups where installing a package manager is impractical. The compiled binary includes the Bun runtime and all CLI code. It is larger than the npm package but requires no external tooling to run.
+
+The binary build is an additional CI step, not a replacement for the npm build. Both artifacts are produced from the same source. The choice between them is made by the installer, not by the gobbi release process.
+
+---
+
+## Testing Strategy
+
+`bun:test` is the test runner for all CLI tests. No additional test framework is required.
+
+> **Test the boundaries, not the internals. The event store, state machine, and prompt templates are the interfaces other subsystems depend on.**
+
+**State machine tests** — The reducer is a pure function and tests cheaply. Each test supplies an initial state and an event and asserts the returned state. Exhaustiveness is validated at compile time via the TypeScript `never` pattern — a new event type without a reducer case is a type error. Transition table compliance is tested by exercising every row in the table and confirming the reducer accepts valid transitions and rejects invalid ones.
+
+**Guard evaluation tests** — Each guard specification is a JSON object. Tests supply a mock state and a mock tool call input and assert the output: `deny`, `allow`, or `warn` with the expected reason. The custom JsonLogic operators (`event_exists`, `event_count`) are unit-tested independently with synthetic event logs.
+
+**Prompt template tests** — Snapshot testing via `bun:test`'s built-in snapshot support. Each template is rendered with a representative set of state inputs and the output is committed as a snapshot. CI fails when a template render changes unexpectedly. This catches unintended prompt changes — the most consequential class of regression in a system where prompt content drives behavior.
+
+**Hook handler tests** — Hook handlers (`gobbi workflow guard`, `gobbi workflow capture-subagent`, etc.) are tested by supplying mock stdin payloads and asserting stdout output and event store writes. File I/O is mocked via Bun's test mocking support. The event store is tested against a real SQLite in-memory database — this is practical because `bun:sqlite` with an in-memory database has no I/O cost.
+
+**Integration tests** — A full workflow cycle test initializes a session, transitions through all five steps, and verifies that the final state matches the expected terminal state. Hook delegation is tested end-to-end with mock stdin and a real CLI subprocess. These are slower than unit tests and run in a separate test suite from the fast unit tests.
+
+---
+
+## Boundaries
+
+This document covers the CLI's role as integration hub, the Bun runtime migration and its rationale, the full command structure for both new `workflow` commands and existing commands, the argument parsing approach, the plugin-CLI boundary, distribution strategy, and testing approach.
+
+For the event store schema and state fields that `gobbi workflow` commands read and write, see `v050-session.md`. For the state machine transitions that `gobbi workflow transition` validates, see `v050-state-machine.md`. For the prompt compilation logic that `gobbi workflow next` executes, see `v050-prompts.md`. For the hook stdin schemas and output format that `gobbi workflow guard` and capture commands handle, see `v050-hooks.md`.

--- a/.claude/project/gobbi/design/v050-hooks.md
+++ b/.claude/project/gobbi/design/v050-hooks.md
@@ -86,6 +86,8 @@ PreToolUse can rewrite the tool's input before execution via the `updatedInput` 
 
 **Agent tool (spawning subagents)** — The guard reads `tool_input.subagent_type` and checks it against the current step's allowed agent types from `state.json`. An orchestrator in the Execution step is allowed to spawn executor-type agents. It is not allowed to spawn evaluator-type agents — evaluation is a separate step and the creating agent must not trigger it. If `subagent_type` is not in the allowed set for the current step, the guard denies.
 
+When the guard allows an Agent tool call, it appends a `delegation.spawn` event to the event store before returning the allow decision. This event records the subagent type, the current step, and the timestamp. The `parent_seq` on the subsequent `delegation.complete` event (written by SubagentStop) references this spawn event, linking the full delegation lifecycle in the event log.
+
 **Write and Edit tools (`.claude/` protection)** — The guard checks whether `tool_input.file_path` targets any path under `.claude/`. If the session is active (a `workflow.start` event exists and no `workflow.finish` event exists), the guard denies. This enforces the directory split from `v050-overview.md`: `.claude/` is read-only during an active workflow. Writes go to `.gobbi/`.
 
 **Execution precondition guard** — Before an executor subagent is spawned, the guard verifies that a plan artifact exists in `plan/` for the current session. It uses the `event_exists("workflow.step.exit", "plan")` check. If the plan step has not completed, the guard denies. An executor without a plan has no bounded scope and will improvise — which is the failure mode v0.5.0 is designed to prevent.
@@ -146,12 +148,24 @@ The delegation pattern for each hook type:
 
 | Hook event | CLI command |
 |------------|-------------|
+| SessionStart | `gobbi workflow init` |
 | PreToolUse | `gobbi workflow guard` |
 | SubagentStop | `gobbi workflow capture-subagent` |
 | PostToolUse (ExitPlanMode) | `gobbi workflow capture-plan` |
 | Stop | `gobbi workflow flush-state` |
 
 Each CLI command reads the full stdin payload, evaluates against the current session state, writes any necessary events, and returns the appropriate JSON response that the hook forwards to stdout. The hook process exits 0 in all cases except unrecoverable startup failures.
+
+The SessionStart hook receives a fixed stdin schema:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `session_id` | string | Claude Code session identifier — becomes the session directory name |
+| `transcript_path` | string | Absolute path to the session transcript file |
+| `cwd` | string | Working directory at session open time — recorded in `metadata.json` |
+| `source` | string | What triggered the session: `user`, `project`, or `api` |
+
+`gobbi workflow init` uses these fields to create the session directory under `.gobbi/sessions/{session-id}/`, write `metadata.json`, initialize `gobbi.db` with the events table schema, and append the first `workflow.start` event. The command is idempotent — if the session directory already exists, it verifies structure and exits cleanly.
 
 This means the hooks registered in `hooks/hooks.json` are stable across releases. The CLI evolves; the hook wiring does not.
 
@@ -166,6 +180,16 @@ V0.5.0 implements two enforcement levels that reflect different violation severi
 **Hard block** — For structural violations, the hook returns `permissionDecision: "deny"`. The tool does not execute. A `guard.violation` event is written to `gobbi.db`. The `violations` array in `state.json` is updated. The orchestrator receives the denial and the reason.
 
 **Escalation on repeat violations** — The `violations` array in `state.json` tracks every `guard.violation` event. The CLI reads the violation count for a specific guard when generating the next prompt. If the same guard has fired more than a configurable threshold (default 3 times), the CLI escalates — it surfaces a warning to the user via the generated prompt, noting that the orchestrator is repeatedly attempting a blocked action. This is a stagnation signal: the orchestrator is stuck, and human intervention may be needed to resolve the underlying confusion.
+
+---
+
+## Hook Profiles
+
+V0.5.0 ships with a single enforcement profile. All guards operate at the levels described in the Escalating Enforcement section above — hard blocks for structural violations, soft nudges for edge cases.
+
+Research into the v0.5.0 enforcement model identified a hook profiles concept: configurable enforcement strictness levels (standard, minimal, strict) that would let users tune how aggressively guards block versus warn. This is a meaningful capability — teams with higher trust in their orchestrator or projects with tighter timelines may want a minimal profile that nudges instead of blocks.
+
+Profile support is planned for v0.5.1 and later. V0.5.0 does not implement enforcement profiles. All hooks behave at the standard enforcement level. This is noted explicitly so that contributors do not implement ad-hoc per-guard softening to work around the missing profiles feature — the right place for that flexibility is the profile system, not guard-by-guard overrides.
 
 ---
 

--- a/.claude/project/gobbi/design/v050-hooks.md
+++ b/.claude/project/gobbi/design/v050-hooks.md
@@ -1,0 +1,186 @@
+# v0.5.0 Hooks
+
+Enforcement and recording layer for v0.5.0. Read this when implementing or reasoning about PreToolUse guards, SubagentStop capture, PostToolUse signals, or the hook-to-CLI delegation pattern. Assumes familiarity with the event model in `v050-session.md` and guard conditions in `v050-state-machine.md`.
+
+---
+
+## Two Categories of Hooks
+
+> **Guards enforce. Capture records. These are separate responsibilities and must not be conflated.**
+
+V0.5.0 hooks divide cleanly into two functional categories based on when they fire and what they do.
+
+**Guard hooks** (PreToolUse) intercept tool calls before execution. They read the current workflow state and evaluate whether the tool call is valid at this point in the workflow. When a call violates a guard, the hook blocks it — the tool never executes. Guard hooks are the enforcement layer. They cannot be bypassed by model reasoning because they operate at the tool layer, not the prompt layer.
+
+**Capture hooks** (SubagentStop, PostToolUse, Stop) observe actions that have already completed. They do not block — they record. A SubagentStop hook reads the subagent's transcript and writes a `delegation.complete` event to the event store. A PostToolUse hook on ExitPlanMode captures the plan content. A Stop hook flushes pending state changes after each turn. Capture hooks are the recording layer.
+
+```
+  Orchestrator action
+         │
+         ▼
+  ┌─────────────────────────────────────┐
+  │          PreToolUse (Guard)         │
+  │                                     │
+  │  Read state.json                    │
+  │  Evaluate guard conditions          │
+  │         │                           │
+  │    deny? ──── block ──▶ guard.violation event
+  │         │                           │
+  │    allow? ─────────────────────────┐│
+  └─────────────────────────────────────┘
+                                        │
+                                        ▼
+                               Tool executes
+                                        │
+                    ┌───────────────────┼───────────────────┐
+                    ▼                   ▼                   ▼
+           SubagentStop          PostToolUse             Stop
+           (Capture)             (Capture)            (Capture)
+                    │                   │                   │
+                    └───────────────────┴───────────────────┘
+                                        │
+                                        ▼
+                             Event written to gobbi.db
+                             state.json updated
+```
+
+---
+
+## Guard Hook Mechanics (PreToolUse)
+
+### Stdin Schema
+
+Every PreToolUse hook invocation receives a JSON object on stdin. The fields relevant to guard evaluation are:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tool_name` | string | Name of the tool being called — e.g., `Write`, `Edit`, `Task` |
+| `tool_input` | object | Full arguments to the tool call |
+| `session_id` | string | Claude Code session identifier |
+| `agent_id` | string, optional | Present when the caller is a subagent, absent for orchestrator |
+
+The `agent_id` field is the critical discriminant. Guard hooks fire recursively — PreToolUse fires inside subagents as well as for the orchestrator. Structural guards should check whether `agent_id` is absent. If it is present, the call is from a subagent and most structural guards do not apply. The orchestrator-level guards enforce workflow step compliance; subagents operate within a narrower, already-validated scope.
+
+### Denial Mechanism
+
+> **Guards deny via `hookSpecificOutput.permissionDecision: "deny"`, not via exit code 2. Exit code 2 ignores JSON output entirely.**
+
+The hook process must exit 0 and write a JSON response to stdout. The denial signal lives inside `hookSpecificOutput`, not at the top level of the response. The `permissionDecision` field accepts four values:
+
+| Value | Meaning |
+|-------|---------|
+| `deny` | Block the tool call — the tool does not execute |
+| `allow` | Explicitly permit — overrides lower-priority guards |
+| `ask` | Surface to user for manual decision |
+| `defer` | Pass to the next applicable hook in the chain |
+
+When multiple hooks respond to the same tool call, precedence is: `deny` beats `defer` beats `ask` beats `allow`. A single deny anywhere in the chain blocks the call.
+
+Every denial must include `permissionDecisionReason` — a human-readable string explaining why the call was blocked. This is what the orchestrator receives. It should be specific enough for the orchestrator to understand what step it is in and what it should do instead.
+
+### Input Modification
+
+PreToolUse can rewrite the tool's input before execution via the `updatedInput` field. The modified input is what the tool receives. This is used sparingly — primarily to normalize file paths or inject missing context. Guard hooks that deny should not also modify input; modification is meaningful only when the call is allowed.
+
+### Specific Guard Behaviors
+
+**Agent tool (spawning subagents)** — The guard reads `tool_input.subagent_type` and checks it against the current step's allowed agent types from `state.json`. An orchestrator in the Execution step is allowed to spawn executor-type agents. It is not allowed to spawn evaluator-type agents — evaluation is a separate step and the creating agent must not trigger it. If `subagent_type` is not in the allowed set for the current step, the guard denies.
+
+**Write and Edit tools (`.claude/` protection)** — The guard checks whether `tool_input.file_path` targets any path under `.claude/`. If the session is active (a `workflow.start` event exists and no `workflow.finish` event exists), the guard denies. This enforces the directory split from `v050-overview.md`: `.claude/` is read-only during an active workflow. Writes go to `.gobbi/`.
+
+**Execution precondition guard** — Before an executor subagent is spawned, the guard verifies that a plan artifact exists in `plan/` for the current session. It uses the `event_exists("workflow.step.exit", "plan")` check. If the plan step has not completed, the guard denies. An executor without a plan has no bounded scope and will improvise — which is the failure mode v0.5.0 is designed to prevent.
+
+---
+
+## Capture Hook Mechanics
+
+### SubagentStop
+
+> **SubagentStop replaces manual `gobbi note collect` entirely. When a subagent stops, its output is automatically recorded.**
+
+SubagentStop fires after every subagent completes, regardless of success or failure. The stdin payload fields are:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `agent_id` | string | Identifier of the subagent that completed |
+| `agent_type` | string | Role type — executor, evaluator, researcher, etc. |
+| `agent_transcript_path` | string | Absolute path to the subagent's conversation transcript |
+| `last_assistant_message` | string | Final message from the subagent before stopping |
+| `stop_hook_active` | boolean | Whether a Stop hook is currently running |
+
+The hook reads the transcript at `agent_transcript_path`, extracts the result, and writes an artifact file to the current step's directory under `.gobbi/sessions/{session-id}/{step}/`. It then appends a `delegation.complete` event to `gobbi.db` with the artifact path as data. The `parent_seq` field on the event references the `delegation.spawn` event that initiated this subagent, linking the two.
+
+`stop_hook_active` must be checked first. If true, the hook exits immediately. SubagentStop can be called from within a Stop hook context — processing in that condition causes infinite loops.
+
+Output length cap applies. Transcripts can be large. The hook writes results to the artifact file, not to stdout. The stdout response is kept minimal — only the event confirmation.
+
+### PostToolUse (ExitPlanMode)
+
+PostToolUse fires after a tool call completes. The hook is registered specifically for the `ExitPlanMode` tool. When ExitPlanMode completes, the plan is finalized. The hook:
+
+1. Reads `tool_input` from the stdin payload to extract the plan content
+2. Writes the plan as an artifact to `.gobbi/sessions/{session-id}/plan/`
+3. Appends an `artifact.write` event to `gobbi.db`
+
+This removes the requirement for the orchestrator to explicitly save the plan. The capture is automatic — the orchestrator uses ExitPlanMode as normal and the hook handles persistence.
+
+PostToolUse does not use `permissionDecision` — it cannot block. If the hook fails, the failure is logged but the tool call result is not affected.
+
+### Stop Hook
+
+The Stop hook fires after each turn of the conversation ends. Its primary responsibility in v0.5.0 is flushing any pending state changes that have not yet been persisted — for example, if a state update was computed but not written due to a mid-turn crash, the Stop hook ensures it is applied.
+
+`stop_hook_active` in the stdin payload must be checked at the start of every Stop hook. If true, the hook exits immediately with a zero exit code and empty output. Claude Code sets `stop_hook_active` when a Stop hook triggers another Stop hook — the reentrance guard prevents cascading. Omitting this check causes infinite loops that stall the session.
+
+The Stop hook is a safety net, not the primary persistence mechanism. Events are written to `gobbi.db` during the turn as they occur. The Stop hook only handles the case where a turn ended with pending state that was not flushed inline.
+
+---
+
+## Hook-to-CLI Delegation
+
+> **Hooks are thin wrappers. All logic lives in the CLI.**
+
+Each hook is a minimal shell script or binary that reads stdin and delegates to a `gobbi` CLI command. The hook itself contains no guard logic, no state evaluation, and no event writing. This separation ensures that guard conditions and event schemas can be updated by updating the CLI package, without touching the hook scripts that live in `.claude/hooks/`.
+
+The delegation pattern for each hook type:
+
+| Hook event | CLI command |
+|------------|-------------|
+| PreToolUse | `gobbi workflow guard` |
+| SubagentStop | `gobbi workflow capture-subagent` |
+| PostToolUse (ExitPlanMode) | `gobbi workflow capture-plan` |
+| Stop | `gobbi workflow flush-state` |
+
+Each CLI command reads the full stdin payload, evaluates against the current session state, writes any necessary events, and returns the appropriate JSON response that the hook forwards to stdout. The hook process exits 0 in all cases except unrecoverable startup failures.
+
+This means the hooks registered in `hooks/hooks.json` are stable across releases. The CLI evolves; the hook wiring does not.
+
+---
+
+## Escalating Enforcement
+
+V0.5.0 implements two enforcement levels that reflect different violation severities.
+
+**Soft nudge** — For edge cases that are unusual but not structurally invalid, the PreToolUse hook returns a response that includes `additionalContext` rather than a denial. The tool call proceeds. The orchestrator receives the additional context and can adjust its behavior. This is appropriate when the action is technically within scope but warrants attention — for example, writing to a step directory that does not match the currently active step.
+
+**Hard block** — For structural violations, the hook returns `permissionDecision: "deny"`. The tool does not execute. A `guard.violation` event is written to `gobbi.db`. The `violations` array in `state.json` is updated. The orchestrator receives the denial and the reason.
+
+**Escalation on repeat violations** — The `violations` array in `state.json` tracks every `guard.violation` event. The CLI reads the violation count for a specific guard when generating the next prompt. If the same guard has fired more than a configurable threshold (default 3 times), the CLI escalates — it surfaces a warning to the user via the generated prompt, noting that the orchestrator is repeatedly attempting a blocked action. This is a stagnation signal: the orchestrator is stuck, and human intervention may be needed to resolve the underlying confusion.
+
+---
+
+## Plugin Hook Registration
+
+> **Plugin hooks register via `hooks/hooks.json` only. Do not also declare them in `plugin.json`.**
+
+Claude Code v2.1 and later auto-load `hooks/hooks.json` from the plugin directory. Declaring the same hooks in `plugin.json` causes duplicate detection errors at plugin load time. The hook manifest lives in one place — `hooks/hooks.json`. The `plugin.json` manifest does not contain a `hooks` key.
+
+The timeout for command hooks is 600 seconds by default. Guard checks complete in milliseconds — they read `state.json` and evaluate JsonLogic conditions. Capture hooks may take longer if they process large transcripts, but should complete well within the timeout. A hook that approaches the timeout indicates a design problem — the heavy work should be offloaded to an async queue rather than blocking the hook execution path.
+
+---
+
+## Boundaries
+
+This document covers the two hook categories and their responsibilities, guard hook mechanics (stdin schema, denial mechanism, input modification, specific guard behaviors), capture hook mechanics (SubagentStop, PostToolUse, Stop), hook-to-CLI delegation, escalating enforcement levels, and plugin hook registration.
+
+For the JsonLogic condition language and guard specification format, see `v050-state-machine.md`. For the event types that hooks write and the `state.json` fields they update, see `v050-session.md`. For the CLI commands that hooks delegate to, see `v050-cli.md`.

--- a/.claude/project/gobbi/design/v050-overview.md
+++ b/.claude/project/gobbi/design/v050-overview.md
@@ -211,8 +211,8 @@ This document covers architecture, philosophy, and positioning. It does not cove
 
 | Document | Covers |
 |----------|--------|
-| `v050-state-machine.md` | Workflow state transitions, step preconditions, event schema |
-| `v050-cli-prompts.md` | Prompt generation, skill material incorporation, template system |
-| `v050-hooks.md` | Hook types, guard patterns, event capture, SubagentStop collection |
-| `v050-event-store.md` | SQLite schema, query patterns, event sourcing design |
-| `v050-directory-layout.md` | `.gobbi/` structure, gotcha promotion, session lifecycle |
+| `v050-session.md` | Session directory, SQLite event store, state derivation, crash recovery |
+| `v050-state-machine.md` | Workflow transitions, typed reducer, guards, JsonLogic conditions |
+| `v050-prompts.md` | Prompt compilation, cache ordering, skills boundary, template format |
+| `v050-hooks.md` | PreToolUse guards, SubagentStop capture, hook schemas, enforcement |
+| `v050-cli.md` | Bun CLI rewrite, commands, distribution, plugin relationship |

--- a/.claude/project/gobbi/design/v050-overview.md
+++ b/.claude/project/gobbi/design/v050-overview.md
@@ -1,0 +1,218 @@
+# v0.5.0 Overview
+
+Foundation document for the v0.5.0 architecture. Read this first before any other v0.5.0 spec doc. All other docs in this series describe one subsystem — this one explains why the system exists, what it changes, and how the pieces fit together.
+
+---
+
+## The Problem with Guidance-Based Orchestration
+
+In v0.4.x, the orchestrator is a general-purpose agent that reads skills and follows their guidance. Ideation, planning, execution, collection, and memorization are documented as workflow steps — but the orchestrator decides when to do them, whether to skip them, and in what order. The skills are advice, not enforcement.
+
+This produces predictable failures. The orchestrator skips collection because the task felt done. It forgets memorization because the conversation was long. It edits `.claude/` mid-workflow to update skill docs, which causes Claude Code to reload context and stall the session. It asks users clarifying questions mid-execution when all the information was already present. These are not bugs that can be fixed with better instructions — they are the structural consequence of "guidance" as the control mechanism.
+
+> **Instructions-as-guidance cannot be made reliable. Runtime enforcement can.**
+
+The orchestrator reads guidance and approximates the workflow. Approximation means drift. The longer the session, the more the workflow drifts from what was intended. A fundamentally different control model is needed.
+
+---
+
+## The Philosophy
+
+V0.5.0 replaces guidance-based orchestration with state-driven orchestration. The orchestrator no longer reads skills to understand what to do next. Instead, the CLI generates prompts from workflow state — the orchestrator receives specific, bounded instructions for the current step and nothing else.
+
+Three principles drive the redesign:
+
+> **The orchestrator should receive instructions, not decide them.**
+
+The CLI knows what step is active, what has been completed, and what comes next. It encodes that knowledge into the prompt. The orchestrator executes that prompt. Workflow logic belongs to the CLI, not the LLM.
+
+> **Constraints enforced at the tool layer cannot be bypassed by the model.**
+
+Hooks intercept tool calls before they execute. A PreToolUse hook that blocks writes to `.claude/` during an execution step cannot be overridden by the orchestrator's reasoning about whether the edit seems fine. Enforcement at the tool layer is structurally reliable in a way that prompt-level guidance is not.
+
+> **Skills provide domain knowledge, not workflow control.**
+
+In v0.5.0, skills still teach agents how to think about specific domains — git conventions, evaluation perspectives, documentation standards. But skills no longer drive orchestration flow. The CLI incorporates relevant skill content as materials in the generated prompt, not as instructions the orchestrator must discover and follow.
+
+---
+
+## The Workflow
+
+V0.5.0 collapses the v0.4.x seven-step cycle into five steps. Research is absorbed into Ideation as an internal loop. Collection and Memorization merge into a single Memorization step.
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                         v0.5.0 Workflow                          │
+└──────────────────────────────────────────────────────────────────┘
+
+  ┌────────────────────────────────────┐
+  │            Ideation                │
+  │                                    │
+  │  ┌──────────────────────────────┐  │
+  │  │  Discuss ◀──────▶ Research  │  │
+  │  │  (internal loop)             │  │
+  │  └──────────────────────────────┘  │
+  │                                    │
+  │  Output: concrete approach         │
+  └──────────────────┬─────────────────┘
+                     │
+                     ▼
+  ┌──────────────────────────────────┐
+  │              Plan                │
+  │                                  │
+  │  Task decomposition              │
+  │  Delegation assignments          │
+  │  Verification criteria           │
+  └────────────────┬─────────────────┘
+                   │
+                   ▼
+  ┌──────────────────────────────────┐
+  │           Execution              │
+  │                                  │
+  │  One task at a time              │
+  │  Verify before next              │
+  └────────────────┬─────────────────┘
+                   │
+                   ▼
+  ┌──────────────────────────────────┐       ┌───────────────────────┐
+  │          Evaluation              │──────▶│  Loop back to any     │
+  │                                  │◀──────│  prior step           │
+  │  Mandatory after Execution       │       └───────────────────────┘
+  │  Optional at other steps         │
+  └────────────────┬─────────────────┘
+                   │
+                   ▼
+  ┌──────────────────────────────────┐
+  │         Memorization             │
+  │                                  │
+  │  Read conversation log           │
+  │  Extract crucial information     │
+  │  Persist decisions and state     │
+  └──────────────────────────────────┘
+```
+
+Each step has a single defined responsibility:
+
+**Ideation** answers "what to do." Discussion with the user and research into the problem space are internal loops within Ideation — they do not surface as separate workflow steps. Ideation completes when the approach is concrete enough to plan against.
+
+**Plan** answers "how to orchestrate." Task decomposition, agent delegation assignments, and verification criteria. The plan is the contract — Execution runs against it.
+
+**Execution** answers "do it." One task at a time, verified before the next begins. Scope is bounded by the plan; no improvisation.
+
+**Evaluation** answers "is it right." Mandatory after Execution. At Ideation and Plan, the decision to evaluate is made once at workflow start, not redecided at each step. Evaluation can loop back to any prior step — not just the immediately preceding one. The creating agent never evaluates its own output.
+
+**Memorization** answers "what should persist." Read the conversation log, extract decisions, state, open questions, and gotchas. Write them where the next session can find them. Without Memorization, every session restarts from zero.
+
+---
+
+## The Directory Split
+
+V0.4.x stores everything under `.claude/`. This creates a conflict: the orchestrator is both reading from `.claude/` (skills, rules, CLAUDE.md) and sometimes writing to it (updating skill docs, recording gotchas mid-session). Writing to `.claude/` during a session causes Claude Code to reload context, which stalls the session. This is the idle problem.
+
+V0.5.0 resolves it with a hard directory split:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                       Directory Split                           │
+└─────────────────────────────────────────────────────────────────┘
+
+  .claude/                          .gobbi/
+  ─────────────────────────         ─────────────────────────────
+  Read-only during workflow         Runtime state — write freely
+
+  CLAUDE.md                         sessions/
+  rules/                            worktrees/
+  skills/                           project/
+  agents/                             notes/
+  settings.json                       gotchas/
+  hooks/                              context/
+```
+
+`.claude/` is the static knowledge layer. During a workflow session, no agent writes to it. The hooks enforce this at the tool layer — a PreToolUse hook blocks any write to `.claude/` while a session is active.
+
+`.gobbi/` is the runtime layer. Session state, worktree management, notes, gotchas recorded mid-session, and context files all live here. Writing to `.gobbi/` does not trigger context reload. Agents write freely.
+
+The implication: gotchas recorded during a session live in `.gobbi/project/gotchas/` until a designated promotion step moves them into `.claude/skills/_gotcha/`. This promotion happens outside an active session. It does not cause idle.
+
+---
+
+## System Architecture
+
+The five components of v0.5.0 form a closed feedback loop:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    v0.5.0 System Architecture                   │
+└─────────────────────────────────────────────────────────────────┘
+
+              ┌─────────────────────────────┐
+              │         SQLite              │
+              │      Event Store            │
+              │  (source of truth)          │
+              └──────┬──────────────────────┘
+                     │ reads state
+                     ▼
+  ┌──────────────────────────────────┐
+  │             CLI                  │
+  │                                  │
+  │  Reads state from event store    │
+  │  Loads skill materials           │
+  │  Generates bounded prompt        │
+  └──────────────────┬───────────────┘
+                     │ delivers prompt
+                     ▼
+  ┌──────────────────────────────────┐
+  │          Orchestrator            │
+  │                                  │
+  │  Executes current step only      │
+  │  Spawns subagents per plan       │
+  │  Writes results to .gobbi/       │
+  └──────────────┬───────────────────┘
+                 │ tool calls
+                 ▼
+  ┌──────────────────────────────────┐
+  │             Hooks                │
+  │                                  │
+  │  PreToolUse — block invalid      │
+  │  PostToolUse — capture signals   │
+  │  SubagentStop — auto-collect     │
+  └──────────────────┬───────────────┘
+                     │ writes events
+                     ▼
+              ┌─────────────────────────────┐
+              │         SQLite              │
+              │      Event Store            │
+              └─────────────────────────────┘
+```
+
+**CLI** is the prompt factory. It reads workflow state from the event store, determines which step is active and what has completed, incorporates relevant skill content as materials, and generates a specific prompt. The orchestrator cannot see outside that prompt — it cannot decide to jump steps or deviate from scope.
+
+**Hooks** are the constraint layer. PreToolUse hooks enforce guards — blocking writes to `.claude/` during sessions, preventing scope violations, enforcing step preconditions. PostToolUse and SubagentStop hooks capture events — when a subagent finishes, its output is automatically recorded in the event store without the orchestrator needing to remember to collect it.
+
+**SQLite event store** is the source of truth. Every step completion, every subagent result, every evaluation verdict, every state transition is an event. The CLI reads events to determine what to generate next. The hooks write events. The event store is the shared memory of the system.
+
+**Skills** still exist and still matter. They provide domain knowledge that the CLI incorporates into generated prompts as materials — git conventions, evaluation perspectives, documentation standards. Skills no longer drive orchestration; they inform it.
+
+---
+
+## Positioning
+
+Gobbi does not replace Claude Code's native orchestration. It enhances it through hooks and CLI tooling — the same mechanisms Claude Code exposes to every project. V0.5.0 deliberately stays within those mechanisms rather than bypassing them.
+
+This positioning matters for longevity. Claude Code will improve. Its native orchestration, context management, and subagent coordination will get better. A gobbi that wraps and enhances Claude Code improves automatically as Claude Code improves. A gobbi that replaces Claude Code becomes a maintenance liability when Claude Code changes.
+
+GSD-2 demonstrated the value of the patterns v0.5.0 adopts: disk-driven state that survives context resets, fresh context per task to prevent contamination, cache-aware prompt ordering to reduce cost. These patterns are proven. V0.5.0 implements them inside Claude Code's native architecture rather than alongside it.
+
+---
+
+## What This Document Covers
+
+This document covers architecture, philosophy, and positioning. It does not cover implementation details of any subsystem. For those, see:
+
+| Document | Covers |
+|----------|--------|
+| `v050-state-machine.md` | Workflow state transitions, step preconditions, event schema |
+| `v050-cli-prompts.md` | Prompt generation, skill material incorporation, template system |
+| `v050-hooks.md` | Hook types, guard patterns, event capture, SubagentStop collection |
+| `v050-event-store.md` | SQLite schema, query patterns, event sourcing design |
+| `v050-directory-layout.md` | `.gobbi/` structure, gotcha promotion, session lifecycle |

--- a/.claude/project/gobbi/design/v050-prompts.md
+++ b/.claude/project/gobbi/design/v050-prompts.md
@@ -1,0 +1,189 @@
+# v0.5.0 Prompts — Compilation Model
+
+Prompt generation reference for v0.5.0. Read this when implementing or reasoning about how the CLI assembles prompts, how cache ordering works, which skills survive as materials versus which become CLI-owned templates, and the open decision on template format.
+
+---
+
+## The Prompt Compilation Model
+
+> **A prompt is a pure function of workflow state plus materials. The orchestrator cannot see outside what the CLI gives it.**
+
+In v0.4.x, the orchestrator discovers what to do by reading skills. In v0.5.0, the CLI determines what to do by reading workflow state and generates a bounded prompt that tells the orchestrator exactly what this step requires. The orchestrator executes that prompt — it does not deviate, does not skip ahead, and cannot access workflow information outside what the CLI included.
+
+The compilation function has five inputs:
+
+```
+prompt = compile(state, artifacts, skills, gotchas, context)
+```
+
+| Input | Source | What it contributes |
+|-------|--------|---------------------|
+| `state` | `state.json` from the active session | Current step, completed steps, eval config, active subagents |
+| `artifacts` | Step directories under `.gobbi/sessions/{id}/` | Prior step outputs inlined as context for the current step |
+| `skills` | `.claude/skills/` — the surviving domain skills | Domain knowledge injected as materials, not instructions |
+| `gotchas` | `.claude/skills/_gotcha/` and `.gobbi/project/gotchas/` | Known failure patterns prepended as guards |
+| `context` | `metadata.json` plus project root scan | Project path, config snapshot, tech stack context |
+
+The CLI reads `state.json` first to determine which step is active. It then selects which artifacts are relevant to the current step — an Execution prompt needs Plan artifacts; an Evaluation prompt needs Execution artifacts. It loads the surviving skills that are appropriate for this step and inlines their content as materials. Gotchas are always included. The resulting prompt is the only thing the orchestrator sees.
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                   Prompt Compilation Pipeline                        │
+└─────────────────────────────────────────────────────────────────────┘
+
+  state.json          skills/            gotchas/
+      │                   │                  │
+      ▼                   ▼                  ▼
+  ┌────────────────────────────────────────────┐
+  │              CLI Compiler                  │
+  │                                            │
+  │  1. Determine active step from state       │
+  │  2. Select relevant artifacts for step     │
+  │  3. Load surviving skills as materials     │
+  │  4. Load gotchas as guards                 │
+  │  5. Apply cache-aware section ordering     │
+  │  6. Apply token budget allocation          │
+  │  7. Render template with interpolated vars │
+  └───────────────────────┬────────────────────┘
+                          │
+                          ▼
+               ┌──────────────────────┐
+               │   Bounded Prompt     │
+               │                      │
+               │  Static prefix ──▶  cache hit
+               │  Session section     │
+               │  Dynamic section     │
+               └──────────────────────┘
+                          │
+                          ▼
+                    Orchestrator
+                  (sees this step only)
+```
+
+---
+
+## Cache-Aware Prompt Ordering
+
+> **Static content first. The cache prefix must be identical across task executions.**
+
+Anthropic prompt caching works on prefix stability: the longer the identical prefix across API calls, the more tokens are served from cache rather than recomputed. The CLI orders prompt sections to maximize prefix stability.
+
+Three sections, ordered by how often they change:
+
+**Static prefix** — Content that is identical across every invocation of this step type, regardless of session or task. This includes the system prompt, project-level rules, CLAUDE.md content, and skill materials that do not vary by session state. The static prefix is the same whether the workflow is on its first run or its tenth feedback loop. Cache hits are the norm here.
+
+**Session section** — Content specific to the active session but stable within it. Workflow state, the evaluation configuration decided at workflow start, the list of completed steps, and session ID. This section changes when the session advances to a new step, but does not change between invocations within the same step. Partial cache hits are possible.
+
+**Dynamic section** — Content that changes on every invocation. Step-specific instructions for the current action, the inlined output of the previous step, delegation target configuration, and any per-invocation variables like timestamps or active subagent counts. No cache benefit expected here; this section is always recomputed.
+
+The order is not negotiable. Placing dynamic content before static content destroys cache prefix stability and causes every invocation to be a full-cost API call. The CLI enforces this ordering at the template rendering stage — no template can place a dynamic variable inside the static prefix section.
+
+---
+
+## Skills Boundary
+
+> **The CLI owns all orchestration. Skills own domain knowledge.**
+
+V0.4.x conflated two concerns: skills taught agents both how the workflow runs and what domain knowledge to apply. In v0.5.0 these are separated. Workflow knowledge moves into CLI-owned prompt templates. Domain knowledge stays in skills as materials the CLI injects.
+
+### Skills That Become CLI Prompts
+
+These skills encoded orchestration logic — what to do at each step, how to transition, what evaluation means. In v0.5.0, this content lives in the CLI's template library and is never read directly by the orchestrator.
+
+`_orchestration`, `_discuss`, `_ideation`, `_plan`, `_research`, `_delegation`, `_execution`, `_collection`, `_memorization`, `_note`, `_evaluation`, `_innovation`, `_best-practice`
+
+The content of these skills does not disappear — it is translated into prompt templates. The difference is ownership: in v0.4.x, the orchestrator discovers and follows these skills; in v0.5.0, the CLI encodes them and presents the result as step instructions.
+
+### Skills That Survive
+
+These skills contain domain knowledge that is not orchestration-specific. They remain as `.claude/skills/` files and the CLI incorporates their content as materials in generated prompts.
+
+| Skill | Domain |
+|-------|--------|
+| `_gotcha` | Known failure patterns — always injected as guards |
+| `_claude` | Documentation standard — injected for doc-authoring steps |
+| `_skills` | Skill authoring conventions — injected when writing skill docs |
+| `_agents` | Agent authoring conventions — injected when writing agent docs |
+| `_rules` | Rule authoring conventions — injected when writing rule files |
+| `_project` | Project documentation structure — injected for project doc steps |
+| `_git` | Git conventions — injected for steps that involve commits or branching |
+
+The criterion for survival is simple: if the content teaches the agent how to think about a specific domain — not how the workflow operates — it belongs in a skill. If the content teaches the workflow itself, it belongs in the CLI.
+
+### How Skills Become Materials
+
+The CLI does not instruct the orchestrator to "load the `_git` skill." It reads the `_git` skill content itself and inlines the relevant portions directly into the generated prompt. The orchestrator receives the knowledge without needing to know where it came from. This eliminates the discovery problem: the orchestrator cannot forget to load a skill because the CLI already loaded it.
+
+---
+
+## Stances as CLI-Managed Configuration
+
+> **Stances are not discovered by the orchestrator — they are configured by the CLI into the delegation prompt.**
+
+In v0.4.x, the orchestrator reads stance guidance and decides how to apply it. In v0.5.0, the CLI encodes stance configuration directly into the delegation prompt for steps that require parallel agents.
+
+For Ideation steps that include a research loop, the CLI generates separate agent prompts — one configured for the innovative stance (depth-first, divergent, challenges constraints), one for the best-practice stance (proven patterns, reliability, established conventions). The stance configuration is part of the template, not a runtime decision.
+
+For Evaluation steps, each evaluator receives a prompt configured for its assigned perspective. The perspective assignment is part of the CLI's evaluation template. The orchestrator does not select evaluators — it receives a delegation block that lists them with their configured perspectives already set.
+
+Domain-specific stances — project-specific evaluation perspectives, specialist agents for a particular tech stack — remain as skills. The CLI guides loading these during delegation: the delegation prompt template includes a slot for domain-specific stance materials, and the CLI fills that slot from the appropriate project skill if one exists.
+
+---
+
+## Fresh Context Per Task
+
+> **Each subagent receives exactly the context its task requires. No more.**
+
+Prior steps' accumulated conversation context is never passed directly to a subagent. The CLI assembles a delegation prompt with specifically selected artifacts — the subset of prior step output that is actually needed for this task. A subagent working on an execution subtask receives the plan artifact for its subtask, the relevant gotchas, and its step instructions. It does not receive the Ideation conversation, prior execution attempts, or evaluation transcripts from earlier in the session.
+
+This boundary has two benefits. First, it prevents context contamination: a subagent executing subtask 3 cannot be distracted by the details of subtasks 1 and 2. Second, it keeps delegation prompts small and their static prefix stable, which preserves cache efficiency even across multiple delegations in the same step.
+
+Artifacts written by subagents to their step directories are available to the CLI for the next compilation cycle. The CLI decides which of those artifacts to include in subsequent prompts — the subagent does not decide what gets forwarded.
+
+---
+
+## Token Budget Awareness
+
+> **The CLI allocates token budget across sections before rendering. Truncation is at section boundaries, never mid-content.**
+
+Each model variant has a fixed context window. The CLI knows the model configured for the session (from `metadata.json`) and computes the available budget before assembling the prompt. Budget is allocated across sections in priority order: static prefix first (it must be complete to preserve cache stability), then gotchas (safety guards must never be truncated), then step instructions, then inlined artifacts, then supplementary materials.
+
+When the available budget is smaller than the sum of all sections, the CLI truncates artifact content at section boundaries. An artifact is included in full or excluded entirely — it is never truncated mid-document. This produces a prompt that is complete and coherent rather than one that ends mid-sentence because the window ran out.
+
+The allocation proportions are configurable per step type. Evaluation steps allocate more budget to inlined execution artifacts. Delegation steps allocate more budget to the delegation block. The defaults are encoded in the template definition for each step.
+
+---
+
+## Template Format — Decision Space (Open)
+
+> **The template format is an open architectural decision. The constraints are fixed; the implementation is not.**
+
+The CLI needs a template format that can express 20-30 prompts for v0.5.0, potentially scaling to 100+ prompts across workflow steps, domain variants, and stance configurations. The format must satisfy four constraints:
+
+**Constraint 1 — Conditional sections**: A template must be able to include or exclude blocks based on session state. Evaluation instructions appear only when `evalConfig` enables evaluation for this step. Gotcha loading appears only when the gotcha file is non-empty. These conditions are known at compile time from `state.json`.
+
+**Constraint 2 — Variable interpolation**: Templates reference session variables — session ID, step name, active step count, inlined artifact content. Interpolation must handle multi-line content (artifact body) without breaking the surrounding structure.
+
+**Constraint 3 — Shared blocks**: Some blocks appear across many templates — the scope boundary warning, the gotcha preamble, the "write artifacts to step directory" instruction. These must be defined once and referenced, not duplicated across templates.
+
+**Constraint 4 — Maintainability at scale**: At 100+ templates, a format that requires reading TypeScript to understand a template's structure creates maintenance cost. Templates should be readable as documents, not as data structures that require a runtime to interpret.
+
+### The Options
+
+**Option A — PAL (Prompt Assembly Language)**: JSON block arrays where each block carries a `type`, optional `condition` expressed in JsonLogic, content with mustache-style `{{vars}}`, and optional `ref` for shared blocks. The CLI evaluates conditions against `state.json`, resolves refs from a shared library, and renders blocks in order. The template is fully declarative — all logic is expressed in data. The cost is that JsonLogic conditions are verbose and the block array structure obscures the narrative flow of the prompt.
+
+**Option B — Simple JSON plus CLI logic**: Flat JSON objects with `{{vars}}` for interpolation. All conditional logic lives in TypeScript — the CLI decides which JSON objects to include based on state, assembles them into a string, and interpolates variables. The template is simple to read but the conditional behavior requires reading TypeScript to understand. At scale, the TypeScript accumulates complexity as each new conditional is added.
+
+**Option C — Hybrid (JSON manifest plus content files)**: A JSON manifest defines the template structure — section order, which sections are conditional, variable names, shared block references. Long text blocks are stored in separate `.md` or `.txt` files referenced by the manifest. The manifest is readable; the prose is readable; the CLI wires them together. The cost is indirection — understanding a template requires reading both the manifest and its referenced files.
+
+All three options satisfy constraints 1 and 2. Options A and C satisfy constraint 3 natively (refs and shared files); Option B requires TypeScript-managed shared blocks. Options B and C satisfy constraint 4 more readily than Option A at high template counts.
+
+This decision is documented here as a design constraint, not a final choice. The implementation must select one option and apply it consistently across all prompt templates in the CLI. The selection should be made once and recorded in this document before implementation begins.
+
+---
+
+## Boundaries
+
+This document covers the prompt compilation model, cache-aware section ordering, the skills boundary between CLI-owned templates and surviving domain skills, stances as CLI-managed configuration, fresh context isolation per subagent task, token budget allocation, and the open template format decision.
+
+For how state transitions determine which step is active, see `v050-state-machine.md`. For how hooks write events that the CLI reads to derive state, see `v050-hooks.md`. For the session artifacts that prompts consume, see `v050-session.md`. For CLI command syntax and distribution, see `v050-cli.md`.

--- a/.claude/project/gobbi/design/v050-session.md
+++ b/.claude/project/gobbi/design/v050-session.md
@@ -1,0 +1,189 @@
+# v0.5.0 Session — Data Model
+
+Data model reference for v0.5.0. Read this when implementing or reasoning about the session directory layout, the SQLite event store, state derivation, or crash recovery. All other v0.5.0 subsystem docs reference this one for the event model.
+
+---
+
+## What a Session Is
+
+A session corresponds to a single Claude Code conversation lifecycle. It begins when the SessionStart hook fires and ends when the user runs `/clear` or opens a new chat. Context compaction is mid-session — it does not end the session, it triggers a resume prompt generated from persisted state.
+
+Sessions are stored under `.gobbi/sessions/{session-id}/`. The session ID is a timestamp-prefixed UUID assigned at creation, chosen for human readability and filesystem sortability.
+
+---
+
+## Session Directory Structure
+
+```
+.gobbi/
+└── sessions/
+    └── {session-id}/
+        ├── metadata.json          immutable — written once at session creation
+        ├── state.json             canonical workflow state — materialized view
+        ├── state.json.backup      previous state before last transition
+        ├── events.jsonl           human-readable event log — mirrors gobbi.db
+        ├── gobbi.db               SQLite event store — source of truth
+        ├── ideation/              step artifacts — flat directory
+        ├── plan/                  step artifacts — flat directory
+        ├── execution/             step artifacts — flat directory
+        ├── evaluation/            step artifacts — flat directory
+        └── memorization/          step artifacts — flat directory
+```
+
+Each file and directory has a single responsibility. `metadata.json` and `gobbi.db` are the permanent record. `state.json` and `events.jsonl` are derived views — they can be rebuilt from `gobbi.db` at any time.
+
+---
+
+## File Responsibilities
+
+**`metadata.json`** is written once when the session is created and never modified. It records the session ID, creation timestamp, the project root path, and the user configuration snapshot that was active at session start. Because it is immutable, it remains valid even if the rest of the session directory is corrupted.
+
+**`gobbi.db`** is the authoritative event store. Every workflow event — step transitions, subagent completions, evaluation verdicts, user decisions, guard violations — is appended as a row. The CLI reads `gobbi.db` to derive workflow state when generating the next prompt. The hooks write to `gobbi.db` when events occur.
+
+**`state.json`** is a materialized view of current workflow state, derived by reducing all events in `gobbi.db`. It is written after every event append. Reading `state.json` is faster than replaying all events on each CLI invocation, but it is a cache, not a source. If `state.json` is absent or corrupted, it is rebuilt from `gobbi.db`.
+
+**`state.json.backup`** holds the state as it was before the most recent transition — the Terraform apply pattern. Before writing a new `state.json`, the CLI copies the current `state.json` to `state.json.backup`. If a transition corrupts `state.json`, the backup provides a known-good rollback point without requiring full event replay.
+
+**`events.jsonl`** mirrors every event written to `gobbi.db` as a newline-delimited JSON record. It exists for human readability only — operators can `grep` or `cat` it without a SQLite client. It is not authoritative; `gobbi.db` is.
+
+**Step directories** (`ideation/`, `plan/`, `execution/`, `evaluation/`, `memorization/`) are flat directories for step artifacts. An ideation step stores its output notes here; an execution step stores subtask results here. Flat structure is deliberate — no nesting, no hierarchy inside step directories.
+
+---
+
+## SQLite Event Store
+
+> **The event store is the source of truth. Everything else is derived from it.**
+
+SQLite with WAL mode is chosen over a pure JSONL approach for three reasons: indexed queries allow efficient filtering by event type and step without full scans; atomic writes with WAL mode survive mid-write crashes without partial records; built-in sequence numbers provide a reliable ordering guarantee. The implementation uses Bun's native `bun:sqlite` module — zero additional runtime dependencies.
+
+### Events Table
+
+The events table has one row per event. Its columns are:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `seq` | integer, primary key | Auto-increment sequence — ordering guarantee |
+| `ts` | text (ISO 8601) | Timestamp of the event |
+| `schema_version` | integer | Schema version at write time |
+| `type` | text | Event type from the enum below |
+| `step` | text, nullable | Workflow step this event belongs to |
+| `data` | text (JSON) | Event-specific payload — structure varies by type |
+| `actor` | text | What produced the event: `cli`, `hook`, `subagent` |
+| `parent_seq` | integer, nullable | References the `seq` of a parent event |
+
+Two indexes cover the common access patterns: one on `type` for queries that filter across the full event history by event category, and one on `(step, type)` for queries scoped to a particular workflow step.
+
+### Event Type Enum
+
+Events are grouped into five categories that reflect the five things that can happen in a session.
+
+**Workflow** events track the high-level session progression:
+
+| Event | Meaning |
+|-------|---------|
+| `workflow.start` | Session began — first event in every session |
+| `workflow.step.enter` | A workflow step became active |
+| `workflow.step.exit` | A workflow step completed normally |
+| `workflow.step.skip` | A workflow step was bypassed (step field indicates which) |
+| `workflow.eval.decide` | The user decided whether to evaluate at a given step |
+| `workflow.finish` | Workflow reached terminal state |
+
+**Delegation** events track subagent lifecycle:
+
+| Event | Meaning |
+|-------|---------|
+| `delegation.spawn` | A subagent was launched |
+| `delegation.complete` | A subagent completed and its output was captured |
+| `delegation.fail` | A subagent failed or was interrupted |
+
+**Artifact** events track writes to the step directories:
+
+| Event | Meaning |
+|-------|---------|
+| `artifact.write` | A file was written to a step directory for the first time |
+| `artifact.overwrite` | An existing artifact was replaced |
+
+**Decision** events record choices that affect workflow direction:
+
+| Event | Meaning |
+|-------|---------|
+| `decision.user` | The user made an explicit decision (approve, reject, defer) |
+| `decision.eval.verdict` | An evaluator returned a verdict (pass, revise, escalate) |
+| `decision.eval.skip` | Evaluation was skipped at a step |
+
+**Guard** events record enforcement actions:
+
+| Event | Meaning |
+|-------|---------|
+| `guard.violation` | A PreToolUse hook blocked a disallowed tool call |
+| `guard.override` | A user explicitly overrode a guard |
+
+---
+
+## State Derivation
+
+> **State is a pure function of events. Given the same event log, the same state is always produced.**
+
+`state.json` holds the materialized workflow state. Its fields are:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `schemaVersion` | integer | State schema version |
+| `sessionId` | string | Session identifier |
+| `currentStep` | string, nullable | The active workflow step, or null if none |
+| `completedSteps` | array of strings | Steps that have exited normally |
+| `evalConfig` | object | Per-step evaluation decisions made at workflow start |
+| `activeSubagents` | array | Subagents that have spawned but not yet completed or failed |
+| `artifacts` | map | Step-to-artifact-list mapping |
+| `violations` | array | Guard violations recorded in this session |
+| `feedbackRound` | integer | How many times the workflow has looped back |
+
+State is produced by a typed reducer: a pure function that takes the current state and one event, and returns the next state. Replaying all events from sequence 1 through the latest produces the identical state as reading `state.json`. The reducer is the canonical definition of what each event means — if the two ever disagree, the reducer wins.
+
+The CLI writes `state.json` after each event append. On startup it reads `state.json` if present; if absent or structurally invalid, it reads `gobbi.db`, replays events through the reducer, and writes a fresh `state.json`.
+
+---
+
+## Crash Recovery
+
+> **No workflow event is lost. Crash recovery is a property of the storage layer, not a special case.**
+
+SQLite with WAL mode provides atomic write semantics: a write either completes fully or does not appear. A process crash during an event append leaves `gobbi.db` in its pre-crash state. The event that was being written is absent — which is correct, because the action it described did not complete.
+
+`state.json.backup` handles state-file corruption without full replay. Before each state transition, the current `state.json` is copied to `state.json.backup`. If `state.json` is found to be invalid on startup, the CLI falls back to `state.json.backup`. If both are invalid, the CLI replays `gobbi.db`.
+
+`gobbi workflow resume` is the user-facing recovery command. It reads `gobbi.db`, derives current state via the reducer, and asks the CLI to generate a resume prompt that re-orients the orchestrator to the current step and what has been completed. This is the same mechanism used after context compaction — compact is not crash recovery, but it uses the same rebuild path.
+
+---
+
+## Schema Versioning
+
+Every persisted JSON file includes a `schemaVersion` integer field at the top level. The events table includes a `schema_version` column on each row.
+
+The CLI reads `schemaVersion` when loading any JSON file. If the version is older than the current schema, a migration function is applied before the data is used. This pattern is already established in the codebase in `config.ts`'s `migrateIfNeeded` function — v0.5.0 extends it to session files.
+
+Migration functions are pure transformations: given a versioned JSON object, return the current-schema equivalent. They are keyed by version number and composed in sequence for multi-version upgrades. A session created at schema version 1 upgraded to a codebase at schema version 3 applies migrations 1→2 and 2→3 in order.
+
+The schema version is incremented whenever a breaking change is made to the event table schema, the `state.json` shape, or the `metadata.json` shape. Additive changes that preserve backward compatibility do not require a version increment.
+
+---
+
+## Session Lifecycle
+
+**Creation** — The SessionStart hook fires when Claude Code opens a new conversation. The hook creates the session directory, writes `metadata.json` with a new session ID, and appends a `workflow.start` event to `gobbi.db`. The session is active from this point.
+
+**Active session** — Hooks append events as the workflow proceeds. The CLI reads the event store to generate each step's prompt. Subagents write artifacts to step directories. `state.json` is updated after each event.
+
+**Context compaction** — When Claude Code compacts the conversation, it is a mid-session event, not a session boundary. The CLI detects the post-compact state, reads persisted state, and generates a resume prompt that re-orients the orchestrator. No new session is created; the existing session ID persists.
+
+**Session end** — The session ends when the user runs `/clear` or opens a new conversation. There is no explicit cleanup event — the session directory remains on disk until the TTL cleanup runs.
+
+**Cleanup** — A background cleanup process removes sessions older than 7 days and enforces a maximum entry cap (default 50 sessions). Cleanup targets the oldest sessions first when the cap is exceeded. The cleanup configuration is stored in the user's gobbi config and can be adjusted.
+
+---
+
+## Boundaries
+
+This document covers the session directory structure, the SQLite event store schema, state derivation via the reducer pattern, crash recovery, schema versioning, and the session lifecycle.
+
+For how state transitions are guarded and what conditions govern step progression, see `v050-state-machine.md`. For how hooks write events to the store, see `v050-hooks.md`. For how the CLI reads state and generates prompts, see `v050-prompts.md` and `v050-cli.md`.

--- a/.claude/project/gobbi/design/v050-session.md
+++ b/.claude/project/gobbi/design/v050-session.md
@@ -131,6 +131,7 @@ Events are grouped into five categories that reflect the five things that can ha
 | `schemaVersion` | integer | State schema version |
 | `sessionId` | string | Session identifier |
 | `currentStep` | string, nullable | The active workflow step, or null if none |
+| `currentSubstate` | string, nullable | The active substate within the current step — only set during Ideation (`discussing` or `researching`); null for all other steps |
 | `completedSteps` | array of strings | Steps that have exited normally |
 | `evalConfig` | object | Per-step evaluation decisions made at workflow start |
 | `activeSubagents` | array | Subagents that have spawned but not yet completed or failed |
@@ -177,6 +178,8 @@ The schema version is incremented whenever a breaking change is made to the even
 **Context compaction** — When Claude Code compacts the conversation, it is a mid-session event, not a session boundary. The CLI detects the post-compact state, reads persisted state, and generates a resume prompt that re-orients the orchestrator. No new session is created; the existing session ID persists.
 
 **Session end** — The session ends when the user runs `/clear` or opens a new conversation. There is no explicit cleanup event — the session directory remains on disk until the TTL cleanup runs.
+
+**Abandoned session detection** — When `gobbi workflow init` runs, it checks all existing session directories for sessions without a `workflow.finish` event. If a session has been inactive for more than 24 hours — meaning no events have been appended in the last 24 hours — it is marked as abandoned. The `.claude/` write guard checks session freshness before blocking writes: if the session's last event is older than 24 hours and no `workflow.finish` event exists, the guard treats the session as expired and allows `.claude/` writes to proceed. This prevents abandoned sessions from permanently blocking the `.claude/` write protection. A session that was interrupted by a crash or a user closing their terminal without clearing will not hold the write guard indefinitely.
 
 **Cleanup** — A background cleanup process removes sessions older than 7 days and enforces a maximum entry cap (default 50 sessions). Cleanup targets the oldest sessions first when the cap is exceeded. The cleanup configuration is stored in the user's gobbi config and can be adjusted.
 

--- a/.claude/project/gobbi/design/v050-state-machine.md
+++ b/.claude/project/gobbi/design/v050-state-machine.md
@@ -122,6 +122,8 @@ Key state fields the reducer maintains:
 
 The reducer never mutates state in place. It produces a new state object on every invocation. This makes the state history reconstructable: each event maps to a state snapshot.
 
+**Why not XState v5** — The typed reducer was chosen over XState v5 for one structural reason: the event-sourced model means `events.jsonl` (and `gobbi.db`) IS the state machine — the complete record of what happened and in what order. Introducing XState would create a second state system that must be kept synchronized with the event store. Two state representations means two places to update when a transition changes, and two sources of truth that can diverge. The reducer pattern keeps the state machine in one place: the reducer function, validated by a `deriveState()` equivalent. It is zero-dependency, pure TypeScript, and naturally aligned with event sourcing. XState's primary advantage — visual graph generation — can be replicated with a simple renderer over the transition table defined in this document.
+
 ---
 
 ## Evaluation Gate Model
@@ -130,7 +132,7 @@ The reducer never mutates state in place. It produces a new state object on ever
 
 Evaluation is mandatory after Execution. It is optional at Ideation and Plan. The decision about whether to run optional evaluation steps is made once — at workflow start — and stored in `evalConfig` within `state.json`.
 
-The `workflow.eval.decide` event captures this decision. It is written during the session initialization flow, before Ideation begins. Its `data` payload records `{ ideation: boolean, plan: boolean }`. Once written, the reducer treats `evalConfig` as immutable — no subsequent event overwrites it.
+The `workflow.eval.decide` event captures this decision. It is written during the session initialization flow by `gobbi workflow init`, before Ideation begins. `gobbi workflow init` asks the user four setup questions including whether to evaluate after Ideation and whether to evaluate after Plan. The answers are stored as a `workflow.eval.decide` event immediately, populating `evalConfig` in `state.json`. The first step's generated prompt includes `evalConfig` in its session section. Its `data` payload records `{ ideation: boolean, plan: boolean }`. Once written, the reducer treats `evalConfig` as immutable — no subsequent event overwrites it.
 
 Why this matters: if evaluation were decided per-step, the orchestrator would ask the user at the Ideation exit and again at the Plan exit. These interruptions mid-workflow are exactly the kind of idle-inducing questions v0.5.0 eliminates. Deciding once, storing the result, and reading it at transition time removes two decision points from the active workflow path.
 

--- a/.claude/project/gobbi/design/v050-state-machine.md
+++ b/.claude/project/gobbi/design/v050-state-machine.md
@@ -1,0 +1,200 @@
+# v0.5.0 State Machine
+
+Workflow transition reference for v0.5.0. Read this when implementing or reasoning about step progression, evaluation gating, feedback loops, or guard conditions. Assumes familiarity with the event model in `v050-session.md`.
+
+---
+
+## Workflow Steps and Substates
+
+The five steps map directly to the workflow defined in `v050-overview.md`. Two steps have internal substates that the CLI tracks separately from the top-level step.
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        Workflow State Machine                        │
+└─────────────────────────────────────────────────────────────────────┘
+
+         ┌──────────┐
+         │   idle   │
+         └────┬─────┘
+              │  workflow.start
+              ▼
+    ┌──────────────────────┐
+    │       ideation       │
+    │  ┌────────────────┐  │
+    │  │   discussing   │◀─┼──── orchestrator ↔ user
+    │  └───────┬────────┘  │
+    │          │ research  │
+    │  ┌───────▼────────┐  │
+    │  │  researching   │  │──── researcher agents
+    │  └───────┬────────┘  │
+    │          │ converged │
+    └──────────┼───────────┘
+               │
+      ┌────────▼────────┐
+      │  ideation_eval  │  (optional — decided at workflow start)
+      └────────┬────────┘
+               │
+    ┌──────────▼──────────┐
+    │         plan        │──── decompose, assign, set criteria
+    └──────────┬──────────┘
+               │
+      ┌────────▼────────┐
+      │    plan_eval    │  (optional — decided at workflow start)
+      └────────┬────────┘
+               │
+    ┌──────────▼──────────┐
+    │      execution      │──── one task at a time, verify before next
+    └──────────┬──────────┘
+               │
+    ┌──────────▼──────────┐
+    │   execution_eval    │  (always mandatory)
+    └──────────┬──────────┘
+               │  pass            ┌─────────────────────────────┐
+               │◀─────────────────│  revise: loop to any prior  │
+               ▼                  └─────────────────────────────┘
+    ┌──────────────────────┐
+    │    memorization      │
+    └──────────┬───────────┘
+               │
+         ┌─────▼────┐
+         │   done   │
+         └──────────┘
+```
+
+**Ideation** has two internal substates: `discussing` and `researching`. `discussing` is the orchestrator-user conversation where the approach is shaped. `researching` is where researcher agents investigate how to realize the approach. These loop — more discussion can follow research, and research can be re-run after discussion refines the question. The CLI tracks the active substate via `currentSubstate` in `state.json`. Ideation exits when the approach is concrete enough to plan against, which is a convergence signal the orchestrator emits as an artifact.
+
+**Plan** has no substates. The orchestrator enters plan mode, produces task decomposition with delegation assignments and verification criteria, and exits. Plan is complete when a plan artifact exists in the `plan/` step directory.
+
+**Execution** has no substates visible to the state machine. Internally, the orchestrator runs one task at a time and verifies before proceeding — but the state machine sees execution as a single active step until it exits. Task-level tracking lives in execution artifacts, not in state transitions.
+
+**Evaluation** steps (`ideation_eval`, `plan_eval`, `execution_eval`) have no substates. They are separate workflow steps, not substeps of the preceding step, because the creating agent must not participate in evaluation. Evaluation enters, collects verdicts from independent evaluator agents, and exits with a `decision.eval.verdict` event.
+
+**Memorization** has no substates. The orchestrator reads the conversation log, extracts decisions, open questions, and gotchas, and writes them to `.gobbi/sessions/{session-id}/memorization/`.
+
+---
+
+## Transition Table
+
+Every valid transition in the state machine. Transitions not in this table are invalid — the guard layer blocks them.
+
+| From | To | Trigger | Condition |
+|------|----|---------|-----------|
+| `idle` | `ideation` | `workflow.start` | Session created |
+| `ideation` | `ideation_eval` | `workflow.step.exit` (ideation) | `evalConfig.ideation == true` |
+| `ideation` | `plan` | `workflow.step.exit` (ideation) | `evalConfig.ideation == false` |
+| `ideation_eval` | `ideation` | `decision.eval.verdict` (revise) | Evaluators returned revise verdict |
+| `ideation_eval` | `plan` | `decision.eval.verdict` (pass) | Evaluators returned pass verdict |
+| `plan` | `plan_eval` | `workflow.step.exit` (plan) | `evalConfig.plan == true` |
+| `plan` | `execution` | `workflow.step.exit` (plan) | `evalConfig.plan == false` |
+| `plan_eval` | `plan` | `decision.eval.verdict` (revise) | Evaluators returned revise verdict |
+| `plan_eval` | `execution` | `decision.eval.verdict` (pass) | Evaluators returned pass verdict |
+| `execution` | `execution_eval` | `workflow.step.exit` (execution) | Always — no condition |
+| `execution_eval` | `memorization` | `decision.eval.verdict` (pass) | Evaluators returned pass verdict |
+| `execution_eval` | `ideation` | `decision.eval.verdict` (revise) | Loop target is ideation |
+| `execution_eval` | `plan` | `decision.eval.verdict` (revise) | Loop target is plan |
+| `execution_eval` | `execution` | `decision.eval.verdict` (revise) | Loop target is execution |
+| `memorization` | `done` | `workflow.finish` | Memorization artifact written |
+| any | `ideation` | `workflow.step.skip` | User explicitly skips forward |
+
+The `loopFrom` field on the `workflow.step.enter` event records which evaluation step triggered the loop. This is what distinguishes a fresh Ideation entry (first time) from a loop-back Ideation entry (triggered by `execution_eval`).
+
+---
+
+## Typed Reducer
+
+> **State is a pure function of events. The reducer is the canonical definition of what each event means.**
+
+The reducer takes the current state and one event, and returns the next state. It is pure — no side effects, no external reads. Replaying all events in sequence order produces the same state as reading `state.json`. When `state.json` is absent or invalid, the CLI replays `gobbi.db` through the reducer to rebuild it.
+
+The reducer is structured as a discriminated union switch: the `type` field of the event is the discriminant, and each case handles one event type. The switch has a default branch that assigns to a `never`-typed variable. This TypeScript exhaustiveness pattern means the compiler reports a type error if a new event type is added to the enum without a corresponding reducer case — no event type can be silently ignored.
+
+The reducer validates transitions as a side effect of processing events. Before applying a `workflow.step.enter` event, the reducer checks that the target step is reachable from the current step given current state. If the transition is invalid, the reducer returns an error result rather than a new state. This means the reducer and transition table are the same system expressed in two forms — the table is documentation, the reducer is enforcement.
+
+Key state fields the reducer maintains:
+
+- `currentStep` — set on `workflow.step.enter`, cleared on `workflow.step.exit`
+- `currentSubstate` — set and cleared within Ideation only
+- `completedSteps` — appended on each `workflow.step.exit`
+- `evalConfig` — set once on `workflow.eval.decide`, never overwritten
+- `feedbackRound` — incremented each time execution_eval loops back to a prior step
+- `activeSubagents` — added on `delegation.spawn`, removed on `delegation.complete` or `delegation.fail`
+- `violations` — appended on each `guard.violation`
+
+The reducer never mutates state in place. It produces a new state object on every invocation. This makes the state history reconstructable: each event maps to a state snapshot.
+
+---
+
+## Evaluation Gate Model
+
+> **The evaluation decision is made once, upfront. No mid-workflow prompts for steps the user already decided.**
+
+Evaluation is mandatory after Execution. It is optional at Ideation and Plan. The decision about whether to run optional evaluation steps is made once — at workflow start — and stored in `evalConfig` within `state.json`.
+
+The `workflow.eval.decide` event captures this decision. It is written during the session initialization flow, before Ideation begins. Its `data` payload records `{ ideation: boolean, plan: boolean }`. Once written, the reducer treats `evalConfig` as immutable — no subsequent event overwrites it.
+
+Why this matters: if evaluation were decided per-step, the orchestrator would ask the user at the Ideation exit and again at the Plan exit. These interruptions mid-workflow are exactly the kind of idle-inducing questions v0.5.0 eliminates. Deciding once, storing the result, and reading it at transition time removes two decision points from the active workflow path.
+
+The `execution_eval` step has no guard condition — it is always entered after Execution exits. This is not configurable. Execution without evaluation is not a valid workflow completion.
+
+---
+
+## Feedback Loops
+
+> **Evaluation can send the workflow back to any prior step, not just the immediately preceding one.**
+
+When `execution_eval` produces a revise verdict, the evaluator specifies a loop target: `ideation`, `plan`, or `execution`. The `workflow.step.enter` event that initiates the loop carries a `loopFrom` field in its `data` payload identifying which evaluation step triggered it. This field is how the CLI distinguishes a loop-back step entry from a first-time entry, which affects the prompt it generates — a loop-back prompt includes the evaluation findings as context.
+
+The `feedbackRound` counter in state tracks how many loop-backs have occurred in this session. It increments each time `execution_eval` routes to a prior step rather than `memorization`. A high `feedbackRound` value is a stagnation signal — the CLI can surface it as a warning and suggest the user consider accepting partial results or restructuring the task.
+
+Feedback loops from `ideation_eval` and `plan_eval` return only to their immediately preceding step (`ideation` and `plan` respectively). They do not carry a `loopFrom` field because the target is unambiguous. The `feedbackRound` counter does not increment for these loops — only loops that cross the execution boundary count as feedback rounds.
+
+---
+
+## Guard Specification with JsonLogic
+
+> **Guards are declarative JSON. The condition language is JsonLogic — the same engine used for prompt template conditionals.**
+
+Guards intercept tool calls via the PreToolUse hook. Each guard is a JSON object with five fields:
+
+| Field | Purpose |
+|-------|---------|
+| `id` | Unique identifier for the guard — referenced in `guard.violation` events |
+| `priority` | Integer — lower number means higher precedence when multiple guards match |
+| `match` | Fast-path filter: `{ step, tool }` — guards only evaluate when the current step and tool call match |
+| `condition` | JsonLogic expression evaluated against current state and the tool call arguments |
+| `effect` | `deny`, `allow`, or `warn` |
+| `reason` | Human-readable message with Mustache variable interpolation for context |
+
+The `match` field exists for performance. Evaluating JsonLogic expressions against every tool call for every guard would be slow. The `match` filter is a cheap structural check — if the current step is not in `match.step` and the tool is not in `match.tool`, the guard is skipped entirely. Only matching guards proceed to JsonLogic evaluation.
+
+### JsonLogic Operators
+
+Standard JsonLogic operators available in conditions: `var`, `==`, `!=`, `in`, `and`, `or`, `!`, `!!`. These cover the common patterns: checking the current step, checking whether a prior step completed, checking the tool call's target path.
+
+Gobbi extends JsonLogic with two custom operators:
+
+**`event_exists(type, step)`** — returns true if at least one event of the given type exists for the given step. Used to check whether a step has been entered or completed. Example: a guard that blocks execution if no plan artifact exists uses `event_exists("workflow.step.exit", "plan")` to verify the plan step completed.
+
+**`event_count(type)`** — returns the number of events of the given type across the full session. Used to detect repeated violations or measure loop depth. Example: a stagnation warning guard uses `event_count("guard.violation")` to detect escalating enforcement.
+
+### Enforcement Levels
+
+Two enforcement levels handle different violation severity:
+
+**Soft nudge** (`warn` effect) — the tool call is allowed but the PreToolUse hook injects an `additionalContext` field into the hook response. This surfaces the warning to the orchestrator without blocking progress. Used for edge cases where the action is technically allowed but unusual — for example, writing to a step directory that is not the current active step.
+
+**Hard block** (`deny` effect) — the tool call is blocked. The hook returns a deny response. A `guard.violation` event is written to the event store. The orchestrator receives only the denial message and the `reason` from the guard. Used for structural violations — writing to `.claude/` during an active session, entering a step out of sequence, spawning evaluators from the creating agent.
+
+### Conflict Resolution
+
+When multiple guards match the same tool call, they are evaluated in ascending `priority` order. The first guard that produces a `deny` effect halts evaluation — no lower-priority guard is consulted. `warn` effects do not halt evaluation; all matching warn guards contribute their `additionalContext` to the response. A `deny` guard always takes precedence over `warn` guards regardless of priority ordering.
+
+This priority scheme means the most critical structural guards (low priority number) are evaluated first and their decisions are final. Informational guards (high priority number) add context without interfering with the structural enforcement.
+
+---
+
+## Boundaries
+
+This document covers step definitions, substates, the full transition table, the typed reducer pattern, the evaluation gate model, feedback loop mechanics, and the guard specification format with JsonLogic.
+
+For how hooks invoke guards and write events to the store, see `v050-hooks.md`. For how the CLI reads state and uses it to generate prompts, see `v050-prompts.md`. For the event store schema and state field definitions, see `v050-session.md`.


### PR DESCRIPTION
## Summary
- 6 design specification documents for gobbi v0.5.0 architecture
- Covers: overview, session data model, state machine, prompts, hooks, CLI
- 1,220 lines total across 6 documents
- Evaluation round addressed 10 findings (3 critical, 7 major)

## v0.5.0 Philosophy
Runtime-enforced orchestration via CLI + hooks + SQLite event store, replacing skill-guided orchestration.

## Documents
| Document | Lines | Covers |
|----------|-------|--------|
| `v050-overview.md` | 218 | Philosophy, workflow, directory split, architecture |
| `v050-session.md` | 192 | Session directory, SQLite events, state derivation |
| `v050-state-machine.md` | 202 | Workflow transitions, reducer, guards, JsonLogic |
| `v050-prompts.md` | 189 | Prompt compilation, cache ordering, skills boundary |
| `v050-hooks.md` | 210 | PreToolUse guards, SubagentStop capture, schemas |
| `v050-cli.md` | 209 | Bun CLI, commands, distribution, plugin relation |

## Open Decision
Template format (PAL vs Simple JSON vs Hybrid) — documented as decision space in v050-prompts.md

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)