### PR TITLE
docs: resolve template format + update architecture/structure for v0.5.0

### DIFF
--- a/.claude/project/gobbi/design/architecture.md
+++ b/.claude/project/gobbi/design/architecture.md
@@ -258,3 +258,40 @@ The principle is straightforward: when a quality dimension exists that an LLM ca
 Tools transform the evaluator's role. Instead of reasoning abstractly about whether something probably works, the evaluator interprets concrete evidence — test results, screenshots, benchmark numbers, accessibility audit reports. The judgment is still the agent's, but the facts are objective.
 
 The tool ecosystem grows with the project's needs. As new quality dimensions become important — accessibility, security, internationalization — the corresponding measurement tools are added. Each tool closes a specific perceptual gap, making evaluation more accurate, more consistent, and more grounded in reality.
+
+---
+
+## v0.5.0 Architecture
+
+> **Runtime-enforced orchestration replaces skill-guided orchestration.**
+
+Prior to v0.5.0, workflow discipline depended on agents reading and following skills. v0.5.0 makes the workflow mechanical: a CLI drives each step, hooks enforce transitions, and a SQLite event store derives session state. Agents cannot skip steps or deviate from the workflow graph because the runtime prevents it — not because a skill asks them not to.
+
+### Workflow Change
+
+The v0.5.0 workflow condenses and formalizes the pre-existing steps:
+
+**Ideation** — Discussion and research run as a loop. The user discusses with the orchestrator; PI agents explore the problem; researcher agents investigate how to implement. The loop continues until the problem is specific enough to plan.
+
+**Plan** — Decompose the approved idea into narrow, ordered subtasks. Each subtask has scope, dependencies, and verification criteria recorded in the session store.
+
+**Execution** — Implement one subtask at a time. Each subtask is delegated, verified, and committed before the next begins.
+
+**Evaluation** — Independent evaluators assess the completed work from multiple perspectives. Findings are discussed with the user before any improvement.
+
+**Memorization** — Capture decisions, gotchas, and session state so the next session resumes without re-discovery.
+
+Transitions between steps are guarded by JsonLogic rules evaluated against the session state. A step cannot advance until its preconditions are satisfied.
+
+### Spec Documents
+
+The v0.5.0 design is spread across six spec files in `packages/cli/src/specs/`:
+
+| Document | Covers |
+|----------|--------|
+| `v050-overview.md` | Philosophy, workflow, directory split, architecture |
+| `v050-session.md` | Session directory, SQLite events, state derivation |
+| `v050-state-machine.md` | Workflow transitions, reducer, guards, JsonLogic |
+| `v050-prompts.md` | Step specs, prompt compilation, skills boundary |
+| `v050-hooks.md` | PreToolUse guards, SubagentStop capture, hook schemas |
+| `v050-cli.md` | Bun CLI, commands, distribution, plugin relation |

--- a/.claude/project/gobbi/design/structure.md
+++ b/.claude/project/gobbi/design/structure.md
@@ -80,6 +80,38 @@ Shell scripts in `.claude/hooks/` that execute in response to Claude Code events
 
 ---
 
+## v0.5.0 Directory Split
+
+> **`.claude/` is read-only during workflow. `.gobbi/` is written freely during workflow.**
+
+v0.5.0 introduces a hard boundary between Claude Code's native directory and gobbi's runtime state. Writing to `.claude/` mid-workflow triggers the Claude Code idle detection heuristic — the model interprets its own file edits as meaningful changes and stalls. The split eliminates this by keeping all workflow writes out of `.claude/`.
+
+### `.gobbi/` Directory
+
+Gobbi's runtime state directory, separate from `.claude/`. Created at the project root alongside `.claude/`.
+
+| Directory | Purpose |
+|:----------|:--------|
+| `sessions/` | Workflow session data — `state.json`, `gobbi.db` (SQLite event store), and one subdirectory per step containing notes, research, and execution output |
+| `worktrees/` | Git worktree isolation — moved from `.claude/worktrees/` to prevent idle false-positives during branch operations |
+| `project/` | Project notes, gotchas, and context — moved from `.claude/project/` so workflow writes do not touch `.claude/` |
+
+`.claude/` retains only static content: skills, agent definitions, hooks, settings, and `CLAUDE.md`. Nothing written during a workflow session goes into `.claude/`.
+
+### Step Spec Files
+
+`packages/cli/src/specs/` contains the step specification files that define the v0.5.0 workflow graph.
+
+| Path | Purpose |
+|:-----|:--------|
+| `index.json` | Workflow graph — step ordering, transition guards, entry points |
+| `{step}/spec.json` | Per-step definition — prompt template, required inputs, output schema, preconditions |
+| `_shared/` | Reusable prompt blocks shared across step specs |
+
+The CLI reads these specs at runtime to compile prompts and enforce transitions. Specs are the source of truth for what each workflow step does and what must be true before it can run.
+
+---
+
 ## Claude Code Gobbi Plugin
 
 The `plugins/gobbi/` directory packages gobbi as a Claude Code plugin for distribution and installation.

--- a/.claude/project/gobbi/design/structure.md
+++ b/.claude/project/gobbi/design/structure.md
@@ -92,7 +92,7 @@ Gobbi's runtime state directory, separate from `.claude/`. Created at the projec
 
 | Directory | Purpose |
 |:----------|:--------|
-| `sessions/` | Workflow session data — `state.json`, `gobbi.db` (SQLite event store), and one subdirectory per step containing notes, research, and execution output |
+| `sessions/` | Workflow session data — `state.json`, `state.json.backup`, `gobbi.db` (SQLite event store), `metadata.json`, `events.jsonl` (human-readable event log), and one subdirectory per step containing notes, research, and execution output |
 | `worktrees/` | Git worktree isolation — moved from `.claude/worktrees/` to prevent idle false-positives during branch operations |
 | `project/` | Project notes, gotchas, and context — moved from `.claude/project/` so workflow writes do not touch `.claude/` |
 
@@ -105,7 +105,7 @@ Gobbi's runtime state directory, separate from `.claude/`. Created at the projec
 | Path | Purpose |
 |:-----|:--------|
 | `index.json` | Workflow graph — step ordering, transition guards, entry points |
-| `{step}/spec.json` | Per-step definition — prompt template, required inputs, output schema, preconditions |
+| `{step}/spec.json` | Per-step definition — content blocks, meta, transitions, delegation assignments, preconditions |
 | `_shared/` | Reusable prompt blocks shared across step specs |
 
 The CLI reads these specs at runtime to compile prompts and enforce transitions. Specs are the source of truth for what each workflow step does and what must be true before it can run.

--- a/.claude/project/gobbi/design/v050-cli.md
+++ b/.claude/project/gobbi/design/v050-cli.md
@@ -1,12 +1,12 @@
 # v0.5.0 CLI — Integration Point
 
-CLI architecture reference for v0.5.0. Read this when implementing or reasoning about command structure, runtime choices, distribution, or the relationship between the plugin and the CLI. This document treats the CLI as a container — how it binds the event store, state machine, prompt templates, and hook system into a single executable. For the internals of each subsystem, see the respective doc.
+CLI architecture reference for v0.5.0. Read this when implementing or reasoning about command structure, runtime choices, distribution, or the relationship between the plugin and the CLI. This document treats the CLI as a container — how it binds the event store, state machine, step specs, and hook system into a single executable. For the internals of each subsystem, see the respective doc.
 
 ---
 
 ## The CLI's Role
 
-The CLI is where all v0.5.0 subsystems converge. It is the only component that has read access to every part of the system simultaneously: workflow state from the event store, domain knowledge from `.claude/skills/`, guard specifications, prompt templates, and project configuration.
+The CLI is where all v0.5.0 subsystems converge. It is the only component that has read access to every part of the system simultaneously: workflow state from the event store, domain knowledge from `.claude/skills/`, guard specifications, step specs, and project configuration.
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
@@ -59,7 +59,7 @@ V0.5.0 migrates the CLI from Node.js to Bun. The current `package.json` declares
 
 **`bun:sqlite`** — The event store in `v050-session.md` requires SQLite with WAL mode and atomic write semantics. `bun:sqlite` is native to the runtime — zero additional dependencies, no `better-sqlite3` binding to compile, and 3–6x faster than equivalent Node.js SQLite solutions. This is the primary technical reason for the Bun migration: the event store architecture depends on SQLite, and Bun makes SQLite a first-class runtime capability.
 
-**`bun:test`** — Jest-compatible test runner built into the runtime. Zero configuration, built-in mocking, snapshot testing support. The testing strategy for prompt templates relies on snapshots to catch unintended changes — `bun:test` supports this natively without additional tooling.
+**`bun:test`** — Jest-compatible test runner built into the runtime. Zero configuration, built-in mocking, snapshot testing support. The testing strategy for step spec compilation relies on snapshots to catch unintended changes — `bun:test` supports this natively without additional tooling.
 
 **File I/O** — `Bun.file()` and `Bun.write()` replace `node:fs/promises` for the common case. State file writes use the temp+rename pattern: the CLI writes to a `.tmp` file, then renames it atomically over the target. This prevents a partial write from corrupting `state.json` — the rename is atomic at the OS level.
 
@@ -77,13 +77,13 @@ The CLI expands from its current eight-command surface to add a `workflow` subco
 
 **`gobbi workflow init`** — Creates the session directory under `.gobbi/sessions/{session-id}/`, writes `metadata.json`, initializes `gobbi.db` with the events table schema, and appends the first `workflow.start` event. Called by the SessionStart hook. Idempotent — if the session directory already exists, it verifies structure and exits cleanly.
 
-During initialization, `gobbi workflow init` asks the user four setup questions: the task description, whether to evaluate after Ideation, whether to evaluate after Plan, and any additional context. The evaluation answers (Ideation and Plan eval on/off) are stored immediately as a `workflow.eval.decide` event in `gobbi.db`, populating `evalConfig` in `state.json`. The prompt template generated for the first step (Ideation) includes the eval decision in its session section so the orchestrator knows the evaluation configuration from the start without needing to ask mid-workflow.
+During initialization, `gobbi workflow init` asks the user four setup questions: the task description, whether to evaluate after Ideation, whether to evaluate after Plan, and any additional context. The evaluation answers (Ideation and Plan eval on/off) are stored immediately as a `workflow.eval.decide` event in `gobbi.db`, populating `evalConfig` in `state.json`. The compiled prompt generated for the first step (Ideation) includes the eval decision in its session section so the orchestrator knows the evaluation configuration from the start without needing to ask mid-workflow.
 
-**`gobbi workflow next`** — The core command. Reads `state.json` (or replays `gobbi.db` if absent), determines the active step, selects the appropriate prompt template, loads relevant skills and artifacts, evaluates token budget, and writes the compiled prompt to stdout. This is what the orchestrator receives at the start of each step. Every other `workflow` command supports this one.
+**`gobbi workflow next`** — The core command. Reads `state.json` (or replays `gobbi.db` if absent), determines the active step, selects the appropriate step spec, loads relevant skills and artifacts, evaluates token budget, and writes the compiled prompt to stdout. This is what the orchestrator receives at the start of each step. Every other `workflow` command supports this one.
 
 **`gobbi workflow transition <event>`** — Advances the state machine by appending a typed event to `gobbi.db` and updating `state.json`. Validates that the event produces a valid transition from the current step before writing. Returns the new state summary on stdout. Invalid transitions produce an error with the reason — useful for diagnosing stalls.
 
-The orchestrator calls this command via Bash, instructed by the prompt template. Each step's generated prompt ends with an explicit instruction: when this step is complete, run `gobbi workflow transition COMPLETE`. The CLI validates the transition against the state machine and advances state — the orchestrator does not decide when to transition, the prompt template instructs it.
+The orchestrator calls this command via Bash, instructed by the step spec. Each step's compiled prompt ends with an explicit instruction: when this step is complete, run `gobbi workflow transition COMPLETE`. The CLI validates the transition against the state machine and advances state — the orchestrator does not decide when to transition, the step spec instructs it.
 
 The Stop hook can also trigger implicit transitions: after each turn, the Stop hook analyzes the conversation to detect whether the orchestrator's response completed a step. If the response contains a recognized completion signal and no explicit transition was already written, the Stop hook writes the transition event. This handles cases where the orchestrator completed the step work but did not execute the transition command.
 
@@ -161,7 +161,7 @@ The gobbi plugin is the Claude Code integration artifact — it is what users in
 
 **CLI responsibilities:**
 - Workflow engine: event store, state machine, reducer
-- Prompt templates for all five workflow steps plus their variants
+- Step specs for all five workflow steps plus their variants
 - Guard specification and JsonLogic evaluation
 - Prompt compilation: selecting artifacts, loading skill materials, applying cache ordering, enforcing token budget
 - Session lifecycle management
@@ -188,13 +188,13 @@ The binary build is an additional CI step, not a replacement for the npm build. 
 
 `bun:test` is the test runner for all CLI tests. No additional test framework is required.
 
-> **Test the boundaries, not the internals. The event store, state machine, and prompt templates are the interfaces other subsystems depend on.**
+> **Test the boundaries, not the internals. The event store, state machine, and step specs are the interfaces other subsystems depend on.**
 
 **State machine tests** — The reducer is a pure function and tests cheaply. Each test supplies an initial state and an event and asserts the returned state. Exhaustiveness is validated at compile time via the TypeScript `never` pattern — a new event type without a reducer case is a type error. Transition table compliance is tested by exercising every row in the table and confirming the reducer accepts valid transitions and rejects invalid ones.
 
 **Guard evaluation tests** — Each guard specification is a JSON object. Tests supply a mock state and a mock tool call input and assert the output: `deny`, `allow`, or `warn` with the expected reason. The custom JsonLogic operators (`event_exists`, `event_count`) are unit-tested independently with synthetic event logs.
 
-**Prompt template tests** — Snapshot testing via `bun:test`'s built-in snapshot support. Each template is rendered with a representative set of state inputs and the output is committed as a snapshot. CI fails when a template render changes unexpectedly. This catches unintended prompt changes — the most consequential class of regression in a system where prompt content drives behavior.
+**Prompt compilation tests** — Snapshot testing via `bun:test`'s built-in snapshot support. Each step spec is compiled with a representative set of state inputs and the output is committed as a snapshot. CI fails when a compiled prompt changes unexpectedly. This catches unintended prompt changes — the most consequential class of regression in a system where prompt content drives behavior.
 
 **Hook handler tests** — Hook handlers (`gobbi workflow guard`, `gobbi workflow capture-subagent`, etc.) are tested by supplying mock stdin payloads and asserting stdout output and event store writes. File I/O is mocked via Bun's test mocking support. The event store is tested against a real SQLite in-memory database — this is practical because `bun:sqlite` with an in-memory database has no I/O cost.
 

--- a/.claude/project/gobbi/design/v050-overview.md
+++ b/.claude/project/gobbi/design/v050-overview.md
@@ -213,6 +213,6 @@ This document covers architecture, philosophy, and positioning. It does not cove
 |----------|--------|
 | `v050-session.md` | Session directory, SQLite event store, state derivation, crash recovery |
 | `v050-state-machine.md` | Workflow transitions, typed reducer, guards, JsonLogic conditions |
-| `v050-prompts.md` | Prompt compilation, cache ordering, skills boundary, template format |
+| `v050-prompts.md` | Prompt compilation, cache ordering, skills boundary, step specs |
 | `v050-hooks.md` | PreToolUse guards, SubagentStop capture, hook schemas, enforcement |
 | `v050-cli.md` | Bun CLI rewrite, commands, distribution, plugin relationship |

--- a/.claude/project/gobbi/design/v050-prompts.md
+++ b/.claude/project/gobbi/design/v050-prompts.md
@@ -1,6 +1,6 @@
 # v0.5.0 Prompts — Compilation Model
 
-Prompt generation reference for v0.5.0. Read this when implementing or reasoning about how the CLI assembles prompts, how cache ordering works, which skills survive as materials versus which become CLI-owned templates, and the open decision on template format.
+Prompt generation reference for v0.5.0. Read this when implementing or reasoning about how the CLI assembles prompts, how cache ordering works, which skills survive as materials versus which become CLI-owned step specs, and how the spec model encodes each workflow step.
 
 ---
 
@@ -43,7 +43,7 @@ The CLI reads `state.json` first to determine which step is active. It then sele
   │  4. Load gotchas as guards                 │
   │  5. Apply cache-aware section ordering     │
   │  6. Apply token budget allocation          │
-  │  7. Render template with interpolated vars │
+  │  7. Assemble prompt from spec blocks        │
   └───────────────────────┬────────────────────┘
                           │
                           ▼
@@ -76,7 +76,7 @@ Three sections, ordered by how often they change:
 
 **Dynamic section** — Content that changes on every invocation. Step-specific instructions for the current action, the inlined output of the previous step, delegation target configuration, and any per-invocation variables like timestamps or active subagent counts. No cache benefit expected here; this section is always recomputed.
 
-The order is not negotiable. Placing dynamic content before static content destroys cache prefix stability and causes every invocation to be a full-cost API call. The CLI enforces this ordering at the template rendering stage — no template can place a dynamic variable inside the static prefix section.
+The order is not negotiable. Placing dynamic content before static content destroys cache prefix stability and causes every invocation to be a full-cost API call. The CLI enforces this ordering when assembling the prompt from spec blocks — no spec can place a conditional or dynamic block before the static blocks.
 
 ---
 
@@ -84,15 +84,15 @@ The order is not negotiable. Placing dynamic content before static content destr
 
 > **The CLI owns all orchestration. Skills own domain knowledge.**
 
-V0.4.x conflated two concerns: skills taught agents both how the workflow runs and what domain knowledge to apply. In v0.5.0 these are separated. Workflow knowledge moves into CLI-owned prompt templates. Domain knowledge stays in skills as materials the CLI injects.
+V0.4.x conflated two concerns: skills taught agents both how the workflow runs and what domain knowledge to apply. In v0.5.0 these are separated. Workflow knowledge moves into CLI-owned step specs. Domain knowledge stays in skills as materials the CLI injects.
 
-### Skills That Become CLI Prompts
+### Skills That Become Step Specs
 
-These skills encoded orchestration logic — what to do at each step, how to transition, what evaluation means. In v0.5.0, this content lives in the CLI's template library and is never read directly by the orchestrator.
+These skills encoded orchestration logic — what to do at each step, how to transition, what evaluation means. In v0.5.0, this content lives in the CLI's spec library and is never read directly by the orchestrator.
 
 `_orchestration`, `_discuss`, `_ideation`, `_plan`, `_research`, `_delegation`, `_execution`, `_collection`, `_memorization`, `_note`, `_evaluation`, `_innovation`, `_best-practice`
 
-The content of these skills does not disappear — it is translated into prompt templates. The difference is ownership: in v0.4.x, the orchestrator discovers and follows these skills; in v0.5.0, the CLI encodes them and presents the result as step instructions.
+The content of these skills does not disappear — it is translated into step specs. The difference is ownership: in v0.4.x, the orchestrator discovers and follows these skills; in v0.5.0, the CLI encodes them and presents the result as step instructions.
 
 ### Skills That Survive
 
@@ -122,11 +122,11 @@ The CLI does not instruct the orchestrator to "load the `_git` skill." It reads 
 
 In v0.4.x, the orchestrator reads stance guidance and decides how to apply it. In v0.5.0, the CLI encodes stance configuration directly into the delegation prompt for steps that require parallel agents.
 
-For Ideation steps that include a research loop, the CLI generates separate agent prompts — one configured for the innovative stance (depth-first, divergent, challenges constraints), one for the best-practice stance (proven patterns, reliability, established conventions). The stance configuration is part of the template, not a runtime decision.
+For Ideation steps that include a research loop, the CLI generates separate agent prompts — one configured for the innovative stance (depth-first, divergent, challenges constraints), one for the best-practice stance (proven patterns, reliability, established conventions). The stance configuration is encoded in the spec's delegation blocks, not decided at runtime.
 
-For Evaluation steps, each evaluator receives a prompt configured for its assigned perspective. The perspective assignment is part of the CLI's evaluation template. The orchestrator does not select evaluators — it receives a delegation block that lists them with their configured perspectives already set.
+For Evaluation steps, each evaluator receives a prompt configured for its assigned perspective. The perspective assignment is part of the CLI's evaluation step spec. The orchestrator does not select evaluators — it receives a delegation block that lists them with their configured perspectives already set.
 
-Domain-specific stances — project-specific evaluation perspectives, specialist agents for a particular tech stack — remain as skills. The CLI guides loading these during delegation: the delegation prompt template includes a slot for domain-specific stance materials, and the CLI fills that slot from the appropriate project skill if one exists.
+Domain-specific stances — project-specific evaluation perspectives, specialist agents for a particular tech stack — remain as skills. The CLI guides loading these during delegation: the delegation blocks in the spec include a slot for domain-specific stance materials, and the CLI fills that slot from the appropriate project skill if one exists.
 
 ---
 
@@ -150,40 +150,64 @@ Each model variant has a fixed context window. The CLI knows the model configure
 
 When the available budget is smaller than the sum of all sections, the CLI truncates artifact content at section boundaries. An artifact is included in full or excluded entirely — it is never truncated mid-document. This produces a prompt that is complete and coherent rather than one that ends mid-sentence because the window ran out.
 
-The allocation proportions are configurable per step type. Evaluation steps allocate more budget to inlined execution artifacts. Delegation steps allocate more budget to the delegation block. The defaults are encoded in the template definition for each step.
+The allocation proportions are configurable per step type. Evaluation steps allocate more budget to inlined execution artifacts. Delegation steps allocate more budget to the delegation block. The defaults are encoded in the `tokenBudget` section of each step's spec.
 
 ---
 
-## Template Format — Decision Space (Open)
+## Step Specs
 
-> **The template format is an open architectural decision. The constraints are fixed; the implementation is not.**
+> **Each workflow step is defined by a spec file. The spec is the step — not a template the CLI fills in.**
 
-The CLI needs a template format that can express 20-30 prompts for v0.5.0, potentially scaling to 100+ prompts across workflow steps, domain variants, and stance configurations. The format must satisfy four constraints:
+The CLI encodes each workflow step as a `spec.json` file under `packages/cli/src/specs/`. There is one spec per step. Specs contain only static instructional content — no variables, no template engine, no mustache syntax. All dynamic data (session context, inlined artifacts, skill content) is added programmatically by the CLI in TypeScript. The spec describes what the step does; the CLI decides what data to supply.
 
-**Constraint 1 — Conditional sections**: A template must be able to include or exclude blocks based on session state. Evaluation instructions appear only when `evalConfig` enables evaluation for this step. Gotcha loading appears only when the gotcha file is non-empty. These conditions are known at compile time from `state.json`.
+### Spec Schema
 
-**Constraint 2 — Variable interpolation**: Templates reference session variables — session ID, step name, active step count, inlined artifact content. Interpolation must handle multi-line content (artifact body) without breaking the surrounding structure.
+Each `spec.json` contains five top-level sections:
 
-**Constraint 3 — Shared blocks**: Some blocks appear across many templates — the scope boundary warning, the gotcha preamble, the "write artifacts to step directory" instruction. These must be defined once and referenced, not duplicated across templates.
+**`meta`** — Step-level metadata: a short description, the list of valid substates (if any), allowed agent types, maximum parallel agent count, required and optional skills to inject, expected artifacts from this step, and the completion signal the CLI watches for.
 
-**Constraint 4 — Maintainability at scale**: At 100+ templates, a format that requires reading TypeScript to understand a template's structure creates maintenance cost. Templates should be readable as documents, not as data structures that require a runtime to interpret.
+**`transitions`** — The valid exit transitions from this step. For steps where the exit depends on runtime conditions (such as whether evaluation is enabled), transition entries may carry JsonLogic conditions. The CLI evaluates these conditions in TypeScript against `state.json`; the spec only declares what the possible transitions are and under what conditions each is taken.
 
-### The Options
+**`delegation`** — The agent topology for this step: each agent's role, stance, model tier, effort level, which skills to inject, the artifact target it should write to, and a reference to the block in `blocks.delegation` that contains its prompt content.
 
-**Option A — PAL (Prompt Assembly Language)**: JSON block arrays where each block carries a `type`, optional `condition` expressed in JsonLogic, content with mustache-style `{{vars}}`, and optional `ref` for shared blocks. The CLI evaluates conditions against `state.json`, resolves refs from a shared library, and renders blocks in order. The template is fully declarative — all logic is expressed in data. The cost is that JsonLogic conditions are verbose and the block array structure obscures the narrative flow of the prompt.
+**`tokenBudget`** — Allocation proportions across the five prompt sections: static prefix, session, instructions, artifacts, and materials. Evaluation steps allocate more to inlined artifacts; delegation steps allocate more to the delegation block. These proportions are the defaults the CLI uses unless session config overrides them.
 
-**Option B — Simple JSON plus CLI logic**: Flat JSON objects with `{{vars}}` for interpolation. All conditional logic lives in TypeScript — the CLI decides which JSON objects to include based on state, assembles them into a string, and interpolates variables. The template is simple to read but the conditional behavior requires reading TypeScript to understand. At scale, the TypeScript accumulates complexity as each new conditional is added.
+**`blocks`** — The static instructional content for this step, organized into five subsections:
 
-**Option C — Hybrid (JSON manifest plus content files)**: A JSON manifest defines the template structure — section order, which sections are conditional, variable names, shared block references. Long text blocks are stored in separate `.md` or `.txt` files referenced by the manifest. The manifest is readable; the prose is readable; the CLI wires them together. The cost is indirection — understanding a template requires reading both the manifest and its referenced files.
+| Subsection | Purpose |
+|------------|---------|
+| `static` | Always-included blocks — role description, core principles, shared references |
+| `conditional` | Blocks the CLI includes or excludes based on state — loop-back context, eval reminders. The conditions are evaluated in TypeScript; each block carries only an ID the TypeScript code matches on |
+| `delegation` | Per-agent delegation prompt content, keyed by the agent reference in `delegation` |
+| `synthesis` | Post-delegation synthesis instructions for the orchestrator |
+| `completion` | The completion instruction and a human-readable criteria list |
 
-All three options satisfy constraints 1 and 2. Options A and C satisfy constraint 3 natively (refs and shared files); Option B requires TypeScript-managed shared blocks. Options B and C satisfy constraint 4 more readily than Option A at high template counts.
+### Workflow Graph
 
-This decision is documented here as a design constraint, not a final choice. The implementation must select one option and apply it consistently across all prompt templates in the CLI. The selection should be made once and recorded in this document before implementation begins.
+`index.json` at the root of `packages/cli/src/specs/` encodes the full workflow graph: all steps, their transitions, and guard conditions. This file enables `gobbi workflow validate` to perform static analysis — dead step detection, cycle validation, and reference resolution checks — without running the workflow.
+
+### Shared Blocks
+
+Reusable content blocks (scope boundary warning, gotcha preamble, system prompt) live in `_shared/` under the specs directory. Spec files reference shared blocks by ID. The CLI resolves these references at compile time before assembling the prompt. Each shared block is defined once; changes propagate to all specs that reference it.
+
+### Substate Overlays
+
+Steps with substates — Ideation has `discussing` and `researching` — use overlay files rather than separate full specs. An overlay patches a base spec with substate-specific modifications using a Kustomize-style pattern: base plus targeted patches, not full duplication. The CLI loads the base spec and applies the overlay for the active substate before assembling the prompt.
+
+### Schema Versioning
+
+Every spec file carries `$schema` and `version` fields. When the CLI loads a spec whose version is behind the current schema, it applies the migration chain before using the spec. This allows the spec format to evolve without requiring all files to be updated simultaneously.
+
+### Why This Model
+
+> **Adding a workflow step means adding a spec file — no TypeScript modification required for content changes.**
+
+The spec model provides four concrete benefits. Guards (`gobbi workflow validate`) can validate structured delegation data without parsing prose. The `SubagentStop` hook knows expected artifacts from the spec's `delegation` config without introspecting the conversation. Static analysis at build time catches structural errors — missing transitions, broken refs, unreachable steps — before they reach runtime. Cache-aware ordering is enforced by the spec schema: `static` blocks always come before `conditional` blocks, which always come before `delegation` blocks, which preserves the static prefix guarantee described in the Cache-Aware Prompt Ordering section above.
 
 ---
 
 ## Boundaries
 
-This document covers the prompt compilation model, cache-aware section ordering, the skills boundary between CLI-owned templates and surviving domain skills, stances as CLI-managed configuration, fresh context isolation per subagent task, token budget allocation, and the open template format decision.
+This document covers the prompt compilation model, cache-aware section ordering, the skills boundary between CLI-owned step specs and surviving domain skills, stances as CLI-managed configuration, fresh context isolation per subagent task, token budget allocation, and the step spec model including the spec schema, workflow graph, shared blocks, substate overlays, and schema versioning.
 
 For how state transitions determine which step is active, see `v050-state-machine.md`. For how hooks write events that the CLI reads to derive state, see `v050-hooks.md`. For the session artifacts that prompts consume, see `v050-session.md`. For CLI command syntax and distribution, see `v050-cli.md`.

--- a/.claude/project/gobbi/design/v050-state-machine.md
+++ b/.claude/project/gobbi/design/v050-state-machine.md
@@ -154,7 +154,7 @@ Feedback loops from `ideation_eval` and `plan_eval` return only to their immedia
 
 ## Guard Specification with JsonLogic
 
-> **Guards are declarative JSON. The condition language is JsonLogic — the same engine used for prompt template conditionals.**
+> **Guards are declarative JSON. The condition language is JsonLogic — the same engine used for step spec conditional blocks.**
 
 Guards intercept tool calls via the PreToolUse hook. Each guard is a JSON object with five fields:
 


### PR DESCRIPTION
## Summary
- Resolve the open template format decision in v050-prompts.md — **step specs** model
- Add v0.5.0 cross-references to architecture.md
- Add .gobbi/ directory split to structure.md

## Template Format Resolution
Step specs (spec.json per step) — complete step definitions, not text templates:
- No variables, no template engine — CLI assembles dynamic data in TypeScript
- Each spec.json: meta, transitions, delegation, tokenBudget, blocks
- index.json workflow graph for static validation
- _shared/ blocks via ref

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)