### PR TITLE
fix(cli): velocity PR — differentiated resume diagnostic, EventStore Read/Write split, claudeCodeVersion schema

### DIFF
--- a/.claude/project/gobbi/design/v050-phase3-backlog.md
+++ b/.claude/project/gobbi/design/v050-phase3-backlog.md
@@ -10,7 +10,7 @@ Items are grouped by trigger class for faster Phase 3 scanning. The trigger-clas
 
 | Trigger class | Items |
 |---|---|
-| `velocity` — ship when capacity allows | #97, #98, #94, #92 |
+| `velocity` — ship when capacity allows | #98 |
 | `signal` — awaits user/data trigger | async ticker, guard daemon, content-hash, `bun --compile` binary, cross-platform CI, #89, #90, #91, #93, #95, #96, #99, #100, ARCH-P1 |
 | `architecture` — blocked on internal decision | stance-skill, docs-banner, `@gobbitools/cli` dep declaration |
 | `external` — blocked on upstream | `bun --compile` CI gate, npm publish |
@@ -169,30 +169,6 @@ Items are grouped by trigger class for faster Phase 3 scanning. The trigger-clas
 
 ---
 
-### `CLAUDE_CODE_VERSION` capture in delegation events
-
-**Source:** #92 (PR E follow-up L12-4)
-
-**Description:** Read `CLAUDE_CODE_VERSION` from the environment at delegation-spawn time and attach it to the `delegation.spawn` event payload, then surface in `gobbi workflow status` and `events` output. Currently no event captures the harness version, making cross-version debugging impossible.
-
-**Trigger:** A version-specific behavior difference between Claude Code releases causes a support case that cannot be diagnosed from the event log.
-
-**Trigger class:** `velocity`
-
----
-
-### `compileResumePrompt` differentiated diagnostic
-
-**Source:** #94 (PR E follow-up NEW-6)
-
-**Description:** `resolveResumeTargetStep` in `packages/cli/src/specs/errors.ts` throws the same error message for four distinct malformed-input classes: missing event, missing `targetStep` field, non-string `targetStep`, and empty-string `targetStep`. Differentiating by sub-class would let callers tell "no event" from "malformed event."
-
-**Trigger:** User reports confusion diagnosing a resume failure — the current uniform message blocks root-cause identification in a real debugging session.
-
-**Trigger class:** `velocity`
-
----
-
 ### Second e2e scenario: `workflow next` + verification runner
 
 **Source:** #95 (PR E follow-up NEW-7); also deferred per L-F10
@@ -216,18 +192,6 @@ Items are grouped by trigger class for faster Phase 3 scanning. The trigger-clas
 **Trigger class:** `signal`
 
 **Blocks:** #90 (overlapping scope — coordinate)
-
----
-
-### EventStore read-only query enforcement
-
-**Source:** #97 (PR E follow-up NEW-9)
-
-**Description:** Tighten `EventStore` query methods to reject writes at the type level — either via a class decorator convention, or by splitting into `WriteStore` + `ReadStore` interfaces with distinct method sets enforced via typing. The current `aggregateDelegationCosts()` approach eliminated raw-SQL-anywhere as a pattern but the enforcement is advisory rather than structural.
-
-**Trigger:** A Phase 3 type-system cleanup pass targets `EventStore`, or a new analytics method adds a read path that bypasses the existing transaction and audit machinery.
-
-**Trigger class:** `velocity`
 
 ---
 

--- a/packages/cli/src/commands/session.ts
+++ b/packages/cli/src/commands/session.ts
@@ -24,7 +24,7 @@ import { join } from 'node:path';
 import { readStdinJson } from '../lib/stdin.js';
 import { getRepoRoot } from '../lib/repo.js';
 import { EventStore } from '../workflow/store.js';
-import type { EventRow } from '../workflow/store.js';
+import type { EventRow, ReadStore } from '../workflow/store.js';
 
 // ---------------------------------------------------------------------------
 // Usage strings
@@ -234,7 +234,7 @@ export interface SessionEventsOptions {
  * in-memory — callers should expect both to take effect.
  */
 export function runSessionEventsWithStore(
-  store: EventStore,
+  store: ReadStore,
   options: SessionEventsOptions = {},
 ): void {
   let rows: readonly EventRow[];

--- a/packages/cli/src/commands/workflow/__tests__/capture-subagent.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/capture-subagent.test.ts
@@ -679,3 +679,153 @@ describe('runCaptureSubagent — tool-call idempotency', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #92 — CLAUDE_CODE_VERSION capture on delegation.spawn
+//
+// The spawn-emission site itself is scheduled for a later wave; today this
+// test suite exercises the end-to-end round trip by seeding a spawn event
+// with the `claudeCodeVersion` field populated from `process.env` via the
+// documented read pattern, then asserting the field survives the append →
+// SQLite `data` column → `store.last('delegation.spawn')` path. The two
+// cases mirror the issue #92 env contract: populate when the env var is a
+// non-empty string, omit otherwise (never write an empty string).
+// ---------------------------------------------------------------------------
+
+describe('delegation.spawn — CLAUDE_CODE_VERSION env capture (issue #92)', () => {
+  test('env present → spawn event data carries claudeCodeVersion', async () => {
+    const { sessionDir } = await initScratchSession('cap-sub-ccv-present');
+    const sessionId = 'cap-sub-ccv-present';
+
+    const originalVersion = process.env['CLAUDE_CODE_VERSION'];
+    try {
+      process.env['CLAUDE_CODE_VERSION'] = '2.1.110';
+      const envVersion = process.env['CLAUDE_CODE_VERSION'];
+      // Emitters populate the field only when the env var is a non-empty
+      // string — this is the documented pattern (see delegation.ts
+      // DelegationSpawnData.claudeCodeVersion JSDoc).
+      const claudeCodeVersion =
+        envVersion !== undefined && envVersion !== '' ? envVersion : undefined;
+
+      const store = new EventStore(join(sessionDir, 'gobbi.db'));
+      try {
+        const state = resolveWorkflowState(sessionDir, store, sessionId);
+        appendEventAndUpdateState(
+          store,
+          sessionDir,
+          state,
+          createDelegationSpawn({
+            agentType: 'executor',
+            step: state.currentStep,
+            subagentId: 'agent-ccv-1',
+            timestamp: new Date().toISOString(),
+            ...(claudeCodeVersion !== undefined ? { claudeCodeVersion } : {}),
+          }),
+          'cli',
+          sessionId,
+          'system',
+        );
+
+        const spawnRow = store.last('delegation.spawn');
+        expect(spawnRow).not.toBeNull();
+        const data = JSON.parse(spawnRow!.data) as {
+          readonly subagentId: string;
+          readonly claudeCodeVersion?: string;
+        };
+        expect(data.subagentId).toBe('agent-ccv-1');
+        expect(data.claudeCodeVersion).toBe('2.1.110');
+      } finally {
+        store.close();
+      }
+    } finally {
+      if (originalVersion === undefined) {
+        delete process.env['CLAUDE_CODE_VERSION'];
+      } else {
+        process.env['CLAUDE_CODE_VERSION'] = originalVersion;
+      }
+    }
+  });
+
+  test('env unset or empty → spawn event data omits claudeCodeVersion', async () => {
+    const { sessionDir } = await initScratchSession('cap-sub-ccv-absent');
+    const sessionId = 'cap-sub-ccv-absent';
+
+    const originalVersion = process.env['CLAUDE_CODE_VERSION'];
+    try {
+      // Scenario A — env var unset.
+      delete process.env['CLAUDE_CODE_VERSION'];
+      let envVersion = process.env['CLAUDE_CODE_VERSION'];
+      let claudeCodeVersion =
+        envVersion !== undefined && envVersion !== '' ? envVersion : undefined;
+
+      const store = new EventStore(join(sessionDir, 'gobbi.db'));
+      try {
+        const state = resolveWorkflowState(sessionDir, store, sessionId);
+        appendEventAndUpdateState(
+          store,
+          sessionDir,
+          state,
+          createDelegationSpawn({
+            agentType: 'executor',
+            step: state.currentStep,
+            subagentId: 'agent-ccv-absent-1',
+            timestamp: new Date().toISOString(),
+            ...(claudeCodeVersion !== undefined ? { claudeCodeVersion } : {}),
+          }),
+          'cli',
+          sessionId,
+          'system',
+          undefined,
+        );
+
+        const rowA = store.last('delegation.spawn');
+        expect(rowA).not.toBeNull();
+        const dataA = JSON.parse(rowA!.data) as Record<string, unknown>;
+        expect(dataA['subagentId']).toBe('agent-ccv-absent-1');
+        // Emitter MUST omit the field, not write an empty string.
+        expect('claudeCodeVersion' in dataA).toBe(false);
+
+        // Scenario B — env var explicitly empty string. Same contract:
+        // emitter must omit the field rather than writing ''.
+        process.env['CLAUDE_CODE_VERSION'] = '';
+        envVersion = process.env['CLAUDE_CODE_VERSION'];
+        claudeCodeVersion =
+          envVersion !== undefined && envVersion !== ''
+            ? envVersion
+            : undefined;
+
+        const stateB = resolveWorkflowState(sessionDir, store, sessionId);
+        appendEventAndUpdateState(
+          store,
+          sessionDir,
+          stateB,
+          createDelegationSpawn({
+            agentType: 'executor',
+            step: stateB.currentStep,
+            subagentId: 'agent-ccv-absent-2',
+            timestamp: new Date().toISOString(),
+            ...(claudeCodeVersion !== undefined ? { claudeCodeVersion } : {}),
+          }),
+          'cli',
+          sessionId,
+          'system',
+          undefined,
+        );
+
+        const rowB = store.last('delegation.spawn');
+        expect(rowB).not.toBeNull();
+        const dataB = JSON.parse(rowB!.data) as Record<string, unknown>;
+        expect(dataB['subagentId']).toBe('agent-ccv-absent-2');
+        expect('claudeCodeVersion' in dataB).toBe(false);
+      } finally {
+        store.close();
+      }
+    } finally {
+      if (originalVersion === undefined) {
+        delete process.env['CLAUDE_CODE_VERSION'];
+      } else {
+        process.env['CLAUDE_CODE_VERSION'] = originalVersion;
+      }
+    }
+  });
+});

--- a/packages/cli/src/commands/workflow/capture-subagent.ts
+++ b/packages/cli/src/commands/workflow/capture-subagent.ts
@@ -57,7 +57,7 @@ import {
   readLastLine,
 } from '../../lib/jsonl.js';
 import { isRecord, isString, isNumber } from '../../lib/guards.js';
-import { EventStore } from '../../workflow/store.js';
+import { EventStore, type ReadStore } from '../../workflow/store.js';
 import {
   appendEventAndUpdateState,
   resolveWorkflowState,
@@ -342,7 +342,7 @@ async function extractLastAssistantText(
  * linkage.
  */
 function findParentSpawnSeq(
-  store: EventStore,
+  store: ReadStore,
   agentId: string,
 ): number | null {
   if (agentId === '') return null;

--- a/packages/cli/src/commands/workflow/status.ts
+++ b/packages/cli/src/commands/workflow/status.ts
@@ -26,7 +26,7 @@ import { join } from 'node:path';
 import { derivedCost, proxyCost } from '../../lib/cost-rates.js';
 import { isNumber, isRecord, isString } from '../../lib/guards.js';
 import { EventStore } from '../../workflow/store.js';
-import type { CostAggregateRow } from '../../workflow/store.js';
+import type { CostAggregateRow, ReadStore } from '../../workflow/store.js';
 import { resolveWorkflowState } from '../../workflow/engine.js';
 import type { GuardViolationRecord, WorkflowState } from '../../workflow/state.js';
 import { resolveSessionDir } from '../session.js';
@@ -303,7 +303,7 @@ export const COST_EMPTY_SESSION_MESSAGE = 'no v0.5.0 sessions found';
  * Rows with neither contribute 0 and do not increment either source
  * counter (they still count as a delegation for the per-step total).
  */
-export function aggregateCost(store: EventStore): CostRollup {
+export function aggregateCost(store: ReadStore): CostRollup {
   const rawRows = store.aggregateDelegationCosts();
   if (rawRows.length === 0) {
     return emptySessionRollup();

--- a/packages/cli/src/commands/workflow/stop.ts
+++ b/packages/cli/src/commands/workflow/stop.ts
@@ -57,6 +57,7 @@ import { fileURLToPath } from 'node:url';
 import { readStdinJson } from '../../lib/stdin.js';
 import { isRecord, isString } from '../../lib/guards.js';
 import { EventStore } from '../../workflow/store.js';
+import type { ReadStore } from '../../workflow/store.js';
 import {
   appendEventAndUpdateState,
   resolveWorkflowState,
@@ -303,7 +304,7 @@ const HEARTBEAT_COUNTER_TAIL_SCAN = 32;
  * typically empty (new ms) or has one to two entries (rapid retry),
  * so the inner loop terminates at the first row whose `ts` differs.
  */
-function computeHeartbeatCounter(store: EventStore, nowMs: number): number {
+function computeHeartbeatCounter(store: ReadStore, nowMs: number): number {
   const heartbeats = store.lastN(
     'session.heartbeat',
     HEARTBEAT_COUNTER_TAIL_SCAN,

--- a/packages/cli/src/specs/__tests__/errors.test.ts
+++ b/packages/cli/src/specs/__tests__/errors.test.ts
@@ -516,3 +516,239 @@ describe('compileResumePrompt — targetStep fallback', () => {
     );
   });
 });
+
+// ===========================================================================
+// compileResumePrompt — class-specific diagnostic messages (#94)
+//
+// `resolveResumeTargetStep` distinguishes six failure classes so operators
+// can root-cause without attaching a debugger:
+//
+//   - Options-empty: caller passed `options.targetStep: ''`.
+//   - Class A: no workflow.resume event AND no options.targetStep override.
+//   - Class B: event exists, `data.targetStep` field is absent.
+//   - Class C: event exists, `data.targetStep` is not a string.
+//   - Class D: event exists, `data.targetStep` is `''`.
+//   - Class E: event exists, `data` is not valid JSON.
+//
+// Every class's message starts with `compileResumePrompt: targetStep missing`
+// so the pre-existing regex tests in the "targetStep fallback" suite above
+// still match (backward-compatible with fallback assertions) — the suffix
+// after the em-dash discriminates the class.
+// ===========================================================================
+
+describe('compileResumePrompt — class-specific diagnostic messages (#94)', () => {
+  it('Class A: throws a no-event diagnostic when store has no workflow.resume event and options.targetStep is undefined', () => {
+    using store = new EventStore(':memory:');
+
+    expect(() => compileResumePrompt(errorState(), store, { targetStep: undefined })).toThrow(
+      /no workflow\.resume event found in store; append one or pass options\.targetStep/,
+    );
+  });
+
+  it('Class B: throws a missing-field diagnostic when workflow.resume event data omits targetStep', () => {
+    using store = new EventStore(':memory:');
+    seedStart(store);
+    // Raw store.append bypasses the validating reducer path to deposit a
+    // payload the normal pipeline would refuse — the same approach the
+    // existing malformed-event fallback test uses. See comment at
+    // resolveResumeTargetStep for why the deliberate bypass is necessary.
+    store.append({
+      ts: '2026-01-01T00:20:00.000Z',
+      type: WORKFLOW_EVENTS.RESUME,
+      step: null,
+      // targetStep intentionally omitted — payload is valid JSON, shape
+      // exercises Class B.
+      data: JSON.stringify({ fromError: true }),
+      actor: 'cli',
+      parent_seq: null,
+      idempotencyKind: 'tool-call',
+      toolCallId: 'tc-resume-class-b',
+      sessionId: 'detect-pathway-test',
+    });
+
+    expect(() => compileResumePrompt(errorState(), store, { targetStep: undefined })).toThrow(
+      /workflow\.resume event is missing the targetStep field/,
+    );
+  });
+
+  it('Class C: throws a non-string diagnostic naming the observed type when targetStep is the wrong type', () => {
+    using store = new EventStore(':memory:');
+    seedStart(store);
+    store.append({
+      ts: '2026-01-01T00:20:00.000Z',
+      type: WORKFLOW_EVENTS.RESUME,
+      step: null,
+      // targetStep is a number — simulates a producer that forgot to
+      // serialize a step enum as its canonical string form.
+      data: JSON.stringify({ targetStep: 42, fromError: true }),
+      actor: 'cli',
+      parent_seq: null,
+      idempotencyKind: 'tool-call',
+      toolCallId: 'tc-resume-class-c',
+      sessionId: 'detect-pathway-test',
+    });
+
+    expect(() => compileResumePrompt(errorState(), store, { targetStep: undefined })).toThrow(
+      /workflow\.resume event targetStep must be a string \(got number\)/,
+    );
+  });
+
+  it('Class D: throws an empty-string diagnostic when targetStep is the empty string', () => {
+    using store = new EventStore(':memory:');
+    seedStart(store);
+    store.append({
+      ts: '2026-01-01T00:20:00.000Z',
+      type: WORKFLOW_EVENTS.RESUME,
+      step: null,
+      data: JSON.stringify({ targetStep: '', fromError: true }),
+      actor: 'cli',
+      parent_seq: null,
+      idempotencyKind: 'tool-call',
+      toolCallId: 'tc-resume-class-d',
+      sessionId: 'detect-pathway-test',
+    });
+
+    expect(() => compileResumePrompt(errorState(), store, { targetStep: undefined })).toThrow(
+      /workflow\.resume event targetStep is an empty string/,
+    );
+  });
+
+  it('Class E: throws a malformed-JSON diagnostic when the resume event data column is not valid JSON', () => {
+    using store = new EventStore(':memory:');
+    seedStart(store);
+    store.append({
+      ts: '2026-01-01T00:20:00.000Z',
+      type: WORKFLOW_EVENTS.RESUME,
+      step: null,
+      // Not valid JSON — a corrupted/hand-edited row. The reducer path
+      // would never emit this (factories use JSON.stringify), but raw
+      // store.append is unchecked, which is the point of exercising this
+      // class distinctly from class A.
+      data: 'this is not valid json {',
+      actor: 'cli',
+      parent_seq: null,
+      idempotencyKind: 'tool-call',
+      toolCallId: 'tc-resume-class-e',
+      sessionId: 'detect-pathway-test',
+    });
+
+    expect(() => compileResumePrompt(errorState(), store, { targetStep: undefined })).toThrow(
+      /workflow\.resume event data is not valid JSON/,
+    );
+  });
+
+  it('Options-empty: throws an options-is-empty-string diagnostic when the caller passes options.targetStep = ""', () => {
+    // Symmetric with class D on the store path. The caller-supplied
+    // override is honored as-is for non-empty strings (no store lookup),
+    // so this case would otherwise slip past into the prompt body.
+    using store = new EventStore(':memory:');
+
+    expect(() => compileResumePrompt(errorState(), store, { targetStep: '' })).toThrow(
+      /options\.targetStep is an empty string/,
+    );
+  });
+
+  it('discriminates classes: each class produces a distinct suffix after the shared "targetStep missing" prefix', () => {
+    // Meta-assertion: the six malformed-input classes must produce six
+    // distinct diagnostic strings. If a future refactor collapses any
+    // two, this test fails before the downstream per-class tests do.
+    const collect = (thunk: () => void): string => {
+      try {
+        thunk();
+      } catch (err) {
+        return err instanceof Error ? err.message : String(err);
+      }
+      throw new Error('expected thunk to throw');
+    };
+
+    using storeA = new EventStore(':memory:');
+    const msgA = collect(() =>
+      compileResumePrompt(errorState(), storeA, { targetStep: undefined }),
+    );
+
+    using storeB = new EventStore(':memory:');
+    seedStart(storeB);
+    storeB.append({
+      ts: '2026-01-01T00:20:00.000Z',
+      type: WORKFLOW_EVENTS.RESUME,
+      step: null,
+      data: JSON.stringify({ fromError: true }),
+      actor: 'cli',
+      parent_seq: null,
+      idempotencyKind: 'tool-call',
+      toolCallId: 'tc-meta-b',
+      sessionId: 'detect-pathway-test',
+    });
+    const msgB = collect(() =>
+      compileResumePrompt(errorState(), storeB, { targetStep: undefined }),
+    );
+
+    using storeC = new EventStore(':memory:');
+    seedStart(storeC);
+    storeC.append({
+      ts: '2026-01-01T00:20:00.000Z',
+      type: WORKFLOW_EVENTS.RESUME,
+      step: null,
+      data: JSON.stringify({ targetStep: 7, fromError: true }),
+      actor: 'cli',
+      parent_seq: null,
+      idempotencyKind: 'tool-call',
+      toolCallId: 'tc-meta-c',
+      sessionId: 'detect-pathway-test',
+    });
+    const msgC = collect(() =>
+      compileResumePrompt(errorState(), storeC, { targetStep: undefined }),
+    );
+
+    using storeD = new EventStore(':memory:');
+    seedStart(storeD);
+    storeD.append({
+      ts: '2026-01-01T00:20:00.000Z',
+      type: WORKFLOW_EVENTS.RESUME,
+      step: null,
+      data: JSON.stringify({ targetStep: '', fromError: true }),
+      actor: 'cli',
+      parent_seq: null,
+      idempotencyKind: 'tool-call',
+      toolCallId: 'tc-meta-d',
+      sessionId: 'detect-pathway-test',
+    });
+    const msgD = collect(() =>
+      compileResumePrompt(errorState(), storeD, { targetStep: undefined }),
+    );
+
+    using storeE = new EventStore(':memory:');
+    seedStart(storeE);
+    storeE.append({
+      ts: '2026-01-01T00:20:00.000Z',
+      type: WORKFLOW_EVENTS.RESUME,
+      step: null,
+      data: '}{ not json',
+      actor: 'cli',
+      parent_seq: null,
+      idempotencyKind: 'tool-call',
+      toolCallId: 'tc-meta-e',
+      sessionId: 'detect-pathway-test',
+    });
+    const msgE = collect(() =>
+      compileResumePrompt(errorState(), storeE, { targetStep: undefined }),
+    );
+
+    using storeOpts = new EventStore(':memory:');
+    const msgOpts = collect(() =>
+      compileResumePrompt(errorState(), storeOpts, { targetStep: '' }),
+    );
+
+    const messages = [msgA, msgB, msgC, msgD, msgE, msgOpts];
+
+    // All six must share the orientation prefix so the existing
+    // `/compileResumePrompt: targetStep missing/` regexes still match.
+    for (const m of messages) {
+      expect(m).toMatch(/^compileResumePrompt: targetStep missing/);
+    }
+
+    // All six must be pairwise distinct — no silent collapse.
+    const unique = new Set(messages);
+    expect(unique.size).toBe(messages.length);
+  });
+});

--- a/packages/cli/src/specs/errors.pathway-compilers.ts
+++ b/packages/cli/src/specs/errors.pathway-compilers.ts
@@ -23,7 +23,7 @@
  */
 
 import type { WorkflowState } from '../workflow/state.js';
-import type { EventStore } from '../workflow/store.js';
+import type { ReadStore } from '../workflow/store.js';
 import type { CompiledPrompt } from './types.js';
 import type {
   ErrorPathwayCrash,
@@ -109,7 +109,7 @@ function recoverySlotOverride(recoveryId: string): Readonly<Record<string, 'mate
 export function compileCrashPrompt(
   pathway: ErrorPathwayCrash,
   state: WorkflowState,
-  _store: EventStore,
+  _store: ReadStore,
 ): CompiledPrompt {
   const staticBlocks = [
     makeStatic({ id: ID_ROLE, content: STATIC_ROLE_ERROR_RECOVERY }),
@@ -150,7 +150,7 @@ export function compileCrashPrompt(
 export function compileTimeoutPrompt(
   pathway: ErrorPathwayTimeout,
   state: WorkflowState,
-  _store: EventStore,
+  _store: ReadStore,
 ): CompiledPrompt {
   const staticBlocks = [
     makeStatic({ id: ID_ROLE, content: STATIC_ROLE_ERROR_RECOVERY }),
@@ -191,7 +191,7 @@ export function compileTimeoutPrompt(
 export function compileFeedbackCapPrompt(
   pathway: ErrorPathwayFeedbackCap,
   state: WorkflowState,
-  _store: EventStore,
+  _store: ReadStore,
 ): CompiledPrompt {
   const staticBlocks = [
     makeStatic({ id: ID_ROLE, content: STATIC_ROLE_ERROR_RECOVERY }),
@@ -235,7 +235,7 @@ export function compileFeedbackCapPrompt(
 export function compileInvalidTransitionPrompt(
   pathway: ErrorPathwayInvalidTransition,
   state: WorkflowState,
-  _store: EventStore,
+  _store: ReadStore,
 ): CompiledPrompt {
   const staticBlocks = [
     makeStatic({ id: ID_ROLE, content: STATIC_ROLE_ERROR_RECOVERY }),
@@ -278,7 +278,7 @@ export function compileInvalidTransitionPrompt(
 export function compileUnknownPrompt(
   pathway: ErrorPathwayUnknown,
   state: WorkflowState,
-  _store: EventStore,
+  _store: ReadStore,
 ): CompiledPrompt {
   const staticBlocks = [
     makeStatic({ id: ID_ROLE, content: STATIC_ROLE_ERROR_RECOVERY }),

--- a/packages/cli/src/specs/errors.pathway-detect.ts
+++ b/packages/cli/src/specs/errors.pathway-detect.ts
@@ -48,7 +48,7 @@ import { existsSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
 import type { WorkflowState } from '../workflow/state.js';
-import type { EventStore } from '../workflow/store.js';
+import type { ReadStore } from '../workflow/store.js';
 import { WORKFLOW_EVENTS } from '../workflow/events/workflow.js';
 import { DECISION_EVENTS } from '../workflow/events/decision.js';
 import { SESSION_EVENTS } from '../workflow/events/session.js';
@@ -227,7 +227,7 @@ function readArtifactFilenames(
  */
 export function detectPathway(
   state: WorkflowState,
-  store: EventStore,
+  store: ReadStore,
   options?: DetectPathwayOptions,
 ): ErrorPathway {
   if (state.currentStep !== 'error') {

--- a/packages/cli/src/specs/errors.ts
+++ b/packages/cli/src/specs/errors.ts
@@ -384,34 +384,97 @@ const ID_RESUME_UNKNOWN_RECAP = 'resume.unknown.recap';
  * event from the store — this handles the compact-recovery scenario where
  * the orchestrator re-opens mid-resume.
  *
- * Throws when neither source has a targetStep — that would be a caller
- * wiring bug (nothing in the codebase should reach the resume compiler
- * without a resume event or an explicit override).
+ * Throws a class-specific diagnostic message for each malformed-input
+ * class so operators (and failing tests) can root-cause without re-running
+ * the compiler under a debugger. The six classes are:
+ *
+ *   - Options-empty: caller passed `options.targetStep: ''`.
+ *   - Class A (no-event): no `workflow.resume` event AND no options override.
+ *   - Class B (missing-field): event exists, `data.targetStep` is absent.
+ *   - Class C (non-string): event exists, `data.targetStep` is not a string.
+ *   - Class D (empty-string): event exists, `data.targetStep` is `''`.
+ *   - Class E (malformed-json): event exists, but `data` is not valid JSON.
+ *
+ * Every thrown message starts with the literal prefix
+ * `compileResumePrompt: targetStep missing` so the existing regex-based
+ * fallback-path tests continue to match while the suffix discriminates
+ * the specific failure class.
  */
 function resolveResumeTargetStep(
   store: EventStore,
   options: { readonly targetStep?: string | undefined } | undefined,
 ): string {
-  if (options?.targetStep !== undefined) return options.targetStep;
+  const override = options?.targetStep;
+  if (override !== undefined) {
+    // Symmetric validation with the workflow.resume event path: the caller
+    // would otherwise inject an empty-string targetStep directly into the
+    // compiled prompt. Non-string is excluded by the TS signature; empty
+    // string is the only realistic runtime degenerate case.
+    if (override === '') {
+      throw new Error(
+        'compileResumePrompt: targetStep missing — options.targetStep is an empty string',
+      );
+    }
+    return override;
+  }
+
   const rows = store.lastN('workflow.resume', 1);
   const last = rows[0];
-  if (last !== undefined) {
-    // EventRow.data is a JSON string; parse to extract targetStep. The
-    // event's schema is stable (workflow.ts::ResumeData) — the migration
-    // pipeline applies to read-time reducers, not here, but the shape for
-    // `targetStep` is identity across every schema version.
-    try {
-      const parsed = JSON.parse(last.data) as { readonly targetStep?: unknown };
-      if (typeof parsed.targetStep === 'string' && parsed.targetStep.length > 0) {
-        return parsed.targetStep;
-      }
-    } catch {
-      // fall through to the throw below
-    }
+  if (last === undefined) {
+    // Class A: no workflow.resume event in the store AND no explicit
+    // options.targetStep override — the compiler has nothing to read.
+    throw new Error(
+      'compileResumePrompt: targetStep missing — no workflow.resume event found in store; append one or pass options.targetStep',
+    );
   }
-  throw new Error(
-    'compileResumePrompt: targetStep missing — supply options.targetStep or append a workflow.resume event before compiling',
-  );
+
+  // EventRow.data is a JSON string; parse to extract targetStep. The
+  // event's schema is stable (workflow.ts::ResumeData) — the migration
+  // pipeline applies to read-time reducers, not here, but the shape for
+  // `targetStep` is identity across every schema version.
+  let parsed: { readonly targetStep?: unknown };
+  try {
+    parsed = JSON.parse(last.data) as { readonly targetStep?: unknown };
+  } catch (err) {
+    // Class E: the store row exists but its `data` column is not valid
+    // JSON. This shouldn't happen for events written through the normal
+    // pipeline (factories emit JSON.stringify output), but raw
+    // store.append callers or a corrupted DB can produce it. A dedicated
+    // class is clearer than silently routing to class A.
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `compileResumePrompt: targetStep missing — workflow.resume event data is not valid JSON (${message})`,
+    );
+  }
+
+  if (parsed.targetStep === undefined) {
+    // Class B: the parsed payload has no `targetStep` field at all. A
+    // distinct class from empty string because the producer is
+    // fundamentally different (omitted vs. explicitly zero-length).
+    throw new Error(
+      'compileResumePrompt: targetStep missing — workflow.resume event is missing the targetStep field',
+    );
+  }
+
+  if (typeof parsed.targetStep !== 'string') {
+    // Class C: the field is present but the wrong type. Surface the
+    // observed `typeof` so the operator can trace back to the producer.
+    throw new Error(
+      `compileResumePrompt: targetStep missing — workflow.resume event targetStep must be a string (got ${typeof parsed.targetStep})`,
+    );
+  }
+
+  if (parsed.targetStep === '') {
+    // Class D: non-null, string-typed, but zero-length. Rejected because
+    // an empty target step would render a syntactically valid but
+    // semantically meaningless resume prompt ("transitioning from error
+    // into ").
+    throw new Error(
+      'compileResumePrompt: targetStep missing — workflow.resume event targetStep is an empty string',
+    );
+  }
+
+  return parsed.targetStep;
 }
 
 /**

--- a/packages/cli/src/specs/errors.ts
+++ b/packages/cli/src/specs/errors.ts
@@ -41,7 +41,7 @@
  */
 
 import type { WorkflowState } from '../workflow/state.js';
-import type { EventStore } from '../workflow/store.js';
+import type { ReadStore } from '../workflow/store.js';
 import type { CompiledPrompt } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -286,7 +286,7 @@ import {
  */
 export function compileErrorPrompt(
   state: WorkflowState,
-  store: EventStore,
+  store: ReadStore,
 ): CompiledPrompt {
   const pathway = detectPathway(state, store);
   return visitPathway(pathway, {
@@ -401,7 +401,7 @@ const ID_RESUME_UNKNOWN_RECAP = 'resume.unknown.recap';
  * the specific failure class.
  */
 function resolveResumeTargetStep(
-  store: EventStore,
+  store: ReadStore,
   options: { readonly targetStep?: string | undefined } | undefined,
 ): string {
   const override = options?.targetStep;
@@ -498,7 +498,7 @@ function resolveResumeTargetStep(
  */
 export function compileResumePrompt(
   state: WorkflowState,
-  store: EventStore,
+  store: ReadStore,
   options?: { readonly targetStep?: string | undefined },
 ): CompiledPrompt {
   const pathway = detectPathway(state, store);

--- a/packages/cli/src/workflow/__tests__/store.test.ts
+++ b/packages/cli/src/workflow/__tests__/store.test.ts
@@ -7,6 +7,8 @@ import type {
   AppendInputSystem,
   AppendInputToolCall,
   EventRow,
+  ReadStore,
+  WriteStore,
 } from '../store.js';
 import { CURRENT_SCHEMA_VERSION, migrateEvent } from '../migrations.js';
 import type { EventRow as MigrationEventRow } from '../migrations.js';
@@ -933,5 +935,49 @@ describe('aggregateDelegationCosts', () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]?.subagentId).toBe('sub-included');
     expect(rows[0]?.step).toBe('plan');
+  });
+});
+
+// ===========================================================================
+// ReadStore / WriteStore — structural read-only enforcement (#97)
+//
+// The pair of interfaces is the type-level guarantee that read-only callers
+// (prompt compilers, pathway detector, cost rollup, state derivation) cannot
+// accidentally invoke write methods. Runtime behaviour is unchanged — this
+// block only exercises `tsc`'s view of the contract.
+//
+// Each `@ts-expect-error` assertion MUST trigger a real compile error; if it
+// doesn't, `tsc` flags the annotation as unused, which fails the typecheck
+// gate. That "unused-directive" mode is what turns the assertion into an
+// enforceable structural check rather than a static-only comment.
+// ===========================================================================
+
+describe('ReadStore / WriteStore — structural read-only enforcement (#97)', () => {
+  it('rejects write calls on a ReadStore reference at compile time', () => {
+    using store = new EventStore(':memory:');
+    const readOnly: ReadStore = store;
+
+    // A legal read — lastN is part of the ReadStore surface.
+    expect(readOnly.lastN('workflow.start', 1)).toEqual([]);
+
+    // @ts-expect-error — `append` is not part of ReadStore; only WriteStore.
+    readOnly.append;
+
+    // @ts-expect-error — `transaction` is not part of ReadStore.
+    readOnly.transaction;
+
+    // @ts-expect-error — `close` is not part of ReadStore.
+    readOnly.close;
+  });
+
+  it('accepts write calls on a WriteStore reference', () => {
+    using store = new EventStore(':memory:');
+    const writeable: WriteStore = store;
+
+    // Structural assertion — both read and write methods are available.
+    expect(typeof writeable.append).toBe('function');
+    expect(typeof writeable.transaction).toBe('function');
+    expect(typeof writeable.close).toBe('function');
+    expect(typeof writeable.lastN).toBe('function');
   });
 });

--- a/packages/cli/src/workflow/engine.ts
+++ b/packages/cli/src/workflow/engine.ts
@@ -13,7 +13,7 @@ import { existsSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { EventStore } from './store.js';
-import type { AppendInput } from './store.js';
+import type { AppendInput, ReadStore } from './store.js';
 import { reduce } from './reducer.js';
 import type { ReducerResult } from './reducer.js';
 import {
@@ -383,7 +383,7 @@ function buildAppendInput(args: BuildAppendInputArgs): AppendInput {
  */
 export function resolveWorkflowState(
   dir: string,
-  store: EventStore,
+  store: ReadStore,
   sessionId: string,
 ): WorkflowState {
   // Fast path — valid state.json short-circuits the replay.
@@ -408,7 +408,7 @@ export function resolveWorkflowState(
  */
 export function deriveWorkflowState(
   sessionId: string,
-  store: EventStore,
+  store: ReadStore,
 ): WorkflowState {
   const events = store.replayAll();
   return deriveState(sessionId, events, reduce);

--- a/packages/cli/src/workflow/events/__tests__/events.test.ts
+++ b/packages/cli/src/workflow/events/__tests__/events.test.ts
@@ -478,6 +478,42 @@ describe('factory functions', () => {
       expect(event.data).toEqual({ agentType: 'researcher', step: 'ideation', subagentId: 'sub-1', timestamp: '2026-01-01T00:00:00Z' });
     });
 
+    // Issue #92 — optional `claudeCodeVersion` field on DelegationSpawnData.
+    // The field is schema-only until a spawn emitter lands; the factory must
+    // accept it as a pass-through and the omit-branch must keep the data
+    // shape identical to the pre-field behaviour.
+
+    it('createDelegationSpawn passes claudeCodeVersion through when set (issue #92)', () => {
+      const event = createDelegationSpawn({
+        agentType: 'researcher',
+        step: 'ideation',
+        subagentId: 'sub-1',
+        timestamp: '2026-01-01T00:00:00Z',
+        claudeCodeVersion: '2.1.110',
+      });
+      expect(event.data).toEqual({
+        agentType: 'researcher',
+        step: 'ideation',
+        subagentId: 'sub-1',
+        timestamp: '2026-01-01T00:00:00Z',
+        claudeCodeVersion: '2.1.110',
+      });
+      // Round-trips through JSON.stringify — the optional field survives
+      // serialization into the event store's `data` column.
+      const round = JSON.parse(JSON.stringify(event));
+      expect(round).toEqual(event);
+    });
+
+    it('createDelegationSpawn omits claudeCodeVersion when caller omits it (issue #92)', () => {
+      const event = createDelegationSpawn({
+        agentType: 'executor',
+        step: 'execution',
+        subagentId: 'sub-2',
+        timestamp: '2026-01-01T00:00:00Z',
+      });
+      expect('claudeCodeVersion' in event.data).toBe(false);
+    });
+
     it('createDelegationComplete with all optional fields', () => {
       const event = createDelegationComplete({
         subagentId: 'sub-1',

--- a/packages/cli/src/workflow/events/delegation.ts
+++ b/packages/cli/src/workflow/events/delegation.ts
@@ -35,6 +35,18 @@ export interface DelegationSpawnData {
   readonly step: string;
   readonly subagentId: string;
   readonly timestamp: string;
+  /**
+   * Claude Code harness version captured from `process.env.CLAUDE_CODE_VERSION`
+   * at spawn time. Enables cross-version debugging — a given trace can be
+   * attributed to the harness that produced it. Optional so v4 events that
+   * never populated this field continue to round-trip cleanly; the field is
+   * also additive, so no schema version bump is required (mirrors the
+   * `DelegationCompleteData.sizeProxyBytes` pattern landed by PR E). Emitters
+   * MUST omit the field entirely when the env var is unset or empty rather
+   * than writing an empty string — keeps events clean. Added by v0.5.0
+   * post-Phase-2 velocity issue #92.
+   */
+  readonly claudeCodeVersion?: string | undefined;
 }
 
 export interface DelegationCompleteData {

--- a/packages/cli/src/workflow/store.ts
+++ b/packages/cli/src/workflow/store.ts
@@ -195,10 +195,63 @@ export interface CostAggregateRow {
 }
 
 // ---------------------------------------------------------------------------
+// Structural read/write interface split
+// ---------------------------------------------------------------------------
+
+/**
+ * Read-only facet of the event store. Every callable on this interface is a
+ * pure query — no INSERT, no transaction boundary, no close. Call sites that
+ * only ever read (prompt compilers, pathway detector, cost rollup, state
+ * derivation) accept this narrow interface so TypeScript rejects accidental
+ * writes at compile time.
+ *
+ * This is the structural (type-level) evolution of what was previously an
+ * advisory "read vs. write" convention in the class docblock. The runtime
+ * class is unchanged — `EventStore` still exposes both facets — but the
+ * declared contract at a callee's boundary now tightens what that callee
+ * can legally do with its `store` parameter.
+ *
+ * To extend: add a new pure-query method signature here AND on the
+ * `EventStore` class body. The class `implements WriteStore` clause (which
+ * extends this interface) closes the loop — adding a query to `ReadStore`
+ * without implementing it on the class is a `tsc` error at the class
+ * declaration, not at the call site.
+ */
+export interface ReadStore {
+  replayAll(): EventRow[];
+  byType(type: string): EventRow[];
+  byStep(step: string, type?: string): EventRow[];
+  since(seq: number): EventRow[];
+  last(type: string): EventRow | null;
+  lastN(type: string, n: number): readonly EventRow[];
+  lastNAny(n: number): readonly EventRow[];
+  eventCount(): number;
+  aggregateDelegationCosts(): readonly CostAggregateRow[];
+}
+
+/**
+ * Full read+write facet of the event store. Extends {@link ReadStore} with
+ * the mutating operations (`append`, `transaction`) and the lifecycle
+ * method (`close`). Call sites that mutate the store — the engine's
+ * `appendEventAndUpdateState`, the CLI command handlers that construct and
+ * tear down the database, the verification runner — keep this wider type.
+ *
+ * Callers SHOULD prefer the narrowest interface that covers their needs:
+ * `ReadStore` for pure queries, `WriteStore` for anything else. `EventStore`
+ * itself remains the concrete construction type — `new EventStore(path)`
+ * returns a value usable as either interface.
+ */
+export interface WriteStore extends ReadStore {
+  append(input: AppendInput): EventRow | null;
+  transaction<T>(fn: () => T): T;
+  close(): void;
+}
+
+// ---------------------------------------------------------------------------
 // EventStore class
 // ---------------------------------------------------------------------------
 
-export class EventStore {
+export class EventStore implements WriteStore {
   private readonly db: Database;
 
   // Cached prepared statements — db.query() returns cached compiled bytecode.


### PR DESCRIPTION
## Summary

Bundles three Phase 3 `velocity`-class follow-ups from v0.5.0 Phase 2 post-PR-F backlog:

- **Closes #94** — `compileResumePrompt` differentiated diagnostic. `resolveResumeTargetStep` now throws 5 distinct class-specific messages (no-event, missing-field, non-string, empty-string, malformed-JSON) plus one symmetric options-empty validator.
- **Closes #97** — `EventStore` split into `ReadStore` + `WriteStore` interfaces. 12 read-only call sites retyped; `@ts-expect-error` triad gates the type-level guarantee.
- **Closes #92** — `claudeCodeVersion?: string` added to `DelegationSpawnData`. **Schema-only change**; see "Known scope gap" below.

## Known scope gap — #92 emitter missing

Issue #92 asked for `CLAUDE_CODE_VERSION` capture on `delegation.spawn` events. The schema change landed in commit `094cfda`, but the repo has **no production code path that emits `delegation.spawn`**:

- Hook config: SessionStart (init), PreToolUse (guard), PostToolUse/ExitPlanMode (capture-plan), SubagentStop (capture-subagent), Stop. None emit spawn.
- `capture-subagent.ts` emits `delegation.complete`/`fail` only; reads the last spawn at line 349 for `parent_seq` linkage.

This is a pre-existing v0.5.0 gap (pre-existing architectural omission, not regressed here). Filed as **#102** to add a `PreToolUse(Task)` spawn emitter. Once #102 lands, the `claudeCodeVersion` field from this PR will populate at runtime.

## Commits

| Hash | Subject | Issue |
|---|---|---|
| `098b714` | `fix(specs): differentiate compileResumePrompt diagnostic by failure class` | #94 |
| `cffa2a5` | `refactor(store): split EventStore into ReadStore + WriteStore for type-level read-only enforcement` | #97 |
| `094cfda` | `feat(events): add claudeCodeVersion field to delegation.spawn` | #92 |

## Test plan

- [x] `bun test` — 1205 pass, 0 fail (+13 over phase/v050-phase-2 baseline of 1192). Breakdown: V.2 +7 (6 class + 1 discrimination), V.3 +2 (type-level), V.1 +4 (2 factory + 2 round-trip).
- [x] `cd packages/cli && bun run typecheck` — clean. V.3's `@ts-expect-error` triad is load-bearing (consumed by real compile errors).
- [x] `git status` — worktree clean; only intended file changes.
- [ ] Post-merge integration testing not in scope — deferred to the integration PR (phase/v050-phase-2 → main) per L-F2.

## Decision annotations

**V.2 / #94:**
- JSON.parse failure promoted to distinct class E (was silent fallthrough to "no event"). Rationale: when a row exists but is unparseable, the "no event" message actively misleads operators.
- Added symmetric `options.targetStep === ''` validator. Non-string options not validated at runtime (TS signature narrows it).
- Preserved the `compileResumePrompt: targetStep missing — ` prefix so pre-existing regex assertions continue to pass.

**V.3 / #97:**
- `EventStore implements WriteStore`. Runtime unchanged.
- 12 read-only call sites retyped to `ReadStore` (engine derivers, pathway compilers, heartbeat computer, cost aggregator, session events runner).
- Write-path call sites explicitly listed in the executor's decision annotation and left alone.

**V.1 / #92:**
- Optional additive field → no schema version bump (consistent with PR E's `sizeProxyBytes` precedent).
- `process.env.CLAUDE_CODE_VERSION === ''` or unset → field omitted from event data (not stored as empty string) to keep analytics queries clean.

## Review focus

1. Type-level `ReadStore` / `WriteStore` split — is the interface partitioning complete and sensible?
2. Class-E (malformed-JSON) diagnostic choice — should it instead route to class A?
3. V.1 `claudeCodeVersion` — confirm schema-only landing is acceptable given #102 follow-up.