### PR TITLE
docs: address #135 path-drift residuals + #136 §THIRD wiring re-integration

### DIFF
--- a/.gobbi/projects/gobbi/README.md
+++ b/.gobbi/projects/gobbi/README.md
@@ -11,8 +11,10 @@ Gobbi v0.5.0 separates runtime state from retrospective records. `.gobbi/session
 ## Directory
 
 - [design/](design/) — Design docs: vision, architecture, workflow, agents, evaluation, state, hacks, distribution, GSD analysis
+- [learnings/](learnings/) — Gotchas and decisions accumulated across sessions
+- [references/](references/) — External references, API docs, research
 - [rules/](rules/) — Project-specific rules and conventions
-- [gotchas/](gotchas/) — Project-specific gotchas (not cross-project)
-- [note/](note/) — Retrospective workflow notes per completed task (gitignored, main tree only)
-- [reference/](reference/) — External references, API docs, research
-- [docs/](docs/) — Other project documents
+- [skills/](skills/) — Project-specific skill files (symlinked into `.claude/skills/` per-file)
+- [agents/](agents/) — Project-specific agent definitions (symlinked into `.claude/agents/` per-file)
+- [sessions/](sessions/) — Per-session runtime state: settings, event store, mid-session notes (gitignored)
+- [README.md](README.md) — This file

--- a/.gobbi/projects/gobbi/design/v050-features/feature-pass-template.md
+++ b/.gobbi/projects/gobbi/design/v050-features/feature-pass-template.md
@@ -41,7 +41,7 @@ New columns use an idempotent `PRAGMA table_info`-guarded ALTER. The guard check
 
 ### Settings path constants
 
-All paths under `.gobbi/` must go through `workspace-paths.ts`. Hard-coding paths like `.gobbi/project/settings.json` bypasses the multi-project routing and breaks `gobbi project switch`. If a function constructs a path by string concatenation rather than calling `workspacePaths(root, projectName)`, it is a bug.
+All paths under `.gobbi/` must go through `workspace-paths.ts`. Hard-coding paths like `.gobbi/projects/<name>/settings.json` as literals bypasses the multi-project routing and breaks `gobbi project switch`. If a function constructs a path by string concatenation rather than calling `workspacePaths(root, projectName)`, it is a bug.
 
 ### Step directory creation
 

--- a/.gobbi/projects/gobbi/design/v050-features/gobbi-config/README.md
+++ b/.gobbi/projects/gobbi/design/v050-features/gobbi-config/README.md
@@ -15,7 +15,7 @@ Gobbi resolves every setting by composing three `settings.json` files — worksp
 | Level | Path | Git | Written by |
 |---|---|---|---|
 | workspace | `.gobbi/settings.json` | gitignored | `ensureSettingsCascade` seed on first run; manual edit |
-| project | `.gobbi/project/settings.json` | tracked | `ensureSettingsCascade` seed; manual edit |
+| project | `.gobbi/projects/<name>/settings.json` | tracked | `ensureSettingsCascade` seed; manual edit |
 | session | `.gobbi/projects/<name>/sessions/{id}/settings.json` | gitignored (inherits `.gobbi/projects/<name>/sessions/`) | `/gobbi` setup FIFTH step; `gobbi config set` |
 
 Session-id resolution: `$CLAUDE_SESSION_ID` env is the CLI-level primary; `--session-id` flag is the fallback. The `/gobbi` skill discovers the real session id per the `session-id-discovery` gotcha (primary env is `$CODEX_COMPANION_SESSION_ID` at the skill level) and passes `--session-id` explicitly when the env is not populated.
@@ -121,7 +121,7 @@ Resolution fires at the eval checkpoint, not at config-write time.
 
 1. If `.gobbi/config.db` exists — delete it and log
 2. If `.claude/gobbi.json` exists — delete it and log
-3. If `.gobbi/project-config.json` (T2-v1 legacy) exists and `.gobbi/project/settings.json` does not — upgrade: rename path, set `schemaVersion: 1`, restructure `git.mode → git.workflow.mode`, convert `eval.{step}: bool → workflow.{step}.evaluate.mode` enum (`true→'always'`, `false→'ask'`), drop `trivialRange`, `verification.*`, `cost.*`, `ui.*`
+3. If `.gobbi/project-config.json` (T2-v1 legacy) exists and `.gobbi/projects/<name>/settings.json` does not — upgrade: rename path, set `schemaVersion: 1`, restructure `git.mode → git.workflow.mode`, convert `eval.{step}: bool → workflow.{step}.evaluate.mode` enum (`true→'always'`, `false→'ask'`), drop `trivialRange`, `verification.*`, `cost.*`, `ui.*`
 4. Seed workspace and project defaults if absent
 5. Ensure `.gobbi/.gitignore` lists `settings.json` and `sessions/`
 

--- a/.gobbi/projects/gobbi/design/v050-features/gobbi-config/checklist.md
+++ b/.gobbi/projects/gobbi/design/v050-features/gobbi-config/checklist.md
@@ -55,7 +55,7 @@ All items target behaviour shipped in Pass 3 (Wave B–D, SHAs cited in `review.
 
 - [EP] `--level workspace` creates `.gobbi/settings.json` when absent, with `schemaVersion: 1` and the set key.
   - Verify: `bun test packages/cli/src/__tests__/features/gobbi-config.test.ts -t 'CFG-6'`
-- [EP] `--level project` writes to `.gobbi/project/settings.json`.
+- [EP] `--level project` writes to `.gobbi/projects/<name>/settings.json`.
   - Verify: CFG-6 variant test for project level
 
 ---
@@ -139,7 +139,7 @@ All items target behaviour shipped in Pass 3 (Wave B–D, SHAs cited in `review.
   - Verify: `bun test packages/cli/src/__tests__/features/gobbi-config.test.ts -t 'CFG-14'`
 - [DT] Boolean `eval.*: true` → `'always'`; boolean `eval.*: false` → `'ask'`. Both cases covered.
   - Verify: CFG-14 test asserts `workflow.ideation.evaluate.mode === 'always'` (true→'always') and `workflow.planning.evaluate.mode === 'ask'` (legacy `eval.plan` → new `workflow.planning`; false→'ask')
-- [EP] After upgrade, `.gobbi/project-config.json` is absent and `.gobbi/project/settings.json` is present with `schemaVersion: 1`.
+- [EP] After upgrade, `.gobbi/project-config.json` is absent and `.gobbi/projects/<name>/settings.json` is present with `schemaVersion: 1`.
   - Verify: CFG-14 test asserts source file gone, target file has correct schema version
 - [EP] `ensureSettingsCascade` idempotent when target already exists — upgrade does NOT run twice.
   - Verify: CFG-14 idempotency case in test file

--- a/.gobbi/projects/gobbi/design/v050-features/gobbi-config/scenarios.md
+++ b/.gobbi/projects/gobbi/design/v050-features/gobbi-config/scenarios.md
@@ -13,7 +13,7 @@ See `README.md` for the feature overview.
 ### CFG-1 — Cascade get — no `--level` returns session → project → workspace → default
 
 **Given** `.gobbi/projects/<name>/sessions/{id}/settings.json` has `git.workflow.mode: 'worktree-pr'`
-And `.gobbi/project/settings.json` has `git.workflow.mode: 'direct-commit'`
+And `.gobbi/projects/<name>/settings.json` has `git.workflow.mode: 'direct-commit'`
 **When** `gobbi config get git.workflow.mode --session-id <id>` runs
 **Then** output is `"worktree-pr"` (session wins) and exit code is `0`
 
@@ -29,7 +29,7 @@ Evidence:
 
 ### CFG-2 — Level-scoped get — `--level project` reads only project file
 
-**Given** `.gobbi/project/settings.json` has `notify.slack.enabled: true`
+**Given** `.gobbi/projects/<name>/settings.json` has `notify.slack.enabled: true`
 And `.gobbi/projects/<name>/sessions/{id}/settings.json` has `notify.slack.enabled: false`
 **When** `gobbi config get notify.slack.enabled --level project` runs
 **Then** output is `true` and exit code is `0`
@@ -47,7 +47,7 @@ Evidence:
 
 ### CFG-3 — Level-scoped get — key absent at level returns exit 1 even when default supplies value
 
-**Given** `.gobbi/project/settings.json` is empty (only `schemaVersion: 1`)
+**Given** `.gobbi/projects/<name>/settings.json` is empty (only `schemaVersion: 1`)
 **When** `gobbi config get git.workflow.mode --level project` runs
 **Then** exit code is `1` and stdout is empty
 
@@ -63,7 +63,7 @@ Evidence:
 
 ### CFG-4 — Cascade get — key absent at all levels returns exit 1
 
-**Given** no `.gobbi/settings.json`, no `.gobbi/project/settings.json`, no session settings
+**Given** no `.gobbi/settings.json`, no `.gobbi/projects/<name>/settings.json`, no session settings
 **When** `gobbi config get workflow.ideation.discuss.mode --session-id <id>` runs
 **Then** exit code is `0` and output is `"user"` (the built-in default)
 
@@ -117,9 +117,9 @@ Evidence:
 
 ### CFG-7 — Deep-path set — nested key created without clobbering siblings
 
-**Given** `.gobbi/project/settings.json` has `git: { workflow: { mode: 'worktree-pr', baseBranch: 'main' } }`
+**Given** `.gobbi/projects/<name>/settings.json` has `git: { workflow: { mode: 'worktree-pr', baseBranch: 'main' } }`
 **When** `gobbi config set git.pr.draft true --level project` runs
-**Then** `.gobbi/project/settings.json` has `git.pr.draft: true`
+**Then** `.gobbi/projects/<name>/settings.json` has `git.pr.draft: true`
 And `git.workflow.mode` is still `'worktree-pr'` and `git.workflow.baseBranch` is still `'main'`
 
 State trace:
@@ -171,7 +171,7 @@ Evidence:
 ### CFG-10 — `null` at narrower level is an explicit leaf
 
 **Given** `.gobbi/settings.json` has `git.workflow.baseBranch: 'main'`
-And `.gobbi/project/settings.json` has `git.workflow.baseBranch: null`
+And `.gobbi/projects/<name>/settings.json` has `git.workflow.baseBranch: null`
 **When** `resolveSettings({ repoRoot })` (no session) runs
 **Then** resolved `git.workflow.baseBranch` is `null` — project's explicit null wins over workspace's `'main'`
 
@@ -246,9 +246,9 @@ Evidence:
 ### CFG-14 — T2-v1 upgrade — `project-config.json` migrated to `project/settings.json`
 
 **Given** `.gobbi/project-config.json` exists with `version: 1`, `git.mode: 'worktree-pr'`, `git.baseBranch: 'main'`, `eval.ideation: true`, `eval.plan: false`
-And `.gobbi/project/settings.json` does not exist
+And `.gobbi/projects/<name>/settings.json` does not exist
 **When** `ensureSettingsCascade(repoRoot)` runs
-**Then** `.gobbi/project/settings.json` exists with:
+**Then** `.gobbi/projects/<name>/settings.json` exists with:
   - `schemaVersion: 1`
   - `git.workflow.mode: 'worktree-pr'` and `git.workflow.baseBranch: 'main'` (renamed)
   - `workflow.ideation.evaluate.mode: 'always'` (true → 'always') and `workflow.planning.evaluate.mode: 'ask'` (legacy `eval.plan` → new `workflow.planning`; false → 'ask')

--- a/.gobbi/projects/gobbi/design/v050-overview.md
+++ b/.gobbi/projects/gobbi/design/v050-overview.md
@@ -128,7 +128,7 @@ V0.5.0 resolves it with a hard directory split:
   hooks/                            gobbi.db                   (workspace event store)
 ```
 
-`.claude/` is the static knowledge layer. During a workflow session, no agent writes to it. The hooks enforce this at the tool layer — a PreToolUse hook blocks any write to `.claude/` while a session is active. The `skills/`, `agents/`, and `rules/` entries in `.claude/` are per-file symlinks pointing into `.gobbi/skills/`, `.gobbi/agents/`, and `.gobbi/rules/` — the symlink farm lets Claude Code load docs from `.claude/` without storing the canonical copies there.
+`.claude/` is the static knowledge layer. During a workflow session, no agent writes to it. The hooks enforce this at the tool layer — a PreToolUse hook blocks any write to `.claude/` while a session is active. The `skills/`, `agents/`, and `rules/` entries in `.claude/` are per-file symlinks pointing into `.gobbi/projects/<name>/skills/`, `.gobbi/projects/<name>/agents/`, and `.gobbi/projects/<name>/rules/` — the symlink farm lets Claude Code load docs from `.claude/` without storing the canonical copies there.
 
 `.gobbi/` is the runtime layer. Session state, worktree management, notes, gotchas recorded mid-session, and context files all live here. Writing to `.gobbi/` does not trigger context reload. Agents write freely.
 

--- a/.gobbi/projects/gobbi/skills/_git/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/_git/SKILL.md
@@ -43,7 +43,7 @@ Before the git workflow can function, certain conditions must hold. These divide
 
 **Critical — block until resolved.** The gh CLI must be available and reachable because the entire PR lifecycle depends on it. The gh CLI must be authenticated to the remote because API access is required for issue creation, PR management, and CI monitoring. The repository must have a configured git remote because pushing and PR creation require a remote target. If any of these are missing, the workflow cannot proceed.
 
-**Warning — inform the user, continue.** The configured base branch should exist on the remote — worktree creation will fail later if it doesn't, but the user may intend to create it. The `.claude/worktrees/` directory should be listed in `.gitignore` — without this, worktree contents appear in the main repo's git status. Orphaned worktrees may exist in `.claude/worktrees/` from crashed or abandoned sessions — offer cleanup or recovery.
+**Warning — inform the user, continue.** The configured base branch should exist on the remote — worktree creation will fail later if it doesn't, but the user may intend to create it. The `.gobbi/projects/<name>/worktrees/` directory should be listed in `.gitignore` — without this, worktree contents appear in the main repo's git status. Orphaned worktrees may exist in `.gobbi/projects/<name>/worktrees/` from crashed or abandoned sessions — offer cleanup or recovery.
 
 > **Fallback principle:**
 
@@ -107,7 +107,7 @@ This skill loads at session start as a core skill. Prerequisites run during sess
 - **After identifying cause:** fix it in the worktree, commit the fix, and push; CI re-runs automatically against the updated branch
 - **Monitor:** until CI passes or the user decides to defer
 
-**Cleanup failure when removing a worktree** — If normal removal fails (uncommitted changes, locked files), force removal is the fallback, followed by pruning to clean up stale references. Nested branch names that use slashes create intermediate directories under `.claude/worktrees/` — git only removes the leaf directory, so empty parent directories must be cleaned up separately after worktree removal.
+**Cleanup failure when removing a worktree** — If normal removal fails (uncommitted changes, locked files), force removal is the fallback, followed by pruning to clean up stale references. Nested branch names that use slashes create intermediate directories under `.gobbi/projects/<name>/worktrees/` — git only removes the leaf directory, so empty parent directories must be cleaned up separately after worktree removal.
 
 ---
 

--- a/.gobbi/projects/gobbi/skills/_git/conventions.md
+++ b/.gobbi/projects/gobbi/skills/_git/conventions.md
@@ -102,9 +102,9 @@ GitHub does not auto-create labels. On a fresh repository, the orchestrator must
 
 ## Worktree Directory Naming
 
-Worktrees are created inside `.claude/worktrees/` within the main repository. The directory name preserves the branch name exactly, including slashes — so a branch named feat/42-oauth-login becomes `.claude/worktrees/feat/42-oauth-login/`. This keeps worktrees co-located with the repo rather than scattered as sibling directories, and the preserved branch path makes it easy to identify what each worktree is for without inspecting git state. Naming collisions are prevented because each branch name is unique.
+Worktrees are created inside `.gobbi/projects/<name>/worktrees/` within the main repository. The directory name preserves the branch name exactly, including slashes — so a branch named feat/42-oauth-login becomes `.gobbi/projects/<name>/worktrees/feat/42-oauth-login/`. This keeps worktrees project-scoped under `.gobbi/` rather than co-located with the `.claude/` static layer, and the preserved branch path makes it easy to identify what each worktree is for without inspecting git state. Naming collisions are prevented because each branch name is unique.
 
-The `.claude/worktrees/` directory must be in `.gitignore` to prevent worktree contents from appearing in the main repo's git status.
+The `.gobbi/projects/*/worktrees/` glob must be in `.gitignore` to prevent worktree contents from appearing in the main repo's git status.
 
 ---
 

--- a/.gobbi/projects/gobbi/skills/_git/gotchas.md
+++ b/.gobbi/projects/gobbi/skills/_git/gotchas.md
@@ -68,11 +68,11 @@ Mistakes in git/GitHub workflow, worktree management, branch handling, and PR li
 
 **Priority:** High
 
-**What happened:** The worktree naming convention preserves branch slashes as directory separators (e.g., `chore/1-bump-version` → `.claude/worktrees/chore/1-bump-version/`). When the worktree was removed with `git worktree remove`, only the leaf directory (`1-bump-version/`) was deleted. The parent directory (`chore/`) remained as an empty directory. This leaves visible clutter that looks like an orphaned worktree.
+**What happened:** The worktree naming convention preserves branch slashes as directory separators (e.g., `chore/1-bump-version` → `.gobbi/projects/<name>/worktrees/chore/1-bump-version/`). When the worktree was removed with `git worktree remove`, only the leaf directory (`1-bump-version/`) was deleted. The parent directory (`chore/`) remained as an empty directory. This leaves visible clutter that looks like an orphaned worktree.
 
 **User feedback:** "There are remains like .claude/worktrees/chore."
 
-**Correct approach:** After removing a worktree, clean up any empty parent directories left behind under `.claude/worktrees/`. The cleanup should walk upward from the removed worktree path, removing empty directories until reaching `.claude/worktrees/` itself. This must be part of the worktree removal step, not left as a manual cleanup.
+**Correct approach:** After removing a worktree, clean up any empty parent directories left behind under `.gobbi/projects/<name>/worktrees/`. The cleanup should walk upward from the removed worktree path, removing empty directories until reaching `.gobbi/projects/<name>/worktrees/` itself. This must be part of the worktree removal step, not left as a manual cleanup.
 
 ---
 

--- a/.gobbi/projects/gobbi/skills/_gobbi-cli/commands.md
+++ b/.gobbi/projects/gobbi/skills/_gobbi-cli/commands.md
@@ -29,7 +29,7 @@ Cross-reference: `_note` for note directory structure, subtask JSON format, and 
 
 ## config
 
-Read and write gobbi settings across the three-level cascade: workspace (`.gobbi/settings.json`), project (`.gobbi/project/settings.json`), and session (`.gobbi/sessions/{id}/settings.json`). Two verbs only — `get` and `set`. Keys use dot-path notation (e.g. `git.workflow.mode`, `notify.slack.enabled`).
+Read and write gobbi settings across the three-level cascade: workspace (`.gobbi/settings.json`), project (`.gobbi/projects/<name>/settings.json`), and session (`.gobbi/projects/<name>/sessions/{id}/settings.json`). Two verbs only — `get` and `set`. Keys use dot-path notation (e.g. `git.workflow.mode`, `notify.slack.enabled`).
 
 | Command | Synopsis | Description |
 |---|---|---|

--- a/.gobbi/projects/gobbi/skills/_orchestration/finish.md
+++ b/.gobbi/projects/gobbi/skills/_orchestration/finish.md
@@ -39,7 +39,7 @@ When the user selects FINISH after Review (or after a FEEDBACK → Review loop),
 
 ## Action Definitions
 
-**Merge** — squash merge the PR, delete the remote branch, explicitly close the linked issue (closing keywords don't auto-close on non-default branch PRs), remove the local worktree, clean up empty parent directories under `.claude/worktrees/`, pull the merge into the local base branch, and prune stale worktree references.
+**Merge** — squash merge the PR, delete the remote branch, explicitly close the linked issue (closing keywords don't auto-close on non-default branch PRs), remove the local worktree, clean up empty parent directories under `.gobbi/projects/<name>/worktrees/`, pull the merge into the local base branch, and prune stale worktree references.
 
 **Commit** — create a git commit with the changes from this workflow.
 

--- a/.gobbi/projects/gobbi/skills/gobbi/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/gobbi/SKILL.md
@@ -36,7 +36,13 @@ gobbi config get workflow --level session --session-id $DISCOVERED
 
 The CLI does NOT know about `$CODEX_COMPANION_SESSION_ID`. Discovery belongs here in the skill; the CLI only consumes the resolved ID. See `cli-vs-skill-session-id.md` in the project gotchas for the full boundary rationale.
 
-**THIRD — check gobbi CLI availability.** Run `gobbi --version` to verify the CLI is installed. If the command fails, load [cli-setup.md](cli-setup.md) and help the user install before proceeding. The CLI is required for workflow initialization, session management, config management, and validation. Without it, the workflow cannot function.
+**THIRD — check gobbi CLI availability and version.** Run `gobbi --version` to verify the CLI is installed. If the command fails, load [cli-setup.md](cli-setup.md) and help the user install before proceeding. The CLI is required for workflow initialization, session management, config management, and validation. Without it, the workflow cannot function.
+
+After confirming the CLI is present, run `gobbi --is-latest` to check whether the installed version matches the latest published release on npm. Exit-code semantics:
+
+- **Exit 0** — installed version is current. Proceed without comment.
+- **Exit 1** — installed version is stale. Surface the version delta to the user and offer to run the install command from [cli-setup.md](cli-setup.md) to update. Do not block session start — the user may choose to defer.
+- **Exit 2** — indeterminate (network unavailable, registry error). Surface the diagnostic to the user but do not block. Proceed with the installed version.
 
 **FOURTH — check for existing session settings.** Run:
 

--- a/.gobbi/projects/gobbi/skills/gobbi/git-setup.md
+++ b/.gobbi/projects/gobbi/skills/gobbi/git-setup.md
@@ -44,10 +44,10 @@ Check if the intended base branch exists locally and on the remote. The base bra
 
 ### 6. Worktree State
 
-Check `.claude/worktrees/` for existing worktrees:
+Check `.gobbi/projects/<name>/worktrees/` for existing worktrees:
 - **Active worktrees** — may indicate concurrent sessions. Report branch names and paths.
 - **Orphaned worktrees** — from crashed or abandoned sessions. Offer cleanup or recovery.
-- **Gitignore** — Check if `.claude/worktrees/` is listed in `.gitignore`. If not, worktree contents will appear in the main repo's git status.
+- **Gitignore** — Check if `.gobbi/projects/*/worktrees/` is listed in `.gitignore`. If not, worktree contents will appear in the main repo's git status.
 
 ### 7. Classify State
 

--- a/packages/cli/src/__tests__/features/one-command-install.test.ts
+++ b/packages/cli/src/__tests__/features/one-command-install.test.ts
@@ -218,11 +218,7 @@ describe('one-command-install feature — code surface', () => {
   });
 
   describe('/gobbi skill wiring', () => {
-    // TODO(#136): Re-integrate Pass 1 'gobbi --is-latest' wiring into §THIRD
-    // of the Pass-3 session-ID-discovery-shape SKILL.md. Skipped during the
-    // phase/v050-phase-2 integration merge on 2026-04-25 because the Pass 1
-    // and Pass 3 bodies of §THIRD diverged too far for an inline merge.
-    test.skip('.claude/skills/gobbi/SKILL.md §THIRD references `gobbi --is-latest`', () => {
+    test('.claude/skills/gobbi/SKILL.md §THIRD references `gobbi --is-latest`', () => {
       const body = readFileSync(GOBBI_SKILL_PATH, 'utf8');
       const thirdStart = body.indexOf('**THIRD');
       const fourthStart = body.indexOf('**FOURTH', thirdStart);

--- a/packages/cli/src/commands/gotcha.ts
+++ b/packages/cli/src/commands/gotcha.ts
@@ -50,7 +50,7 @@ export const GOTCHA_COMMANDS: readonly GotchaCommand[] = [
   {
     name: 'promote',
     summary:
-      'Move gotcha drafts from .gobbi/project/gotchas/ into .claude/ (refuses during active sessions)',
+      'Move gotcha drafts from .gobbi/projects/<name>/learnings/gotchas/ into .claude/ (refuses during active sessions)',
     run: async (args: string[]): Promise<void> => {
       const { runPromote } = await import('./gotcha/promote.js');
       await runPromote(args);


### PR DESCRIPTION
Closes #135 — 7 doc path-drifts from W8 final-eval cleanup.
Closes #136 — restore SKIP'd Pass-1 SKILL.md §THIRD wiring assertion.

## Summary

- Path-drift fixes across 7+ docs and CLI help strings:
  - `.claude/worktrees/` → `.gobbi/projects/<name>/worktrees/` (`_git/SKILL.md`, `conventions.md`, `gotchas.md`, `git-setup.md`, `_orchestration/finish.md`)
  - `.gobbi/project/` → `.gobbi/projects/<name>/` (`gotcha.ts:53`, `gobbi-config/{scenarios,README,checklist}.md`, `v050-overview.md`, `feature-pass-template.md`, `_gobbi-cli/commands.md`)
  - `.gobbi/projects/<name>/README.md`: 6-dir → current 8-dir taxonomy
- §THIRD wiring re-integration:
  - `gobbi/SKILL.md §THIRD`: added \`gobbi --is-latest\` version-check (exit 0 current, 1 stale, 2 indeterminate)
  - `one-command-install.test.ts`: un-skipped the §THIRD references test (10/10 pass)

## Verification

- rg-sweep: zero \`.gobbi/project/settings\` residue, zero \`.claude/worktrees/\` residue (historical user-quote in gotchas.md preserved)
- Full suite: 1730 pass / 0 fail
- typecheck: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)