### PR TITLE
docs: v0.5.0 design review — GSD-2 and ECC comparison

### DIFF
--- a/.claude/project/gobbi/design/architecture.md
+++ b/.claude/project/gobbi/design/architecture.md
@@ -281,7 +281,7 @@ The v0.5.0 workflow condenses and formalizes the pre-existing steps:
 
 **Memorization** — Capture decisions, gotchas, and session state so the next session resumes without re-discovery.
 
-Transitions between steps are guarded by JsonLogic rules evaluated against the session state. A step cannot advance until its preconditions are satisfied.
+Transitions between steps are guarded by predicate conditions evaluated against the session state. A step cannot advance until its preconditions are satisfied.
 
 ### Spec Documents
 
@@ -291,7 +291,7 @@ The v0.5.0 design is spread across six spec files in `packages/cli/src/specs/`:
 |----------|--------|
 | `v050-overview.md` | Philosophy, workflow, directory split, architecture |
 | `v050-session.md` | Session directory, SQLite events, state derivation |
-| `v050-state-machine.md` | Workflow transitions, reducer, guards, JsonLogic |
+| `v050-state-machine.md` | Workflow transitions, reducer, guards, predicate registry |
 | `v050-prompts.md` | Step specs, prompt compilation, skills boundary |
 | `v050-hooks.md` | PreToolUse guards, SubagentStop capture, hook schemas |
 | `v050-cli.md` | Bun CLI, commands, distribution, plugin relation |

--- a/.claude/project/gobbi/design/v050-cli.md
+++ b/.claude/project/gobbi/design/v050-cli.md
@@ -1,51 +1,30 @@
 # v0.5.0 CLI — Integration Point
 
-CLI architecture reference for v0.5.0. Read this when implementing or reasoning about command structure, runtime choices, distribution, or the relationship between the plugin and the CLI. This document treats the CLI as a container — how it binds the event store, state machine, step specs, and hook system into a single executable. For the internals of each subsystem, see the respective doc.
+CLI architecture reference for v0.5.0. Read this when implementing or reasoning about command structure, runtime choices, distribution, or the relationship between the plugin and the CLI. This document treats the CLI as a container — how it binds the event store, state machine, step specs, predicate registry, and hook system into a single executable. For the internals of each subsystem, see the respective doc.
 
 ---
 
 ## The CLI's Role
 
-The CLI is where all v0.5.0 subsystems converge. It is the only component that has read access to every part of the system simultaneously: workflow state from the event store, domain knowledge from `.claude/skills/`, guard specifications, step specs, and project configuration.
+The CLI is where all v0.5.0 subsystems converge. It is the only component that has read access to every part of the system simultaneously: workflow state from the event store, domain knowledge from `.claude/skills/`, step specs with their predicate references, and project configuration.
 
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│                         CLI as Integration Hub                       │
-└─────────────────────────────────────────────────────────────────────┘
+> **The CLI is the prompt factory, the guard enforcer, and the predicate registry owner. Hooks are thin wrappers that delegate to it.**
 
-   .claude/                      .gobbi/
-   ────────────────              ─────────────────────────────────
-   skills/          ──read──▶   sessions/{id}/gobbi.db
-   rules/           ──read──▶   sessions/{id}/state.json
-   CLAUDE.md        ──read──▶   sessions/{id}/{step}/
-   agents/          ──read──▶   project/gotchas/
-                                                  │
-                                                  │
-                    ┌─────────────────────────────┘
-                    │
-                    ▼
-          ┌─────────────────────┐
-          │        CLI          │
-          │                     │
-          │  Event store reads  │
-          │  State derivation   │
-          │  Guard evaluation   │
-          │  Prompt compilation │
-          │  Event writes       │
-          └──────────┬──────────┘
-                     │
-          ┌──────────▼──────────┐
-          │   Hook scripts      │──▶  Claude Code (hook delegation)
-          └─────────────────────┘
-                     │
-          ┌──────────▼──────────┐
-          │   Orchestrator      │──▶  receives bounded prompt
-          └─────────────────────┘
-```
+Hook scripts registered in `hooks/hooks.json` contain no logic. Each hook reads stdin and calls the appropriate `gobbi workflow *` command. Guard logic, predicate evaluation, event schemas, and capture behavior all live in the CLI — not in the hooks. Updating workflow behavior means updating the CLI package, not touching the hook scripts.
 
-> **The CLI is the prompt factory and the guard enforcer. Hooks are thin wrappers that delegate to it.**
+---
 
-Hook scripts registered in `hooks/hooks.json` contain no logic. Each hook reads stdin and calls the appropriate `gobbi workflow *` command. Guard logic, event schemas, and capture behavior all live in the CLI — not in the hooks. This means updating workflow behavior means updating the CLI package, not touching the hook scripts.
+## Predicate Registry
+
+> **All guard conditions and transition predicates resolve through a single typed registry owned by the CLI.**
+
+At startup, the CLI loads all step specs from `packages/cli/src/specs/` and extracts every predicate name referenced in `transitions` and guard `condition` fields. Each predicate name maps to a TypeScript function in the registry — a pure function that receives the current workflow state and relevant arguments and returns a boolean.
+
+The registry is the single mapping between spec-level names (strings in JSON data) and TypeScript implementations. Step specs remain pure JSON — they declare which predicate governs a transition or guard, but never contain inline logic. The CLI resolves names to functions at compilation time.
+
+`gobbi workflow validate` checks that every predicate name referenced in any spec or guard has a registered implementation. A misspelled predicate name, a reference to a removed predicate, or an unimplemented predicate is caught at validation time — not at runtime when a guard fires or a transition attempts to evaluate.
+
+Adding a new condition means adding a TypeScript function to the registry and referencing its name from the spec. No expression parser, no custom operator protocol. Cross-reference `v050-state-machine.md` for the predicate model definition, guard specification format, and the task-size validation predicate.
 
 ---
 
@@ -55,15 +34,15 @@ V0.5.0 migrates the CLI from Node.js to Bun. The current `package.json` declares
 
 > **Bun matches Claude Code's own runtime, eliminates the build step, and brings native SQLite — three wins with one dependency choice.**
 
-**Native TypeScript execution** — Bun runs `.ts` files directly. No `tsc` build step during development. `bun run src/cli.ts` executes immediately. The build step for distribution still exists (`bun build`), but the development loop no longer requires it.
+**Native TypeScript execution** — Bun runs `.ts` files directly. No `tsc` build step during development. The build step for distribution still exists (`bun build`), but the development loop no longer requires it.
 
-**`bun:sqlite`** — The event store in `v050-session.md` requires SQLite with WAL mode and atomic write semantics. `bun:sqlite` is native to the runtime — zero additional dependencies, no `better-sqlite3` binding to compile, and 3–6x faster than equivalent Node.js SQLite solutions. This is the primary technical reason for the Bun migration: the event store architecture depends on SQLite, and Bun makes SQLite a first-class runtime capability.
+**`bun:sqlite`** — The event store in `v050-session.md` requires SQLite with WAL mode and atomic write semantics. `bun:sqlite` is native to the runtime — zero additional dependencies, no `better-sqlite3` binding to compile, and significantly faster than equivalent Node.js SQLite solutions. This is the primary technical reason for the Bun migration: the event store architecture depends on SQLite, and Bun makes SQLite a first-class runtime capability.
 
-**`bun:test`** — Jest-compatible test runner built into the runtime. Zero configuration, built-in mocking, snapshot testing support. The testing strategy for step spec compilation relies on snapshots to catch unintended changes — `bun:test` supports this natively without additional tooling.
+**`bun:test`** — Jest-compatible test runner built into the runtime. Zero configuration, built-in mocking, snapshot testing support. The testing strategy for step spec compilation relies on snapshots to catch unintended changes — `bun:test` supports this natively.
 
-**File I/O** — `Bun.file()` and `Bun.write()` replace `node:fs/promises` for the common case. State file writes use the temp+rename pattern: the CLI writes to a `.tmp` file, then renames it atomically over the target. This prevents a partial write from corrupting `state.json` — the rename is atomic at the OS level.
+**File I/O** — `Bun.file()` and `Bun.write()` replace `node:fs/promises` for the common case. State file writes use the temp+rename pattern for atomic persistence.
 
-**Startup time** — Hook scripts are invoked on every tool call. A PreToolUse guard fires before every `Write`, `Edit`, or `Task` tool call during a workflow session. Guard evaluation must be fast — slow hooks stall the session. Bun's startup time (sub-10ms for a simple script) makes per-call invocation practical in a way that a Node.js + tsc compiled CLI struggles to match.
+**Startup time** — Hook scripts are invoked on every tool call. Guard evaluation must complete in single-digit milliseconds. Bun's startup time makes per-call invocation practical in a way that a Node.js + tsc compiled CLI struggles to match.
 
 The `package.json` `name` (`@gobbitools/cli`) and `bin` configuration remain unchanged. The migration is internal — callers invoke `gobbi` the same way.
 
@@ -77,39 +56,50 @@ The CLI expands from its current eight-command surface to add a `workflow` subco
 
 **`gobbi workflow init`** — Creates the session directory under `.gobbi/sessions/{session-id}/`, writes `metadata.json`, initializes `gobbi.db` with the events table schema, and appends the first `workflow.start` event. Called by the SessionStart hook. Idempotent — if the session directory already exists, it verifies structure and exits cleanly.
 
-During initialization, `gobbi workflow init` asks the user four setup questions: the task description, whether to evaluate after Ideation, whether to evaluate after Plan, and any additional context. The evaluation answers (Ideation and Plan eval on/off) are stored immediately as a `workflow.eval.decide` event in `gobbi.db`, populating `evalConfig` in `state.json`. The compiled prompt generated for the first step (Ideation) includes the eval decision in its session section so the orchestrator knows the evaluation configuration from the start without needing to ask mid-workflow.
+During initialization, `gobbi workflow init` asks the user four setup questions: the task description, whether to evaluate after Ideation, whether to evaluate after Plan, and any additional context. The evaluation answers are stored immediately as a `workflow.eval.decide` event in `gobbi.db`, populating `evalConfig` in `state.json`. The compiled prompt generated for the first step includes the eval decision in its session section.
 
-**`gobbi workflow next`** — The core command. Reads `state.json` (or replays `gobbi.db` if absent), determines the active step, selects the appropriate step spec, loads relevant skills and artifacts, evaluates token budget, and writes the compiled prompt to stdout. This is what the orchestrator receives at the start of each step. Every other `workflow` command supports this one.
+**`gobbi workflow next`** — The core command. Reads `state.json` (or replays `gobbi.db` if absent), determines the active step, selects the appropriate step spec, loads relevant skills and artifacts, evaluates token budget, and writes the compiled prompt to stdout. This is what the orchestrator receives at the start of each step.
 
-**`gobbi workflow transition <event>`** — Advances the state machine by appending a typed event to `gobbi.db` and updating `state.json`. Validates that the event produces a valid transition from the current step before writing. Returns the new state summary on stdout. Invalid transitions produce an error with the reason — useful for diagnosing stalls.
+When the session is in `error` state, `gobbi workflow next` generates a pathway-specific error prompt instead of the normal step prompt. The error prompt is selected based on which pathway caused the error entry. Four pathways produce distinct prompts:
 
-The orchestrator calls this command via Bash, instructed by the step spec. Each step's compiled prompt ends with an explicit instruction: when this step is complete, run `gobbi workflow transition COMPLETE`. The CLI validates the transition against the state machine and advances state — the orchestrator does not decide when to transition, the step spec instructs it.
+- **Normal crash** — the workflow was active when the process terminated. The prompt includes the last active step, recent events leading up to the crash, and available artifacts in the step directory.
+- **Timeout error** — a step exceeded its configured timeout. The prompt includes which step timed out, elapsed time at timeout, and what artifacts were in progress.
+- **Feedback cap error** — `feedbackRound` exceeded `maxFeedbackRounds`. The prompt includes the evaluation history across rounds — each round's verdict and findings — and partial artifacts from the final round.
+- **Invalid transition error** — the reducer rejected an event. The prompt includes the rejected event, the reducer error message, and the state at rejection time.
 
-The Stop hook can also trigger implicit transitions: after each turn, the Stop hook analyzes the conversation to detect whether the orchestrator's response completed a step. If the response contains a recognized completion signal and no explicit transition was already written, the Stop hook writes the transition event. This handles cases where the orchestrator completed the step work but did not execute the transition command.
+Each error prompt includes the available recovery options: retry from the errored step, force-advance to memorization (`--force-memorization`), or abort. The prompt also includes available artifacts so the orchestrator or user can assess what was produced before the error. Cross-reference `v050-session.md` for pathway definitions and `v050-prompts.md` for resume prompt compilation.
 
-**`gobbi workflow guard`** — Invoked by the PreToolUse hook. Reads the full hook stdin payload, loads `state.json`, evaluates guard conditions using the JsonLogic engine, and writes the appropriate JSON response to stdout. If the call violates a guard, appends a `guard.violation` event and returns `permissionDecision: "deny"`. If the call is valid, returns `permissionDecision: "allow"` or defers to the next hook. Guard evaluation is the hottest code path in the CLI — it must complete in single-digit milliseconds.
+**`gobbi workflow transition <event>`** — Advances the state machine by appending a typed event to `gobbi.db` and updating `state.json`. Validates that the event produces a valid transition from the current step before writing. Returns the new state summary on stdout. Invalid transitions produce an error with the reason.
+
+The orchestrator calls this command via Bash, instructed by the step spec. Each step's compiled prompt ends with an explicit instruction: when this step is complete, run `gobbi workflow transition COMPLETE`. The CLI validates the transition against the state machine and advances state. The Stop hook can also trigger implicit transitions when it detects a completion signal that the orchestrator did not explicitly transition.
+
+**`gobbi workflow guard`** — Invoked by the PreToolUse hook. Reads the full hook stdin payload, loads `state.json`, evaluates guard conditions by resolving predicate names through the registry, and writes the appropriate JSON response to stdout. If the call violates a guard, appends a `guard.violation` event and returns `permissionDecision: "deny"`. If the call is valid, returns `permissionDecision: "allow"` or defers. Guard evaluation is the hottest code path — it must complete in single-digit milliseconds.
 
 **`gobbi workflow capture-subagent`** — Invoked by the SubagentStop hook. Reads the hook stdin payload, extracts the subagent's transcript from `agent_transcript_path`, writes an artifact to the current step directory, and appends a `delegation.complete` event linked to the originating `delegation.spawn` event via `parent_seq`. This replaces manual `gobbi note collect`.
 
-**`gobbi workflow capture-plan`** — Invoked by the PostToolUse hook on ExitPlanMode. Reads the plan content from the hook stdin payload, writes a plan artifact to `.gobbi/sessions/{id}/plan/`, and appends an `artifact.write` event. The orchestrator does not need to explicitly save the plan — this capture is automatic.
+**`gobbi workflow capture-plan`** — Invoked by the PostToolUse hook on ExitPlanMode. Reads the plan content from the hook stdin payload, writes a plan artifact to `.gobbi/sessions/{id}/plan/`, and appends an `artifact.write` event. Capture is automatic — the orchestrator does not need to explicitly save the plan.
 
-**`gobbi workflow flush-state`** — Invoked by the Stop hook. Checks for pending state changes that were not flushed during the turn and applies them. Respects `stop_hook_active` — exits immediately if true to prevent reentrance loops. This is a safety net, not the primary persistence path.
+**`gobbi workflow stop`** — Invoked by the Stop hook. Handles three responsibilities: heartbeat writing, timeout detection, and state flush for pending changes. Respects `stop_hook_active` — exits immediately if true to prevent reentrance loops. Cross-reference `v050-hooks.md` for the full Stop hook behavior.
 
 **`gobbi workflow resume`** — User-facing recovery command. Replays `gobbi.db` through the reducer, writes a fresh `state.json`, and outputs a resume prompt that re-orients the orchestrator to the current step. Used after crash recovery and after context compaction — both cases use the same rebuild path.
 
-**`gobbi workflow status`** — Reads `state.json` and prints the current workflow step, completed steps, active subagent count, evaluation configuration, and feedback round count. Human-readable output. Useful for diagnosing where a session is in the workflow without reading raw JSON.
+**`gobbi workflow status`** — Reads `state.json` and the event store and prints the current workflow step, completed steps, active subagent count, evaluation configuration, feedback round count, and cost summary. Human-readable output.
+
+The cost section displays: cumulative billed tokens (cache-adjusted) across all delegations, per-step token breakdown, and cache hit ratio. Cost data is derived from `delegation.complete` events in the event store (see `v050-session.md` for cost field definitions). When token data was unavailable for some delegations and the CLI fell back to file-size proxy, the output annotates which entries are estimates versus actual measurements. Cost surfaces ONLY in `gobbi workflow status` — it must NOT appear in compiled prompts or guard conditions.
+
+**`gobbi workflow validate`** — Performs static analysis of the spec library and predicate registry. Checks that every predicate name referenced in specs and guards has a registered TypeScript implementation. Also checks the workflow graph for dead steps, cycles, and broken references. This is a build-time check — it catches structural errors before they reach runtime.
 
 ### New: `gobbi session` commands
 
-**`gobbi session events`** — Formats the `events.jsonl` log for human consumption. New in v0.5.0. Provides a readable audit trail of every event in a session without requiring a SQLite client.
+**`gobbi session events`** — Formats the event log from `gobbi.db` for human consumption. Provides a readable audit trail without requiring a SQLite client.
 
 ### New: `gobbi gotcha` commands
 
-**`gobbi gotcha promote`** — Moves gotchas from `.gobbi/project/gotchas/` to the permanent store in `.claude/skills/_gotcha/`. This command runs outside active sessions only — it checks that no session is active (no `workflow.start` event without a corresponding `workflow.finish` in any session directory) before proceeding. Gotchas recorded during a session live in `.gobbi/project/gotchas/` until this promotion step runs. The promotion is the mechanism that turns mid-session learnings into permanent `.claude/` knowledge without causing context reload during the session itself.
+**`gobbi gotcha promote`** — Moves gotchas from `.gobbi/project/gotchas/` to the permanent store in `.claude/skills/_gotcha/`. Runs outside active sessions only — checks that no session is active before proceeding. The promotion turns mid-session learnings into permanent `.claude/` knowledge without causing context reload during the session.
 
 ### Existing commands (unchanged)
 
-**`gobbi session list`** — Lists sessions with their IDs, creation timestamps, and current steps. Unchanged in v0.5.0 except the session source moves from the v0.4.x session files to `.gobbi/sessions/`.
+**`gobbi session list`** — Lists sessions with their IDs, creation timestamps, and current steps. Session source moves from v0.4.x session files to `.gobbi/sessions/`.
 
 **`gobbi config`** — Session configuration management. Unchanged.
 
@@ -121,15 +111,29 @@ The Stop hook can also trigger implicit transitions: after each turn, the Stop h
 
 ---
 
+## Verification Command Support
+
+> **Mechanical verification after subtask completion catches regressions before they compound across tasks.**
+
+The CLI runs project-configurable verification commands after each subtask delegation completes. Verification commands — lint, test, typecheck, or any custom command — are specified in `.gobbi/` project configuration.
+
+When the SubagentStop capture hook finishes writing the delegation event, the CLI runs all configured verification commands against the codebase. Results are recorded as events in the event store: which commands ran, their exit codes, and a summary of output. This makes verification history available to all downstream compilation — prompt generation, crash recovery briefings, evaluation context, and status reporting.
+
+Verification does not block the SubagentStop capture. The delegation event is always written first — the subagent's output is never lost even if verification itself fails or times out. Verification runs after capture, as a separate phase.
+
+When verification fails, the CLI includes the failure context in the next compiled prompt. The orchestrator receives concrete error output and can decide whether to re-execute, adjust the approach, or flag for user attention. Verification failure does not automatically trigger re-execution — it provides information; the orchestrator decides the action.
+
+Cross-reference `v050-hooks.md` for how hooks trigger verification after SubagentStop events and `v050-prompts.md` for how verification blocks appear in step specs.
+
+---
+
 ## Argument Parsing
 
-The current CLI uses `node:util` `parseArgs` with manual command routing — the `switch` on `command` in `cli.ts`. This pattern is kept for v0.5.0. It has a manageable cost at the current command count and adding a `workflow` subcommand group is straightforward.
+The current CLI uses `node:util` `parseArgs` with manual command routing — the `switch` on `command` in `cli.ts`. This pattern is kept for v0.5.0.
 
 > **The parsing layer is isolated. Migration to a typed routing library is a contained refactor, not an architectural change.**
 
-The `gobbi workflow <subcommand>` routing follows the same pattern as the existing top-level commands: `process.argv[2]` routes to `workflow`, and `process.argv[3]` routes to the subcommand. The workflow subcommand handler lives in `src/commands/workflow.ts`.
-
-When the command count grows significantly — particularly when workflow subcommands multiply for domain-specific variants — the CLI can migrate the parsing layer to a typed subcommand router without touching the handler implementations. The handlers are isolated from the parsing surface.
+The `gobbi workflow <subcommand>` routing follows the same pattern as existing top-level commands: `process.argv[2]` routes to `workflow`, and `process.argv[3]` routes to the subcommand. The workflow subcommand handler lives in `src/commands/workflow.ts`. When the command count grows significantly, the CLI can migrate the parsing layer to a typed subcommand router without touching the handler implementations.
 
 ---
 
@@ -139,36 +143,25 @@ When the command count grows significantly — particularly when workflow subcom
 
 The gobbi plugin is the Claude Code integration artifact — it is what users install, what registers hooks with Claude Code, and what declares the rules that load into every session. The CLI is the runtime engine that the plugin delegates to.
 
-```
-  Plugin (distribution layer)          CLI (runtime layer)
-  ──────────────────────────           ─────────────────────────────
-  hooks/hooks.json         ──calls──▶  gobbi workflow guard
-  hooks/hooks.json         ──calls──▶  gobbi workflow capture-subagent
-  hooks/hooks.json         ──calls──▶  gobbi workflow capture-plan
-  hooks/hooks.json         ──calls──▶  gobbi workflow flush-state
-  rules/                   ──reads──▶  (loaded by Claude Code directly)
-  agents/                  ──reads──▶  (loaded by Claude Code directly)
-  skills/ (domain only)    ──reads──▶  CLI inlines into generated prompts
-  settings.json            ──declares──▶  hook registration, permissions
-```
-
 **Plugin responsibilities:**
 - Hook registration via `hooks/hooks.json`
 - Always-active behavioral rules in `rules/`
 - Agent definitions for the workflow agents
-- Domain knowledge skills (`_gotcha`, `_claude`, `_git`, and others that survive as materials per `v050-prompts.md`)
+- Domain knowledge skills that survive as materials per `v050-prompts.md`
 - `settings.json` declaring permissions and hook timeouts
 
 **CLI responsibilities:**
 - Workflow engine: event store, state machine, reducer
-- Step specs for all five workflow steps plus their variants
-- Guard specification and JsonLogic evaluation
+- Predicate registry: loading, validation, runtime resolution
+- Step specs for all workflow steps plus their variants
+- Guard specification and predicate evaluation
 - Prompt compilation: selecting artifacts, loading skill materials, applying cache ordering, enforcing token budget
-- Session lifecycle management
+- Verification command execution after subtask completion
+- Session lifecycle management and cost tracking
 
-The plugin does not contain orchestration logic. It contains wiring. When guard behavior changes, the CLI package is updated. The hook scripts in `hooks/hooks.json` remain stable across releases because they contain no logic to change — they only invoke `gobbi workflow *` commands.
+The plugin does not contain orchestration logic. It contains wiring. When guard behavior changes, the CLI package is updated. The hook scripts remain stable across releases because they contain no logic — they only invoke `gobbi workflow *` commands.
 
-**Installation path** — The plugin declares `@gobbitools/cli` as a dependency in its `package.json`. When the plugin is installed, the CLI installs with it. The `gobbi` binary is available as a project-local command, invokable from hook scripts via the standard node_modules path or a resolved absolute path stored in plugin configuration.
+**Installation path** — The plugin declares `@gobbitools/cli` as a dependency in its `package.json`. When the plugin is installed, the CLI installs with it. The `gobbi` binary is available as a project-local command.
 
 ---
 
@@ -176,11 +169,11 @@ The plugin does not contain orchestration logic. It contains wiring. When guard 
 
 > **npm is primary. Single-binary is secondary for environments where npm is unavailable.**
 
-**Primary: npm package** — `@gobbitools/cli` published to the npm registry. This is the current distribution mechanism and it remains correct for v0.5.0. Plugin installation pulls the CLI as a dependency. Users with a standard Node.js or Bun environment install once and update via `npm update` or `bun update`.
+**Primary: npm package** — `@gobbitools/cli` published to the npm registry. Plugin installation pulls the CLI as a dependency. Users with a standard Node.js or Bun environment install once and update via `npm update` or `bun update`.
 
-**Secondary: `bun --compile` binary** — Bun can compile a TypeScript project into a self-contained binary with no runtime dependency. This is the distribution path for users in environments where npm is unavailable — CI systems, restricted corporate environments, or setups where installing a package manager is impractical. The compiled binary includes the Bun runtime and all CLI code. It is larger than the npm package but requires no external tooling to run.
+**Secondary: `bun --compile` binary** — Bun can compile a TypeScript project into a self-contained binary with no runtime dependency. This is the distribution path for environments where npm is unavailable — CI systems, restricted corporate environments. The compiled binary includes the Bun runtime and all CLI code.
 
-The binary build is an additional CI step, not a replacement for the npm build. Both artifacts are produced from the same source. The choice between them is made by the installer, not by the gobbi release process.
+Both artifacts are produced from the same source. The choice between them is made by the installer, not by the gobbi release process.
 
 ---
 
@@ -188,22 +181,26 @@ The binary build is an additional CI step, not a replacement for the npm build. 
 
 `bun:test` is the test runner for all CLI tests. No additional test framework is required.
 
-> **Test the boundaries, not the internals. The event store, state machine, and step specs are the interfaces other subsystems depend on.**
+> **Test the boundaries, not the internals. The event store, state machine, predicate registry, and step specs are the interfaces other subsystems depend on.**
 
-**State machine tests** — The reducer is a pure function and tests cheaply. Each test supplies an initial state and an event and asserts the returned state. Exhaustiveness is validated at compile time via the TypeScript `never` pattern — a new event type without a reducer case is a type error. Transition table compliance is tested by exercising every row in the table and confirming the reducer accepts valid transitions and rejects invalid ones.
+**State machine tests** — The reducer is a pure function and tests cheaply. Each test supplies an initial state and an event and asserts the returned state. Exhaustiveness is validated at compile time via the TypeScript `never` pattern. Transition table compliance is tested by exercising every row in the table.
 
-**Guard evaluation tests** — Each guard specification is a JSON object. Tests supply a mock state and a mock tool call input and assert the output: `deny`, `allow`, or `warn` with the expected reason. The custom JsonLogic operators (`event_exists`, `event_count`) are unit-tested independently with synthetic event logs.
+**Predicate registry tests** — Each predicate is a pure function with a typed signature. Tests supply mock state and arguments and assert the boolean return. `gobbi workflow validate` is itself tested by constructing spec sets with missing or misspelled predicate names and asserting that validation fails with descriptive errors.
 
-**Prompt compilation tests** — Snapshot testing via `bun:test`'s built-in snapshot support. Each step spec is compiled with a representative set of state inputs and the output is committed as a snapshot. CI fails when a compiled prompt changes unexpectedly. This catches unintended prompt changes — the most consequential class of regression in a system where prompt content drives behavior.
+**Guard evaluation tests** — Each guard specification is a JSON object. Tests supply a mock state and a mock tool call input and assert the output: `deny`, `allow`, or `warn` with the expected reason. Predicates referenced by guards are unit-tested independently.
 
-**Hook handler tests** — Hook handlers (`gobbi workflow guard`, `gobbi workflow capture-subagent`, etc.) are tested by supplying mock stdin payloads and asserting stdout output and event store writes. File I/O is mocked via Bun's test mocking support. The event store is tested against a real SQLite in-memory database — this is practical because `bun:sqlite` with an in-memory database has no I/O cost.
+**Prompt compilation tests** — Snapshot testing via `bun:test`. Each step spec is compiled with a representative set of state inputs and the output is committed as a snapshot. CI fails when a compiled prompt changes unexpectedly. Error-state prompts are snapshot-tested for each of the four pathways.
 
-**Integration tests** — A full workflow cycle test initializes a session, transitions through all five steps, and verifies that the final state matches the expected terminal state. Hook delegation is tested end-to-end with mock stdin and a real CLI subprocess. These are slower than unit tests and run in a separate test suite from the fast unit tests.
+**Hook handler tests** — Hook handlers are tested by supplying mock stdin payloads and asserting stdout output and event store writes. The event store is tested against a real SQLite in-memory database — `bun:sqlite` with an in-memory database has no I/O cost.
+
+**Verification tests** — Verification command execution is tested with mock commands that simulate pass, fail, and timeout conditions. Event recording for each verification outcome is asserted.
+
+**Integration tests** — A full workflow cycle test initializes a session, transitions through all steps, and verifies the final state. Hook delegation is tested end-to-end with mock stdin and a real CLI subprocess.
 
 ---
 
 ## Boundaries
 
-This document covers the CLI's role as integration hub, the Bun runtime migration and its rationale, the full command structure for both new `workflow` commands and existing commands, the argument parsing approach, the plugin-CLI boundary, distribution strategy, and testing approach.
+This document covers the CLI's role as integration hub, the predicate registry, the Bun runtime migration and its rationale, the full command structure including error-state prompt generation and cost tracking in status output, verification command support, the argument parsing approach, the plugin-CLI boundary, distribution strategy, and testing approach.
 
-For the event store schema and state fields that `gobbi workflow` commands read and write, see `v050-session.md`. For the state machine transitions that `gobbi workflow transition` validates, see `v050-state-machine.md`. For the prompt compilation logic that `gobbi workflow next` executes, see `v050-prompts.md`. For the hook stdin schemas and output format that `gobbi workflow guard` and capture commands handle, see `v050-hooks.md`.
+For the event store schema and state fields that `gobbi workflow` commands read and write, see `v050-session.md`. For the state machine transitions and the predicate model that guards and transitions reference, see `v050-state-machine.md`. For the prompt compilation logic including resume prompts and verification blocks in step specs, see `v050-prompts.md`. For the hook stdin schemas and output format that `gobbi workflow guard` and capture commands handle, see `v050-hooks.md`.

--- a/.claude/project/gobbi/design/v050-design-review.md
+++ b/.claude/project/gobbi/design/v050-design-review.md
@@ -1,0 +1,176 @@
+# v0.5.0 Design Review
+
+Comparison analysis and improvement recommendations for gobbi v0.5.0, derived from deep review of GSD-2 (gsd-build/gsd-2) and everything-claude-code (affaan-m/everything-claude-code). Read this when evaluating v0.5.0 spec completeness, prioritizing implementation work, or understanding what was considered and rejected. Assumes familiarity with `v050-overview.md`.
+
+---
+
+## Comparison Analysis
+
+### GSD-2
+
+GSD-2 is a shell-driven orchestration framework for Claude Code. It uses Markdown task files on disk as its state mechanism — each task is a file with YAML frontmatter tracking status, and a shell coordinator script manages transitions. GSD-2 and gobbi independently converged on three foundational patterns: disk-driven state that survives context resets, fresh context per subagent to prevent contamination, and cache-aware prompt ordering to reduce cost. This convergence validates gobbi's architectural direction.
+
+Where GSD-2 contributes ideas gobbi should adopt: task-size validation ("a task must fit in one context window — if it cannot, it is two tasks"), step-level timeout detection for stuck workflows, and verification command integration after subtask execution. These appear in the recommendations below as C6, B3, and B8.
+
+Where gobbi does better: event-sourced single source of truth versus GSD-2's scattered task files, hook-based enforcement versus prompt-level guidance, multi-perspective evaluation versus mechanical verification, and the gotcha prevention system which GSD-2 lacks entirely. GSD-2's shell scripts are also harder to extend and test than gobbi's TypeScript CLI.
+
+### Everything-Claude-Code (ECC)
+
+ECC is a comprehensive configuration framework that operates primarily at the prompt and rules layer. It uses a layered rule system with domain-specific configurations, an instinct mechanism for learning from past interactions (with confidence scoring and promotion pipelines), and an AgentShield security layer for detecting secrets and unsafe operations. ECC targets cross-harness portability — its configurations are designed to work with multiple AI coding tools, not just Claude Code.
+
+Where ECC contributes ideas gobbi should adopt: secret pattern detection in tool call inputs (AgentShield concept, adapted as C7), and positive pattern recording as a lightweight extension to the gotcha system (deferred as D10 — the full instinct system with confidence scoring exceeds boundary, but structured positive patterns do not).
+
+Where gobbi does better: runtime enforcement through hooks versus ECC's prompt-level-only guidance, state-driven orchestration versus ECC's guidance-based approach (the same structural problem v0.5.0 solves for gobbi's own v0.4.x), and event sourcing versus ECC's file-based state which has no replay or crash recovery guarantees.
+
+### Shared Observation
+
+Both references validate the move from guidance to enforcement. GSD-2 enforces through shell scripts and file-based state transitions. ECC enforces through layered rules and security checks. Gobbi enforces through hooks and a typed reducer — structurally the most reliable of the three because hook-level enforcement cannot be bypassed by model reasoning.
+
+---
+
+## Recommendations
+
+Fifteen improvements split into two tiers. Spec clarifications document intended behavior that current specs imply but do not make explicit — low risk, no new dependencies. Behavioral additions add new runtime behavior with cross-component dependencies — higher risk, sequenced.
+
+### Spec Clarifications
+
+Low risk, no sequencing dependencies. Each can be implemented independently.
+
+| # | Name | Spec affected | Source | Priority |
+|---|------|---------------|--------|----------|
+| C1 | Predicate registry for guard conditions | `v050-state-machine.md`, `v050-prompts.md`, `v050-cli.md` | Architecture evaluation + user decision | High |
+| C2 | Lazy event schema migration (read-time) | `v050-session.md` | Best, event sourcing pattern | Medium |
+| C3 | Event idempotency key | `v050-session.md` | Best, Kafka/EventBridge pattern | Medium |
+| C4 | SubagentStop transcript failure handling | `v050-hooks.md` | Best, ETL patterns | High |
+| C5 | Minimum token allocations per prompt section | `v050-prompts.md` | Best, content budgeting | Medium |
+| C6 | Task-size validation in Plan step | `v050-prompts.md`, `v050-state-machine.md` | Best, GSD-2 | Medium |
+| C7 | Secret pattern detection guard | `v050-hooks.md` | Best, ECC AgentShield | High |
+
+**C1 — Predicate registry for guard conditions.** Spec files reference TypeScript predicate names instead of inline expressions. The CLI maintains a typed registry mapping names to pure functions. `gobbi workflow validate` checks that all referenced predicates exist in the registry. Specs remain pure JSON data; conditions resolve at CLI compilation time, not at runtime. This was a user decision — TypeScript predicates with a registry were chosen over JsonLogic to preserve static validation while avoiding expression language complexity.
+
+**C2 — Lazy event schema migration (read-time).** Store events in their original schema version. Apply migrations during reducer replay, not at write time. This prevents corrupted migrations from being irrecoverable — the original event data is always preserved.
+
+**C3 — Event idempotency key.** Add an `idempotency_key` column (session_id + tool_call_id + event_type) with a UNIQUE constraint. Defensive against future Claude Code hook retry behavior — if hooks fire twice for the same tool call, the duplicate event is rejected at the database level.
+
+**C4 — SubagentStop transcript failure handling.** Three explicit cases: (1) transcript present and parseable — extract and write artifact; (2) transcript present but unparseable — write `delegation.fail` event with transcript path; (3) transcript absent — write `delegation.fail` with reason. The current spec does not address cases 2 and 3, which means silent data loss on transcript failures.
+
+**C5 — Minimum token allocations per prompt section.** Define minimums for static prefix, step instructions, and gotchas. If minimums exceed the model context window, the CLI emits a clear error instead of silently truncating critical prompt sections.
+
+**C6 — Task-size validation in Plan step.** The CLI estimates token budget for each task's delegation prompt. Tasks exceeding the budget trigger a warning (not a block — the user decides). Drawn from GSD-2's rule that a task must fit in one context window.
+
+**C7 — Secret pattern detection guard.** A PreToolUse guard checks Write/Edit inputs for API key and token patterns. The match filter excludes `.gobbi/sessions/**` paths (narrowed from `.gobbi/**`) to avoid false-positives on session artifacts while still checking `.gobbi/config.json` and other non-session files.
+
+### Behavioral Additions
+
+Higher risk with cross-component dependencies. Must be implemented in the sequence below.
+
+| # | Name | Spec affected | Source | Dependencies |
+|---|------|---------------|--------|--------------|
+| B1 | Explicit error state in state machine | `v050-state-machine.md` | Best, AWS Step Functions | None — prerequisite for B2, B3, B4 |
+| B2 | Feedback round hard cap (default 3) | `v050-state-machine.md` | Both, circuit breaker | Requires B1 |
+| B3 | Stuck detection with per-step timeouts | `v050-state-machine.md`, `v050-hooks.md` | Both, GSD-2 | Requires B1 |
+| B4 | Crash recovery briefing with pathway differentiation | `v050-session.md`, `v050-prompts.md`, `v050-cli.md` | Both, GSD-2 | Requires B1, B5 |
+| B5 | Artifact versioning across feedback rounds | `v050-session.md`, `v050-hooks.md` | Innovative, saga pattern | None — prerequisite for B4 |
+| B6 | Cost/token tracking on delegation events | `v050-session.md`, `v050-hooks.md` | Both, GSD-2 | Depends on Claude Code API surface |
+| B7 | Abandoned session: 1h threshold + heartbeat | `v050-session.md`, `v050-hooks.md` | Best | None |
+| B8 | Verification command integration | `v050-prompts.md`, `v050-hooks.md`, `v050-cli.md` | Innovative, GSD-2 | Requires B5 (verification events reference artifact filenames) |
+
+**Sequencing constraint:** B1 (error state) must precede B2 (feedback cap) and B3 (stuck detection), because both transition to the error state. B5 (artifact versioning) must precede B4 (crash recovery briefing) and B8 (verification commands), because both reference versioned artifact filenames.
+
+**B1 — Explicit error state in state machine.** Add `error` as a first-class state variant in the discriminated union. Reachable from any active step via timeout, feedback cap exceeded, or invalid transition rejection. Not terminal — the user can resume or abort. Five integration points: typed reducer exhaustiveness, feedback round counter (does not increment on error entry), active subagent handling (in-flight subagents complete normally), transition priority (error takes precedence over skip), and resume pathway differentiation. Full integration requirements are specified in `v050-state-machine.md`.
+
+**B2 — Feedback round hard cap (default 3).** When `feedbackRound >= maxFeedbackRounds`, the next revise verdict transitions to `error` instead of looping back. The workflow does NOT proceed to Memorization — work produced by a pathological loop may be broken. The `error` state gives the user intervention options: `gobbi workflow resume --force-memorization` to save partial work, or `gobbi workflow abort` to discard.
+
+**B3 — Stuck detection with per-step timeouts.** Timeout configuration lives in step spec `meta`. The Stop hook (fires after each turn) checks elapsed time since step entry. If exceeded, writes a `workflow.step.timeout` event and transitions to `error`. Historical median detection is deferred (D11) — requires K>=3 completed sessions before activation.
+
+**B4 — Crash recovery briefing with pathway differentiation.** `gobbi workflow resume` synthesizes a briefing from the event store. Must differentiate four pathways: (a) normal mid-step crash, (b) error from timeout, (c) error from feedback cap, (d) error from invalid transition. Each produces a different briefing because recovery options differ.
+
+**B5 — Artifact versioning across feedback rounds.** Filename-based versioning (`execution-r1.md`, `execution-r2.md`) instead of subdirectories — preserves the flat-directory design principle. The SubagentStop capture hook reads `feedbackRound` from state to construct the filename suffix. Failed rounds get a `delegation-fail-r2.md` marker per C4.
+
+**B6 — Cost/token tracking on delegation events.** Track billed tokens (cache-adjusted, not raw) when available from the Claude Code API. If token data is unavailable in the SubagentStop hook payload, fall back to transcript file size as a rough proxy. Surfaced via `gobbi workflow status` only — cost data must NOT appear in compiled prompts or guard conditions. Data availability depends on the Claude Code API and must be verified before designing the event schema.
+
+**B7 — Abandoned session: 1h threshold + heartbeat.** The Stop hook writes a `session.heartbeat` event with timestamp each turn. Sessions without a heartbeat for 60 minutes are treated as abandoned. Replaces the current 24-hour inactivity threshold.
+
+**B8 — Verification command integration.** Add verification blocks to execution step specs. The CLI runs configured commands (lint, test, typecheck) after each subtask, records results as events. Failure triggers re-execution with error context included in the next prompt.
+
+---
+
+## Deferred Items
+
+Deferred to v0.5.1+ with rationale. These are valid ideas that exceed v0.5.0 scope or require data from v0.5.0 usage before implementation.
+
+| # | Feature | Reason for deferral |
+|---|---------|---------------------|
+| D1 | Parallel task execution | Requires file conflict detection between concurrent subagents and dependency-aware dispatch. Linear execution is sufficient for v0.5.0 launch. Parallel execution is an optimization, not a correctness requirement. |
+| D2 | Prompt compilation IR | Multi-pass compilation adds value only when prompt optimization is a measured bottleneck. V0.5.0 should ship single-pass, instrument compilation timing, and evaluate whether IR is needed based on data. Premature optimization. |
+| D3 | ECS-style agent composition | Replaces fixed PI/Executor/Evaluator model with composable capability components. Changes the agent model fundamentally. Fixed categories are well-understood and sufficient for v0.5.0. Composition becomes valuable when project-specific agents need mixed capabilities. |
+| D4 | Project-level spec overrides | Allows `.gobbi/spec-overrides/{step}.json` to patch default specs. Ships one workflow profile first; customization requires a stable base to patch against. V0.5.0 establishes that base. |
+| D5 | Hook profiles (minimal/standard/strict) | Already planned for v0.5.1 per `v050-hooks.md`. ECC validates demand. |
+| D6 | Guard testing harness | `gobbi workflow guard --test` for dry-run evaluation. Valuable for contributors but not blocking for launch. |
+| D7 | Headless/CI mode | Architecture naturally supports it (CLI reads state, generates prompts). Implement when CI integration demand materializes. |
+| D8 | Conditional evaluation triggers | CLI recommends evaluation based on artifact complexity metrics instead of an upfront decision. Needs threshold calibration data from v0.5.0 sessions. |
+| D9 | Codebase map injection | Generate project structure summary during `gobbi workflow init`, include in static prefix. Subagents currently discover structure via tool calls, which works but costs tokens. |
+| D10 | Positive pattern recording | Expand gotcha system to include "what works" alongside "what fails." ECC's instinct system validates the concept. The full confidence-scoring version adds learning burden; a lightweight version (structured positive patterns without scoring) is within boundary but deferred to focus v0.5.0. |
+| D11 | Historical stuck detection | Step-duration anomaly detection using historical median across sessions. Requires K>=3 completed sessions per step. V0.5.0 ships with hard timeouts only; historical detection activates after sufficient data accumulates. |
+
+---
+
+## Rejected Items
+
+Outside the boundary filter: ClaudeX only, no user study burden. Each rejection includes reasoning.
+
+| # | Feature | Source | Reason for rejection |
+|---|---------|--------|----------------------|
+| R1 | Cross-harness portability | ECC | Outside ClaudeX scope by definition. Gobbi is Claude Code specific — abstracting across harnesses would dilute the depth of integration that makes gobbi valuable. |
+| R2 | Multi-language rule ecosystems | ECC | Project-specific domain knowledge, not ClaudeX tooling. Projects already create their own rules in `.claude/rules/`. A rule ecosystem framework adds infrastructure burden without ClaudeX benefit. |
+| R3 | Dashboard GUI | ECC | Heavy UI surface with significant learning burden. Gobbi is a CLI tool; adding a GUI changes the product category. `gobbi workflow status` covers the visibility need. |
+| R4 | Milestone/slice hierarchy | GSD-2 | Adds structural concepts users must learn. Gobbi's flat task list with validation is simpler and achieves the same decomposition goal. Hierarchy becomes relevant only for multi-week projects, which are outside v0.5.0's interactive session model. |
+| R5 | Full instinct/confidence system | ECC | Requires users to understand confidence scoring, promotion pipelines, and threshold tuning. Significant learning burden for uncertain payoff. The lightweight positive-pattern variant is deferred as D10 instead. |
+| R6 | Fleet orchestration | GSD-2 | Enterprise CI concern, not interactive ClaudeX. Gobbi's session model is one user, one workflow, one machine. Fleet orchestration solves a different problem. |
+| R7 | Multi-model provider routing | GSD-2 | Gobbi works within Claude Code's model selection, not alongside it. Routing across providers would bypass Claude Code's native model management, contradicting v0.5.0's philosophy of enhancing rather than replacing. |
+| R8 | File-level activity tracking | ECC | High event volume with marginal benefit. Tracking every file read/write as an event overwhelms the event store without improving orchestration decisions. Step-level events are the right granularity. |
+| R9 | Cost budget ceilings with model downgrading | GSD-2 | Requires gobbi to control model selection, which Claude Code owns. Cost visibility (B6) is within boundary; cost control is not. |
+
+---
+
+## Known Limitations
+
+Accepted risks the implementation team must understand. These are not deferrable features — they are structural tradeoffs inherent to v0.5.0's design decisions.
+
+### Persistent orchestrator quality degradation
+
+With fresh-per-step rejected, the orchestrator accumulates reasoning traces across workflow steps even though bounded prompts constrain what it receives. Mitigation: bounded prompts reduce the impact (each step's prompt is compiled fresh), and Claude Code's compaction handles extreme cases. This is a known tradeoff — the simplicity of a single session outweighs the theoretical purity of fresh-per-step for v0.5.0's use case (interactive ClaudeX, not autonomous CI pipelines).
+
+### Cost tracking data availability
+
+Token usage tracking (B6) depends on Claude Code exposing token data in SubagentStop hook payloads or transcript files. If unavailable, the feature degrades to transcript file-size proxy. This must be verified during implementation before designing the event schema.
+
+### Stuck detection bootstrapping
+
+Historical step-duration metrics (D11) require K>=3 completed sessions. V0.5.0 ships with hard timeouts only. First-time users have no anomaly detection until enough sessions accumulate.
+
+---
+
+## User Decisions
+
+Resolved during ideation and locked as constraints for all recommendations.
+
+### Persistent orchestrator per workflow
+
+> **One Claude Code session = one orchestrator = one full workflow.**
+
+Fresh-per-step was rejected. Bounded prompts and hook enforcement constrain the orchestrator. Quality degradation across steps is an accepted risk (see Known Limitations above). The simplicity of a single session — no inter-session state handoff, no context reconstruction — outweighs the theoretical benefit of fresh orchestrator context per step.
+
+### TypeScript predicates with predicate registry
+
+> **Guard conditions are TypeScript functions, not JsonLogic expressions.**
+
+Specs reference predicates by name. A typed predicate registry maps names to functions. `gobbi workflow validate` checks that all referenced predicates exist in the registry. This preserves static validation while avoiding JsonLogic's complexity. Adding a new guard condition means adding a function to the registry — no custom operator protocol, no expression parser, and full IDE support for implementation and testing.
+
+---
+
+## Boundaries
+
+This document covers comparison analysis of GSD-2 and everything-claude-code against gobbi v0.5.0, fifteen improvement recommendations (seven spec clarifications, eight behavioral additions), eleven deferred items with rationale, nine rejected items with reasoning, three known limitations, and two user decisions.
+
+For the specs these recommendations modify, see: `v050-state-machine.md`, `v050-session.md`, `v050-hooks.md`, `v050-prompts.md`. For the architectural overview, see `v050-overview.md`.

--- a/.claude/project/gobbi/design/v050-hooks.md
+++ b/.claude/project/gobbi/design/v050-hooks.md
@@ -1,6 +1,6 @@
 # v0.5.0 Hooks
 
-Enforcement and recording layer for v0.5.0. Read this when implementing or reasoning about PreToolUse guards, SubagentStop capture, PostToolUse signals, or the hook-to-CLI delegation pattern. Assumes familiarity with the event model in `v050-session.md` and guard conditions in `v050-state-machine.md`.
+Enforcement and recording layer for v0.5.0. Read this when implementing or reasoning about PreToolUse guards, SubagentStop capture, PostToolUse signals, Stop hook behaviors, or the hook-to-CLI delegation pattern. Assumes familiarity with the event model in `v050-session.md`, guard conditions and predicate registry in `v050-state-machine.md`, and step spec structure in `v050-prompts.md`.
 
 ---
 
@@ -12,37 +12,7 @@ V0.5.0 hooks divide cleanly into two functional categories based on when they fi
 
 **Guard hooks** (PreToolUse) intercept tool calls before execution. They read the current workflow state and evaluate whether the tool call is valid at this point in the workflow. When a call violates a guard, the hook blocks it — the tool never executes. Guard hooks are the enforcement layer. They cannot be bypassed by model reasoning because they operate at the tool layer, not the prompt layer.
 
-**Capture hooks** (SubagentStop, PostToolUse, Stop) observe actions that have already completed. They do not block — they record. A SubagentStop hook reads the subagent's transcript and writes a `delegation.complete` event to the event store. A PostToolUse hook on ExitPlanMode captures the plan content. A Stop hook flushes pending state changes after each turn. Capture hooks are the recording layer.
-
-```
-  Orchestrator action
-         │
-         ▼
-  ┌─────────────────────────────────────┐
-  │          PreToolUse (Guard)         │
-  │                                     │
-  │  Read state.json                    │
-  │  Evaluate guard conditions          │
-  │         │                           │
-  │    deny? ──── block ──▶ guard.violation event
-  │         │                           │
-  │    allow? ─────────────────────────┐│
-  └─────────────────────────────────────┘
-                                        │
-                                        ▼
-                               Tool executes
-                                        │
-                    ┌───────────────────┼───────────────────┐
-                    ▼                   ▼                   ▼
-           SubagentStop          PostToolUse             Stop
-           (Capture)             (Capture)            (Capture)
-                    │                   │                   │
-                    └───────────────────┴───────────────────┘
-                                        │
-                                        ▼
-                             Event written to gobbi.db
-                             state.json updated
-```
+**Capture hooks** (SubagentStop, PostToolUse, Stop) observe actions that have already completed. They do not block — they record. A SubagentStop hook reads the subagent's transcript and writes a delegation event to the event store. A PostToolUse hook on ExitPlanMode captures the plan content. A Stop hook writes heartbeat events and checks for step timeouts. Capture hooks are the recording layer.
 
 ---
 
@@ -86,11 +56,21 @@ PreToolUse can rewrite the tool's input before execution via the `updatedInput` 
 
 **Agent tool (spawning subagents)** — The guard reads `tool_input.subagent_type` and checks it against the current step's allowed agent types from `state.json`. An orchestrator in the Execution step is allowed to spawn executor-type agents. It is not allowed to spawn evaluator-type agents — evaluation is a separate step and the creating agent must not trigger it. If `subagent_type` is not in the allowed set for the current step, the guard denies.
 
-When the guard allows an Agent tool call, it appends a `delegation.spawn` event to the event store before returning the allow decision. This event records the subagent type, the current step, and the timestamp. The `parent_seq` on the subsequent `delegation.complete` event (written by SubagentStop) references this spawn event, linking the full delegation lifecycle in the event log.
+When the guard allows an Agent tool call, it appends a `delegation.spawn` event to the event store before returning the allow decision. This event records the subagent type, the current step, and the timestamp. The `parent_seq` on the subsequent `delegation.complete` or `delegation.fail` event (written by SubagentStop) references this spawn event, linking the full delegation lifecycle in the event log. All events include `idempotency_key` per the schema in `v050-session.md`.
 
 **Write and Edit tools (`.claude/` protection)** — The guard checks whether `tool_input.file_path` targets any path under `.claude/`. If the session is active (a `workflow.start` event exists and no `workflow.finish` event exists), the guard denies. This enforces the directory split from `v050-overview.md`: `.claude/` is read-only during an active workflow. Writes go to `.gobbi/`.
 
-**Execution precondition guard** — Before an executor subagent is spawned, the guard verifies that a plan artifact exists in `plan/` for the current session. It uses the `event_exists("workflow.step.exit", "plan")` check. If the plan step has not completed, the guard denies. An executor without a plan has no bounded scope and will improvise — which is the failure mode v0.5.0 is designed to prevent.
+**Execution precondition guard** — Before an executor subagent is spawned, the guard verifies that a plan artifact exists in `plan/` for the current session. It uses the predicate that checks for a completed plan step exit event. If the plan step has not completed, the guard denies. An executor without a plan has no bounded scope and will improvise — which is the failure mode v0.5.0 is designed to prevent.
+
+### Secret Pattern Detection Guard
+
+> **Prevent accidental secret leakage in tool outputs without blocking legitimate writes.**
+
+A PreToolUse guard checks Write and Edit tool inputs for common secret patterns — API keys, tokens, credentials, and other sensitive material. The match filter fires only on `Write` and `Edit` tool calls. The guard's effect is `warn`, not `deny`, because false positives are possible and blocking would stall the workflow unnecessarily.
+
+The match filter must exclude paths under `.gobbi/sessions/**`. Gobbi's session artifact writes — subagent results, event data, state files — may contain strings that resemble secret patterns without being actual secrets. The exclusion is narrowed to `sessions/` specifically so that writes to `.gobbi/config.json` or other non-session files are still checked for secrets.
+
+When the guard fires, it injects an `additionalContext` warning into the hook response and writes a `guard.warn` event to the event store with `idempotency_key`. The orchestrator receives the warning and can inspect the flagged content. The `guard.warn` event is distinct from `guard.violation` (which is written by deny guards) — both count toward escalation thresholds, but `guard.warn` does not block the tool call.
 
 ---
 
@@ -98,7 +78,7 @@ When the guard allows an Agent tool call, it appends a `delegation.spawn` event 
 
 ### SubagentStop
 
-> **SubagentStop replaces manual `gobbi note collect` entirely. When a subagent stops, its output is automatically recorded.**
+> **SubagentStop replaces manual `gobbi note collect` entirely. When a subagent stops, its output is automatically recorded — success or failure.**
 
 SubagentStop fires after every subagent completes, regardless of success or failure. The stdin payload fields are:
 
@@ -110,9 +90,33 @@ SubagentStop fires after every subagent completes, regardless of success or fail
 | `last_assistant_message` | string | Final message from the subagent before stopping |
 | `stop_hook_active` | boolean | Whether a Stop hook is currently running |
 
-The hook reads the transcript at `agent_transcript_path`, extracts the result, and writes an artifact file to the current step's directory under `.gobbi/sessions/{session-id}/{step}/`. It then appends a `delegation.complete` event to `gobbi.db` with the artifact path as data. The `parent_seq` field on the event references the `delegation.spawn` event that initiated this subagent, linking the two.
-
 `stop_hook_active` must be checked first. If true, the hook exits immediately. SubagentStop can be called from within a Stop hook context — processing in that condition causes infinite loops.
+
+#### Three-Case Failure Handling
+
+Every SubagentStop produces either a `delegation.complete` or `delegation.fail` event. No subagent completion is silently dropped. The capture hook handles three cases:
+
+**Transcript present and parseable** — The hook reads the transcript at `agent_transcript_path`, extracts the result, and writes an artifact file to the current step's directory under `.gobbi/sessions/{session-id}/{step}/`. It then appends a `delegation.complete` event to `gobbi.db` with the artifact path as data. The `parent_seq` field references the `delegation.spawn` event that initiated this subagent.
+
+**Transcript present but unparseable** — The transcript file exists but the hook cannot extract a structured result from it — malformed content, unexpected format, or extraction logic failure. The hook writes a `delegation.fail` event with the transcript path included as context in the event data, so the operator can inspect the raw transcript. A failure marker artifact (`delegation-fail-r{N}.md`) is written to the step directory.
+
+**Transcript absent** — The transcript file at `agent_transcript_path` does not exist. The subagent may have crashed before producing output, or the path may be stale. The hook writes a `delegation.fail` event with reason "transcript not found" in the event data. A failure marker artifact is written to the step directory.
+
+This defensive approach follows ETL pipeline patterns: every input produces an output record, even if that record is a failure. Silent drops in pipelines cause state inconsistencies that are difficult to diagnose.
+
+#### Artifact Filename Construction
+
+The capture hook reads `feedbackRound` from `state.json` to construct artifact filenames with a round suffix. First-pass artifacts use `r1` (e.g., `execution-r1.md`). After a feedback loop, the next round uses `r2` (e.g., `execution-r2.md`). Failed rounds get a failure marker: `delegation-fail-r2.md`. Cross-reference `v050-session.md` for the full naming scheme and how the CLI's prompt compilation selects the latest round.
+
+#### Cost and Token Capture
+
+When extracting from the transcript, the capture hook captures token usage data if present in the hook payload or transcript — billed tokens (cache-adjusted, not raw), and cache hit ratio. These are included as optional fields on the `delegation.complete` event's data payload. If token data is not available, the hook falls back to transcript file size as a rough proxy and records that instead.
+
+Cost data surfaces via `gobbi workflow status` only — it must NOT appear in compiled prompts or guard conditions. This is a visibility feature for the operator, not a control mechanism. Data availability depends on the Claude Code API — this is a precondition to verify during implementation before designing the full schema. Cross-reference `v050-session.md` for the `delegation.complete` event's cost field definitions.
+
+#### Idempotency
+
+All events written by the SubagentStop hook — `delegation.complete` and `delegation.fail` — include the `idempotency_key` field per the schema in `v050-session.md`. This prevents duplicate events if Claude Code retries the hook.
 
 Output length cap applies. Transcripts can be large. The hook writes results to the artifact file, not to stdout. The stdout response is kept minimal — only the event confirmation.
 
@@ -122,7 +126,7 @@ PostToolUse fires after a tool call completes. The hook is registered specifical
 
 1. Reads `tool_input` from the stdin payload to extract the plan content
 2. Writes the plan as an artifact to `.gobbi/sessions/{session-id}/plan/`
-3. Appends an `artifact.write` event to `gobbi.db`
+3. Appends an `artifact.write` event to `gobbi.db` with `idempotency_key`
 
 This removes the requirement for the orchestrator to explicitly save the plan. The capture is automatic — the orchestrator uses ExitPlanMode as normal and the hook handles persistence.
 
@@ -130,11 +134,31 @@ PostToolUse does not use `permissionDecision` — it cannot block. If the hook f
 
 ### Stop Hook
 
-The Stop hook fires after each turn of the conversation ends. Its primary responsibility in v0.5.0 is flushing any pending state changes that have not yet been persisted — for example, if a state update was computed but not written due to a mid-turn crash, the Stop hook ensures it is applied.
+> **The Stop hook is the continuous observer — heartbeat, timeout detection, and state flush on every turn.**
 
-`stop_hook_active` in the stdin payload must be checked at the start of every Stop hook. If true, the hook exits immediately with a zero exit code and empty output. Claude Code sets `stop_hook_active` when a Stop hook triggers another Stop hook — the reentrance guard prevents cascading. Omitting this check causes infinite loops that stall the session.
+The Stop hook fires after each turn of the conversation ends. It has three responsibilities in v0.5.0:
 
-The Stop hook is a safety net, not the primary persistence mechanism. Events are written to `gobbi.db` during the turn as they occur. The Stop hook only handles the case where a turn ended with pending state that was not flushed inline.
+**Heartbeat writing** — On each firing, the Stop hook writes a `session.heartbeat` event with the current timestamp to `gobbi.db`. This event includes `idempotency_key`. The heartbeat enables abandoned session detection: sessions without a heartbeat for 60 minutes are treated as abandoned, which releases the `.claude/` write guard. Cross-reference `v050-session.md` for the heartbeat event type and the abandoned session threshold.
+
+**Timeout detection** — On each firing, the Stop hook checks elapsed time since the current step's `workflow.step.enter` event. If elapsed time exceeds the step's configured timeout (from the step spec `meta` section), the hook writes a `workflow.step.timeout` event with `idempotency_key`. This event triggers transition to `error` state per the transition table in `v050-state-machine.md`. Default timeouts are generous — 30 minutes for execution steps, 15 minutes for evaluation steps — because human interaction is expected during most steps. Timeout configuration lives in step spec `meta`; cross-reference `v050-prompts.md` for step spec structure.
+
+**State flush** — If any state changes computed during the turn were not yet persisted, the Stop hook ensures they are applied. This is a safety net — events are written to `gobbi.db` during the turn as they occur, and the Stop hook only handles the case where a turn ended with pending state that was not flushed inline.
+
+`stop_hook_active` in the stdin payload must be checked at the start of every Stop hook invocation. If true, the hook exits immediately with a zero exit code and empty output. Claude Code sets `stop_hook_active` when a Stop hook triggers another Stop hook — the reentrance guard prevents cascading. Omitting this check causes infinite loops that stall the session.
+
+---
+
+## Verification Command Integration
+
+> **Mechanical verification after each subtask completion catches regressions before they compound.**
+
+After each subtask completes and the SubagentStop hook captures the result, verification commands can run against the codebase. Verification commands are project-configurable — lint, test, typecheck, or any command the project defines in `.gobbi/` project config.
+
+Verification results are recorded as events in the event store with `idempotency_key`. A passing verification is informational. A failing verification records the failure context — which command failed, the output — so the CLI can include it in the next compiled prompt. This gives the orchestrator or the next subagent concrete error context rather than requiring re-discovery.
+
+Verification commands are not guards — they do not block the SubagentStop capture. The capture always completes first (writing the `delegation.complete` or `delegation.fail` event), and verification runs afterward. This ordering ensures the subagent's output is never lost even if verification itself fails or times out.
+
+Cross-reference `v050-prompts.md` for how verification result blocks appear in step specs and how the CLI includes failure context in the next delegation prompt.
 
 ---
 
@@ -152,9 +176,11 @@ The delegation pattern for each hook type:
 | PreToolUse | `gobbi workflow guard` |
 | SubagentStop | `gobbi workflow capture-subagent` |
 | PostToolUse (ExitPlanMode) | `gobbi workflow capture-plan` |
-| Stop | `gobbi workflow flush-state` |
+| Stop | `gobbi workflow stop` |
 
 Each CLI command reads the full stdin payload, evaluates against the current session state, writes any necessary events, and returns the appropriate JSON response that the hook forwards to stdout. The hook process exits 0 in all cases except unrecoverable startup failures.
+
+The Stop hook now delegates to `gobbi workflow stop` (renamed from `flush-state`) because its responsibilities expanded beyond state flushing to include heartbeat writing and timeout detection.
 
 The SessionStart hook receives a fixed stdin schema:
 
@@ -175,11 +201,11 @@ This means the hooks registered in `hooks/hooks.json` are stable across releases
 
 V0.5.0 implements two enforcement levels that reflect different violation severities.
 
-**Soft nudge** — For edge cases that are unusual but not structurally invalid, the PreToolUse hook returns a response that includes `additionalContext` rather than a denial. The tool call proceeds. The orchestrator receives the additional context and can adjust its behavior. This is appropriate when the action is technically within scope but warrants attention — for example, writing to a step directory that does not match the currently active step.
+**Soft nudge** — For edge cases that are unusual but not structurally invalid, the PreToolUse hook returns a response that includes `additionalContext` rather than a denial. The tool call proceeds. The orchestrator receives the additional context and can adjust its behavior. This is appropriate when the action is technically within scope but warrants attention — for example, writing to a step directory that does not match the currently active step, or when the secret pattern guard detects a potential credential in a Write call.
 
-**Hard block** — For structural violations, the hook returns `permissionDecision: "deny"`. The tool does not execute. A `guard.violation` event is written to `gobbi.db`. The `violations` array in `state.json` is updated. The orchestrator receives the denial and the reason.
+**Hard block** — For structural violations, the hook returns `permissionDecision: "deny"`. The tool does not execute. A `guard.violation` event is written to `gobbi.db` with `idempotency_key`. The `violations` array in `state.json` is updated. The orchestrator receives the denial and the reason.
 
-**Escalation on repeat violations** — The `violations` array in `state.json` tracks every `guard.violation` event. The CLI reads the violation count for a specific guard when generating the next prompt. If the same guard has fired more than a configurable threshold (default 3 times), the CLI escalates — it surfaces a warning to the user via the generated prompt, noting that the orchestrator is repeatedly attempting a blocked action. This is a stagnation signal: the orchestrator is stuck, and human intervention may be needed to resolve the underlying confusion.
+**Escalation on repeat triggers** — The `violations` array in `state.json` tracks both `guard.violation` events (from deny guards) and `guard.warn` events (from warn guards). The CLI reads the trigger count for a specific guard when generating the next prompt. If the same guard has fired more than a configurable threshold (default 3 times), the CLI escalates — it surfaces a warning to the user via the generated prompt. For deny guards, this means the orchestrator is repeatedly attempting a blocked action. For warn guards like the secret pattern detector, this means the orchestrator is repeatedly writing content that triggers the warning. Both are stagnation signals that may require human intervention.
 
 ---
 
@@ -199,12 +225,12 @@ Profile support is planned for v0.5.1 and later. V0.5.0 does not implement enfor
 
 Claude Code v2.1 and later auto-load `hooks/hooks.json` from the plugin directory. Declaring the same hooks in `plugin.json` causes duplicate detection errors at plugin load time. The hook manifest lives in one place — `hooks/hooks.json`. The `plugin.json` manifest does not contain a `hooks` key.
 
-The timeout for command hooks is 600 seconds by default. Guard checks complete in milliseconds — they read `state.json` and evaluate JsonLogic conditions. Capture hooks may take longer if they process large transcripts, but should complete well within the timeout. A hook that approaches the timeout indicates a design problem — the heavy work should be offloaded to an async queue rather than blocking the hook execution path.
+The timeout for command hooks is 600 seconds by default. Guard checks complete in milliseconds — they read `state.json` and evaluate predicate conditions. Capture hooks may take longer if they process large transcripts, but should complete well within the timeout. A hook that approaches the timeout indicates a design problem — the heavy work should be offloaded to an async queue rather than blocking the hook execution path.
 
 ---
 
 ## Boundaries
 
-This document covers the two hook categories and their responsibilities, guard hook mechanics (stdin schema, denial mechanism, input modification, specific guard behaviors), capture hook mechanics (SubagentStop, PostToolUse, Stop), hook-to-CLI delegation, escalating enforcement levels, and plugin hook registration.
+This document covers the two hook categories and their responsibilities, guard hook mechanics (stdin schema, denial mechanism, input modification, specific guard behaviors, secret pattern detection), capture hook mechanics (SubagentStop with three-case failure handling and cost capture, PostToolUse, Stop with heartbeat and timeout detection), verification command integration, hook-to-CLI delegation, escalating enforcement levels, and plugin hook registration.
 
-For the JsonLogic condition language and guard specification format, see `v050-state-machine.md`. For the event types that hooks write and the `state.json` fields they update, see `v050-session.md`. For the CLI commands that hooks delegate to, see `v050-cli.md`.
+For the predicate registry and guard specification format, see `v050-state-machine.md`. For the event types that hooks write and the `state.json` fields they update, see `v050-session.md`. For the CLI commands that hooks delegate to and step spec structure, see `v050-cli.md` and `v050-prompts.md`.

--- a/.claude/project/gobbi/design/v050-overview.md
+++ b/.claude/project/gobbi/design/v050-overview.md
@@ -212,7 +212,7 @@ This document covers architecture, philosophy, and positioning. It does not cove
 | Document | Covers |
 |----------|--------|
 | `v050-session.md` | Session directory, SQLite event store, state derivation, crash recovery |
-| `v050-state-machine.md` | Workflow transitions, typed reducer, guards, JsonLogic conditions |
+| `v050-state-machine.md` | Workflow transitions, typed reducer, guards, predicate registry |
 | `v050-prompts.md` | Prompt compilation, cache ordering, skills boundary, step specs |
 | `v050-hooks.md` | PreToolUse guards, SubagentStop capture, hook schemas, enforcement |
 | `v050-cli.md` | Bun CLI rewrite, commands, distribution, plugin relationship |

--- a/.claude/project/gobbi/design/v050-prompts.md
+++ b/.claude/project/gobbi/design/v050-prompts.md
@@ -148,7 +148,17 @@ Artifacts written by subagents to their step directories are available to the CL
 
 Each model variant has a fixed context window. The CLI knows the model configured for the session (from `metadata.json`) and computes the available budget before assembling the prompt. Budget is allocated across sections in priority order: static prefix first (it must be complete to preserve cache stability), then gotchas (safety guards must never be truncated), then step instructions, then inlined artifacts, then supplementary materials.
 
-When the available budget is smaller than the sum of all sections, the CLI truncates artifact content at section boundaries. An artifact is included in full or excluded entirely — it is never truncated mid-document. This produces a prompt that is complete and coherent rather than one that ends mid-sentence because the window ran out.
+### Section Minimums
+
+Each prompt section has a minimum token allocation — the floor that section receives regardless of budget pressure. The static prefix must be complete to preserve cache stability. Gotchas must be complete because they are safety guards. Step instructions must be complete because a partial instruction is worse than no instruction.
+
+If the sum of all section minimums exceeds the model's context window, the CLI emits an error rather than silently truncating. The error is descriptive: it identifies which sections' minimums contribute to the overflow and by how many tokens the total exceeds the budget. This makes the problem diagnosable — the operator knows whether the overflow comes from an oversized static prefix, too many gotchas, or step instructions that grew beyond what the model can hold.
+
+Sections whose content exceeds their minimum are subject to the priority-based truncation described below. The minimum guarantees a floor; the priority determines how remaining budget is distributed above that floor.
+
+### Priority-Based Truncation
+
+When the available budget is smaller than the sum of all sections, the CLI truncates at section boundaries. An artifact is included in full or excluded entirely — it is never truncated mid-document. This produces a prompt that is complete and coherent rather than one that ends mid-sentence because the window ran out.
 
 The allocation proportions are configurable per step type. Evaluation steps allocate more budget to inlined execution artifacts. Delegation steps allocate more budget to the delegation block. The defaults are encoded in the `tokenBudget` section of each step's spec.
 
@@ -166,7 +176,7 @@ Each `spec.json` contains five top-level sections:
 
 **`meta`** — Step-level metadata: a short description, the list of valid substates (if any), allowed agent types, maximum parallel agent count, required and optional skills to inject, expected artifacts from this step, and the completion signal the CLI watches for.
 
-**`transitions`** — The valid exit transitions from this step. For steps where the exit depends on runtime conditions (such as whether evaluation is enabled), transition entries may carry JsonLogic conditions. The CLI evaluates these conditions in TypeScript against `state.json`; the spec only declares what the possible transitions are and under what conditions each is taken.
+**`transitions`** — The valid exit transitions from this step. Each transition entry carries a `condition` field that names a predicate from the CLI's predicate registry — a string like `"evalEnabled.ideation"` or `"feedbackCapReached"`, not inline logic. The spec declares what the possible transitions are and which predicate governs each; the CLI resolves predicate names to TypeScript functions at compilation time. `gobbi workflow validate` checks that every predicate name referenced in any spec's `transitions` section exists in the registry. See `v050-state-machine.md` for the full predicate registry model.
 
 **`delegation`** — The agent topology for this step: each agent's role, stance, model tier, effort level, which skills to inject, the artifact target it should write to, and a reference to the block in `blocks.delegation` that contains its prompt content.
 
@@ -181,6 +191,24 @@ Each `spec.json` contains five top-level sections:
 | `delegation` | Per-agent delegation prompt content, keyed by the agent reference in `delegation` |
 | `synthesis` | Post-delegation synthesis instructions for the orchestrator |
 | `completion` | The completion instruction and a human-readable criteria list |
+
+### Plan Step: Task-Size Validation
+
+The Plan step spec includes a validation phase after the plan artifact is written. The CLI estimates the token budget of each task's delegation prompt based on three inputs: the task description length, the artifacts the delegation prompt would reference, and the skill materials that would be injected. If a task's estimated delegation prompt exceeds the model's context budget, the CLI injects a warning into the compiled prompt for the orchestrator.
+
+The warning is informational, not a hard block. The orchestrator sees which tasks are flagged and by how much they exceed the budget, then decides how to respond — typically by decomposing the oversized task into smaller subtasks. This follows the GSD-2 principle: a task must fit in one context window; if it cannot, it is two tasks. The warning gives the orchestrator the data to apply that principle without the CLI making the decomposition decision.
+
+The task-size validation predicate that powers this check is defined in the CLI's predicate registry. See `v050-state-machine.md` for the predicate definition and its typed signature.
+
+### Execution Step: Verification Blocks
+
+Execution step specs can include a `verification` block that specifies commands the CLI should run after each subtask completes. Verification commands are project-configurable — projects specify their lint, test, and typecheck commands in `.gobbi/` config, and the execution step spec references them.
+
+When a subtask's delegation completes, the CLI runs the configured verification commands before proceeding to the next subtask. Verification results are recorded as events in the event store — the event captures which commands ran, their exit codes, and a summary of any failures. This makes verification history available to all downstream compilation: crash recovery briefings, evaluation context, and status reporting.
+
+If verification fails, the execution step's compiled prompt for the next invocation includes the failure context. The orchestrator receives the failing command output and can decide whether to re-execute the subtask, adjust the approach, or flag the failure for user attention. Verification failure does not automatically trigger re-execution — it provides the information; the orchestrator decides the action.
+
+See `v050-hooks.md` for how hooks trigger verification command execution after SubagentStop events.
 
 ### Workflow Graph
 
@@ -206,8 +234,28 @@ The spec model provides four concrete benefits. Guards (`gobbi workflow validate
 
 ---
 
+## Resume Prompt Compilation
+
+> **A resume prompt replaces the normal step prompt. It includes everything a fresh orchestrator needs to understand the session state.**
+
+When `gobbi workflow resume` is invoked, the CLI does not generate a normal step prompt. It compiles a pathway-specific resume prompt based on how the session reached its current state. The resume prompt uses the same three-section structure (static prefix, session section, dynamic section) and the same cache-aware ordering — the difference is in the dynamic section's content, which is tailored to the recovery pathway.
+
+Four pathways produce four different resume prompts. See `v050-session.md` for the pathway definitions and recovery options.
+
+**Normal mid-step crash** — The workflow was active when the process terminated. The resume prompt includes the last active step, the most recent events leading up to the crash, and the artifacts available in the step directory. The CLI uses filename versioning to identify the latest round's artifacts. The orchestrator receives enough context to continue from where the step was interrupted.
+
+**Error from step timeout** — A step exceeded its configured timeout. The resume prompt includes which step timed out, the elapsed time, and the artifacts that were in progress at timeout. Three recovery options: retry the step with fresh context, force-advance to memorization, or abort.
+
+**Error from feedback round cap** — The evaluation loop exceeded `maxFeedbackRounds`. The resume prompt includes the evaluation history across rounds — each round's verdict and the pattern of findings — plus partial artifacts from the final round. The orchestrator sees why the loop did not converge, which informs whether force-memorization is appropriate.
+
+**Error from invalid transition** — The reducer rejected an event. The resume prompt includes the rejected event details, the reducer error message, and the state at rejection time. This pathway is rare — it indicates a structural problem rather than a workflow problem.
+
+The resume prompt replaces the normal step prompt entirely. It is not appended to or merged with a step prompt. The orchestrator that receives a resume prompt is oriented to the recovery situation, not to normal step execution. Context compaction uses the same compilation pipeline — compact is not crash recovery, but the rebuild path is shared.
+
+---
+
 ## Boundaries
 
-This document covers the prompt compilation model, cache-aware section ordering, the skills boundary between CLI-owned step specs and surviving domain skills, stances as CLI-managed configuration, fresh context isolation per subagent task, token budget allocation, and the step spec model including the spec schema, workflow graph, shared blocks, substate overlays, and schema versioning.
+This document covers the prompt compilation model, cache-aware section ordering, the skills boundary between CLI-owned step specs and surviving domain skills, stances as CLI-managed configuration, fresh context isolation per subagent task, token budget allocation with section minimums, the step spec model including the spec schema, task-size validation, verification blocks, workflow graph, shared blocks, substate overlays, schema versioning, and resume prompt compilation for crash recovery pathways.
 
-For how state transitions determine which step is active, see `v050-state-machine.md`. For how hooks write events that the CLI reads to derive state, see `v050-hooks.md`. For the session artifacts that prompts consume, see `v050-session.md`. For CLI command syntax and distribution, see `v050-cli.md`.
+For how state transitions determine which step is active and the predicate registry model, see `v050-state-machine.md`. For how hooks write events that the CLI reads to derive state and trigger verification, see `v050-hooks.md`. For the session artifacts that prompts consume and crash recovery pathway definitions, see `v050-session.md`. For CLI command syntax and distribution, see `v050-cli.md`.

--- a/.claude/project/gobbi/design/v050-session.md
+++ b/.claude/project/gobbi/design/v050-session.md
@@ -48,6 +48,12 @@ Each file and directory has a single responsibility. `metadata.json` and `gobbi.
 
 **Step directories** (`ideation/`, `plan/`, `execution/`, `evaluation/`, `memorization/`) are flat directories for step artifacts. An ideation step stores its output notes here; an execution step stores subtask results here. Flat structure is deliberate — no nesting, no hierarchy inside step directories.
 
+### Artifact Filename Versioning
+
+When feedback loops send the workflow back to a prior step, artifacts from each round are preserved through filename-based versioning. Artifact filenames include a round suffix: `execution-r1.md`, `execution-r2.md` for successive feedback rounds. Failed rounds — where a SubagentStop reports failure — get a failure marker: `delegation-fail-r2.md`. This is filename-based versioning, not subdirectory-based. The flat-directory principle is preserved: no `round-1/` or `round-2/` subdirectories exist inside step directories.
+
+The SubagentStop capture hook reads `feedbackRound` from `state.json` to construct the filename suffix using `feedbackRound + 1` as the round number. A round suffix of `r1` means the first pass (`feedbackRound == 0`); `r2` means the first feedback round produced a revision (`feedbackRound == 1`). The CLI's prompt compilation loads the latest round's artifacts — the highest round number — when assembling step context. Earlier rounds remain on disk for audit and for crash recovery briefings but are not included in active prompts.
+
 ---
 
 ## SQLite Event Store
@@ -70,12 +76,15 @@ The events table has one row per event. Its columns are:
 | `data` | text (JSON) | Event-specific payload — structure varies by type |
 | `actor` | text | What produced the event: `cli`, `hook`, `subagent` |
 | `parent_seq` | integer, nullable | References the `seq` of a parent event |
+| `idempotency_key` | text, unique | Deduplication key — see formula below |
 
-Two indexes cover the common access patterns: one on `type` for queries that filter across the full event history by event category, and one on `(step, type)` for queries scoped to a particular workflow step.
+The `idempotency_key` column prevents duplicate events from hook retries. Two formulas cover the two event categories. Tool-call events (guard violations, delegation events) use `session_id + tool_call_id + event_type` — the tool call ID uniquely identifies the action. System events (heartbeat, timeout) have no tool call context, so they use `session_id + timestamp_ms + event_type` — millisecond timestamps are sufficient because the Stop hook fires at most once per conversation turn. A UNIQUE constraint on this column means a retry that produces the same event is silently deduplicated at the storage layer. This is defensive engineering — even if Claude Code hooks do not retry today, future behavior may change. The pattern follows Kafka and EventBridge deduplication semantics: exactly-once append regardless of delivery guarantees.
+
+Three indexes cover the common access patterns: one on `type` for queries that filter across the full event history by event category, one on `(step, type)` for queries scoped to a particular workflow step, and the implicit unique index on `idempotency_key` for deduplication.
 
 ### Event Type Enum
 
-Events are grouped into five categories that reflect the five things that can happen in a session.
+Events are grouped into six categories that reflect the things that can happen in a session.
 
 **Workflow** events track the high-level session progression:
 
@@ -93,8 +102,12 @@ Events are grouped into five categories that reflect the five things that can ha
 | Event | Meaning |
 |-------|---------|
 | `delegation.spawn` | A subagent was launched |
-| `delegation.complete` | A subagent completed and its output was captured |
+| `delegation.complete` | A subagent completed and its output was captured — optional cost fields in data |
 | `delegation.fail` | A subagent failed or was interrupted |
+
+The `delegation.complete` event carries optional cost fields in its `data` payload: `tokensUsed` (billed, cache-adjusted — not raw tokens) and `cacheHitRatio`. These fields are optional because their availability depends on whether the Claude Code API exposes token data in the SubagentStop hook payload. If token data is unavailable, the CLI falls back to transcript file size as a rough proxy and records that in the `data` payload instead. First sessions (cold cache) and subsequent sessions (warm cache) produce different token counts — tracking billed tokens rather than raw tokens captures this difference.
+
+Cost data surfaces via `gobbi workflow status` only. It must NOT appear in compiled prompts or guard conditions. This is a visibility feature, not a control mechanism — cost data informs the operator but does not alter workflow behavior.
 
 **Artifact** events track writes to the step directories:
 
@@ -117,6 +130,12 @@ Events are grouped into five categories that reflect the five things that can ha
 |-------|---------|
 | `guard.violation` | A PreToolUse hook blocked a disallowed tool call |
 | `guard.override` | A user explicitly overrode a guard |
+
+**Session** events track liveness:
+
+| Event | Meaning |
+|-------|---------|
+| `session.heartbeat` | Liveness signal — written by the Stop hook after each turn |
 
 ---
 
@@ -153,19 +172,37 @@ SQLite with WAL mode provides atomic write semantics: a write either completes f
 
 `state.json.backup` handles state-file corruption without full replay. Before each state transition, the current `state.json` is copied to `state.json.backup`. If `state.json` is found to be invalid on startup, the CLI falls back to `state.json.backup`. If both are invalid, the CLI replays `gobbi.db`.
 
-`gobbi workflow resume` is the user-facing recovery command. It reads `gobbi.db`, derives current state via the reducer, and asks the CLI to generate a resume prompt that re-orients the orchestrator to the current step and what has been completed. This is the same mechanism used after context compaction — compact is not crash recovery, but it uses the same rebuild path.
+### Resume Briefing with Pathway Differentiation
+
+`gobbi workflow resume` synthesizes a pathway-specific briefing from the event store. The briefing content differs based on how the workflow arrived at its current state, because different causes require different recovery actions.
+
+**Normal mid-step crash** — The workflow was in an active step when the process terminated. The briefing includes the last active step, the most recent events leading up to the crash, and the artifacts available in the step directory (using filename versioning to identify the latest round). Recovery options: retry the step from where it left off, or force-advance to memorization.
+
+**Error state from step timeout** — A step exceeded its configured timeout and the Stop hook wrote a `workflow.step.timeout` event. The briefing includes which step timed out, the elapsed time at timeout, and what artifacts were in progress. Recovery options: retry the step with a fresh context, force-advance to memorization, or abort.
+
+**Error state from feedback round cap** — The `feedbackRound` exceeded `maxFeedbackRounds` and the evaluation loop transitioned to `error`. The briefing includes the evaluation history across rounds — each round's verdict and findings — and the partial artifacts from the final round. Recovery options: force memorization to save partial work (`gobbi workflow resume --force-memorization`), or abort.
+
+**Error state from invalid transition** — The reducer rejected an event because the transition was not valid from the current state. The briefing includes the rejected event, the reducer error message, and the state at the time of rejection. Recovery options: retry from the last valid state, or abort.
+
+Each pathway's briefing is compiled into the resume prompt by the CLI. This is the same mechanism used after context compaction — compact is not crash recovery, but it uses the same rebuild path. The pathway determines what context is included, but the compilation pipeline is shared.
 
 ---
 
 ## Schema Versioning
 
-Every persisted JSON file includes a `schemaVersion` integer field at the top level. The events table includes a `schema_version` column on each row.
+> **Events are stored in their original schema version and never rewritten. Migrations are applied at read time, not write time.**
 
-The CLI reads `schemaVersion` when loading any JSON file. If the version is older than the current schema, a migration function is applied before the data is used. This pattern is already established in the codebase in `config.ts`'s `migrateIfNeeded` function — v0.5.0 extends it to session files.
+Every persisted JSON file includes a `schemaVersion` integer field at the top level. The events table includes a `schema_version` column on each row — this records the schema version at the time the event was written, and it is never updated.
 
-Migration functions are pure transformations: given a versioned JSON object, return the current-schema equivalent. They are keyed by version number and composed in sequence for multi-version upgrades. A session created at schema version 1 upgraded to a codebase at schema version 3 applies migrations 1→2 and 2→3 in order.
+Events are immutable once written. When the schema evolves, existing events stay in their original format on disk. Migration happens at read time: during reducer replay, each event passes through a migration pipeline keyed by its `schema_version` before the reducer processes it. The reducer always sees events in the current schema format, but the storage layer preserves originals. This is a lazy migration pattern — only the events that are actually replayed are migrated, and only in memory.
 
-The schema version is incremented whenever a breaking change is made to the event table schema, the `state.json` shape, or the `metadata.json` shape. Additive changes that preserve backward compatibility do not require a version increment.
+This design makes corrupted migrations recoverable. If a migration function has a bug, the original events are untouched — fix the migration, replay again, and the correct state emerges. A write-time migration that rewrites events in place would make the original data irrecoverable if the migration is wrong. The pattern follows Greg Young's event sourcing recommendation and EventStoreDB's approach to schema evolution.
+
+Migration functions are pure transformations: given a versioned event, return the current-schema equivalent. They are keyed by version number and composed in sequence for multi-version upgrades. An event written at schema version 1 replayed in a codebase at schema version 3 applies migrations 1→2 and 2→3 in order. This pipeline is already established in the codebase in `config.ts`'s `migrateIfNeeded` function — v0.5.0 extends the same pattern to event replay.
+
+For `state.json` and `metadata.json`, the same lazy approach applies: the CLI reads `schemaVersion` when loading either file and applies migration in memory before use, without rewriting the file on disk.
+
+The schema version is incremented whenever a breaking change is made to the event schema, the `state.json` shape, or the `metadata.json` shape. Additive changes that preserve backward compatibility do not require a version increment.
 
 ---
 
@@ -179,7 +216,7 @@ The schema version is incremented whenever a breaking change is made to the even
 
 **Session end** — The session ends when the user runs `/clear` or opens a new conversation. There is no explicit cleanup event — the session directory remains on disk until the TTL cleanup runs.
 
-**Abandoned session detection** — When `gobbi workflow init` runs, it checks all existing session directories for sessions without a `workflow.finish` event. If a session has been inactive for more than 24 hours — meaning no events have been appended in the last 24 hours — it is marked as abandoned. The `.claude/` write guard checks session freshness before blocking writes: if the session's last event is older than 24 hours and no `workflow.finish` event exists, the guard treats the session as expired and allows `.claude/` writes to proceed. This prevents abandoned sessions from permanently blocking the `.claude/` write protection. A session that was interrupted by a crash or a user closing their terminal without clearing will not hold the write guard indefinitely.
+**Abandoned session detection** — The Stop hook (which fires after each turn) writes a `session.heartbeat` event with a timestamp to `gobbi.db`. When `gobbi workflow init` runs, it checks all existing session directories for sessions without a `workflow.finish` event. If a session has no heartbeat within the last 60 minutes, it is treated as abandoned. The `.claude/` write guard checks heartbeat freshness before blocking writes: if the most recent `session.heartbeat` is older than 60 minutes and no `workflow.finish` event exists, the guard treats the session as expired and allows `.claude/` writes to proceed. This prevents abandoned sessions from permanently blocking the `.claude/` write protection. A session that was interrupted by a crash or a user closing their terminal without clearing will not hold the write guard indefinitely. The 1-hour threshold replaces a 24-hour threshold — stale sessions should release the write guard quickly, not hold it for an entire day.
 
 **Cleanup** — A background cleanup process removes sessions older than 7 days and enforces a maximum entry cap (default 50 sessions). Cleanup targets the oldest sessions first when the cap is exceeded. The cleanup configuration is stored in the user's gobbi config and can be adjusted.
 

--- a/.claude/project/gobbi/design/v050-state-machine.md
+++ b/.claude/project/gobbi/design/v050-state-machine.md
@@ -14,7 +14,7 @@ The five steps map directly to the workflow defined in `v050-overview.md`. Two s
 └─────────────────────────────────────────────────────────────────────┘
 
          ┌──────────┐
-         │   idle   │
+         │   idle   │◀─────────────────── workflow.abort (from error)
          └────┬─────┘
               │  workflow.start
               ▼
@@ -59,6 +59,11 @@ The five steps map directly to the workflow defined in `v050-overview.md`. Two s
          ┌─────▼────┐
          │   done   │
          └──────────┘
+
+                              ┌──────────┐
+          any ──────────────▶ │  error   │ ──── workflow.resume → prior step
+          (timeout, cap,      └──────────┘      workflow.abort  → done
+           invalid transition)
 ```
 
 **Ideation** has two internal substates: `discussing` and `researching`. `discussing` is the orchestrator-user conversation where the approach is shaped. `researching` is where researcher agents investigate how to realize the approach. These loop — more discussion can follow research, and research can be re-run after discussion refines the question. The CLI tracks the active substate via `currentSubstate` in `state.json`. Ideation exits when the approach is concrete enough to plan against, which is a convergence signal the orchestrator emits as an artifact.
@@ -93,10 +98,31 @@ Every valid transition in the state machine. Transitions not in this table are i
 | `execution_eval` | `ideation` | `decision.eval.verdict` (revise) | Loop target is ideation |
 | `execution_eval` | `plan` | `decision.eval.verdict` (revise) | Loop target is plan |
 | `execution_eval` | `execution` | `decision.eval.verdict` (revise) | Loop target is execution |
+| `execution_eval` | `error` | `decision.eval.verdict` (revise) | `feedbackRound >= maxFeedbackRounds` |
 | `memorization` | `done` | `workflow.finish` | Memorization artifact written |
-| any | `ideation` | `workflow.step.skip` | User explicitly skips forward |
+| `any` | `error` | `workflow.step.timeout` | Step elapsed time exceeds configured timeout |
+| `any` | `error` | (reducer) | Reducer rejects an invalid transition |
+| `any` | `ideation` | `workflow.step.skip` | User explicitly skips forward |
+| `error` | `done` | `workflow.abort` | User aborts the workflow |
+| `error` | (prior step) | `workflow.resume` | User resumes from last valid state |
+
+**Priority rule:** `any` → `error` has HIGHER priority than `any` → `ideation` (skip). Error takes precedence over skip.
+
+**Terminal state rule:** `done` accepts no events. A `workflow.resume` from `done` is rejected by the reducer — the workflow must start a new session. This is enforced by the exhaustiveness check: the `done` case handles no event types.
 
 The `loopFrom` field on the `workflow.step.enter` event records which evaluation step triggered the loop. This is what distinguishes a fresh Ideation entry (first time) from a loop-back Ideation entry (triggered by `execution_eval`).
+
+### Skip Semantics
+
+The `workflow.step.skip` transition allows the user to jump the workflow forward to Ideation from any step. Skip has specific behaviors for edge cases:
+
+**In-flight subagents** — SubagentStop hooks continue firing for any active subagents. Their `delegation.complete` events are applied to state normally — artifacts are preserved. Skip does not cancel or discard subagent work.
+
+**Artifact preservation** — Artifacts from the skipped step remain in the step directory. They are not deleted or overwritten. The new Ideation entry starts with a clean ideation directory but prior step directories retain their content.
+
+**No `loopFrom`** — Skip does not set a `loopFrom` field on the resulting `workflow.step.enter` event. Skip is user-initiated navigation, not evaluation-triggered feedback. The CLI uses the absence of `loopFrom` to distinguish skip entries from loop-back entries.
+
+**Self-skip guard** — Skip from `ideation` to `ideation` is a no-op. The reducer rejects the transition because the target is the current step. Skip from `ideation_eval` or `plan_eval` to `ideation` is valid — it abandons the evaluation and restarts ideation.
 
 ---
 
@@ -106,7 +132,7 @@ The `loopFrom` field on the `workflow.step.enter` event records which evaluation
 
 The reducer takes the current state and one event, and returns the next state. It is pure — no side effects, no external reads. Replaying all events in sequence order produces the same state as reading `state.json`. When `state.json` is absent or invalid, the CLI replays `gobbi.db` through the reducer to rebuild it.
 
-The reducer is structured as a discriminated union switch: the `type` field of the event is the discriminant, and each case handles one event type. The switch has a default branch that assigns to a `never`-typed variable. This TypeScript exhaustiveness pattern means the compiler reports a type error if a new event type is added to the enum without a corresponding reducer case — no event type can be silently ignored.
+The reducer is structured as a discriminated union switch: the `type` field of the event is the discriminant, and each case handles one event type. The switch has a default branch that assigns to a `never`-typed variable. This TypeScript exhaustiveness pattern means the compiler reports a type error if a new event type is added to the enum without a corresponding reducer case — no event type can be silently ignored. The `error` state is a variant in this discriminated union — its valid events and transitions are handled by the same exhaustiveness mechanism as all other states.
 
 The reducer validates transitions as a side effect of processing events. Before applying a `workflow.step.enter` event, the reducer checks that the target step is reachable from the current step given current state. If the transition is invalid, the reducer returns an error result rather than a new state. This means the reducer and transition table are the same system expressed in two forms — the table is documentation, the reducer is enforcement.
 
@@ -117,6 +143,7 @@ Key state fields the reducer maintains:
 - `completedSteps` — appended on each `workflow.step.exit`
 - `evalConfig` — set once on `workflow.eval.decide`, never overwritten
 - `feedbackRound` — incremented each time execution_eval loops back to a prior step
+- `maxFeedbackRounds` — configurable cap (default 3), set at workflow start
 - `activeSubagents` — added on `delegation.spawn`, removed on `delegation.complete` or `delegation.fail`
 - `violations` — appended on each `guard.violation`
 
@@ -146,15 +173,25 @@ The `execution_eval` step has no guard condition — it is always entered after 
 
 When `execution_eval` produces a revise verdict, the evaluator specifies a loop target: `ideation`, `plan`, or `execution`. The `workflow.step.enter` event that initiates the loop carries a `loopFrom` field in its `data` payload identifying which evaluation step triggered it. This field is how the CLI distinguishes a loop-back step entry from a first-time entry, which affects the prompt it generates — a loop-back prompt includes the evaluation findings as context.
 
-The `feedbackRound` counter in state tracks how many loop-backs have occurred in this session. It increments each time `execution_eval` routes to a prior step rather than `memorization`. A high `feedbackRound` value is a stagnation signal — the CLI can surface it as a warning and suggest the user consider accepting partial results or restructuring the task.
+The `feedbackRound` counter in state tracks how many loop-backs have occurred in this session. It increments each time `execution_eval` routes to a prior step rather than `memorization`.
+
+### Feedback Round Hard Cap
+
+> **A configurable `maxFeedbackRounds` (default 3) acts as a circuit breaker against infinite evaluation loops.**
+
+When `feedbackRound >= maxFeedbackRounds`, the next revise verdict from `execution_eval` transitions to `error` instead of looping back. The workflow does NOT proceed to `memorization` — work produced by a pathological loop may be broken, and saving it as completed output would be misleading. The `error` state gives the user explicit intervention options: `gobbi workflow resume --force-memorization` to save partial work despite the cap, or `gobbi workflow abort` to discard.
+
+This is a circuit breaker pattern. Without it, an evaluation loop where evaluators consistently return revise verdicts would run indefinitely, consuming tokens and producing no convergent result.
+
+**Pre-cap warning** — When `feedbackRound == maxFeedbackRounds - 1`, the CLI injects a synthesis of previous evaluation findings into the compiled prompt with an explicit directive: this is the last feedback round before the cap fires. The orchestrator sees the accumulated pattern of revise verdicts and can make a final focused attempt to resolve the issues. This is a prompt compilation concern — no new events or state fields, purely the CLI assembling context for the penultimate round.
 
 Feedback loops from `ideation_eval` and `plan_eval` return only to their immediately preceding step (`ideation` and `plan` respectively). They do not carry a `loopFrom` field because the target is unambiguous. The `feedbackRound` counter does not increment for these loops — only loops that cross the execution boundary count as feedback rounds.
 
 ---
 
-## Guard Specification with JsonLogic
+## Guard Specification with Predicate Registry
 
-> **Guards are declarative JSON. The condition language is JsonLogic — the same engine used for step spec conditional blocks.**
+> **Guards are declarative JSON data. Conditions reference TypeScript predicate names, not inline expressions.**
 
 Guards intercept tool calls via the PreToolUse hook. Each guard is a JSON object with five fields:
 
@@ -163,40 +200,88 @@ Guards intercept tool calls via the PreToolUse hook. Each guard is a JSON object
 | `id` | Unique identifier for the guard — referenced in `guard.violation` events |
 | `priority` | Integer — lower number means higher precedence when multiple guards match |
 | `match` | Fast-path filter: `{ step, tool }` — guards only evaluate when the current step and tool call match |
-| `condition` | JsonLogic expression evaluated against current state and the tool call arguments |
+| `condition` | Predicate name (string) — references a function in the CLI's predicate registry |
 | `effect` | `deny`, `allow`, or `warn` |
-| `reason` | Human-readable message with Mustache variable interpolation for context |
+| `reason` | Human-readable message explaining the guard's purpose |
 
-The `match` field exists for performance. Evaluating JsonLogic expressions against every tool call for every guard would be slow. The `match` filter is a cheap structural check — if the current step is not in `match.step` and the tool is not in `match.tool`, the guard is skipped entirely. Only matching guards proceed to JsonLogic evaluation.
+The `match` field exists for performance. The `match` filter is a cheap structural check — if the current step is not in `match.step` and the tool is not in `match.tool`, the guard is skipped entirely. Only matching guards proceed to predicate evaluation.
 
-### JsonLogic Operators
+### Predicate Registry
 
-Standard JsonLogic operators available in conditions: `var`, `==`, `!=`, `in`, `and`, `or`, `!`, `!!`. These cover the common patterns: checking the current step, checking whether a prior step completed, checking the tool call's target path.
+The CLI maintains a typed predicate registry mapping predicate names to TypeScript functions. Each predicate is a pure function that receives the current workflow state and the tool call arguments and returns a boolean. Predicates live in the CLI codebase, not in spec files — specs remain pure JSON data that reference predicates by name.
 
-Gobbi extends JsonLogic with two custom operators:
+`gobbi workflow validate` checks that every predicate name referenced in any guard's `condition` field exists in the registry. This preserves static validation — a misspelled predicate name or a reference to a removed predicate is caught at validation time, not at runtime.
 
-**`event_exists(type, step)`** — returns true if at least one event of the given type exists for the given step. Used to check whether a step has been entered or completed. Example: a guard that blocks execution if no plan artifact exists uses `event_exists("workflow.step.exit", "plan")` to verify the plan step completed.
+Checking whether a step completed, counting events, or inspecting tool call paths are all predicate functions with typed signatures and testable implementations. Adding a new condition means adding a function to the registry — no custom operator protocol, no expression parser.
 
-**`event_count(type)`** — returns the number of events of the given type across the full session. Used to detect repeated violations or measure loop depth. Example: a stagnation warning guard uses `event_count("guard.violation")` to detect escalating enforcement.
+### Task-Size Validation Predicate
+
+A predicate that validates task delegation size during the Plan step. The predicate estimates the token budget of each task's delegation prompt and returns true when the task exceeds the context window budget. This predicate is used with `warn` effect — it flags oversized tasks without blocking, because the user may have good reason to accept the risk. The prompt-side implementation of this validation is defined in `v050-prompts.md`.
 
 ### Enforcement Levels
 
 Two enforcement levels handle different violation severity:
 
-**Soft nudge** (`warn` effect) — the tool call is allowed but the PreToolUse hook injects an `additionalContext` field into the hook response. This surfaces the warning to the orchestrator without blocking progress. Used for edge cases where the action is technically allowed but unusual — for example, writing to a step directory that is not the current active step.
+**Soft nudge** (`warn` effect) — the tool call is allowed but the PreToolUse hook injects an `additionalContext` field into the hook response. This surfaces the warning to the orchestrator without blocking progress. Used for edge cases where the action is technically allowed but unusual — for example, writing to a step directory that is not the current active step, or delegating a task that exceeds the context window budget.
 
 **Hard block** (`deny` effect) — the tool call is blocked. The hook returns a deny response. A `guard.violation` event is written to the event store. The orchestrator receives only the denial message and the `reason` from the guard. Used for structural violations — writing to `.claude/` during an active session, entering a step out of sequence, spawning evaluators from the creating agent.
 
 ### Conflict Resolution
 
-When multiple guards match the same tool call, they are evaluated in ascending `priority` order. The first guard that produces a `deny` effect halts evaluation — no lower-priority guard is consulted. `warn` effects do not halt evaluation; all matching warn guards contribute their `additionalContext` to the response. A `deny` guard always takes precedence over `warn` guards regardless of priority ordering.
+When multiple guards match the same tool call, they are evaluated in ascending `priority` order. The first guard that produces a `deny` effect halts evaluation — no lower-priority guard is consulted. `warn` effects do not halt evaluation; all matching warn guards contribute their `additionalContext` to the response. A `deny` guard always takes precedence over `warn` guards regardless of priority ordering. When two deny guards share the same `priority` integer, evaluation order within that priority level is deterministic but unspecified — both would deny, so the first encountered writes the `guard.violation` event.
 
 This priority scheme means the most critical structural guards (low priority number) are evaluated first and their decisions are final. Informational guards (high priority number) add context without interfering with the structural enforcement.
 
 ---
 
+## Error State Integration
+
+> **`error` is a first-class state variant, not a flag on an existing state.**
+
+The error state is reachable from any active step when a structural failure occurs — step timeout, feedback round cap exceeded, or reducer rejecting an invalid transition. It is not a terminal state: the user can resume or abort.
+
+### Typed Reducer Exhaustiveness
+
+`error` is a variant in the discriminated union. The reducer's exhaustiveness check covers it like any other state. Valid events when in `error` state: `workflow.resume` (rebuilds from last valid state), `workflow.abort` (transitions to `done`), `delegation.complete` (applied normally — in-flight subagents may complete after the workflow enters error). All other events are rejected by the reducer.
+
+### Feedback Round Counter
+
+Transitions into `error` do NOT increment `feedbackRound`. The counter reflects deliberate evaluation loop-backs, not error conditions. A workflow that enters error at `feedbackRound == 3` stays at `feedbackRound == 3` — the cap triggered the error, but the counter does not advance past the cap.
+
+### Active Subagents
+
+SubagentStop hooks continue firing for in-flight subagents even when the workflow is in `error` state. `delegation.complete` events are applied to state normally — artifacts from completing subagents are preserved, not discarded. This prevents data loss when an error occurs while subagents are mid-execution.
+
+### Transition Priority
+
+`any` → `error` has higher priority than `any` → `ideation` (skip). If both an error condition and a skip request are pending, error takes precedence. This ensures structural failures are never masked by user navigation.
+
+### Resume from Error
+
+`gobbi workflow resume` from `error` state generates a pathway-specific briefing based on what caused the error:
+
+- **Timeout** — briefing includes the step that timed out, elapsed time, and the step's artifacts at the time of timeout
+- **Feedback cap** — briefing includes the feedback round history, each round's evaluation findings, and the pattern of revise verdicts
+- **Invalid transition** — briefing includes the rejected event and the state at the time of rejection
+
+The user is offered three options: retry from the errored step, force-advance to memorization (`gobbi workflow resume --force-memorization`), or abort (`gobbi workflow abort`).
+
+---
+
+## Step Timeouts
+
+> **Each step has a configurable timeout. The Stop hook checks elapsed time each turn.**
+
+A new event type `workflow.step.timeout` triggers transition to `error` state when a step exceeds its configured timeout. The Stop hook (which fires after each turn) checks elapsed time since the current step's entry. If elapsed time exceeds the step's timeout, the hook writes a `workflow.step.timeout` event.
+
+Default timeouts are generous because human interaction is expected during most steps — the orchestrator frequently pauses for user input. Timeout configuration lives in the step spec `meta` section (cross-reference to `v050-prompts.md` for step spec structure). A step with no configured timeout uses the default.
+
+Timeouts are a structural safety net, not a performance constraint. They catch abandoned or stuck workflows — for example, a session where the user walked away and the orchestrator is cycling without progress.
+
+---
+
 ## Boundaries
 
-This document covers step definitions, substates, the full transition table, the typed reducer pattern, the evaluation gate model, feedback loop mechanics, and the guard specification format with JsonLogic.
+This document covers step definitions, substates, the full transition table, the typed reducer pattern, the evaluation gate model, feedback loop mechanics with hard cap, the guard specification format with predicate registry, error state integration, and step timeouts.
 
-For how hooks invoke guards and write events to the store, see `v050-hooks.md`. For how the CLI reads state and uses it to generate prompts, see `v050-prompts.md`. For the event store schema and state field definitions, see `v050-session.md`.
+For how hooks invoke guards and write events to the store, see `v050-hooks.md`. For how the CLI reads state and uses it to generate prompts (including step spec `meta` for timeout configuration and task-size validation), see `v050-prompts.md`. For the event store schema and state field definitions, see `v050-session.md`.


### PR DESCRIPTION
## Summary

- Deep review of v0.5.0 design comparing against GSD-2 and everything-claude-code
- 15 improvement recommendations: 7 spec clarifications (C1-C7) + 8 behavioral additions (B1-B8)
- All 5 v0.5.0 spec docs revised to incorporate findings
- New `v050-design-review.md` as persistent reference document

## Key Changes

- **Predicate registry** replaces JsonLogic for guard conditions
- **Error state** with 5 integration requirements + feedback round cap + step timeouts
- **Artifact filename versioning** preserving flat-directory principle
- **Crash recovery briefing** with 4 pathway-specific briefings
- **Cost tracking**, **secret guard**, **verification commands**, and more

## Files Changed (8)

- `v050-design-review.md` — NEW: comparison analysis, 15 recommendations, boundary filtering
- `v050-state-machine.md` — predicate registry, error state, skip semantics, feedback cap
- `v050-session.md` — lazy migration, idempotency, artifact versioning, crash recovery
- `v050-hooks.md` — SubagentStop failure handling, secret guard, timeout, heartbeat
- `v050-prompts.md` — token minimums, task-size validation, verification blocks, resume prompts
- `v050-cli.md` — predicate registry management, error prompts, cost tracking
- `architecture.md` — stale JsonLogic refs updated
- `v050-overview.md` — stale JsonLogic refs updated

## Test plan

- [ ] Verify all 15 recommendations have spec doc pointers that match actual file content
- [ ] Verify zero JsonLogic references remain in spec docs
- [ ] Cross-reference error state transitions across state-machine, hooks, session, prompts, cli
- [ ] Verify predicate registry model consistent across state-machine, prompts, cli

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)