### PR TITLE
Phase 2 PR F — Plugin wiring + docs rewrite + MIGRATION + CHANGELOG + Phase 3 backlog

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,5 +1,3 @@
-> **⚠ v0.5.0 in progress** — PRs A–F are building the state-driven workflow (`gobbi workflow init`) that will replace the current skill-based orchestration. During this transition, both systems coexist in the repo but the current workflow continues to use the skill-based cycle. Track progress in #77.
-
 # CLAUDE.md
 
 Gobbi is an open-source ClaudeX (Claude Experience) tool for Claude Code.
@@ -10,17 +8,19 @@ MUST load this at session start, resume, and compaction. MUST follow the core pr
 
 ## Core Principles
 
-> **The logic of good work: ideate (stances) → plan → research (stances) → execute → collect → memorize → review (stances). Evaluate after each creative step.**
+> **The logic of good work: Ideation → Plan → Execution → Evaluation → Memorization.**
 
-Every non-trivial task must follow this cycle. Each stage produces output, evaluation catches problems before they propagate. Evaluation is optional after ideation, planning, research, and execution — always ask before spawning evaluators. Evaluation findings must be discussed with the user before acting on them.
+Every non-trivial task must follow this cycle. Research is absorbed into Ideation's internal loop — it surfaces as discussion and investigation, not as a separate step. Evaluation is a first-class step, mandatory after Execution and optional at earlier steps. The state machine lives in `packages/cli/src/specs/` and is driven by `gobbi workflow init`.
 
-1. **Ideation** — PI agents (innovative + best stances) explore what to do. Orchestrator discusses with user first, then synthesizes options. Optional evaluation.
-2. **Plan** — use EnterPlanMode. Decompose the chosen idea into narrow, specific, ordered tasks with clear scope and verification criteria. Optional evaluation.
-3. **Research** — Researcher agents (innovative + best stances) investigate how to implement the approved plan. Orchestrator synthesizes findings. Optional evaluation.
-4. **Execution** — Executors read research first, then implement one task at a time. Complete, verify, then move to the next. Optional evaluation.
-5. **Collection** — verify notes, write README, record gotchas. Ensure project documentation reflects what was done.
-6. **Memorization** — save context for session continuity. Capture decisions, state, and open questions so the next session can resume without re-discovery.
-7. **Review** — PI agents assess the work with verdict and documentation. Then FEEDBACK (return to earlier step) or FINISH.
+**Ideation** — Explore what to do. PI agents (innovative + best stances) investigate the problem space with the user. Discuss until the approach is concrete enough to plan against. Optional evaluation.
+
+**Plan** — Decompose the chosen approach into narrow, specific, ordered tasks with clear scope and verification criteria. Optional evaluation.
+
+**Execution** — Implement one task at a time. Complete, verify, then move to the next. Scope is bounded by the plan; no improvisation. Optional evaluation.
+
+**Evaluation** — Assess the work. Mandatory after Execution; optional at Ideation and Plan. Can loop back to any prior step. The creating agent never evaluates its own output.
+
+**Memorization** — Read the conversation log, extract decisions, state, open questions, and gotchas. Write them where the next session can find them. Without Memorization, every session restarts from zero.
 
 > **Evaluation must be separated, multi-perspective, and discussed.**
 
@@ -32,7 +32,7 @@ MUST use AskUserQuestion to discuss with the user at every stage — ideation, p
 
 > **Never repeat the same mistake. Read gotchas before acting, write gotchas after feedback.**
 
-Every agent MUST load _gotcha skill before starting work. When the user corrects any approach, immediately record it as a gotcha. A correction not recorded is a correction repeated across sessions. Gotchas are the highest-value knowledge in this system.
+Every agent MUST load `_gotcha` skill before starting work. When the user corrects any approach, immediately record it as a gotcha. During an active workflow session, gotchas are written to `.gobbi/project/gotchas/` and promoted to permanent storage in `.claude/skills/_gotcha/` via `gobbi gotcha promote` outside the session — promotion does not cause context reload. A correction not recorded is a correction repeated across sessions. Gotchas are the highest-value knowledge in this system.
 
 > **Split into narrow tasks. Execute step by step, not all at once.**
 
@@ -46,4 +46,6 @@ MUST decompose work into small, specific tasks and track them with TaskCreate. E
 |----------|--------|
 | [gobbi skill](skills/gobbi/SKILL.md) | Entry point, session setup questions, skill map |
 | [_claude skill](skills/_claude/SKILL.md) | Documentation standard for `.claude/` authoring |
+| [design/v050-overview.md](project/gobbi/design/v050-overview.md) | v0.5.0 state machine, 5-step cycle, directory split |
+| [design/v050-cli.md](project/gobbi/design/v050-cli.md) | CLI command surface, `gobbi workflow *` commands |
 | [rules/](rules/) | Naming conventions and project rules |

--- a/.claude/project/gobbi/README.md
+++ b/.claude/project/gobbi/README.md
@@ -4,11 +4,15 @@
 
 Gobbi is an open-source ClaudeX (Claude Experience) tool for Claude Code. It benchmarks [GSD (get-shit-done)](https://github.com/gsd-build/get-shit-done) but takes a fundamentally different approach.
 
+## v0.5.0 Note Structure
+
+Gobbi v0.5.0 separates runtime state from retrospective records. `.gobbi/sessions/{id}/` holds per-session state written during an active workflow — event store, heartbeats, and mid-session notes. `.claude/project/gobbi/note/` is the retrospective archive: completed-task notes written after the session, gitignored, stored in the main tree rather than the feature branch.
+
 ## Directory
 
 - [design/](design/) — Design docs: vision, architecture, workflow, agents, evaluation, state, hacks, distribution, GSD analysis
 - [rules/](rules/) — Project-specific rules and conventions
 - [gotchas/](gotchas/) — Project-specific gotchas (not cross-project)
-- [note/](note/) — Workflow notes per task (managed by _note)
+- [note/](note/) — Retrospective workflow notes per completed task (gitignored, main tree only)
 - [reference/](reference/) — External references, API docs, research
 - [docs/](docs/) — Other project documents

--- a/.claude/project/gobbi/design/v050-phase3-backlog.md
+++ b/.claude/project/gobbi/design/v050-phase3-backlog.md
@@ -1,0 +1,315 @@
+# v0.5.0 Phase 3 Backlog
+
+Items deferred from v0.5.0 Phase 2 to a future release cycle. Each item has a decision trigger — the condition that signals revisiting. Without triggers, backlog items accumulate indefinitely and Phase 3 planners have no way to know when an item is ready to resurface. Triggers convert a wishlist into an actionable queue: when the condition fires, the item moves into the next release plan.
+
+---
+
+## Backlog items
+
+Items are grouped by trigger class for faster Phase 3 scanning. The trigger-class index below identifies which items can ship at any time versus which are blocked on a precondition.
+
+| Trigger class | Items |
+|---|---|
+| `velocity` — ship when capacity allows | #97, #98, #94, #92 |
+| `signal` — awaits user/data trigger | async ticker, guard daemon, content-hash, `bun --compile` binary, cross-platform CI, #89, #90, #91, #93, #95, #96, #99, #100, ARCH-P1 |
+| `architecture` — blocked on internal decision | stance-skill, docs-banner, `@gobbitools/cli` dep declaration |
+| `external` — blocked on upstream | `bun --compile` CI gate, npm publish |
+
+---
+
+### Async verification ticker
+
+**Source:** #77 Deferred to Phase 3 (item 1)
+
+**Description:** Async verification mode (`verification.mode: async` per CP4) for long-running test suites. v0.5.0 ships synchronous-default only. Async mode would allow the workflow to continue while verification runs in a background ticker, reporting results on the next `SubagentStop` cycle.
+
+**Trigger:** User reports verification blocking workflow progress on a real project — sync mode p50 latency exceeds 5 seconds on representative sessions. Surface via `gobbi workflow status --verification`.
+
+**Trigger class:** `signal`
+
+---
+
+### Guard daemon
+
+**Source:** #77 Deferred to Phase 3 (item 2)
+
+**Description:** Long-running guard process to reduce per-tool-call CLI startup cost. Current design per `v050-cli.md:45` relies on Bun's single-digit-millisecond startup being fast enough; the daemon would replace per-invocation cold start with an IPC call to an already-warm process.
+
+**Trigger:** Profiling across representative sessions shows guard hook p99 latency exceeds 20ms. Until that data exists, the current per-invocation model is presumed sufficient.
+
+**Trigger class:** `signal`
+
+---
+
+### Content-hash migrations
+
+**Source:** #77 Deferred to Phase 3 (item 3)
+
+**Description:** Spec-file content-hash invalidation for the predicate registry to detect silent spec drift. When a spec file changes without a schema-version bump, the predicate registry currently has no mechanism to detect the stale registration.
+
+**Trigger:** One or more silent-drift incidents reported — a spec changed without triggering re-validation, producing incorrect predicate behavior. Until that happens, the migration-on-schema-bump discipline is sufficient.
+
+**Trigger class:** `signal`
+
+---
+
+### `bun --compile` binary distribution
+
+**Source:** #77 Deferred to Phase 3 (item 4); `v050-cli.md:173`
+
+**Description:** Standalone binary distribution for environments without npm. `bun build --compile` produces a self-contained executable; users in restricted environments could install gobbi without requiring npm or Node.
+
+**Trigger:** Two or more user reports of restricted environments blocking npm install of `@gobbitools/cli`.
+
+**Trigger class:** `signal`
+
+---
+
+### Cross-platform CI tests
+
+**Source:** #77 Deferred to Phase 3 (item 5)
+
+**Description:** Windows and macOS CI matrix. Current CI is Linux-only. Cross-platform gaps are unknown until tests run on those systems — path separators, shell assumptions, and Bun behavior differences are the primary risk surface.
+
+**Trigger:** Windows or macOS user bug report, OR a planned open-source launch that requires platform-coverage confidence.
+
+**Trigger class:** `signal`
+
+---
+
+### Docs-banner CLI helper
+
+**Source:** #77 Deferred to Phase 3 (item 6)
+
+**Description:** `gobbi docs banner add/remove` command to automate the deprecation-banner workflow used manually in PR F.3. PR F.3 applied banners by hand-editing skill files; a CLI helper would reduce friction for future major deprecations.
+
+**Trigger:** Another major deprecation event at v0.6.0 or later that would require applying banners to multiple skill files simultaneously.
+
+**Trigger class:** `architecture`
+
+---
+
+### Stance-skill JSON-embedding maintainability
+
+**Source:** #77 Deferred to Phase 3 (item 7)
+
+**Description:** Review how stance skills (`_innovation`, `_best-practice`) embed content into compiled prompts. Current embedding is string-based; the compiler inlines stance text directly without a structured indirection layer. This becomes a maintenance burden when stance content needs updating.
+
+**Trigger:** Adding a third stance skill, OR any stance-content edit that requires touching the compiler source rather than just the skill file.
+
+**Trigger class:** `architecture`
+
+---
+
+### `bun --compile` CI gate
+
+**Source:** #77 Deferred to Phase 3 (item 8)
+
+**Description:** CI gate that runs `bun build --compile` on every PR to catch compile-time regressions before merge. Currently no CI step validates that the CLI produces a working compiled binary.
+
+**Trigger:** Ships when the `bun --compile` binary distribution path (item 4 above) activates — the CI gate is only meaningful once the binary is a deliverable.
+
+**Trigger class:** `external`
+
+**Blocked-by:** `bun --compile` binary distribution (item 4)
+
+---
+
+### Verification dependency DAG spec
+
+**Source:** #89 (PR E follow-up L12-1)
+
+**Description:** Replace the sequential `runAfterSubagentStop` array in `.gobbi/project-config.json` with a DAG representation. Real-world verification often has dependency structure — typecheck must pass before test is meaningful; lint can run in parallel with both. The current array shape treats all commands as strictly sequential.
+
+**Trigger:** User configures four or more verification commands on one project and reports dependency pain — commands that could parallelize are serialized, or a downstream command runs despite an upstream gate failure.
+
+**Trigger class:** `signal`
+
+---
+
+### Rate-card refresh cadence + cache-economics telemetry
+
+**Source:** #90 (PR E follow-up L12-2)
+
+**Description:** Automate `MODEL_RATES` refresh when Anthropic publishes new pricing, and surface prompt-cache hit-rate telemetry in `gobbi workflow status --cost --cache`. The current `packages/cli/src/lib/cost-rates.ts` has a `lastUpdated` comment but no enforcement mechanism.
+
+**Trigger:** Anthropic publishes a rate-card change that makes the stored rates stale by more than 5%. Overlaps with #96 (MODEL_RATES refresh automation) — coordinate with that item.
+
+**Trigger class:** `signal`
+
+**Blocks:** #96 (coordinate, overlapping scope)
+
+---
+
+### Actionable verification briefing
+
+**Source:** #91 (PR E follow-up L12-3)
+
+**Description:** Extend `compileVerificationBlock` to render actionable briefing — short-form suggestions a subagent can act on directly from the compiled prompt. Today the block renders structured digests only.
+
+**Trigger:** Verification failure rate exceeds 15% of sessions across representative users, OR user feedback explicitly requesting richer failure context in the compiled prompt.
+
+**Trigger class:** `signal`
+
+**Blocked-by:** #93 (`joinCompiledPrompts` unified-budget primitive — must land before actionable briefing to avoid silent budget overflow)
+
+---
+
+### `joinCompiledPrompts` unified-budget primitive
+
+**Source:** #93 (PR E follow-up NEW-5)
+
+**Description:** Extract a `joinCompiledPrompts(primary, ...appendices)` primitive that lets `allocate()` see the full prompt payload when verification-block or other appendices are attached. Current architecture concatenates the verification block outside the allocator, which silently allows total prompt size to exceed the caller's budget invariant.
+
+**Trigger:** Any feature that enlarges the verification block beyond digest-only rendering (e.g., actionable briefing from #91, full stream capture, multi-variant outcomes). This item is a prerequisite; it fires when #91 fires.
+
+**Trigger class:** `signal`
+
+**Blocks:** #91 (actionable verification briefing)
+
+---
+
+### `CLAUDE_CODE_VERSION` capture in delegation events
+
+**Source:** #92 (PR E follow-up L12-4)
+
+**Description:** Read `CLAUDE_CODE_VERSION` from the environment at delegation-spawn time and attach it to the `delegation.spawn` event payload, then surface in `gobbi workflow status` and `events` output. Currently no event captures the harness version, making cross-version debugging impossible.
+
+**Trigger:** A version-specific behavior difference between Claude Code releases causes a support case that cannot be diagnosed from the event log.
+
+**Trigger class:** `velocity`
+
+---
+
+### `compileResumePrompt` differentiated diagnostic
+
+**Source:** #94 (PR E follow-up NEW-6)
+
+**Description:** `resolveResumeTargetStep` in `packages/cli/src/specs/errors.ts` throws the same error message for four distinct malformed-input classes: missing event, missing `targetStep` field, non-string `targetStep`, and empty-string `targetStep`. Differentiating by sub-class would let callers tell "no event" from "malformed event."
+
+**Trigger:** User reports confusion diagnosing a resume failure — the current uniform message blocks root-cause identification in a real debugging session.
+
+**Trigger class:** `velocity`
+
+---
+
+### Second e2e scenario: `workflow next` + verification runner
+
+**Source:** #95 (PR E follow-up NEW-7); also deferred per L-F10
+
+**Description:** Add a second e2e scenario at `packages/cli/src/__tests__/e2e/workflow-cycle.test.ts` that exercises `workflow next`, `runVerification`, `compileVerificationBlock`, and `detectAndEmitTimeout` end-to-end through real CLI subprocesses. The existing scenario walks `init → transition×3 → PASS → FINISH` and bypasses the verification path entirely.
+
+**Trigger:** Regression found in the `workflow next` + verification integration that the current single-scenario e2e suite fails to catch.
+
+**Trigger class:** `signal`
+
+---
+
+### `MODEL_RATES` refresh automation
+
+**Source:** #96 (PR E follow-up NEW-8)
+
+**Description:** Scheduled GitHub Actions workflow or release-cut hook that scrapes Anthropic's pricing documentation and compares against the stored `MODEL_RATES` in `packages/cli/src/lib/cost-rates.ts`. On drift, opens a draft PR updating rates and `lastUpdated`. Alternative: at-startup warning when `lastUpdated` is older than N days.
+
+**Trigger:** Anthropic publishes a rate change. Overlaps with #90 (cache-economics telemetry) — coordinate scope at planning time to avoid duplicate automation.
+
+**Trigger class:** `signal`
+
+**Blocks:** #90 (overlapping scope — coordinate)
+
+---
+
+### EventStore read-only query enforcement
+
+**Source:** #97 (PR E follow-up NEW-9)
+
+**Description:** Tighten `EventStore` query methods to reject writes at the type level — either via a class decorator convention, or by splitting into `WriteStore` + `ReadStore` interfaces with distinct method sets enforced via typing. The current `aggregateDelegationCosts()` approach eliminated raw-SQL-anywhere as a pattern but the enforcement is advisory rather than structural.
+
+**Trigger:** A Phase 3 type-system cleanup pass targets `EventStore`, or a new analytics method adds a read path that bypasses the existing transaction and audit machinery.
+
+**Trigger class:** `velocity`
+
+---
+
+### Fast-check + TS-strict gotchas consolidation
+
+**Source:** #98 (PR E follow-up NEW-10); also deferred per L-F4
+
+**Description:** Create `.claude/project/gobbi/gotchas/test-tooling.md` and migrate the fast-check v4 and `exactOptionalPropertyTypes` gotcha entries from `phase2-planning.md`. These are generic test-tooling patterns, not phase-specific planning errors. Discoverability for future test authors is lower than it should be at the current location.
+
+**Trigger:** A third fast-check-related or TS-strict gotcha is filed, making the case for a dedicated test-tooling doc unambiguous.
+
+**Trigger class:** `velocity`
+
+---
+
+### Fail-fast policy-scope config flag
+
+**Source:** #99 (PR E follow-up NEW-11)
+
+**Description:** Extend `.gobbi/project-config.json` with `verification.policyScope: 'subagent' | 'global'` (default `subagent`). The current implementation stops only the failing subagent's remaining verification commands on gate failure. Projects with cross-subagent correctness gates may need global scope where any gate failure stops all subagents' remaining commands.
+
+**Trigger:** User requests global fail-fast mode — a project has cross-subagent interlocking correctness gates where a failure in one subagent's verification should halt all others.
+
+**Trigger class:** `signal`
+
+---
+
+### `meta.timeoutMs` telemetry emission
+
+**Source:** #100 (PR E follow-up NEW-12)
+
+**Description:** Surface `workflow.step.timeout` events in `gobbi workflow status`, add a `status --timeouts` flag reporting timeout-event counts per step, and optionally emit a structured log line at detection time. Currently the event is persisted but not surfaced in any command output.
+
+**Trigger:** First timeout event seen in production on a real project session.
+
+**Trigger class:** `signal`
+
+---
+
+### Dual-registration duplicate-fire investigation
+
+**Source:** ARCH-P1 (plan-eval Architecture finding)
+
+**Description:** Pre-existing v0.4.x behavior may result in hook events registered in both `plugins/gobbi/hooks/hooks.json` and `.claude/settings.json` simultaneously. If Claude Code does not deduplicate, guard hook may double-emit `guard.violation` or `delegation.complete` events, producing duplicated event-store entries and incorrect cost tallies.
+
+**Trigger:** Reports of double-emitted guard or delegation events in the event store, OR PR F integration testing reveals duplicate events during hook registration verification.
+
+**Trigger class:** `signal`
+
+---
+
+### `@gobbitools/cli` dep declaration in `plugin.json`
+
+**Source:** ARCH-5 (plan-eval Architecture finding)
+
+**Description:** `plugins/gobbi/.claude-plugin/plugin.json` should declare `@gobbitools/cli` as a dependency per `v050-cli.md:158-163`. The declaration is currently absent. Adding it signals to plugin managers that the CLI must be installed before the plugin can function.
+
+**Trigger:** After `@gobbitools/cli@0.5.0` is published to npm. The declaration references a published package — adding it before publish would reference a version that doesn't exist yet.
+
+**Trigger class:** `architecture`
+
+**Blocked-by:** npm publish of `@gobbitools/cli@0.5.0`
+
+---
+
+### npm publish of `@gobbitools/cli@0.5.0` + integration PR
+
+**Source:** L-F2 (plan explicit out-of-scope deferral)
+
+**Description:** Publish `@gobbitools/cli@0.5.0` to npm and open the integration PR merging `phase/v050-phase-2` into `main`/`develop`. Both are out of PR F scope. The publish runs after the integration PR merges — not as part of the feature branch merge. No `.github/workflows/release.yml` exists; publish is currently manual via `npm publish --workspace=packages/cli` from the maintainer's machine.
+
+**Trigger:** PR F merges into `phase/v050-phase-2` and the user decides to ship v0.5.0. The trigger is a deliberate decision, not a data signal.
+
+**Trigger class:** `external`
+
+**Blocks:** `@gobbitools/cli` dep declaration in `plugin.json`
+
+---
+
+## Revisit cadence
+
+- Review this backlog before every minor release transition (v0.5.x → v0.6.x). Items whose triggers have fired move into the next release plan.
+- Items in the `velocity` class have no external dependency — they can be picked up whenever capacity allows. Prefer scheduling them alongside structurally related work (e.g., #97 + #98 in the same cleanup pass).
+- Items that have not triggered after 12 months should be reassessed: either the trigger condition is wrong, the need no longer exists, or the item should be closed as won't-fix.
+- When filing a new follow-up issue, add a backlog entry here with source, description, trigger, and trigger class before the session closes. An issue without a backlog entry has no signal for when to resurface.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,8 +21,6 @@
       "Skill(_collection)",
       "Skill(_memorization)",
       "Skill(_notification)",
-      "Skill(_audit)",
-      "Skill(_doctor)",
       "Skill(_git)",
       "Skill(_gobbi-rule-container)",
       "Skill(_innovation)",
@@ -44,67 +42,31 @@
         "hooks": [
           {
             "type": "command",
-            "command": "gobbi session metadata",
+            "command": "gobbi workflow init",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "gobbi workflow guard",
             "timeout": 5
           }
         ]
-      },
-      {
-        "matcher": "startup|resume",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "gobbi session load-env",
-            "timeout": 5
-          }
-        ]
-      },
-      {
-        "matcher": "startup|resume",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "gobbi notify session",
-            "timeout": 5,
-            "async": true
-          }
-        ]
       }
     ],
-    "Stop": [
+    "PostToolUse": [
       {
+        "matcher": "ExitPlanMode",
         "hooks": [
           {
             "type": "command",
-            "command": "gobbi notify completion",
-            "timeout": 10,
-            "async": true
-          }
-        ]
-      }
-    ],
-    "Notification": [
-      {
-        "matcher": "permission_prompt|idle_prompt|elicitation_dialog",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "gobbi notify attention",
-            "timeout": 5,
-            "async": true
-          }
-        ]
-      }
-    ],
-    "StopFailure": [
-      {
-        "matcher": "rate_limit|authentication_failed|billing_error|server_error",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "gobbi notify error",
-            "timeout": 5,
-            "async": true
+            "command": "gobbi workflow capture-plan",
+            "timeout": 30
           }
         ]
       }
@@ -114,22 +76,19 @@
         "hooks": [
           {
             "type": "command",
-            "command": "gobbi notify subagent",
-            "timeout": 5,
-            "async": true
+            "command": "gobbi workflow capture-subagent",
+            "timeout": 60
           }
         ]
       }
     ],
-    "SessionEnd": [
+    "Stop": [
       {
-        "matcher": "logout|prompt_input_exit",
         "hooks": [
           {
             "type": "command",
-            "command": "gobbi notify session",
-            "timeout": 5,
-            "async": true
+            "command": "gobbi workflow stop",
+            "timeout": 10
           }
         ]
       }

--- a/.claude/skills/_orchestration/ARCHIVED.md
+++ b/.claude/skills/_orchestration/ARCHIVED.md
@@ -1,0 +1,170 @@
+# _orchestration — Archived (deprecated in v0.5.0)
+
+> Historical reference for gobbi v0.4.x's skill-based 7-step orchestration.
+> The skill remains on disk (per CP6) but is no longer loaded by the v0.5.0
+> workflow machinery. Workflow control now lives in the CLI's step specs
+> at `packages/cli/src/specs/` and is driven by `gobbi workflow init`.
+
+---
+
+## Why this skill existed
+
+Gobbi v0.4.x needed an orchestration contract — a document that told the agent
+how to run a workflow: when to ideate, when to plan, when to execute, when to
+review. The `_orchestration` skill was that contract. Agents loaded it at
+session start and used its seven named steps as a cognitive checklist.
+
+The seven-step cycle (Ideation → Plan → Research → Execution → Collection →
+Memorization → Review) represented the accumulated learning from many gobbi
+sessions. Each step earned its place by catching a class of recurring failures:
+Research prevented poorly-scoped execution; Collection prevented notes from
+disappearing; Memorization prevented session-to-session re-discovery; Review
+prevented unreviewed work from shipping.
+
+The skill embedded the contract as prose. Agents read the narrative, internalized
+the steps, and followed them — at least in principle. For short sessions on
+well-scoped tasks, this worked well. The orchestrator kept pace with the seven
+steps and produced consistent results.
+
+Importantly, v0.4.x's workflow knowledge lived in a single file that could be
+updated without a code release. A new step, a modified constraint, a renamed
+phase: one pull request, no version bump. That flexibility was a real advantage
+when the workflow was still evolving.
+
+---
+
+## Why it was replaced in v0.5.0
+
+Prose contracts are unmeasurable. There is no mechanism to verify that an agent
+followed Step 3 (Research) before starting Step 4 (Execution), or that Step 5
+(Collection) actually ran before Step 6 (Memorization). The contract is
+advisory — an agent that skips Collection loses no more than a warning in the
+review step.
+
+The gobbi `v050-overview.md` design document describes this as the
+guidance-based orchestration failure mode: "The orchestrator skips collection
+because the task felt done. It forgets memorization because the conversation was
+long. These are not bugs that can be fixed with better instructions — they are
+the structural consequence of 'guidance' as the control mechanism."
+
+Three specific drift patterns drove the replacement decision:
+
+First, step-skipping was silent. Agents would jump from Execution to Review
+without Collection or Memorization. Notes never landed on disk. The next session
+re-discovered context that was already paid for.
+
+Second, Research was expensive and inconsistently applied. For genuinely novel
+problems it was essential; for familiar work it added overhead without value.
+The prose contract offered no mechanism for the system to apply Research
+selectively — only the agent's judgment, which varied.
+
+Third, writing to `.claude/` mid-session triggered Claude Code context reload.
+The `_orchestration` skill instructed agents to update gotchas and project docs
+during Collection. Writing to a monitored directory caused session stalls.
+
+V0.5.0 moves workflow control into a state machine encoded in JSON specs under
+`packages/cli/src/specs/`. The CLI reads state, determines the active step, and
+generates a bounded prompt that contains only the instructions relevant to that
+step. The orchestrator cannot skip Collection because it never receives the
+Execution-step prompt and the Memorization-step prompt simultaneously.
+
+---
+
+## 7-step → v0.5.0 mapping
+
+| v0.4.x step | v0.5.0 equivalent |
+|---|---|
+| Step 1 Ideation | Ideation step spec (`packages/cli/src/specs/ideation/spec.json`). Discussion with the user and stance-based exploration are internal loops within this step. |
+| Step 2 Plan | Plan step spec (`packages/cli/src/specs/plan/spec.json`). Decomposition, delegation assignments, and verification criteria remain the same; the CLI generates the step prompt from state. |
+| Step 3 Research | Absorbed into Ideation's internal loop (per `design/v050-overview.md` §The Workflow). Researcher stances (`_innovation`, `_best-practice`) are still loaded — now as sub-agent instructions within the Ideation step spec rather than as a separate workflow gate. |
+| Step 4 Execution | Execution step spec (`packages/cli/src/specs/execution/spec.json`). One task at a time, verified before next — same discipline, enforced by the state machine rather than by prose. |
+| Step 5 Collection | SubagentStop hook auto-capture via `gobbi workflow capture-subagent`. Notes no longer require a manual `gobbi note collect` call mid-workflow. The hook fires automatically when a subagent completes and writes the transcript extract to `.gobbi/sessions/{id}/`. |
+| Step 6 Memorization | Memorization step spec (`packages/cli/src/specs/memorization/spec.json`), which absorbs the former Collection step. Reading the conversation log and extracting decisions into `.gobbi/project/` is now a single bounded step, not two separate ones. |
+| Step 7 Review | Evaluation step spec (`packages/cli/src/specs/evaluation/spec.json`). Evaluation is now a first-class step — mandatory after Execution, optional at Ideation and Plan. The v0.5.0 model treats evaluation as a loop-back gate, not a final verdict: the step can return to any prior step, not just the immediately preceding one. |
+
+---
+
+## Concept glossary
+
+Terms v0.4.x agents and users will search for, mapped to where their v0.5.0
+equivalents live.
+
+**FEEDBACK phase** — the v0.4.x FEEDBACK cycle (lightweight fix loop after
+Review) maps to the Evaluation step's loop-back transitions in v0.5.0. When
+evaluation directs a return to Execution or Plan, the state machine drives that
+transition. For user-facing resume semantics, see `gobbi workflow resume`
+(documented in `design/v050-cli.md`).
+
+**Structured routine** — the v0.4.x tier for tasks with a known execution
+pattern (skip Ideation, Plan, Research; go directly to Execution). In v0.5.0,
+workflow variants (`feedback-`, `error-`, and normal variants per
+`design/v050-prompts.md`) serve the same differentiation. A structured routine
+becomes a session initialized with the appropriate variant rather than a
+skip-tier classification by the orchestrator.
+
+**Collection (Step 5)** — replaced by the SubagentStop hook and
+`gobbi workflow capture-subagent`. Collection is now automatic. The note
+directory during a session is `.gobbi/sessions/{session-id}/` (runtime). The
+retrospective archive for a completed task still lands in
+`.claude/project/{project-name}/note/` after the session closes.
+
+**Note directory** — two locations now serve different purposes. During a
+session: `.gobbi/sessions/{session-id}/` is the write target (runtime state,
+not monitored by Claude Code). After a session: `.claude/project/{project-name}/note/{YYYYMMDD-HHMM}-{slug}-{id}/`
+is the retrospective archive (per `design/v050-overview.md` §The Directory
+Split).
+
+**PI agent** — the Innovative and Best stance agents from v0.4.x Ideation and
+Review steps. Still exist and are still loaded. Now an implementation detail of
+the Ideation step spec rather than a top-level workflow concept; users see only
+the step output.
+
+**Research stance** — stance skills `_innovation` and `_best-practice` still
+exist and are invoked by the Ideation step spec as sub-agent instructions.
+The user-facing difference: Research is no longer a gated step with its own
+AskUserQuestion checkpoint. It is an internal loop within Ideation.
+
+**Plan agent** — the Plan step spec drives planning in v0.5.0. The
+human-driven plan mode (`EnterPlanMode` in Claude Code) remains orthogonal to
+the workflow state machine and is still used inside the Plan step.
+
+**Ideation discussion-first** — encoded in the Ideation step spec as a required
+predicate. The orchestrator cannot bypass the discussion gate because the
+Ideation prompt does not advance until the predicate clears.
+
+**Ask-each-time / always-evaluate / skip-evaluation** — these v0.4.x session
+flags map to the `evaluationMode` session config. The evaluation decision is
+now captured at `gobbi workflow init` as a `workflow.eval.decide` event stored
+in `gobbi.db`. The Evaluation step spec reads `evalConfig` from state and
+applies the decision automatically — no per-step AskUserQuestion required.
+
+**`gobbi note collect`** — the v0.4.x command for extracting subagent output
+from transcripts. Still available but no longer the primary collection path.
+The SubagentStop hook handles transcript extraction automatically via
+`gobbi workflow capture-subagent`. Manual `gobbi note collect` calls are
+reserved for recovery scenarios where the hook did not fire.
+
+---
+
+## What to read instead
+
+For v0.5.0 workflow guidance:
+
+- `.claude/CLAUDE.md` — project-level workflow principles and the 5-step cycle.
+- `.claude/skills/gobbi/SKILL.md` — session-bootstrap entry point for `/gobbi`.
+- `.claude/project/gobbi/design/v050-overview.md` — v0.5.0 architecture overview, drift pathology rationale, directory split.
+- `.claude/project/gobbi/design/v050-cli.md` — CLI command surface, `gobbi workflow *` command reference.
+- `.claude/project/gobbi/design/v050-hooks.md` — hook-to-CLI wiring, SubagentStop capture details.
+
+---
+
+## Migration path
+
+If a prior session loaded `_orchestration` and you are resuming under v0.5.0,
+run `gobbi workflow init` to bootstrap a v0.5.0 session and continue there.
+The session directory at `.gobbi/sessions/{id}/` is created fresh; prior note
+files in `.claude/project/{project-name}/note/` remain intact and readable.
+
+See `MIGRATION.md` at the repo root for user-facing migration guidance,
+including restoration paths for notification hooks and upgrade verification
+commands.

--- a/.claude/skills/_orchestration/SKILL.md
+++ b/.claude/skills/_orchestration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: _orchestration
-description: Adaptive workflow coordinator for the 7-step cycle. MUST load at workflow start to route tasks and manage transitions.
+description: Deprecated in v0.5.0 — historical reference for the v0.4.x skill-based 7-step workflow. Workflow control now lives in the CLI's step specs (see ARCHIVED.md and design/v050-overview.md).
 allowed-tools: Read, Grep, Glob, Bash, Write, Agent, Task, AskUserQuestion
 ---
 

--- a/.claude/skills/_orchestration/SKILL.md
+++ b/.claude/skills/_orchestration/SKILL.md
@@ -6,6 +6,9 @@ allowed-tools: Read, Grep, Glob, Bash, Write, Agent, Task, AskUserQuestion
 
 # Orchestration
 
+> **⚠ Deprecated in v0.5.0** — see [ARCHIVED.md](ARCHIVED.md) for historical reference.
+> Workflow control now lives in the CLI's step specs; see [`design/v050-overview.md`](../../project/gobbi/design/v050-overview.md).
+
 You are an orchestrator. You must delegate everything to specialist subagents except trivial cases. Must load _gotcha before proceeding. When loading this skill, also load _note, _evaluation, _discuss, and _delegation — they are needed at every workflow step.
 
 **Navigate deeper from here:**

--- a/.claude/skills/_orchestration/feedback.md
+++ b/.claude/skills/_orchestration/feedback.md
@@ -1,5 +1,8 @@
 # FEEDBACK Phase
 
+> **⚠ Deprecated in v0.5.0** — see [ARCHIVED.md](ARCHIVED.md) for historical reference.
+> Workflow control now lives in the CLI's step specs; see [`design/v050-overview.md`](../../project/gobbi/design/v050-overview.md).
+
 How iterative feedback works after Review completes. Load this when entering FEEDBACK to understand iteration tracking, stagnation detection, and when to escalate. FEEDBACK always returns to Review — the cycle is FEEDBACK → Review → (FEEDBACK or FINISH).
 
 ---

--- a/.claude/skills/_orchestration/finish.md
+++ b/.claude/skills/_orchestration/finish.md
@@ -1,5 +1,8 @@
 # FINISH Phase
 
+> **⚠ Deprecated in v0.5.0** — see [ARCHIVED.md](ARCHIVED.md) for historical reference.
+> Workflow control now lives in the CLI's step specs; see [`design/v050-overview.md`](../../project/gobbi/design/v050-overview.md).
+
 How the workflow concludes with merge, commit, and compact options. FINISH comes after Review (Step 7) or after a FEEDBACK → Review loop. Load this when the user selects FINISH to understand the decision tree, pre-action verification, and cleanup responsibilities.
 
 

--- a/.claude/skills/_orchestration/gotchas.md
+++ b/.claude/skills/_orchestration/gotchas.md
@@ -1,5 +1,8 @@
 # Gotcha: _orchestration
 
+> **⚠ Deprecated in v0.5.0** — see [ARCHIVED.md](ARCHIVED.md) for historical reference.
+> Workflow control now lives in the CLI's step specs; see [`design/v050-overview.md`](../../project/gobbi/design/v050-overview.md).
+
 Mistakes in following the orchestration workflow (steps, transitions, FEEDBACK/FINISH cycle).
 
 

--- a/.claude/skills/gobbi/SKILL.md
+++ b/.claude/skills/gobbi/SKILL.md
@@ -10,7 +10,7 @@ You are an orchestrator based on gobbi. You must delegate everything to speciali
 
 In v0.5.0, `/gobbi` is the session-bootstrap front door. It completes the four setup questions below, then drives `gobbi workflow init` to create the session's runtime directory under `.gobbi/sessions/{session-id}/` and record the first `workflow.start` event. The 5-step cycle — Ideation, Plan, Execution, Evaluation, Memorization — is governed by the CLI's step specs at `packages/cli/src/specs/`. Once setup is complete, hand off to `gobbi workflow init`.
 
-**FIRST — load core skills before anything else.** Load `_gotcha`, `_claude`, and `_git` immediately. Also load `_orchestration` for backwards-compatibility reference if needed, but note it is deprecated in v0.5.0 — see `_orchestration/ARCHIVED.md` for historical reference. Do not ask questions, do not run project setup, do not proceed until skills are loaded.
+**FIRST — load core skills before anything else.** Load `_gotcha`, `_claude`, and `_git` immediately. Do not ask questions, do not run project setup, do not proceed until skills are loaded. (`_orchestration` is deprecated in v0.5.0 and no longer loads — see `_orchestration/ARCHIVED.md` only if you need historical reference for v0.4.x terminology.)
 
 **SECOND — ensure `_gobbi-rule` symlink exists.** Check whether `.claude/rules/_gobbi-rule.md` exists in `$CLAUDE_PROJECT_DIR`. If it is missing, create a symlink from `.claude/rules/` pointing to `_gobbi-rule.md` in the `_gobbi-rule-container` skill directory. This symlink makes the core behavioral rules always-active and auto-updates when the gobbi plugin is updated.
 

--- a/.claude/skills/gobbi/SKILL.md
+++ b/.claude/skills/gobbi/SKILL.md
@@ -4,19 +4,19 @@ description: Entry point for gobbi, an open-source ClaudeX tool. MUST load at se
 allowed-tools: Read, Grep, Glob, Bash, Write, Edit, Agent, Task, AskUserQuestion
 ---
 
-> **⚠ v0.5.0 in progress** — PRs A–F are building the state-driven workflow (`gobbi workflow init`) that will replace the current skill-based orchestration. During this transition, both systems coexist in the repo but the current workflow continues to use the skill-based cycle. Track progress in #77.
-
 # Gobbi
 
 You are an orchestrator based on gobbi. You must delegate everything to specialist subagents except trivial cases.
 
-**FIRST — load core skills before anything else.** Load `_orchestration`, `_gotcha`, `_claude`, and `_git` immediately. Do not ask questions, do not run project setup, do not proceed until all four are loaded.
+In v0.5.0, `/gobbi` is the session-bootstrap front door. It completes the four setup questions below, then drives `gobbi workflow init` to create the session's runtime directory under `.gobbi/sessions/{session-id}/` and record the first `workflow.start` event. The 5-step cycle — Ideation, Plan, Execution, Evaluation, Memorization — is governed by the CLI's step specs at `packages/cli/src/specs/`. Once setup is complete, hand off to `gobbi workflow init`.
+
+**FIRST — load core skills before anything else.** Load `_gotcha`, `_claude`, and `_git` immediately. Also load `_orchestration` for backwards-compatibility reference if needed, but note it is deprecated in v0.5.0 — see `_orchestration/ARCHIVED.md` for historical reference. Do not ask questions, do not run project setup, do not proceed until skills are loaded.
 
 **SECOND — ensure `_gobbi-rule` symlink exists.** Check whether `.claude/rules/_gobbi-rule.md` exists in `$CLAUDE_PROJECT_DIR`. If it is missing, create a symlink from `.claude/rules/` pointing to `_gobbi-rule.md` in the `_gobbi-rule-container` skill directory. This symlink makes the core behavioral rules always-active and auto-updates when the gobbi plugin is updated.
 
-**THIRD — check gobbi CLI availability.** Run `gobbi --version` to verify the CLI is installed. If the command fails, load [cli-setup.md](cli-setup.md) and help the user install before proceeding. The CLI is required for note initialization, subtask collection, config management, and validation. Without it, the workflow cannot function.
+**THIRD — check gobbi CLI availability.** Run `gobbi --version` to verify the CLI is installed. If the command fails, load [cli-setup.md](cli-setup.md) and help the user install before proceeding. The CLI is required for workflow initialization, session management, config management, and validation. Without it, the workflow cannot function.
 
-**FOURTH — check for existing session settings.** Run `gobbi config get $CLAUDE_SESSION_ID` to check if this session already has saved settings in `gobbi.json`. If settings exist (e.g., after a resume or compact), present the saved settings to the user and ask whether to reuse them or reconfigure. If the user chooses to reuse, skip the setup questions and proceed directly. If no settings exist for this session, continue to the setup questions.
+**FOURTH — check for existing session settings.** Run `gobbi config get $CLAUDE_SESSION_ID` to check if this session already has saved settings in `gobbi.json`. If settings exist (e.g., after a resume or compact), present the saved settings to the user and ask whether to reuse them or reconfigure. If the user chooses to reuse, skip the setup questions and proceed directly to `gobbi workflow init`. If no settings exist for this session, continue to the setup questions.
 
 **FIFTH — ask the user four setup questions** with AskUserQuestion (only if no existing settings were reused).
 
@@ -31,7 +31,7 @@ You are an orchestrator based on gobbi. You must delegate everything to speciali
 
 **Third question — git workflow mode:**
 - **Direct commit (default)** — Work happens in the main working tree. Commits are created at FINISH. No worktrees, no PRs. Use for solo sessions or quick tasks.
-- **Git workflow (worktree + PR)** — Each task gets its own worktree and branch. Work is integrated via pull request. If selected, also ask for the base branch (what branch to create feature branches from). When selected, the orchestrator verifies _git prerequisites (tool availability, authentication, repository state) before proceeding.
+- **Git workflow (worktree + PR)** — Each task gets its own worktree and branch. Work is integrated via pull request. If selected, also ask for the base branch (what branch to create feature branches from). When selected, the orchestrator verifies `_git` prerequisites (tool availability, authentication, repository state) before proceeding.
 
 **Fourth question — notification channels:**
 - Multi-select. If any channel is selected alongside Skip, channels take priority.
@@ -40,7 +40,7 @@ You are an orchestrator based on gobbi. You must delegate everything to speciali
 - **Discord** — Notify via Discord webhook.
 - **Skip notifications** — No notifications this session.
 
-After selection, check `$CLAUDE_PROJECT_DIR/.claude/.env` for credentials. If credentials exist for the selected channels, enable notifications. If credentials are missing, load _notification and read the relevant channel doc (`slack.md`, `telegram.md`, `discord.md`) to help the user configure them before proceeding.
+After selection, check `$CLAUDE_PROJECT_DIR/.claude/.env` for credentials. If credentials exist for the selected channels, enable notifications. If credentials are missing, load `_notification` and read the relevant channel doc (`slack.md`, `telegram.md`, `discord.md`) to help the user configure them before proceeding.
 
 **After all four questions — persist session choices.** The orchestrator writes the user's selections to `gobbi.json` via `gobbi config` so that hooks and subagents can read them without conversation context. Persistence calls use `$CLAUDE_SESSION_ID` as the session key:
 
@@ -53,7 +53,7 @@ After selection, check `$CLAUDE_PROJECT_DIR/.claude/.env` for credentials. If cr
 
 These session choices set defaults for the orchestrator. Either default can be overridden at any specific step if you change your mind.
 
-**SIXTH — project context detection.** This runs automatically at session start without asking. Load project-setup.md to execute detection.
+**SIXTH — project context detection.** This runs automatically at session start without asking. Load [project-setup.md](project-setup.md) to execute detection.
 
 This skill defines the agent principles, rules, and skill map you must follow.
 
@@ -65,6 +65,7 @@ This skill defines the agent principles, rules, and skill map you must follow.
 | [project-setup.md](project-setup.md) | Project-specific context and technology stack signals |
 | [notification-setup.md](notification-setup.md) | Notification channel and credential detection |
 | [git-setup.md](git-setup.md) | Git tooling and repository state detection |
+| [design/v050-overview.md](../../project/gobbi/design/v050-overview.md) | v0.5.0 state machine, 5-step cycle, directory split — authoritative architecture doc |
 
 ---
 
@@ -78,11 +79,11 @@ This skill defines the agent principles, rules, and skill map you must follow.
 
 ### Work
 
-Workflow participant skills — loaded during the 7-step cycle: Ideation, Plan, Research, Execution, Collection, Memorization, Review.
+Workflow participant skills — loaded during the 5-step cycle: Ideation, Plan, Execution, Evaluation, Memorization.
 
 | Skill | Purpose |
 |---|---|
-| **_orchestration** | Adaptive workflow coordinator. Routes tasks through the 7-step workflow and post-workflow phases. |
+| **_orchestration** | Adaptive workflow coordinator for v0.4.x skill-based orchestration — deprecated in v0.5.0. See `_orchestration/ARCHIVED.md` for historical reference and the v0.4.x-to-v0.5.0 step mapping. |
 | **_discuss** | Critical, structured discussion. Challenge vague thinking, surface hidden problems, push ideas toward concrete specificity. |
 | **_ideation** | Structured idea refinement. PI agents (innovative + best stances) improve the user's idea through discussion and synthesis. |
 | **_plan** | Task decomposition. Break complex work into narrow, ordered, agent-assigned tasks. |

--- a/.claude/skills/gobbi/cli-setup.md
+++ b/.claude/skills/gobbi/cli-setup.md
@@ -1,6 +1,8 @@
 # CLI Setup
 
+> Status: v0.5.0 stable — updated 2026-04-19
 
+Check gobbi CLI availability at session start. If `gobbi --version` succeeds, proceed. If not, use this doc to install.
 
 ---
 
@@ -8,7 +10,7 @@
 
 > **Gobbi CLI must be available before the workflow can proceed.**
 
-The gobbi CLI (`gobbi` command) powers note initialization, subtask collection, config management, and validation. Without it, hooks fail silently and notes can't be initialized. Check availability at the start of every session before asking setup questions.
+The gobbi CLI (`gobbi` command) powers workflow initialization, session management, config management, and validation. Without it, hooks fail silently and `gobbi workflow init` cannot run. Check availability at the start of every session before asking setup questions.
 
 ---
 
@@ -18,8 +20,8 @@ Run `gobbi --version` at session start. Three outcomes:
 
 | Outcome | Meaning | Action |
 |---|---|---|
-| Version prints (e.g., `0.4.0`) | CLI is installed and in PATH | Proceed to setup questions |
-| Command outputs version via `node packages/cli/bin/gobbi.js --version` | CLI is available locally but not installed globally | Usable for development — proceed, but suggest global install for convenience |
+| Version prints (e.g., `0.5.0`) | CLI is installed and in PATH | Proceed to setup questions |
+| Command outputs version via `bun packages/cli/bin/gobbi.js --version` | CLI is available locally but not installed globally | Usable for development — proceed, but suggest global install for convenience |
 | Command not found | CLI is not installed | Help the user install before proceeding |
 
 ---
@@ -30,61 +32,59 @@ There are three ways to install the gobbi CLI, depending on the user's setup:
 
 ### Option 1: npm global install (Recommended)
 
-Install globally so `gobbi` is available in all terminals:
+Install globally via npm so `gobbi` is available in all terminals. npm is the registry; Bun is the runtime. Installing via npm handles both:
 
-```
-npm install -g @gobbi/cli
-```
+`npm install -g @gobbitools/cli`
 
 Verify: `gobbi --version`
 
 This is the recommended approach for users who want `gobbi` available across all projects.
 
-### Option 2: npm link (for development)
+### Option 2: Claude Code plugin install
 
-If working on the gobbi repository itself, link the local builds:
+If using the gobbi plugin for Claude Code, install via the plugin system:
 
-```
-npm link --workspace=packages/cli
-npm link --workspace=packages/media
-```
+`/plugin install gobbi`
 
-This creates global symlinks to the local bin scripts. Changes to the source are immediately available after `npm run build`.
+The plugin registers the CLI and the five v0.5.0 workflow hook entries (`gobbi workflow init`, `gobbi workflow guard`, `gobbi workflow capture-subagent`, `gobbi workflow capture-plan`, `gobbi workflow stop`) automatically.
 
 Verify: `gobbi --version`
 
-### Option 3: Local execution (no install)
+### Option 3: Local execution (development)
 
-Run directly from the project:
+Run directly from the gobbi project root when working on the gobbi repository itself:
 
-```
-node packages/cli/bin/gobbi.js <command>
-```
+`bun packages/cli/bin/gobbi.js <command>`
 
-This works without any installation but requires being in the gobbi project root. Hooks in `settings.json` use the bare `gobbi` command, so this option only works for manual CLI usage — hooks will fail without a global install or link.
+This works without any installation but requires being in the gobbi project root. Hooks in `settings.json` use the bare `gobbi` command, so this option only works for manual CLI usage — hooks will fail without a global install.
 
 ---
 
 ## Prerequisites
 
-- **Node.js >= 18** — required for the TypeScript CLI. Check with `node --version`.
-- **npm** — for installing the package. Bundled with Node.js.
-- **TypeScript build** — if using npm link, run `npm run build` first to compile TypeScript to `dist/`.
+- **Bun >= 1.2.0** — the v0.5.0 CLI runs on Bun, not Node.js. Check with `bun --version`. Install from `bun.sh` if missing.
+- **npm** — for Option 1 global install. Bundled with Node.js or available standalone.
+
+The `@gobbitools/cli` package is published to npm but the runtime is Bun. This means `npm install -g @gobbitools/cli` handles distribution while Bun executes the commands.
 
 ---
 
 ## What the CLI Provides
 
-The gobbi CLI replaces the shell scripts that were previously in `.claude/skills/_note/scripts/` and `.claude/hooks/`. Key commands:
+The gobbi CLI manages workflow state, session configuration, notes, and validation. Key commands:
 
 | Command | Purpose |
 |---|---|
-| `gobbi note init <project> <slug>` | Initialize a note directory with per-step subdirectories |
-| `gobbi note collect <agent-id> <num> <slug> <dir> [--phase]` | Extract subagent results from JSONL transcripts |
-| `gobbi config set <session> <key> <value>` | Set session configuration in gobbi.json |
+| `gobbi workflow init` | Initialize a session directory under `.gobbi/sessions/{id}/`, write `metadata.json`, open `gobbi.db`, emit the first `workflow.start` event |
+| `gobbi workflow guard` | Evaluate guard predicates against current workflow state before each tool call |
+| `gobbi workflow capture-subagent` | Record subagent completion — called by the SubagentStop hook |
+| `gobbi workflow capture-plan` | Record the current plan when ExitPlanMode fires |
+| `gobbi workflow stop` | Write the final session event and flush state on Stop |
+| `gobbi workflow status` | Show current workflow state for the active session |
+| `gobbi workflow resume` | Resume an interrupted session, replaying events from `gobbi.db` |
+| `gobbi config set <session> <key> <value>` | Set session configuration in `gobbi.json` |
 | `gobbi config get <session> [key]` | Read session configuration |
-| `gobbi session metadata` | Output session metadata (used by SessionStart hook) |
-| `gobbi notify <event>` | Send notifications (used by hooks) |
+| `gobbi notify send` | Send a notification (used inline by `gobbi workflow init` when channels are configured) |
 | `gobbi validate <type> <path>` | Validate agent, skill, or gotcha definitions |
 
 ---
@@ -93,6 +93,7 @@ The gobbi CLI replaces the shell scripts that were previously in `.claude/skills
 
 | Problem | Cause | Fix |
 |---|---|---|
-| `gobbi: command not found` | Not installed globally or not linked | Run `npm install -g @gobbi/cli` or `npm link` in the gobbi directory |
-| `gobbi note init` fails with CLAUDE_SESSION_ID not set | SessionStart hook didn't run | Check `.claude/settings.json` hooks — the `gobbi session metadata` hook must fire on startup |
-| Hooks fail silently | `gobbi` not in PATH when hooks execute | Ensure global install or link — hooks run in a shell that may not have local node_modules/.bin in PATH |
+| `gobbi: command not found` | Not installed globally | Run `npm install -g @gobbitools/cli` |
+| `bun: command not found` | Bun not installed | Install from `bun.sh` |
+| `gobbi workflow init` fails | CLI version mismatch or SQLite init error | Verify `gobbi --version` is `0.5.0`; reinstall if stale |
+| Hooks fail silently | `gobbi` not in PATH when hooks execute | Ensure global install — hooks run in a shell that may not have local `node_modules/.bin` in PATH |

--- a/.claude/skills/gobbi/git-setup.md
+++ b/.claude/skills/gobbi/git-setup.md
@@ -1,5 +1,7 @@
 # Git Setup
 
+> Status: v0.5.0 stable — updated 2026-04-19
+
 Check git tooling and repository state at session start. Determines whether the git workflow (worktree + PR) is viable and what issues need attention before work begins.
 
 ---

--- a/.claude/skills/gobbi/notification-setup.md
+++ b/.claude/skills/gobbi/notification-setup.md
@@ -1,5 +1,7 @@
 # Notification Setup
 
+> Status: v0.5.0 stable — updated 2026-04-19
+
 Check notification configuration state at session start. Determines which channels are ready, which need setup, and what the orchestrator should offer the user.
 
 ---
@@ -12,11 +14,19 @@ Detection before the first task means the orchestrator can offer credential setu
 
 > **Both session flag AND credentials must be present for notifications to fire.**
 
-Notification delivery requires two independent conditions: the session flag in `gobbi.json` is `true` for the channel, and the channel's credentials exist in `.env`. Missing either one suppresses delivery. This means credentials alone are not sufficient — the user must explicitly opt in per session during `/gobbi` setup.
+Notification delivery requires two independent conditions: the session flag in `gobbi.json` is `true` for the channel, and the channel's credentials exist in `.env`. Missing either one suppresses delivery. This means credentials alone are not sufficient — the user must explicitly opt in per session during the setup questions in FIFTH.
 
 > **Detection is read-only.**
 
 Never modify credentials, hooks, or settings during detection. Report state; let the user decide what to fix.
+
+---
+
+## How Notifications Work in v0.5.0
+
+In v0.5.0, the four-channel setup question (Slack / Telegram / Discord / Skip) runs inside `gobbi workflow init` — not as a separate `/gobbi` step. When `gobbi workflow init` fires at SessionStart, it reads the session flags from `gobbi.json` and calls `gobbi notify send` inline at workflow boundaries (session open, step transitions, completion). No plugin hook is registered for notifications: CP3 and L-F3 removed the auto-registered `gobbi notify *` hook entries from the plugin.
+
+If you want notifications to auto-fire independently of the workflow CLI (for example, on Stop events outside an active session), see the "Restoring auto-fire notifications" section below.
 
 ---
 
@@ -35,34 +45,29 @@ Check if `$CLAUDE_PROJECT_DIR/.claude/.env` exists. If it does, read it and iden
 
 A channel is "configured" when all its required credentials are present and non-empty.
 
-### 2. Hook Scripts
+### 2. Session Preferences in gobbi.json
 
-Check `settings.json` (and `settings.local.json`) for hook entries that invoke `gobbi notify` commands. There are no standalone shell scripts in `.claude/hooks/` — hooks are registered directly in the settings files and call the gobbi CLI.
+The user's notification choices from the setup questions (FIFTH) are persisted to `gobbi.json` via `gobbi config`. The `gobbi notify send` command reads these per-session flags before attempting delivery. Without a session entry, all channels default to `false` — no notifications fire until the user explicitly selects during setup.
 
-- `gobbi notify send` — the shared sender invoked by hook entries
-- Event-specific entries in `settings.json` hooks array
+Slack and Telegram have conditional session-level control. Discord delivery is deferred to a future version. Desktop notifications (`NOTIFY_DESKTOP`) remain environment-level only — they are not gated by `gobbi.json` session flags.
 
-Missing hook entries indicate an incomplete installation. Verify `gobbi` is in PATH by running `which gobbi`.
+### 3. Classify State
 
-### 3. Hook Configuration
+**Fully configured** — Credentials exist in `.env` and session flags are set in `gobbi.json` for the selected channels. After the user selects channels at setup, the orchestrator persists session flags. Notifications fire via `gobbi notify send` at workflow boundaries.
 
-Check `settings.json` for hook entries that reference the notification scripts. Hooks must be registered for the desired events (typically `Stop` and `Notification`).
+**Partially configured** — Credentials exist but session flags are missing, or flags are set but credentials are absent. Report what's missing and offer to fix. Both conditions must be true for delivery.
 
-### 4. Session Preferences in gobbi.json
-
-The user's notification choices from `/gobbi` setup Q4 are persisted to `gobbi.json` via `gobbi config`. The `gobbi notify send` command reads these per-session flags before attempting delivery. Without a session entry, all channels default to `false` — no notifications fire until the user explicitly selects during setup.
-
-Only Slack and Telegram have conditional session-level control in v0.3.2. Discord delivery is deferred to a future version. Desktop notifications (`NOTIFY_DESKTOP`) remain environment-level only — they are not gated by `gobbi.json` session flags.
-
-### 5. Classify State
-
-**Fully configured** — Credentials exist in `.env`, hooks are registered in `settings.json`, and session flags are set in `gobbi.json`. After the user selects channels at setup, the orchestrator persists session flags. Notifications fire for selected channels.
-
-**Partially configured** — Some pieces are in place but others are missing (e.g., credentials exist but hooks aren't registered in `settings.json`). Report what's missing and offer to fix. Session flags alone are not sufficient — credentials and hook registration must also be present.
-
-**Not configured** — No `$CLAUDE_PROJECT_DIR/.claude/.env` or no notification credentials. If the user selected notification channels at session start, load _notification and read the relevant channel doc (`slack.md`, `telegram.md`, `discord.md`) to help set up. Session flags are still written to `gobbi.json` so that notifications activate immediately once credentials are added.
+**Not configured** — No `$CLAUDE_PROJECT_DIR/.claude/.env` or no notification credentials. If the user selected notification channels at session start, load `_notification` and read the relevant channel doc (`slack.md`, `telegram.md`, `discord.md`) to help set up. Session flags are still written to `gobbi.json` so that notifications activate immediately once credentials are added.
 
 **Degraded** — Credentials exist but a dependency is missing (e.g., `gobbi` not in PATH, `notify-send` not available for Desktop). Report the dependency gap.
+
+---
+
+## Restoring Auto-Fire Notifications
+
+V0.5.0 removes the plugin's automatic `gobbi notify *` hook registrations (per L-F3). If you want notifications to fire automatically on Claude Code session events — independent of the workflow CLI — add your own hook entries to your user-level `~/.claude/settings.json`. The `gobbi notify` subcommand continues to work in v0.5.0.
+
+For the exact hook entries to copy into your `~/.claude/settings.json` and the three restoration paths (keep v0.4.5 alongside, wire your own hooks, or wait for Phase 3), see `MIGRATION.md` — Breaking change 1. The migration guide has copy-paste-ready command strings and explains which restoration path fits which usage pattern.
 
 ---
 
@@ -70,5 +75,5 @@ Only Slack and Telegram have conditional session-level control in v0.3.2. Discor
 
 - Detection must be lightweight — reading a few files, not running network checks or sending test messages
 - Never modify `$CLAUDE_PROJECT_DIR/.claude/.env`, hook scripts, or settings during detection
-- Never send test notifications during detection — that belongs to the _notification setup flow
+- Never send test notifications during detection — that belongs to the `_notification` setup flow
 - If `$CLAUDE_PROJECT_DIR/.claude/.env` exists, check file permissions are 600 — warn if not, but do not change them during detection

--- a/.claude/skills/gobbi/project-setup.md
+++ b/.claude/skills/gobbi/project-setup.md
@@ -1,8 +1,8 @@
 # Project Setup
 
-Check for `$CLAUDE_PROJECT_DIR/.claude/project/` at session start. If project documentation exists, read it for context. If not, create the project directory using the _project skill.
+> Status: v0.5.0 stable — updated 2026-04-19
 
-
+Check for project directories at session start. Two layers exist in v0.5.0: the static-knowledge layer at `$CLAUDE_PROJECT_DIR/.claude/project/{name}/` and the runtime layer at `$CLAUDE_PROJECT_DIR/.gobbi/sessions/{session-id}/`. This doc covers detection and setup of both.
 
 ---
 
@@ -10,11 +10,23 @@ Check for `$CLAUDE_PROJECT_DIR/.claude/project/` at session start. If project do
 
 > **Every project needs a `$CLAUDE_PROJECT_DIR/.claude/project/{project-name}/` directory.**
 
-Notes, gotchas, and project documentation accumulate here across sessions. Without it, workflow output has nowhere to persist.
+Notes, gotchas, and project documentation accumulate here across sessions. Without it, workflow output has nowhere to persist in the permanent record.
 
 > **Read only `README.md`, `design/`, and `gotchas/` at setup.**
 
 Other directories like `note/` may contain many files and are not needed for session context. Keep setup lightweight.
+
+---
+
+## Directory Model in v0.5.0
+
+V0.5.0 splits runtime and static-knowledge into separate root directories:
+
+`.claude/` is the static-knowledge layer. Skills, rules, agents, and project docs live here. This directory is not written to during an active session — it is read-only during workflow.
+
+`.gobbi/` is the runtime layer. Per-session directories (`sessions/{session-id}/`) hold the event store (`gobbi.db`), `metadata.json`, and `state.json`. Notes recorded during an active session write to `.gobbi/sessions/{id}/` via `gobbi workflow capture-subagent`. This directory is gitignored and does not persist across repository clones.
+
+When `gobbi workflow init` runs, it creates `.gobbi/sessions/{session-id}/` automatically. Detection below determines whether the static-knowledge layer is also ready.
 
 ---
 
@@ -43,7 +55,13 @@ Look for `$CLAUDE_PROJECT_DIR/.claude/project/` and identify any `{project-name}
 
 Do not read other directories (e.g., `note/`) at setup — they may contain many files and are not needed for session context.
 
-### 3. New Projects
+### 3. Check for Active Session Runtime Directory
+
+Look for `$CLAUDE_PROJECT_DIR/.gobbi/sessions/` to understand the runtime state. This directory is created by `gobbi workflow init` on the first run. If it does not exist, no sessions have been initialized yet — this is normal for new projects.
+
+Notes written during an active session go to `.gobbi/sessions/{session-id}/` (ephemeral, gitignored). After a session completes, retrospective archive notes land in `.claude/project/{name}/note/` (also gitignored, main-tree only). Do not confuse the two locations — the runtime path is transient; the archive path is persistent.
+
+### 4. New Projects
 
 When `$CLAUDE_PROJECT_DIR/.claude/project/` is absent or has no project subdirectory, ask the user for a project name via AskUserQuestion, then create the full standard structure:
 
@@ -51,13 +69,13 @@ When `$CLAUDE_PROJECT_DIR/.claude/project/` is absent or has no project subdirec
 - `$CLAUDE_PROJECT_DIR/.claude/project/{name}/design/` — architecture and design decisions
 - `$CLAUDE_PROJECT_DIR/.claude/project/{name}/rules/` — project-specific rules and conventions
 - `$CLAUDE_PROJECT_DIR/.claude/project/{name}/gotchas/` — project-specific gotchas
-- `$CLAUDE_PROJECT_DIR/.claude/project/{name}/note/` — workflow notes per task (managed by _note)
+- `$CLAUDE_PROJECT_DIR/.claude/project/{name}/note/` — workflow notes per task (managed by `_note`)
 - `$CLAUDE_PROJECT_DIR/.claude/project/{name}/reference/` — external references, API docs, research
 - `$CLAUDE_PROJECT_DIR/.claude/project/{name}/docs/` — other project documents
 
 Create all directories upfront. The README.md must list each directory with a one-line description. Load `_project` for detailed authoring guidelines if the user wants to populate design docs or rules immediately.
 
-### 4. Help Set Up Claude Docs
+### 5. Help Set Up Claude Docs
 
 After project directory setup, check what the project is missing in `$CLAUDE_PROJECT_DIR/.claude/` and offer to help create them via AskUserQuestion. This is the onboarding moment — guide the user toward a well-structured project.
 
@@ -79,3 +97,4 @@ Do not create all of these at once — ask the user which they want to set up no
 - Never generate a user-facing report or summary document. Output is internal orchestrator context only.
 - Skip setup for gobbi's own repository — `$CLAUDE_PROJECT_DIR/.claude/project/` is already structured
 - When `$CLAUDE_PROJECT_DIR/.claude/project/` docs exist, trust them over filesystem inference
+- Never create `.gobbi/` directories manually — `gobbi workflow init` creates the runtime directory; detection here is read-only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-04-19
+
+### Breaking
+
+- Hook wiring replaced — `gobbi notify *` hooks removed; `gobbi workflow *` hooks registered in `plugins/gobbi/hooks/hooks.json` and `.claude/settings.json` (#83)
+- `_orchestration` skill deprecated — see `.claude/skills/_orchestration/ARCHIVED.md` for the 7-step → 5-step mapping (#83)
+- 7-step cycle replaced by 5-step state machine (Ideation → Plan → Execution → Evaluation → Memorization); see `design/v050-overview.md` (#78, #79, #80, #81, #82, #83)
+- Directory split — `.claude/` is static knowledge (skills, rules, docs, gotchas); `.gobbi/` is runtime state (event store, sessions, heartbeats); `.gobbi/` is gitignored (#78, #83)
+
+### Added
+
+- `gobbi workflow` command group — 11 subcommands: `init`, `next`, `transition`, `guard`, `capture-subagent`, `capture-plan`, `stop`, `resume`, `status`, `validate`, `events` (#78, #80)
+- Predicate registry — typed TS functions replacing JsonLogic; `gobbi workflow validate` enforces coverage (#79)
+- Spec library — 5 step specs as validated JSON under `packages/cli/src/specs/{ideation,plan,execution,evaluation,memorization}/spec.json` (#79)
+- Event store + schema v1→v4 migrations — `packages/cli/src/workflow/migrations.ts` with lazy read-time migration (#78, #80, #81, #82)
+- State reducer — `packages/cli/src/workflow/reducer.ts`, pure function state evolution (#78)
+- Verification runner — synchronous serial execution wired into `next.ts`; results reduce to state (#82)
+- Cost rollup — `gobbi workflow status --cost` aggregates token-derived dollar cost from `delegation.complete` events (#82)
+- `stepStartedAt` state field — enables `workflow.step.timeout` emission from `stop.ts` (#82)
+- `gobbi gotcha promote` — CLI to move session-local gotchas to tracked skill dirs (#80)
+- `gobbi session events` — inspect and export the event log (#80)
+- Error-state + resume compilers — 5 pathway variants (crash, timeout, feedbackCap, invalidTransition, unknown) (#81)
+- `EvalSkipData.priorError` — CP11 reversibility snapshot on `resume --force-memorization` (#81)
+- `workflow.invalid_transition` event + audit-emit refactor in `engine.ts` (#81)
+- Verification-block prompt compiler — `packages/cli/src/specs/verification-block.ts` (#82)
+- Property-based tests — fast-check v4 reducer idempotency + transition exhaustiveness (#82)
+- End-to-end subprocess tests — `workflow-cycle.test.ts` (full cycle) + `migration-chain.test.ts` (v1→v4 replay) (#82, #83)
+- `MIGRATION.md` at repo root — v0.4.x → v0.5.0 upgrade guide (#83)
+- Phase 3 backlog — `.claude/project/gobbi/design/v050-phase3-backlog.md` (#83)
+- `_orchestration/ARCHIVED.md` — pedagogical mapping of 7-step to v0.5.0 equivalents (#83)
+
+### Changed
+
+- Runtime moved from Node to Bun (`engines.bun: ">=1.2.0"` in `packages/cli/package.json`) (#78)
+- `@gobbitools/cli` version 0.4.5 → 0.5.0 (#83)
+- `gobbi` plugin version 0.4.5 → 0.5.0 (`plugins/gobbi/.claude-plugin/plugin.json`) (#83)
+- Directory layout — specs live at `packages/cli/src/specs/` (#79)
+- `ajv` added as first production dependency for spec validation (#79)
+
 ### Removed
 
 - `gobbi docs` CLI command and all subcommands (#64)
@@ -14,6 +53,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `gobbi audit` CLI command (#64)
 - JSON-first documentation authoring system — Markdown is now the directly-editable format (#64)
 - `_doctor` and `_audit` skill directories (#64)
+- 6 `gobbi notify *` hook entries in `plugins/gobbi/hooks/hooks.json` + `.claude/settings.json`: SessionStart×1, Stop×1, Notification×1, StopFailure×1, SubagentStop×1, SessionEnd×1 (#83)
+
+### Fixed
+
+- Plugin config path corrected — `plugins/gobbi/.claude-plugin/plugin.json`, not `plugins/gobbi/plugin.json` (see `phase2-planning.md` gotcha) (#79)
+- Schema-version bump grep gates extended to rendered-output literals (`Schema: v[0-9]`) and `CURRENT_SCHEMA_VERSION).toBe(N)` canary pins (#81, #82)
 
 ## [0.4.0] - 2026-04-04
 
@@ -170,7 +215,8 @@ Internal version bump for session config, notification control, and JSON-templat
 - Slack notification hooks
 - Project state directory (`.claude/project/`) with design docs, gotchas, rules, and notes
 
-[Unreleased]: https://github.com/HahyeonJeon/gobbi/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/HahyeonJeon/gobbi/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/HahyeonJeon/gobbi/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/HahyeonJeon/gobbi/compare/v0.3.1...v0.4.0
 [0.3.2]: https://github.com/HahyeonJeon/gobbi/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/HahyeonJeon/gobbi/compare/v0.3.0...v0.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `gobbi audit` CLI command (#64)
 - JSON-first documentation authoring system — Markdown is now the directly-editable format (#64)
 - `_doctor` and `_audit` skill directories (#64)
-- 6 `gobbi notify *` hook entries in `plugins/gobbi/hooks/hooks.json` + `.claude/settings.json`: SessionStart×1, Stop×1, Notification×1, StopFailure×1, SubagentStop×1, SessionEnd×1 (#83)
+- 8 v0.4.x hook entries in `plugins/gobbi/hooks/hooks.json` + `.claude/settings.json`: SessionStart×3 (`gobbi session metadata`, `gobbi session load-env`, `gobbi notify session`), Stop×1 (`gobbi notify completion`), Notification×1 (`gobbi notify attention`), StopFailure×1 (`gobbi notify error`), SubagentStop×1 (`gobbi notify subagent`), SessionEnd×1 (`gobbi notify session`) (#83)
 
 ### Fixed
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -27,7 +27,7 @@ v0.4.5 remains installable from npm for archival purposes: `npm install -g @gobb
 | v0.4.x | v0.5.0 | Action required | Data compat |
 |---|---|---|---|
 | Skill-based orchestration (`_orchestration` skill) | CLI state machine (`gobbi workflow init`) | Plugin auto-registers new hooks on install | n/a — conceptual change |
-| 6 `gobbi notify *` hook entries (SessionStart, PreToolUse, Notification, Stop, StopFailure, SubagentStop) | 5 `gobbi workflow *` hook entries (SessionStart, PreToolUse, PostToolUse, SubagentStop, Stop) | Breaking — see below | n/a — hook wiring |
+| 8 v0.4.x hook entries (3×SessionStart + Stop + Notification + StopFailure + SubagentStop + SessionEnd — calling `gobbi notify *` and `gobbi session *`) | 5 `gobbi workflow *` hook entries (SessionStart, PreToolUse, PostToolUse, SubagentStop, Stop) | Breaking — see below | n/a — hook wiring |
 | Notes in `.claude/project/{name}/note/` (retrospective archive) | Active sessions in `.gobbi/sessions/{id}/` (runtime state) | Both coexist; no migration needed | Existing note archives remain valid |
 | 7-step cycle (ideation → plan → research → execute → collect → memorize → review) | 5-step cycle (Ideation → Plan → Execution → Evaluation → Memorization) | Conceptual; no user action needed | n/a |
 | `_orchestration` skill as workflow entry | Deprecated — banner + `ARCHIVED.md` | Skill remains on disk for reference; no deletion | n/a |
@@ -36,9 +36,9 @@ v0.4.5 remains installable from npm for archival purposes: `npm install -g @gobb
 
 ### Breaking change 1 — Notification hooks replaced
 
-**What changed.** v0.4.x registered 6 `gobbi notify *` hook entries in `plugins/gobbi/hooks/hooks.json` and `.claude/settings.json`, covering SessionStart, PreToolUse, Notification, Stop, StopFailure, and SubagentStop events. These entries auto-fired Slack, Telegram, Discord, and Desktop notifications at workflow boundaries.
+**What changed.** v0.4.x registered 8 hook entries in `plugins/gobbi/hooks/hooks.json` and `.claude/settings.json`: three SessionStart handlers (`gobbi session metadata`, `gobbi session load-env`, `gobbi notify session`), plus one each for Stop (`gobbi notify completion`), Notification (`gobbi notify attention`), StopFailure (`gobbi notify error`), SubagentStop (`gobbi notify subagent`), and SessionEnd (`gobbi notify session`). The 6 `gobbi notify *` entries auto-fired Slack, Telegram, Discord, and Desktop notifications at workflow boundaries; the 2 `gobbi session *` entries handled session metadata bootstrapping (now subsumed by `gobbi workflow init`).
 
-v0.5.0 removes all 6 `gobbi notify *` entries and replaces them with 5 `gobbi workflow *` entries (see `design/v050-hooks.md:172-180`):
+v0.5.0 removes all 8 v0.4.x entries and replaces them with 5 `gobbi workflow *` entries (see `design/v050-hooks.md:172-180`):
 
 | Hook event | v0.5.0 command |
 |---|---|

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,136 @@
+# Migration Guide
+
+This guide documents breaking changes and upgrade steps for major version bumps. See `CHANGELOG.md` for comprehensive release notes.
+
+---
+
+## v0.4.x → v0.5.0
+
+### Summary
+
+v0.5.0 replaces skill-based orchestration with a CLI-driven state machine. The `_orchestration` skill's 7-step prose cycle is retired; the v0.5.0 CLI takes over workflow initialization, step sequencing, guard enforcement, and session capture via five registered hook events. This is a major bump because the hook surface, directory layout, and orchestration model all change in ways that require user action.
+
+Three things change for every v0.4.x user: (1) the plugin's auto-registered hooks fire different commands, (2) the `_orchestration` skill is deprecated, and (3) a new `.gobbi/` runtime directory sits alongside `.claude/`. Each is a breaking change described below.
+
+---
+
+### Who must migrate
+
+All v0.4.x users must read this guide. If you customized your notification hooks, you must act before upgrading — see Breaking change 1 below.
+
+v0.4.5 remains installable from npm for archival purposes: `npm install -g @gobbitools/cli@0.4.5`. The 0.4.x branch is frozen and receives no further updates. Only v0.4.5 is supported for archival.
+
+---
+
+### Upgrade path at a glance
+
+| v0.4.x | v0.5.0 | Action required | Data compat |
+|---|---|---|---|
+| Skill-based orchestration (`_orchestration` skill) | CLI state machine (`gobbi workflow init`) | Plugin auto-registers new hooks on install | n/a — conceptual change |
+| 6 `gobbi notify *` hook entries (SessionStart, PreToolUse, Notification, Stop, StopFailure, SubagentStop) | 5 `gobbi workflow *` hook entries (SessionStart, PreToolUse, PostToolUse, SubagentStop, Stop) | Breaking — see below | n/a — hook wiring |
+| Notes in `.claude/project/{name}/note/` (retrospective archive) | Active sessions in `.gobbi/sessions/{id}/` (runtime state) | Both coexist; no migration needed | Existing note archives remain valid |
+| 7-step cycle (ideation → plan → research → execute → collect → memorize → review) | 5-step cycle (Ideation → Plan → Execution → Evaluation → Memorization) | Conceptual; no user action needed | n/a |
+| `_orchestration` skill as workflow entry | Deprecated — banner + `ARCHIVED.md` | Skill remains on disk for reference; no deletion | n/a |
+
+---
+
+### Breaking change 1 — Notification hooks replaced
+
+**What changed.** v0.4.x registered 6 `gobbi notify *` hook entries in `plugins/gobbi/hooks/hooks.json` and `.claude/settings.json`, covering SessionStart, PreToolUse, Notification, Stop, StopFailure, and SubagentStop events. These entries auto-fired Slack, Telegram, Discord, and Desktop notifications at workflow boundaries.
+
+v0.5.0 removes all 6 `gobbi notify *` entries and replaces them with 5 `gobbi workflow *` entries (see `design/v050-hooks.md:172-180`):
+
+| Hook event | v0.5.0 command |
+|---|---|
+| SessionStart | `gobbi workflow init` |
+| PreToolUse | `gobbi workflow guard` |
+| PostToolUse (ExitPlanMode) | `gobbi workflow capture-plan` |
+| SubagentStop | `gobbi workflow capture-subagent` |
+| Stop | `gobbi workflow stop` |
+
+**Consumer impact.** If you relied on auto-fired notifications (Slack/Telegram/Discord/Desktop), they no longer fire after upgrading the plugin. The `gobbi notify` subcommand itself remains in the CLI — only the plugin's automatic registration is removed.
+
+**Restoration paths.** Choose the path that fits your situation:
+
+**Path A — Keep v0.4.5 installed alongside v0.5.0.**
+Best for: users who depend heavily on notification automation and cannot tolerate a lag in notification coverage.
+
+Install the archival version under a separate binary: `npm install -g @gobbitools/cli@0.4.5`. Then manually add the v0.4.x notify entries back into your user-level `~/.claude/settings.json` under the appropriate hook events. Both CLI versions coexist on your PATH under their respective binary names.
+
+**Path B — Wire your own notification hooks in `~/.claude/settings.json`.**
+Best for: users who want the v0.5.0 workflow core and are willing to configure custom notifications.
+
+The `gobbi notify` subcommand (`gobbi notify session`, `gobbi notify completion`, `gobbi notify attention`, `gobbi notify error`, `gobbi notify subagent`) continues to work in v0.5.0. Add hook entries calling these commands to your user-level `~/.claude/settings.json` under the hook events that matter to you (SessionStart, Stop, Notification, SubagentStop). User-level settings are not overwritten by the plugin.
+
+**Path C — Wait for Phase 3.**
+Best for: users who want the canonical gobbi notification setup restored and can tolerate a gap.
+
+Phase 3 may restore notification events over the v0.5.0 hook surface. No timeline is committed. See `CHANGELOG.md` for release history and the Phase 3 backlog doc at `.claude/project/gobbi/design/v050-phase3-backlog.md` for the tracked item.
+
+---
+
+### Breaking change 2 — `_orchestration` skill deprecated
+
+**What changed.** The `_orchestration` skill's SKILL.md, which contained the 7-step prose orchestration cycle, is deprecated in v0.5.0. The skill directory remains on disk (per CP6 locked decision — no deletion) and is marked with a deprecation banner. The authoritative deprecation context, including the 7-step → 5-step mapping, lives in `.claude/skills/_orchestration/ARCHIVED.md`.
+
+**Consumer impact.** If you have muscle memory loading the `_orchestration` skill or following its 7-step cycle, read `ARCHIVED.md` first. The new entry point for v0.5.0 orchestration is the `gobbi` skill (`/gobbi`), which now bootstraps a `gobbi workflow init` session instead of driving the 7-step prose cycle. The `_orchestration` skill remains on disk for reference; you will see a deprecation banner if you load it directly.
+
+Removal is not scheduled. The deprecated skill will remain in v0.5.x as an archived pointer.
+
+---
+
+### Breaking change 3 — Directory split
+
+**What changed.** v0.5.0 introduces a hard split between two directories (per `design/v050-overview.md:119-136`):
+
+- `.claude/` — static knowledge layer. Skills, rules, agents, gotchas, CLAUDE.md, settings. Read-only during an active workflow session. A PreToolUse guard blocks writes to `.claude/` while a session is running.
+
+- `.gobbi/` — runtime layer. Active sessions (`sessions/{id}/`), event store (`gobbi.db`), heartbeats, and mid-session gotchas. Agents write freely here. Writing to `.gobbi/` does not trigger Claude Code context reload.
+
+**Consumer impact.** The gobbi repo itself already has `.gobbi/` in `.gitignore` (line 7). If you are adopting the gobbi plugin in your own project, add `.gobbi/` to your project's `.gitignore`. The `.gobbi/` directory is created on first `gobbi workflow init` run.
+
+Gotchas recorded mid-session land in `.gobbi/project/gotchas/` and must be promoted to `.claude/skills/_gotcha/` via `gobbi gotcha promote` — run this outside an active session. The promotion step is a deliberate gate that prevents mid-session noise from polluting the permanent gotcha store.
+
+---
+
+### Verification after upgrade
+
+Run these commands to confirm v0.5.0 is active after installing:
+
+```bash
+# 1. Version confirms 0.5.0
+gobbi --version
+# → 0.5.0
+
+# 2. Workflow CLI is available
+gobbi workflow init --help
+# → prints usage
+
+# 3. Hook events are the 5 v0.5.0 entries (no gobbi notify entries)
+jq '.hooks | keys' plugins/gobbi/hooks/hooks.json
+# → ["PostToolUse","PreToolUse","SessionStart","Stop","SubagentStop"]
+
+# 4. No v0.4.x notify entries remain
+grep -n "gobbi notify" plugins/gobbi/hooks/hooks.json
+# → 0 hits
+
+# 5. Session directory is created on init
+cd /tmp && mkdir test-gobbi && cd test-gobbi
+gobbi workflow init --session-id smoke-test --task "verify install"
+ls .gobbi/sessions/smoke-test/
+# → metadata.json  gobbi.db
+```
+
+---
+
+### Keeping v0.4.x
+
+If you need to stay on v0.4.x, install the archival version:
+
+```bash
+npm install -g @gobbitools/cli@0.4.5
+```
+
+v0.4.5 will remain installable from npm indefinitely. Gobbi does not unpublish releases. The 0.4.x branch is frozen — no further updates, no security patches. Only v0.4.5 is supported for archival.
+
+See `CHANGELOG.md` for the full v0.4.x history.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 <p align="center"><sub>고삐 (gobbi) — Korean for reins, the essential equipment for handling a horse</sub></p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/@gobbi/cli"><img src="https://img.shields.io/npm/v/@gobbi/cli" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/@gobbitools/cli"><img src="https://img.shields.io/npm/v/@gobbitools/cli" alt="npm version"></a>
   <a href="./LICENSE"><img src="https://img.shields.io/github/license/HahyeonJeon/gobbi" alt="License: MIT"></a>
-  <a href="https://nodejs.org"><img src="https://img.shields.io/node/v/@gobbi/cli" alt="Node version"></a>
+  <a href="https://bun.sh"><img src="https://img.shields.io/badge/bun-%3E%3D1.2.0-orange" alt="Bun version"></a>
 </p>
 
 ---
@@ -24,7 +24,7 @@ Gobbi is an open-source ClaudeX tool.
 
 **Quality through structured evaluation** — Multi-perspective evaluation examines your work through independent lenses — project scope, architecture, performance, aesthetics, and holistic quality — catching problems no single viewpoint would find.
 
-**Claude docs managed, not scattered** — Skills, agents, and hooks organized with source-of-truth separation. The `.gobbi/` directory is the authoritative source; `.claude/` is generated output. Install plugins or create your own through Claude Code.
+**Claude docs managed, not scattered** — Skills, agents, and hooks organized with a clear separation between static knowledge and runtime state. `.claude/` is the static knowledge layer — skills, rules, agents, and hooks that Claude Code reads on every session. `.gobbi/` is the runtime layer — active session state, event store, heartbeats, and mid-session notes written during workflow execution.
 
 **Domain expertise built in** — Domain-specific skills (Python, TypeScript, data engineering) bring specialized knowledge to your sessions without requiring you to explain the domain each time.
 
@@ -34,41 +34,27 @@ Gobbi is an open-source ClaudeX tool.
 
 ## Quick Start
 
-In Claude Code:
+Install the plugin from inside Claude Code:
 
 ```
 /plugin install gobbi
 ```
 
+The plugin includes the CLI. Once installed, start a workflow with:
+
+```
+gobbi workflow init
+```
+
 Then run `/gobbi` to begin.
 
-### CLI Install
+### Direct CLI Install
+
+To install the CLI without the plugin:
 
 ```bash
-npx @gobbi/cli install
+npm install -g @gobbitools/cli
 ```
-
-This creates the `.gobbi/` directory with gobbi's skill and agent definitions, then syncs everything to `.claude/` where Claude Code reads them.
-
----
-
-## Commands
-
-| Command | Purpose |
-|---------|---------|
-| `npx @gobbi/cli install` | Install gobbi into the current project |
-| `npx @gobbi/cli update` | Update gobbi core to the latest version |
-| `npx @gobbi/cli sync` | Manually sync `.gobbi/` to `.claude/` |
-
----
-
-## Migration from v0.2.0
-
-```bash
-npx @gobbi/cli install
-```
-
-Automatically detects existing `.claude/` gobbi files, migrates them to `.gobbi/`, and syncs back. No manual intervention needed.
 
 ---
 

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "packages/cli": {
       "name": "@gobbitools/cli",
-      "version": "0.4.5",
+      "version": "0.5.0",
       "bin": {
         "gobbi": "./bin/gobbi.js",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gobbitools/cli",
-  "version": "0.4.5",
+  "version": "0.5.0",
   "description": "Gobbi CLI — workflow orchestration and docs management for Claude Code",
   "type": "module",
   "bin": {

--- a/packages/cli/src/__tests__/e2e/migration-chain.test.ts
+++ b/packages/cli/src/__tests__/e2e/migration-chain.test.ts
@@ -1,0 +1,176 @@
+/**
+ * End-to-end migration-chain test — exercises the CLI binary's lazy
+ * v1→vN event-schema migration through a `Bun.$` subprocess (plan §F.9 /
+ * L-F11 / ARCH-P2).
+ *
+ * Flow:
+ *   1. `gobbi workflow init` seeds a session (metadata.json, gobbi.db at
+ *      v4, state.json).
+ *   2. Inject schema_version=1 rows directly via `bun:sqlite`.
+ *   3. Delete state.json (ARCH-P2) so resolveWorkflowState can no longer
+ *      short-circuit through readState — next CLI call falls through to
+ *      store.replayAll → deriveState → rowToEvent → migrateEvent.
+ *   4. `gobbi workflow status --json` triggers the chain. Assert the
+ *      resulting schemaVersion equals CURRENT_SCHEMA_VERSION (imported,
+ *      NOT literal 4 — L-F11 + R2 canary).
+ *   5. Triangulation (innovative I11): stored rows still carry
+ *      schema_version=1 — migration must stay lazy/in-memory.
+ *
+ * Complements `workflow/__tests__/migrations.test.ts` (function-level) by
+ * locking the full CLI binary path — if a future refactor caches
+ * schemaVersion on metadata.json and bypasses deriveState, the in-process
+ * test still passes but this one fails.
+ *
+ * Option A (state.json delete + `workflow status`) chosen over Option B
+ * (`workflow resume`) because resume requires currentStep==='error',
+ * forcing extra fixture complexity; Option A is strictly simpler.
+ */
+
+import { test, describe, expect } from 'bun:test';
+import { $ } from 'bun';
+import { Database } from 'bun:sqlite';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  CURRENT_SCHEMA_VERSION,
+  type EventRow,
+} from '../../workflow/migrations.js';
+
+// CLI entry — mirrors workflow-cycle.test.ts. Two `..` hops land at
+// packages/cli/src/cli.ts.
+const CLI_PATH: string = join(import.meta.dir, '..', '..', 'cli.ts');
+
+/**
+ * Narrow `status --json` stdout into a record so index reads are strict-
+ * TS clean. Duplicates workflow-cycle.test.ts's helper rather than
+ * cross-importing — e2e tests stay self-contained.
+ */
+function parseStatus(buf: Buffer): Record<string, unknown> {
+  const text = buf.toString('utf8');
+  const parsed: unknown = JSON.parse(text);
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`status --json did not return an object: ${text}`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+/**
+ * v1 fixture events, shapes from `workflow/__tests__/migrations.test.ts:103-183`.
+ * Inlined rather than shared-extracted — duplication locks the v1 wire
+ * format in each test. `seq` starts at 100 to dodge init's v4 events
+ * (PRIMARY KEY at seq 1 + 2). `parent_seq` is null so we don't create
+ * dangling FKs to init's rows — migration is orthogonal to parent-seq.
+ */
+const v1Events: readonly EventRow[] = [
+  { seq: 100, ts: '2026-01-01T00:00:00.000Z', schema_version: 1, type: 'workflow.step.exit', step: 'ideation',
+    data: JSON.stringify({ step: 'ideation' }),
+    actor: 'orchestrator', parent_seq: null, idempotency_key: 'tool-call:tc-mig-001:workflow.step.exit' },
+  { seq: 101, ts: '2026-01-01T00:00:01.000Z', schema_version: 1, type: 'guard.violation', step: 'plan',
+    data: JSON.stringify({ guardId: 'g-scope', toolName: 'Write', reason: 'outside scope', step: 'plan',
+      timestamp: '2026-01-01T00:00:01.000Z' }),
+    actor: 'hook', parent_seq: null, idempotency_key: 'tool-call:tc-mig-002:guard.violation' },
+  { seq: 102, ts: '2026-01-01T00:00:02.000Z', schema_version: 1, type: 'artifact.write', step: 'execution',
+    data: JSON.stringify({ step: 'execution', filename: 'research.md', artifactType: 'note' }),
+    actor: 'executor', parent_seq: null, idempotency_key: 'tool-call:tc-mig-003:artifact.write' },
+];
+
+describe('migration chain e2e', () => {
+  test(
+    'v1 events injected directly into gobbi.db migrate to CURRENT_SCHEMA_VERSION on next CLI read',
+    async () => {
+      const tmpRoot = mkdtempSync(join(tmpdir(), 'gobbi-mig-e2e-'));
+      const sessionId = 'migrate-e2e';
+      // Same env shape as workflow-cycle.test.ts — blank CLAUDE_SESSION_ID
+      // so --session-id is authoritative; CLAUDE_TRANSCRIPT_PATH defensive.
+      const childEnv: Record<string, string> = {
+        ...process.env,
+        CLAUDE_SESSION_ID: '',
+        CLAUDE_TRANSCRIPT_PATH: '',
+      };
+
+      try {
+        // Step A — init a session shell (state.json at v4).
+        const initResult = await $`bun run ${CLI_PATH} workflow init --session-id ${sessionId} --task migration-e2e`
+          .cwd(tmpRoot)
+          .env(childEnv)
+          .quiet();
+        expect(initResult.exitCode).toBe(0);
+
+        const sessionDir = join(tmpRoot, '.gobbi', 'sessions', sessionId);
+        const dbPath = join(sessionDir, 'gobbi.db');
+        const statePath = join(sessionDir, 'state.json');
+        const stateBackupPath = join(sessionDir, 'state.json.backup');
+        expect(existsSync(join(sessionDir, 'metadata.json'))).toBe(true);
+        expect(existsSync(dbPath)).toBe(true);
+
+        // Step B — inject schema_version=1 rows directly.
+        const db = new Database(dbPath);
+        try {
+          const insert = db.prepare(
+            'INSERT INTO events (seq, ts, schema_version, type, step, data, actor, parent_seq, idempotency_key) ' +
+              'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+          );
+          for (const row of v1Events) {
+            insert.run(
+              row.seq,
+              row.ts,
+              row.schema_version,
+              row.type,
+              row.step,
+              row.data,
+              row.actor,
+              row.parent_seq,
+              row.idempotency_key,
+            );
+          }
+        } finally {
+          db.close();
+        }
+
+        // ARCH-P2 fix + innovative I11 pre-triangulation: delete state.json
+        // so the next CLI call falls through to deriveState. The pre-assert
+        // locks the intent (we deliberately removed a file we know existed).
+        expect(existsSync(statePath)).toBe(true);
+        rmSync(statePath);
+        rmSync(stateBackupPath, { force: true }); // defensive — init may add one later
+        expect(existsSync(statePath)).toBe(false);
+
+        // Step C — trigger migration via `workflow status --json`. With
+        // state.json gone, resolveWorkflowState walks replayAll → rowToEvent
+        // → migrateEvent on every seeded v1 row.
+        const statusResult = await $`bun run ${CLI_PATH} workflow status --session-id ${sessionId} --json`
+          .cwd(tmpRoot)
+          .env(childEnv)
+          .quiet();
+        expect(statusResult.exitCode).toBe(0);
+
+        const snap = parseStatus(statusResult.stdout);
+        expect(snap['schemaVersion']).toBe(CURRENT_SCHEMA_VERSION);
+        expect(snap['sessionId']).toBe(sessionId);
+
+        // Innovative I11 post-triangulation — stored rows still v1.
+        // Migration is lazy/in-memory: rowToEvent migrates during replay
+        // but does NOT rewrite disk. If a future refactor eagerly persists
+        // migrated rows, this assert flips and the owner must re-certify
+        // the lazy-migration invariant.
+        const dbPost = new Database(dbPath, { readonly: true });
+        try {
+          const rows = dbPost
+            .query<{ schema_version: number }, [string]>(
+              'SELECT schema_version FROM events WHERE idempotency_key = ?',
+            )
+            .all(v1Events[0]!.idempotency_key);
+          expect(rows.length).toBe(1);
+          expect(rows[0]?.schema_version).toBe(1);
+        } finally {
+          dbPost.close();
+        }
+      } finally {
+        rmSync(tmpRoot, { recursive: true, force: true });
+      }
+    },
+    60_000,
+  );
+});

--- a/plugins/gobbi/.claude-plugin/plugin.json
+++ b/plugins/gobbi/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gobbi",
-  "version": "0.4.5",
+  "version": "0.5.0",
   "description": "Open-source ClaudeX tool for Claude Code — structured orchestration with multi-stance evaluation, adaptive planning, and git workflow isolation",
   "author": {
     "name": "HahyeonJeon"

--- a/plugins/gobbi/hooks/hooks.json
+++ b/plugins/gobbi/hooks/hooks.json
@@ -6,67 +6,31 @@
         "hooks": [
           {
             "type": "command",
-            "command": "gobbi session metadata",
+            "command": "gobbi workflow init",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "gobbi workflow guard",
             "timeout": 5
           }
         ]
-      },
-      {
-        "matcher": "startup|resume",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "gobbi session load-env",
-            "timeout": 5
-          }
-        ]
-      },
-      {
-        "matcher": "startup|resume",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "gobbi notify session",
-            "timeout": 5,
-            "async": true
-          }
-        ]
       }
     ],
-    "Stop": [
+    "PostToolUse": [
       {
+        "matcher": "ExitPlanMode",
         "hooks": [
           {
             "type": "command",
-            "command": "gobbi notify completion",
-            "timeout": 10,
-            "async": true
-          }
-        ]
-      }
-    ],
-    "Notification": [
-      {
-        "matcher": "permission_prompt|idle_prompt|elicitation_dialog",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "gobbi notify attention",
-            "timeout": 5,
-            "async": true
-          }
-        ]
-      }
-    ],
-    "StopFailure": [
-      {
-        "matcher": "rate_limit|authentication_failed|billing_error|server_error",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "gobbi notify error",
-            "timeout": 5,
-            "async": true
+            "command": "gobbi workflow capture-plan",
+            "timeout": 30
           }
         ]
       }
@@ -76,22 +40,19 @@
         "hooks": [
           {
             "type": "command",
-            "command": "gobbi notify subagent",
-            "timeout": 5,
-            "async": true
+            "command": "gobbi workflow capture-subagent",
+            "timeout": 60
           }
         ]
       }
     ],
-    "SessionEnd": [
+    "Stop": [
       {
-        "matcher": "logout|prompt_input_exit",
         "hooks": [
           {
             "type": "command",
-            "command": "gobbi notify session",
-            "timeout": 5,
-            "async": true
+            "command": "gobbi workflow stop",
+            "timeout": 10
           }
         ]
       }


### PR DESCRIPTION
Closes #83 (explicit close in FINISH — closing keywords do not fire on non-default-branch PRs).

Last piece of v0.5.0 Phase 2 (umbrella #77). PRs A–E shipped the state-driven CLI + event store + migrations + verification runner. PR F makes v0.5.0 what users actually encounter on install.

## Commits (11)

| SHA | Subtask | Summary |
|---|---|---|
| `585f95b` | F.4 | register v0.5.0 workflow hooks in hooks.json + settings.json |
| `748a511` | F.5 | MIGRATION.md for v0.4.x → v0.5.0 with hook restoration paths |
| `d82c4ff` | F.8 | README/AGENTS/plugin-agents consistency sweep for v0.5.0 |
| `6874098` | F.7 | Phase 3 backlog with 18+ triggered items (allow-empty attribution) |
| `067d9f5` | F.1 | CLAUDE.md rewrite for v0.5.0 state-driven workflow |
| `ece8db2` | F.3 | deprecate _orchestration skill + rich pedagogical ARCHIVED.md |
| `df8212e` | F.2 | gobbi skill + 4 child docs rewritten for v0.5.0 |
| `3488824` | F.6 | bump @gobbitools/cli + plugin to 0.5.0 + CHANGELOG |
| `e4debc7` | F.9 | subprocess e2e for v1→v4 migration chain |
| `18721b7` | W7 fix | Project F-2/F-4/F-5 + Overall M-1 (gotcha) |
| `10acba0` | W7 fix | MIGRATION.md hook count 6→8 alignment with CHANGELOG |

## Changes

- **Hook rewiring (F.4):** 8 v0.4.x hook entries (3×SessionStart + Stop + Notification + StopFailure + SubagentStop + SessionEnd) → 5 v0.5.0 workflow hook entries (SessionStart → init, PreToolUse → guard, SubagentStop → capture-subagent, PostToolUse → capture-plan, Stop → stop) in BOTH plugins/gobbi/hooks/hooks.json and .claude/settings.json per L-F12. Timeouts per L-F15 (init=10s, guard=5s, capture-subagent=60s, capture-plan=30s, stop=10s).
- **Docs rewrite (F.1, F.2, F.3, F.8):** CLAUDE.md 7-step → 5-step narrative; gobbi skill + 4 child docs rewritten; _orchestration skill deprecated with rich pedagogical ARCHIVED.md (7-step → 5-step mapping + concept glossary); root README corrected (package name badge, broken Quick Start commands removed, .claude/ vs .gobbi/ architecture inversion fixed, Bun runtime).
- **Release (F.5, F.6):** MIGRATION.md documents the breaking changes + 3 notification-hook restoration paths. CHANGELOG [0.5.0] section per Keep-a-Changelog 1.1.0. @gobbitools/cli + plugin bumped to 0.5.0. bun.lock regenerated.
- **Backlog (F.7):** Phase 3 backlog doc with 23 items, trigger-class index, blocked-by edges (#91 blocked-by #93).
- **Test (F.9):** Subprocess-e2e migration-chain test at packages/cli/src/__tests__/e2e/migration-chain.test.ts. Uses Bun.$ + bun:sqlite direct-write to force deriveState cold-path migration. Triangulated assertions lock the lazy-migration invariant.

## Verification

- **Tests:** 1192 pass / 0 fail / 59 files / 53 snapshots (baseline 1191 + F.9 +1 per L-F14).
- **TypeScript:** \`bunx tsc --noEmit -p packages/cli/tsconfig.json\` clean.
- **SC20 grep gates:** 4/5 clean (1 pre-existing _collection drift flagged to Phase 3).
- **Hook verification:** \`jq '.hooks | keys' plugins/gobbi/hooks/hooks.json .claude/settings.json\` → 5 keys each; \`grep -n \"gobbi notify\" ...\` → 0 hits; \`jq '.hooks' plugins/gobbi/.claude-plugin/plugin.json\` → null.
- **Version coherence:** both package.json + plugin.json at 0.5.0; CLI prints 0.5.0.

## Evaluation

Three rounds of 3-perspective evaluation (sonnet max):
- **Ideation:** 1 Critical + 5 High + 6 Med/Low → all folded into locked decisions L-F4 through L-F16.
- **Plan:** Architecture PASS 2 Med + 2 Low; Overall PASS 1 High + 2 Med + 3 Low → ARCH-P2 + OV-H1 + timeout/count corrections applied inline.
- **Execution W7 bulk eval:** Project PASS 5 Low; Architecture PASS 2 Low; Overall PASS 1 Medium + 2 Low → 4-item quick-fix bundle + MIGRATION.md count fix applied.
- **Step 7 PI Review:** both innovative + best PASS.

## Scope (per issue #83 + L-F2)

- **In scope:** docs rewrite, plugin hook rewiring, MIGRATION.md, CHANGELOG, Phase 3 backlog, migration-chain e2e test.
- **Out of scope (deferred):** integration PR (phase/v050-phase-2 → main), npm publish @gobbitools/cli@0.5.0, @gobbitools/cli dep declaration in plugin.json (ARCH-P5), dual-registration investigation (ARCH-P1). All captured in v050-phase3-backlog.md.

## New gotchas recorded

Three new entries in .claude/project/gobbi/gotchas/phase2-planning.md (main tree, will commit as chore(gotchas) on phase/v050-phase-2 post-merge):

1. \`bun test\` count differs between main tree (1229/60) and worktree (1191/58) at same commit — Bun discovery divergence; use worktree baseline.
2. Parallel executor broad \`git add\` absorbs peer executor's new files — stage by explicit paths only.
3. \`gobbi workflow init\` pre-seeds events at seq=1,2 — e2e fixtures injecting raw rows must use seq ≥ 100.

## Test plan

- [x] bun test in worktree → 1192 pass
- [x] bunx tsc --noEmit → clean
- [x] SC20 grep gates (4/5 clean, 1 Phase-3 defer)
- [x] CLI prints 0.5.0
- [ ] CI passes on the pushed branch (verifying)