### PR TITLE
docs(project): capture post-Phase-2 session learnings

### DIFF
--- a/.claude/project/gobbi/gotchas/delegation-discipline.md
+++ b/.claude/project/gobbi/gotchas/delegation-discipline.md
@@ -1,0 +1,37 @@
+Gotchas tied to orchestrator ↔ subagent delegation — briefing accuracy, parallel-executor mechanics, and verification completeness. Read when authoring a delegation brief or when reviewing a multi-executor wave.
+
+---
+
+## Briefing references non-existent production code path — grep before accepting literal syntax
+
+**Priority:** High
+
+**What happened:** PR #103 V.1 briefing directed the executor to read `process.env.CLAUDE_CODE_VERSION` "when constructing the `delegation.spawn` data in `capture-subagent.ts`". The executor's study phase revealed that `capture-subagent.ts` constructs only `delegation.complete` / `delegation.fail` events — no production code in `packages/cli/src/` constructs `delegation.spawn`. The schema factory is used solely by test fixtures and the reducer handles spawns when they arrive from an emitter that does not yet exist. The executor had to interpret the briefing as schema-only + future-proofing tests, and the gap became PR-blocker-level discovery only at evaluation time (resulting in follow-up #102).
+
+**User feedback:** Self-caught by V.1 executor 2026-04-20; orchestrator re-verified and confirmed no emitter exists (guard hook does not emit spawn; `SubagentStop` → `capture-subagent` emits complete/fail only).
+
+**Correct approach:** Before writing a briefing that names a specific line or function as the edit site, run `rg -n '<symbol>' packages/ -g '!**/__tests__/**' -g '!*.test.ts'` to verify the symbol exists in production code at the claimed location. Non-test call sites are what will execute at runtime; briefings should cite them, not test-fixture occurrences. If a symbol exists only in test code, the briefing must either expand scope to add the emitter, scope down to schema-only with explicit acknowledgment, or file the missing piece as a prerequisite issue before execution.
+
+---
+
+## Parallel executor lint/tooling re-applies on file save — verify staged vs unstaged split, do NOT use stash
+
+**Priority:** Medium
+
+**What happened:** PR #103 wave had 3 parallel executors in a shared worktree. V.2 (editing `specs/errors.ts`) and V.3 (retyping `specs/errors.ts` as part of the `EventStore` → `ReadStore` cascade) hit transient apparent-reverts of each other's edits. The underlying cause: a peer executor's active tooling re-applied type narrowing as an unstaged diff on top of a freshly staged file; `git status` briefly showed one executor's edit as "staged by a peer." Resolution was to stage own changes by explicit file-path-list and let the peer commit land first, not to `git stash` a "conflict" or run a broad `git checkout HEAD -- <file>`.
+
+**User feedback:** Self-caught by V.3 executor 2026-04-20; scope separation held because the type-narrowing rename was entirely in V.3's unstaged diff while V.2's diagnostic rewrite stayed within its function body. No data loss.
+
+**Correct approach:** In a shared worktree with parallel executors, verify staged/unstaged separation with two greps rather than assuming: `git diff --staged <file> | head` and `git diff <file> | head`. If the unstaged portion is entirely peer-scope, commit your staged portion verbatim — the peer will pick up their own unstaged work. Never `git stash` to "clean up" a perceived conflict; stash is shared across the repo and pops back into peer worktrees (see sibling gotcha on stash-across-worktrees). Never `git checkout HEAD -- <file>` to reset a working-tree state that a peer is actively editing.
+
+---
+
+## Partial-rewrite pattern — grep for concrete identifiers, not just the renamed phrase
+
+**Priority:** Medium
+
+**What happened:** PR #104's D.2 sub-task rewrote `_research/SKILL.md` at the description-and-intro level for 5-step framing but left the body untouched. The "What Research Produces" table still pointed at `research/innovative.md`, `research/best.md`, `research/research.md`, `research/results/`, `research/subtasks/` while the sibling `_delegation/SKILL.md` was updated to direct orchestrators to `ideation/`. The orchestrator's own verification command (`rg "(?i)7[- ]?step|seven[- ]?step" .claude/skills/`) returned zero hits — success by that check — but missed the residual path divergence because paths use identifier names, not step-count phrases. All three post-execution evaluators independently caught the mismatch as a Critical / High finding.
+
+**User feedback:** Flagged as convergent Critical/High by Skills, Project, and Overall evaluators 2026-04-20. Orchestrator accepted REVISE and spawned a second remediation executor (`e1b22bb`, `c40607e`) to align `_research` body + `_gobbi-rule` path.
+
+**Correct approach:** When renaming a shared concept across multiple docs (path convention, step name, component name), the verification grep must target **specific identifier names** the concept maps to — not the conceptual phrase being renamed. For path-convention renames, grep for the old path segment (`research/`) against every file in scope, not just the phrase describing the structure. For API renames, grep for the old symbol. The briefing should include the specific greps as part of its verification checklist so executors can run them before reporting done. When a rewrite touches a skill's description but leaves the body referencing old identifiers, the skill is in a worse state than pre-rewrite: its stated contract contradicts its operational content, and downstream agents get conflicting instructions.

--- a/.claude/project/gobbi/rules/docs-cleanup-parallelism.md
+++ b/.claude/project/gobbi/rules/docs-cleanup-parallelism.md
@@ -1,0 +1,34 @@
+# Docs-cleanup parallelism
+
+When the task is a small docs-cleanup batch — 3 to 5 related markdown files, under ~200 lines of cumulative diff — prefer a **single sequential `gobbi-agent`** over parallel executors. Context consistency across the batch is worth more than the wall-clock savings of parallel execution.
+
+---
+
+## Why
+
+Parallel executors produce divergent terminology when the concepts touched are interconnected. PR #104's docs cleanup touched `_collection`, `_delegation`, `_research` — three skills whose semantics reference each other (research output location, collection's dependence on subdirectory naming, delegation's handoff paths). A single agent holding all three files in working context converges on consistent substitutions ("Ideation Investigation Delegation", "investigation findings", `ideation/` paths). Three parallel agents would have made different local choices — one might keep "Research Step" as a header while another removes it — leaving a patchwork that requires a follow-up remediation pass to reconcile.
+
+The same trade-off does not apply to code PRs like #103's CLI velocity bundle: three TypeScript changes with non-overlapping files, no cross-file semantic links, three parallel executors were the right call.
+
+---
+
+## When to apply
+
+- Rewriting shared vocabulary across interconnected skills
+- Renaming a concept (step name, path convention, component name) where every occurrence must agree
+- Small backlog edits plus the skill or docs they reference
+- Gotcha migrations where source and destination must stay in sync
+
+---
+
+## When NOT to apply
+
+- Code changes with non-overlapping file targets and no shared vocabulary (parallel is faster with no cost)
+- Large rewrites where a single agent would exceed comfortable context budget (split by coherent chunks, each handled by its own agent)
+- Genuinely independent sub-tasks that touch different subsystems (delegate separately)
+
+---
+
+## Related
+
+See `_delegation` for the general delegation principles and the "When to split vs combine" judgment call. See `_plan` for how to decide task boundaries during Planning. This rule narrows the split-vs-combine judgment for the specific case of docs-cleanup batches — the default should be combine.


### PR DESCRIPTION
## Summary

Memorization artifacts from the PR #103 + PR #104 session (2026-04-20). All additive; no code, no skills, no rules changed in place.

**Adds:**
- `.claude/project/gobbi/gotchas/delegation-discipline.md` — three gotchas sourced from execution findings:
  1. **Briefing references non-existent production code path** — grep before accepting literal syntax (PR #103 V.1 surface area gap).
  2. **Parallel executor lint/tooling re-applies on save** — verify staged vs unstaged split; do NOT stash (PR #103 V.2/V.3 shared-worktree episode).
  3. **Partial-rewrite pattern** — grep for concrete identifiers, not just the renamed phrase (PR #104 `_research` path-mismatch catch).

- `.claude/project/gobbi/rules/docs-cleanup-parallelism.md` — establishes the single-sequential-gobbi-agent default for small interconnected docs batches (< ~200 lines, 3-5 related files), with explicit when-NOT-to-apply list.

## Context

PR #103 (CLI velocity, commit `7233ac5`) + PR #104 (docs cleanup, commit `e13cba2`) produced four reusable lessons. Three are phrased as gotchas (concrete mistakes with a correct-approach prescription); one is phrased as a rule (a positive convention to follow). This split follows the _gotcha / _rules skill guidance.

The `rules/` subdirectory under `.claude/project/gobbi/` did not exist before this PR — created here as the first project-specific rule file. Follows the `_project` skill's expected layout.

## Test plan

- [x] `gobbi validate gotcha .claude/project/gobbi/gotchas/delegation-discipline.md` — PASS.
- [x] No code touched; `bun test` unchanged from `e13cba2` baseline (1205 pass).
- [x] No skill touched; `_orchestration` archive and all rewritten skills from PR #104 unchanged.

## Review focus

- Are the gotcha entries specific enough to change an agent's behavior, or too abstract?
- Is the docs-cleanup parallelism rule scoped narrowly enough (only small interconnected batches, not general docs work)?