### PR TITLE
docs: v0.5.0 5-step cleanup — test-tooling gotchas + 3 skill rewrites + backlog namespace fix

### DIFF
--- a/.claude/project/gobbi/design/v050-phase3-backlog.md
+++ b/.claude/project/gobbi/design/v050-phase3-backlog.md
@@ -81,7 +81,7 @@ Items are grouped by trigger class for faster Phase 3 scanning. The trigger-clas
 
 **Source:** #77 Deferred to Phase 3 (item 6)
 
-**Description:** `gobbi docs banner add/remove` command to automate the deprecation-banner workflow used manually in PR F.3. PR F.3 applied banners by hand-editing skill files; a CLI helper would reduce friction for future major deprecations.
+**Description:** `gobbi banner add/remove` command to automate the deprecation-banner workflow used manually in PR F.3. PR F.3 applied banners by hand-editing skill files; a CLI helper would reduce friction for future major deprecations. Named under a new top-level `gobbi banner` namespace — `gobbi docs` was removed in PR #65, so this does not reuse that namespace.
 
 **Trigger:** Another major deprecation event at v0.6.0 or later that would require applying banners to multiple skill files simultaneously.
 
@@ -274,6 +274,6 @@ Items are grouped by trigger class for faster Phase 3 scanning. The trigger-clas
 ## Revisit cadence
 
 - Review this backlog before every minor release transition (v0.5.x → v0.6.x). Items whose triggers have fired move into the next release plan.
-- Items in the `velocity` class have no external dependency — they can be picked up whenever capacity allows. Prefer scheduling them alongside structurally related work (e.g., #97 + #98 in the same cleanup pass).
+- Items in the `velocity` class have no external dependency — they can be picked up whenever capacity allows. Prefer scheduling them alongside structurally related work (e.g., #90 + #96 in the same rate-card pass, as both items share overlapping scope).
 - Items that have not triggered after 12 months should be reassessed: either the trigger condition is wrong, the need no longer exists, or the item should be closed as won't-fix.
 - When filing a new follow-up issue, add a backlog entry here with source, description, trigger, and trigger class before the session closes. An issue without a backlog entry has no signal for when to resurface.

--- a/.claude/project/gobbi/design/v050-phase3-backlog.md
+++ b/.claude/project/gobbi/design/v050-phase3-backlog.md
@@ -12,7 +12,7 @@ Items are grouped by trigger class for faster Phase 3 scanning. The trigger-clas
 |---|---|
 | `velocity` — ship when capacity allows | #98 |
 | `signal` — awaits user/data trigger | async ticker, guard daemon, content-hash, `bun --compile` binary, cross-platform CI, #89, #90, #91, #93, #95, #96, #99, #100, ARCH-P1 |
-| `architecture` — blocked on internal decision | stance-skill, docs-banner, `@gobbitools/cli` dep declaration |
+| `architecture` — blocked on internal decision | stance-skill, banner, `@gobbitools/cli` dep declaration |
 | `external` — blocked on upstream | `bun --compile` CI gate, npm publish |
 
 ---
@@ -77,7 +77,7 @@ Items are grouped by trigger class for faster Phase 3 scanning. The trigger-clas
 
 ---
 
-### Docs-banner CLI helper
+### Banner CLI helper
 
 **Source:** #77 Deferred to Phase 3 (item 6)
 

--- a/.claude/project/gobbi/gotchas/phase2-planning.md
+++ b/.claude/project/gobbi/gotchas/phase2-planning.md
@@ -183,32 +183,6 @@ Orchestration-level mitigations:
 
 ---
 
-## fast-check v4 dropped `fc.hexaString` — use `fc.array(fc.constantFrom(...'0123456789abcdef'.split('')))`
-
-**Priority:** Low
-
-**What happened:** Plan/research docs targeting fast-check v3 frequently reference `fc.hexaString({ minLength: 64, maxLength: 64 })` for generating 64-char sha256 digests. fast-check v4 (this repo pins `^4.6.0`) removed the shorthand. The E.7 executor hit this writing the `VerificationResultData` round-trip property and had to substitute.
-
-**User feedback:** Self-caught by E.7 executor during property-test authoring 2026-04-18; no user correction required.
-
-**Correct approach:** In fast-check v4+, generate hex strings via `fc.array(fc.constantFrom(...'0123456789abcdef'.split('')), { minLength: 64, maxLength: 64 }).map(chars => chars.join(''))`. Same output shape, no semantic change. When following research docs for property generators, reconcile against the installed fast-check major version at import time — v3 → v4 dropped several shorthands.
-
----
-
-## `fc.option(arb, { nil: undefined })` ≠ `exactOptionalPropertyTypes` — wrap with `stripUndefined` map
-
-**Priority:** Medium
-
-**What happened:** The E.7 executor generated partial `ProjectConfigInput` values for the `loadProjectConfig` default-completeness property using `fc.option(arb, { nil: undefined })`. `fc.option(x, { nil: undefined })` produces `T | undefined`. Under TS `exactOptionalPropertyTypes: true`, interfaces that declare optional fields as `field?: T` (with no explicit `| undefined`) reject values where the field is present and set to `undefined` — the TS contract requires the key to be absent, not the value to be `undefined`. Type-narrowing + the typed cast into `ProjectConfigInput` failed until the generated value had `undefined` keys stripped.
-
-**User feedback:** Self-caught by E.7 executor during `loadProjectConfig` property authoring 2026-04-18; no user correction required.
-
-**Correct approach:** Wrap `fc.option` generators with a `stripUndefined` map step that recursively drops `undefined` leaves before handing the value to the SUT:
-- `fc.option(arb, { nil: undefined }).map(stripUndefined)` preserves the "field absent" coverage the generator intended without tripping `exactOptionalPropertyTypes`.
-- Applies to any arbitrary feeding an interface with `field?: T` (no explicit undefined) style optionals. Reference: `packages/cli/src/specs/__tests__/properties.test.ts::loadProjectConfig default completeness`.
-
----
-
 ## Parallel executor broad `git add` absorbs peer executor's untracked new files
 
 **Priority:** Medium

--- a/.claude/project/gobbi/gotchas/test-tooling.md
+++ b/.claude/project/gobbi/gotchas/test-tooling.md
@@ -1,0 +1,29 @@
+# Test Tooling Gotchas
+
+Gotchas for test tooling used in this repo — fast-check property-based testing, TypeScript strict-mode interactions with test generators, and test framework patterns. Read before authoring or modifying property tests.
+
+---
+
+## fast-check v4 dropped `fc.hexaString` — use `fc.array(fc.constantFrom(...'0123456789abcdef'.split('')))`
+
+**Priority:** Low
+
+**What happened:** Plan/research docs targeting fast-check v3 frequently reference `fc.hexaString({ minLength: 64, maxLength: 64 })` for generating 64-char sha256 digests. fast-check v4 (this repo pins `^4.6.0`) removed the shorthand. The E.7 executor hit this writing the `VerificationResultData` round-trip property and had to substitute.
+
+**User feedback:** Self-caught by E.7 executor during property-test authoring 2026-04-18; no user correction required.
+
+**Correct approach:** In fast-check v4+, generate hex strings via `fc.array(fc.constantFrom(...'0123456789abcdef'.split('')), { minLength: 64, maxLength: 64 }).map(chars => chars.join(''))`. Same output shape, no semantic change. When following research docs for property generators, reconcile against the installed fast-check major version at import time — v3 → v4 dropped several shorthands.
+
+---
+
+## `fc.option(arb, { nil: undefined })` ≠ `exactOptionalPropertyTypes` — wrap with `stripUndefined` map
+
+**Priority:** Medium
+
+**What happened:** The E.7 executor generated partial `ProjectConfigInput` values for the `loadProjectConfig` default-completeness property using `fc.option(arb, { nil: undefined })`. `fc.option(x, { nil: undefined })` produces `T | undefined`. Under TS `exactOptionalPropertyTypes: true`, interfaces that declare optional fields as `field?: T` (with no explicit `| undefined`) reject values where the field is present and set to `undefined` — the TS contract requires the key to be absent, not the value to be `undefined`. Type-narrowing + the typed cast into `ProjectConfigInput` failed until the generated value had `undefined` keys stripped.
+
+**User feedback:** Self-caught by E.7 executor during `loadProjectConfig` property authoring 2026-04-18; no user correction required.
+
+**Correct approach:** Wrap `fc.option` generators with a `stripUndefined` map step that recursively drops `undefined` leaves before handing the value to the SUT:
+- `fc.option(arb, { nil: undefined }).map(stripUndefined)` preserves the "field absent" coverage the generator intended without tripping `exactOptionalPropertyTypes`.
+- Applies to any arbitrary feeding an interface with `field?: T` (no explicit undefined) style optionals. Reference: `packages/cli/src/specs/__tests__/properties.test.ts::loadProjectConfig default completeness`.

--- a/.claude/skills/_collection/SKILL.md
+++ b/.claude/skills/_collection/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: _collection
-description: Note completeness verification and task README. Load during Step 5 (Collection).
+description: Note completeness verification and task README. Load during Execution wrap-up to verify note completeness before Memorization.
 allowed-tools: Write, Read, Glob, Bash
 ---
 
 # Collection
 
-Verify that all per-step subdirectories contain their expected note files and write the task-level `README.md`. Collection is Step 5 in the 7-step workflow (Ideation, Plan, Research, Execution, Collection, Memorization, Review). Notes are written during their respective steps — Collection verifies completeness, it does not create the notes themselves.
+Verify that all per-step note files are present and write the task-level `README.md`. Collection is a utility run during Execution wrap-up in the v0.5.0 5-step cycle (Ideation, Plan, Execution, Evaluation, Memorization) — it is not a named step but a completeness gate before Memorization begins. Notes are written during their respective steps; Collection verifies completeness, it does not create the notes themselves.
 
 **Navigate deeper from here:**
 
@@ -20,17 +20,14 @@ Verify that all per-step subdirectories contain their expected note files and wr
 
 Collection has three responsibilities: **note verification**, **README.md writing**, and **gotcha recording**.
 
-**Note verification** — Verify that all expected files exist in their per-step subdirectories. Notes are written during their respective workflow steps (Ideation writes `ideation/`, Plan writes `plan/`, Research writes `research/`, Execution writes `execution/`). Collection does not create these files — it confirms they are present and complete. Required files by subdirectory:
+**Note verification** — Verify that all expected files exist in their per-step subdirectories. Notes are written during their respective workflow steps (Ideation writes `ideation/`, Plan writes `plan/`, Execution writes `execution/`). Collection does not create these files — it confirms they are present and complete. Required files by subdirectory:
 
 - `ideation/ideation.md` (orchestrator synthesis) — must exist
 - `ideation/innovative.md` and `ideation/best.md` (PI agent notes) — must exist
 - `plan/plan.md` — must exist
-- `research/research.md` (orchestrator synthesis) — must exist for non-trivial tasks
-- `research/innovative.md` and `research/best.md` — must exist for non-trivial tasks
-- `research/subtasks/` — verify subtask JSON files exist for non-trivial tasks
 - `execution/execution.md` — must exist
 - `execution/subtasks/` — verify subtask JSON files exist
-- `ideation/evaluation/`, `plan/evaluation/`, `research/evaluation/`, `execution/evaluation/` — verify evaluation files exist where evaluation was performed
+- `ideation/evaluation/`, `plan/evaluation/`, `execution/evaluation/` — verify evaluation files exist where evaluation was performed
 
 If any required file is missing, report the gap and investigate — do not silently proceed.
 
@@ -55,23 +52,12 @@ Task note directories follow the structure defined in _note. Each task directory
   plan/
     plan.md                         — plan details
     evaluation/                     — evaluation files (if evaluation performed)
-  research/
-    research.md                     — orchestrator synthesis
-    innovative.md                   — Innovative researcher
-    best.md                         — Best-practice researcher
-    subtasks/
-      01-{slug}.json                — research subtask records
-    evaluation/                     — evaluation files (if evaluation performed)
   execution/
     execution.md                    — execution outcomes
     subtasks/
       01-{slug}.json                — execution subtask records
     evaluation/                     — evaluation files (if evaluation performed)
   feedback.md                       — feedback rounds (if FEEDBACK)
-  review/
-    innovative.md                   — Innovative PI review + verdict
-    best.md                         — Best-practice PI review + verdict
-    review.md                       — orchestrator synthesis
 ```
 
 The task directory and its subdirectories are initialized by `gobbi note init` and populated during their respective workflow steps. Collection only writes `README.md` at the task root level.
@@ -84,8 +70,8 @@ Collection writes the task-level `README.md` after verifying all per-step subdir
 
 The task `README.md` must include:
 
-- **Subdirectory listing** — each subdirectory (`ideation/`, `plan/`, `research/`, `execution/`) with its key files
-- **Step summaries** — a one-line summary of what each step produced (the chosen approach from ideation, the task count from planning, the key findings from research, the deliverables from execution)
+- **Subdirectory listing** — each subdirectory (`ideation/`, `plan/`, `execution/`) with its key files
+- **Step summaries** — a one-line summary of what each step produced (the chosen approach from ideation, the task count from planning, the deliverables from execution)
 - **Evaluation status** — which steps had evaluation performed and the verdict (pass/revise)
 - **Links to related docs** — gotchas recorded, project docs updated, or other artifacts created during the workflow
 
@@ -95,21 +81,17 @@ Also update the parent `README.md` (the index file that lists all task note dire
 
 ## Phase-Specific Collection
 
-Collection runs at different points depending on the workflow phase. The verification checklist adapts to what the phase produced.
+Collection adapts to what the workflow phase produced.
 
-### After standard workflow (Steps 1-4)
+### After standard workflow (Ideation → Plan → Execution)
 
-Verify all four subdirectories: `ideation/`, `plan/`, `research/`, `execution/`. Check that subtask JSON files exist in `research/subtasks/` and `execution/subtasks/`. Check that `evaluation/` subdirectories exist for any step where evaluation was performed.
+Verify all three subdirectories: `ideation/`, `plan/`, `execution/`. Check that subtask JSON files exist in `execution/subtasks/`. Check that `evaluation/` subdirectories exist for any step where evaluation was performed.
 
-Subtask JSON files are written during their respective steps (Step 3 and Step 4) via `gobbi note collect` with a `--phase` argument. Collection verifies they exist and conform to the subtask JSON format defined in _note — each file must contain the required fields: `agentId`, `agentType`, `description`, `model`, `effort`, `timestamp`, `delegationPrompt`, `finalResult`. Collection does not create these files.
+Subtask JSON files are written via `gobbi note collect` with a `--phase` argument. Collection verifies they exist and conform to the subtask JSON format defined in _note — each file must contain the required fields: `agentId`, `agentType`, `description`, `model`, `effort`, `timestamp`, `delegationPrompt`, `finalResult`. Collection does not create these files.
 
 ### After FEEDBACK
 
 Write `feedback.md` to the task root directory. Append each feedback round — do not overwrite previous rounds. Re-verify any subdirectories whose contents were modified during the feedback cycle.
-
-### After FEEDBACK then Review
-
-The `review/` subdirectory is updated with new PI review files. Verify that `review/` contains the expected review artifacts. Update the task `README.md` to reflect the review results.
 
 ---
 

--- a/.claude/skills/_delegation/SKILL.md
+++ b/.claude/skills/_delegation/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: _delegation
-description: Subagent briefing and context handoff. Load during Step 4 (Execution) to spawn specialists.
+description: Subagent briefing and context handoff. Load during the Execution step to spawn specialists.
 allowed-tools: Agent, Read, Grep, Glob, Bash, Write
 ---
 
 # Delegation Skill
 
-Hand off work to subagents so they succeed on the first attempt. Load this skill when entering Step 4 (Execution) of orchestration.
+Hand off work to subagents so they succeed on the first attempt. Load this skill when entering the Execution step of orchestration.
 
 **Navigate deeper from here:**
 
@@ -55,9 +55,9 @@ Every subagent needs three layers of context:
 - `_claude` skill — docs structure, anti-patterns, navigation standard
 - The project skill — project architecture, conventions, constraints
 - Gotchas — MUST check `_gotcha` and the project skill's `gotchas/` before starting work
-- Note directory path — the absolute path to the task's note directory so the subagent can write its output to the appropriate subdirectory (e.g., `ideation/innovative.md`, `research/best.md`, `execution/subtasks/`)
+- Note directory path — the absolute path to the task's note directory so the subagent can write its output to the appropriate subdirectory (e.g., `ideation/innovative.md`, `execution/subtasks/`)
 
-**Load per stance (PI and Researcher agents):**
+**Load per stance (PI and Ideation-phase investigation agents):**
 
 - `_innovation` — load when spawning the innovative stance. Defines how the agent thinks creatively, challenges conventions, and explores cross-domain patterns.
 - `_best-practice` — load when spawning the best-practice stance. Defines how the agent follows proven patterns, cites documentation, and applies community standards.
@@ -72,7 +72,7 @@ Every subagent needs three layers of context:
 
 - Project docs in the project skill directory — architecture, reference, review docs
 - Existing code in the area they'll modify — the codebase is the source of truth for patterns
-- Research materials from the `research/` subdirectory — when delegating execution tasks after Step 3 (Research), include the path to the `research/` directory so executors can read it during their Study phase. Research materials are guidance, not prescriptions — executors use them to make better-informed decisions but are not bound by the researchers' conclusions
+- Research materials from the `ideation/` subdirectory — when delegating execution tasks after Ideation investigation, include the path to the investigation findings so executors can read them during their Study phase. Research materials are guidance, not prescriptions — executors use them to make better-informed decisions but are not bound by the investigators' conclusions
 
 **Load when _git is active:**
 
@@ -124,7 +124,7 @@ Creative and implementation work demands deep reasoning — opus handles ambigui
 
 > **All review tasks use sonnet — override via the Agent tool's `model` parameter.**
 
-Review is assessment, not creation. When the orchestrator spawns any subagent for a review task — Step 7 Review, code review, PR review, or any other assessment delegation — set `model: "sonnet"` in the Agent tool call. This applies even to agents that default to opus (like `__pi`). The Agent tool's `model` parameter overrides the agent definition's default for that specific invocation. Review at sonnet with max effort provides rigorous assessment without opus cost.
+Review is assessment, not creation. When the orchestrator spawns any subagent for a review task — Evaluation step, code review, PR review, or any other assessment delegation — set `model: "sonnet"` in the Agent tool call. This applies even to agents that default to opus (like `__pi`). The Agent tool's `model` parameter overrides the agent definition's default for that specific invocation. Review at sonnet with max effort provides rigorous assessment without opus cost.
 
 > **Model tiers and capabilities evolve — these are current guidelines, not permanent assignments.**
 
@@ -152,21 +152,21 @@ The orchestrator delegates to these agent types. Each has a distinct role in the
 
 | Agent | Role | When to use | Model |
 |---|---|---|---|
-| `__pi` | "What to do" — ideation, review, creative assessment | Step 1 (Ideation) and Step 7 (Review). Spawned in parallel with innovative + best stances. | Opus |
-| `__researcher` | "What approach to take" — directional research, best references, architectural guidance | Step 3 (Research). Spawned in parallel with innovative + best stances. Writes findings to `research/` subdirectory. | Opus |
+| `__pi` | "What to do" — ideation, review, creative assessment | Ideation step and Evaluation step. Spawned in parallel with innovative + best stances. | Opus |
+| `__researcher` | "What approach to take" — directional research, best references, architectural guidance | Ideation investigation loop. Spawned in parallel with innovative + best stances. Writes findings to `ideation/` subdirectory. | Opus |
 | `_agent-evaluator` | Structured assessment — evaluates agent output against criteria | After creative or execution steps when evaluation is requested. | Sonnet |
 | `_skills-evaluator` | Structured assessment — evaluates skill documentation quality | After skill authoring when evaluation is requested. | Sonnet |
 | `_project-evaluator` | Structured assessment — evaluates project alignment and conventions | After any step when project-perspective evaluation is requested. | Sonnet |
-| `__executor` | "Do it" — code implementation, file changes, concrete deliverables | Step 4 (Execution). Reads research for direction, then implements with engineering judgment. Commits verified work. | Opus |
-| `gobbi-agent` | Claude Code specialist — `.claude/` documentation, skills, agents, rules, hooks | Step 4 (Execution) for any subtask involving `.claude/` configuration. Loaded with _claude, _skills, _agents, _rules as needed. | Sonnet |
+| `__executor` | "Do it" — code implementation, file changes, concrete deliverables | Execution step. Reads investigation findings for direction, then implements with engineering judgment. Commits verified work. | Opus |
+| `gobbi-agent` | Claude Code specialist — `.claude/` documentation, skills, agents, rules, hooks | Execution step for any subtask involving `.claude/` configuration. Loaded with _claude, _skills, _agents, _rules as needed. | Sonnet |
 
 Creative agents (PI, researcher) and implementation agents (executor) run at opus. Evaluators and gobbi-agent run at sonnet — they follow structured criteria and established patterns, not creative reasoning. See Model Selection for the full assignment table.
 
 ---
 
-## Research Step Delegation
+## Ideation Investigation Delegation
 
-Step 3 (Research) delegates to `__researcher` agents. Research happens after the plan is approved and before execution begins. The goal is to investigate "how to do" so executors can implement with confidence.
+During the Ideation step's investigation phase, the orchestrator spawns `__researcher` agents to investigate "how to do" before execution begins. Investigation happens as an internal loop within Ideation — after the approach is concrete enough to plan against, and before the plan is approved for execution. The goal is to give executors direction and references so they can implement with confidence.
 
 > **Spawn two researchers in parallel — innovative and best stances.**
 
@@ -176,36 +176,35 @@ Each researcher receives the same research brief but with a different stance dir
 
 Include a clear stance directive in each researcher's prompt: "Your stance is **innovative**" or "Your stance is **best**." The stance shapes which sources they prioritize, what patterns they surface, and what they recommend. Do not mix stances in a single prompt.
 
-> **Research prompts need the approved plan, not the raw idea.**
+> **Investigation prompts need the approved plan, not the raw idea.**
 
-Researchers need the decomposed plan from Step 2 — specific tasks, files affected, constraints, and acceptance criteria. The plan is their research scope. Include the path to `plan/` so they can read the full plan, not just a summary in the delegation prompt.
+Researchers need the decomposed plan — specific tasks, files affected, constraints, and acceptance criteria. The plan is their investigation scope. Include the path to `plan/` so they can read the full plan, not just a summary in the delegation prompt.
 
 **What a researcher delegation prompt needs:**
 
 - The approved plan — path to the `plan/` subdirectory or the plan content itself
 - The stance skill — `_innovation` for innovative stance, `_best-practice` for best stance
 - The stance directive — innovative or best
-- The research scope — which parts of the plan need investigation (may be the full plan or specific tasks)
-- The output location — path to the `research/` subdirectory where findings should be written
+- The investigation scope — which parts of the plan need investigation (may be the full plan or specific tasks)
+- The output location — path to the `ideation/` subdirectory where findings should be written
 - Context to load — project skill, `_gotcha`, `_research`, domain skills relevant to the investigation
-- What executors need to know — frame the research around executor readiness: "what does the executor need to know to implement this correctly?"
+- What executors need to know — frame the investigation around executor readiness: "what does the executor need to know to implement this correctly?"
 
 **After both researchers complete:**
 
-- Run `subtask-collect.sh` with the `research` phase argument to extract each researcher's output from their transcript
-- Read both researcher outputs — `research/innovative.md` and `research/best.md`
-- Synthesize into `research/research.md` — merge the strongest findings from both stances, resolve contradictions, and produce a unified set of implementation guidance
-- Optionally evaluate the research quality before proceeding to execution
+- Run `gobbi note collect` with the appropriate phase argument to extract each researcher's output from their transcript
+- Read both researcher outputs
+- Synthesize into a unified investigation note — merge the strongest findings from both stances, resolve contradictions, and produce a unified set of implementation guidance
+- Optionally evaluate the investigation quality before proceeding to execution
 
 ---
 
 ## Subtask Collection Phases
 
-The orchestrator runs `subtask-collect.sh` after each subagent completes to extract the delegation prompt and final result from the JSONL transcript. The phase argument determines which `subtasks/` subdirectory receives the output.
+The orchestrator runs `gobbi note collect` after each subagent completes to extract the delegation prompt and final result from the JSONL transcript. The phase argument determines which `subtasks/` subdirectory receives the output.
 
 | Phase argument | Used after | Writes to |
 |---|---|---|
-| `research` | Step 3 — after each researcher completes | `research/subtasks/{NN}-{slug}.json` |
-| `execution` | Step 4 — after each executor completes | `execution/subtasks/{NN}-{slug}.json` |
+| `execution` | Execution step — after each executor completes | `execution/subtasks/{NN}-{slug}.json` |
 
-Always run `subtask-collect.sh` immediately after each subagent wave completes — before launching synthesis, evaluation, or any downstream agent that depends on the output. Subtask JSON files on disk are the handoff mechanism between agents. An agent that reads from disk gets the full output; an agent that receives a summary in its prompt gets a lossy approximation.
+Always run `gobbi note collect` immediately after each subagent wave completes — before launching synthesis, evaluation, or any downstream agent that depends on the output. Subtask JSON files on disk are the handoff mechanism between agents. An agent that reads from disk gets the full output; an agent that receives a summary in its prompt gets a lossy approximation.

--- a/.claude/skills/_gobbi-rule-container/_gobbi-rule.md
+++ b/.claude/skills/_gobbi-rule-container/_gobbi-rule.md
@@ -28,7 +28,7 @@ Always-active behavioral safety net — minimum invariants every agent must foll
 - When loading a skill, also load its child `gotchas.md` if one exists.
 - Study existing code and docs before making changes — the codebase is the source of truth.
 - Every subagent prompt must include specific requirements, constraints, and context — never a one-liner.
-- Executors must read research materials from the `research/` subdirectory before implementing.
+- Executors must read investigation materials from the task's note directory before implementing.
 
 ---
 

--- a/.claude/skills/_research/SKILL.md
+++ b/.claude/skills/_research/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: _research
-description: Research investigation for approved plans. MUST load during Step 3 (Research).
+description: Research investigation within the Ideation step's investigation loop. Load when spawning researcher agents to investigate approach direction before Execution.
 allowed-tools: Read, Grep, Glob, Bash, WebSearch, WebFetch, Write
 ---
 
 # Research
 
-After the plan is approved, researcher agents investigate the best approach for each task. This skill guides the two researcher stances (innovative and best-practice), what they produce, and how the orchestrator synthesizes their findings into directional guidance for executor agents.
+Researcher agents investigate the best approach for each plan task as an internal loop within the Ideation step. This skill guides the two researcher stances (innovative and best-practice), what they produce, and how the orchestrator synthesizes their findings into directional guidance for executor agents.
 
 Research answers "what approach to take and why" — ideation answers "what to do" and planning answers "in what order." Think of researchers as architects sketching a blueprint: they design the direction and gather the best references, but executors own the implementation details. The output of research is directional guidance with strong references, organized by plan task, stored in note files that executors read before starting work.
 
@@ -91,7 +91,7 @@ Research writes to the note directory for the current task. The orchestrator ini
 
 ## When to Research
 
-Research is Step 3 — after Plan approval (Step 2 complete), before Execution (Step 4).
+Research is the investigation loop within Ideation — after Plan approval, before Execution begins.
 
 - **Always research** for non-trivial tasks — any task that involves design decisions, unfamiliar code areas, or multiple possible implementation approaches
 - **Skip research** for structured routines where the execution pattern is fully known — applying a well-documented migration, running a standard release process, or following a step-by-step procedure that has been done before

--- a/.claude/skills/_research/SKILL.md
+++ b/.claude/skills/_research/SKILL.md
@@ -38,7 +38,7 @@ Think big picture: what approach to take, which architectural decisions to make,
 
 > **Results directory for detailed reference materials.**
 
-Beyond the summary notes, researchers save detailed findings — relevant code snippets found in the codebase, API documentation excerpts, comparison tables, pattern analysis — in the `research/results/` directory. These are reference materials that the synthesis note and executors can draw on.
+Beyond the summary notes, researchers save detailed findings — relevant code snippets found in the codebase, API documentation excerpts, comparison tables, pattern analysis — in the `ideation/results/` directory. These are reference materials that the synthesis note and executors can draw on.
 
 ---
 
@@ -70,28 +70,28 @@ Both stances share a common investigation discipline regardless of their perspec
 - Organize findings by plan task — each task in the approved plan gets a section
 - Include specific file paths, function names, documentation links, and patterns — references are your primary deliverable
 - Focus on approach direction and trade-offs, not step-by-step implementation — executors own the implementation details
-- Save detailed reference materials (comparison tables, API excerpts, code snippets found, pattern analysis) to `research/results/`
+- Save detailed reference materials (comparison tables, API excerpts, code snippets found, pattern analysis) to `ideation/results/`
 - Be explicit about confidence level — distinguish "this is proven in the codebase" from "this is my recommendation based on external reading"
 
 ---
 
 ## What Research Produces
 
-Research writes to the note directory for the current task. The orchestrator initializes the `research/` subdirectory and the `research/results/` directory before spawning researchers.
+Research writes to the note directory for the current task. The orchestrator initializes the `ideation/` subdirectory and the `ideation/results/` directory before spawning researchers.
 
 | File | Author | Contains |
 |---|---|---|
-| `research/innovative.md` | Innovative researcher | Approach direction, architectural ideas, cross-domain patterns, trade-off analysis — organized by plan task |
-| `research/best.md` | Best-practice researcher | Approach direction, proven patterns, community standards, key references — organized by plan task |
-| `research/research.md` | Orchestrator | Recommended direction per plan task with cited references — which approach to take and why, not how to code it |
-| `research/results/` | Both researchers | Reference materials: relevant code snippets from the codebase, API documentation excerpts, comparison tables, pattern analysis |
-| `research/subtasks/01-{slug}.json` | Post-hook | Subtask records extracted from researcher transcripts |
+| `ideation/innovative.md` | Innovative researcher | Approach direction, architectural ideas, cross-domain patterns, trade-off analysis — organized by plan task |
+| `ideation/best.md` | Best-practice researcher | Approach direction, proven patterns, community standards, key references — organized by plan task |
+| `ideation/research.md` | Orchestrator | Recommended direction per plan task with cited references — which approach to take and why, not how to code it |
+| `ideation/results/` | Both researchers | Reference materials: relevant code snippets from the codebase, API documentation excerpts, comparison tables, pattern analysis |
+| `ideation/subtasks/01-{slug}.json` | Post-hook | Subtask records extracted from researcher transcripts |
 
 ---
 
 ## When to Research
 
-Research is the investigation loop within Ideation — after Plan approval, before Execution begins.
+Research is the investigation loop inside the Ideation step — used during Ideation before the approach is locked for planning.
 
 - **Always research** for non-trivial tasks — any task that involves design decisions, unfamiliar code areas, or multiple possible implementation approaches
 - **Skip research** for structured routines where the execution pattern is fully known — applying a well-documented migration, running a standard release process, or following a step-by-step procedure that has been done before
@@ -101,7 +101,7 @@ Research is the investigation loop within Ideation — after Plan approval, befo
 
 ## Orchestrator Synthesis
 
-After both researcher agents complete, the orchestrator reads `innovative.md` and `best.md` and writes `research.md`. The synthesis is not a merge — it is a judgment call that draws from both stances to produce the best implementation guidance.
+After both researcher agents complete, the orchestrator reads `ideation/innovative.md` and `ideation/best.md` and writes `ideation/research.md`. The synthesis is not a merge — it is a judgment call that draws from both stances to produce the best implementation guidance.
 
 - Organize by plan task — each task in the approved plan gets a section in `research.md` with the relevant findings
 - For each task, state the recommended approach and which stance it draws from


### PR DESCRIPTION
## Summary

Three independent doc-cleanup sub-tasks bundled into one PR. All scope stays inside `.claude/`; no code, no CLI, no hook changes.

- **Closes #98** — Migrate fast-check v4 `fc.hexaString` + `fc.option` vs `exactOptionalPropertyTypes` gotchas from `phase2-planning.md` to a new `test-tooling.md`. The existing source entries preserved verbatim, just relocated to a discoverable test-tooling doc per #98.
- **7-step → 5-step language cleanup** — `_collection`, `_delegation`, `_research` SKILL.md files now match the v0.5.0 canonical 5-step cycle (Ideation → Plan → Execution → Evaluation → Memorization). `_orchestration/*` archive intentionally untouched.
- **Backlog namespace fix** — `v050-phase3-backlog.md`'s docs-banner entry referenced the removed `gobbi docs` namespace (removed by PR #65). Renamed to `gobbi banner` (new top-level helper). Also refreshed the Revisit-cadence example that still cited now-closed #97.

## Context

Follow-up cleanup after PR #103 landed the CLI velocity bundle. Covers the remaining "Phase 2 L-F list" housekeeping items except integration PR and npm publish (deferred per user).

- **#64** (Remove JSON-first authoring strategy) — closed separately as already-implemented (PR #65 landed the removal earlier; only the issue close was outstanding).

## Commits

| Hash | Subject |
|---|---|
| `46b4d0d` | `docs(gotchas): migrate fast-check + exactOptional gotchas to test-tooling.md` |
| `4d9a79d` | `docs(skills): rewrite _collection, _delegation, _research for v0.5.0 5-step cycle` |
| `e30022b` | `docs(backlog): rename gobbi-docs-banner to gobbi-banner + refresh revisit-cadence example` |

## Test plan

- [x] `bun test` — 1205 pass / 0 fail (no code changes).
- [x] `cd packages/cli && bun run typecheck` — clean.
- [x] `rg "(?i)7[- ]?step|seven[- ]?step" .claude/skills/ -g '!_orchestration/**'` — zero hits.
- [x] `gobbi validate skill` on each of the 3 edited SKILL.md files — all PASS (two skills have pre-existing WARN notices about trigger-oriented language that are out of scope for this PR).
- [x] `gobbi validate gotcha` on test-tooling.md + phase2-planning.md — both PASS.
- [x] `gobbi validate lint` on the 3 skills — CLEAN.

## Decision annotations

- **`_collection`** kept (path 1: keep + rewrite) rather than deprecated. Note-verification and README-writing utility remains useful in v0.5.0; only the Step-5 identity + `research/` subdirectory verification were removed.
- **`_delegation` "Research Step Delegation" section** reframed as "Ideation Investigation Delegation" (not removed). Dual-stance investigation machinery still valid; it now lives inside Ideation's loop. Subtask-collect table dropped the `research` phase row.
- **Revisit-cadence example** updated from `#97 + #98` (both now closed/closing) to `#90 + #96` (explicit overlapping-scope items in their backlog entries).

## Review focus

1. `_delegation` restructure — does "Ideation Investigation Delegation" correctly capture the dual-stance pattern without losing operational detail?
2. `_collection` utility framing — is the skill's value proposition still clear now that "Step 5" identity is gone?
3. `test-tooling.md` — does the new file location improve discoverability for future test authors, as #98 intended?