### PR TITLE
fix(workflow): wire workflow.{step}.maxIterations into initialState (#134)

### DIFF
--- a/packages/cli/src/commands/workflow/init.ts
+++ b/packages/cli/src/commands/workflow/init.ts
@@ -58,6 +58,7 @@ import { ensureSettingsCascade } from '../../lib/ensure-settings-cascade.js';
 import { type Settings } from '../../lib/settings.js';
 import {
   loadSettingsAtLevel,
+  resolveSettings,
   writeSettingsAtLevel,
 } from '../../lib/settings-io.js';
 import { sessionDir as sessionDirForProject } from '../../lib/workspace-paths.js';
@@ -273,6 +274,17 @@ export async function runInitWithOptions(
 
   writeFileSync(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, 'utf8');
 
+  // Resolve the cascaded settings AFTER metadata is written so the
+  // session-level `settings.json` (if one was seeded by a future Pass) is
+  // visible. The resolved cascade feeds `initialState` so
+  // `state.maxFeedbackRounds` reflects the configured per-step
+  // `workflow.{step}.maxIterations` instead of the hardcoded 3 (issue #134).
+  const resolvedSettings = resolveSettings({
+    repoRoot,
+    sessionId,
+    projectName,
+  });
+
   // Open the SQLite store and emit the opening events atomically inside a
   // single transaction. `appendEventAndUpdateState` already uses IMMEDIATE
   // locking; composing two calls under `store.transaction` yields a single
@@ -291,7 +303,14 @@ export async function runInitWithOptions(
       if (state.currentStep !== 'idle' && state.currentStep !== 'ideation') {
         // Defensive: should never happen on a fresh session. Fall back to
         // initialState rather than emit events against an unknown base.
-        state = initialState(sessionId);
+        state = initialState(sessionId, resolvedSettings);
+      } else if (state.currentStep === 'idle') {
+        // Fresh session — overlay the settings-derived feedback cap onto the
+        // initialState the cold fallback returned. The replay path inside
+        // `resolveWorkflowState` calls `initialState(sessionId)` without
+        // settings so the cascaded cap must be threaded in here. All other
+        // initialState fields are unchanged for an empty event stream.
+        state = initialState(sessionId, resolvedSettings);
       }
 
       const startEvent = createWorkflowStart({

--- a/packages/cli/src/workflow/__tests__/state.test.ts
+++ b/packages/cli/src/workflow/__tests__/state.test.ts
@@ -17,6 +17,8 @@ import {
   normaliseToLatestSchema,
 } from '../state.js';
 import type { WorkflowState, ReduceFn } from '../state.js';
+import type { ResolvedSettings } from '../../lib/settings.js';
+import { DEFAULTS } from '../../lib/settings.js';
 import { EventStore } from '../store.js';
 import type { AppendInput, AppendInputToolCall } from '../store.js';
 import { reduce } from '../reducer.js';
@@ -130,6 +132,70 @@ describe('isValidState', () => {
   it('rejects non-boolean evalConfig fields', () => {
     const bad = { ...initialState('s1'), evalConfig: { ideation: 'yes', planning: false } };
     expect(isValidState(bad)).toBe(false);
+  });
+});
+
+// ===========================================================================
+// initialState — settings-driven maxFeedbackRounds (issue #134)
+// ===========================================================================
+
+describe('initialState maxFeedbackRounds wiring', () => {
+  it('falls back to 3 when settings argument is omitted', () => {
+    const state = initialState('s-no-settings');
+    expect(state.maxFeedbackRounds).toBe(3);
+  });
+
+  it('reads workflow.execution.maxIterations from settings', () => {
+    const settings: ResolvedSettings = {
+      ...DEFAULTS,
+      workflow: {
+        ...DEFAULTS.workflow,
+        execution: { ...DEFAULTS.workflow?.execution, maxIterations: 5 },
+      },
+    };
+    const state = initialState('s-exec-5', settings);
+    expect(state.maxFeedbackRounds).toBe(5);
+  });
+
+  it('prefers execution over planning over ideation', () => {
+    const settings: ResolvedSettings = {
+      ...DEFAULTS,
+      workflow: {
+        ideation: { maxIterations: 7 },
+        planning: { maxIterations: 6 },
+        execution: { maxIterations: 9 },
+      },
+    };
+    const state = initialState('s-cascade', settings);
+    expect(state.maxFeedbackRounds).toBe(9);
+  });
+
+  it('falls back to planning when execution is absent', () => {
+    const settings: ResolvedSettings = {
+      schemaVersion: 1,
+      projects: { active: null, known: [] },
+      workflow: {
+        ideation: { maxIterations: 7 },
+        planning: { maxIterations: 6 },
+        // execution slot omitted entirely
+      },
+    };
+    const state = initialState('s-fallback-plan', settings);
+    expect(state.maxFeedbackRounds).toBe(6);
+  });
+
+  it('falls back to 3 when no step carries maxIterations', () => {
+    const settings: ResolvedSettings = {
+      schemaVersion: 1,
+      projects: { active: null, known: [] },
+      workflow: {
+        ideation: { discuss: { mode: 'user' } },
+        planning: { discuss: { mode: 'user' } },
+        execution: { discuss: { mode: 'agent' } },
+      },
+    };
+    const state = initialState('s-no-iter', settings);
+    expect(state.maxFeedbackRounds).toBe(3);
   });
 });
 

--- a/packages/cli/src/workflow/state.ts
+++ b/packages/cli/src/workflow/state.ts
@@ -27,6 +27,7 @@ import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 
 import { isRecord, isString, isNumber, isBoolean, isArray } from '../lib/guards.js';
+import type { ResolvedSettings } from '../lib/settings.js';
 import { isValidEventType } from './events/index.js';
 import type { Event } from './events/index.js';
 import type { VerificationResultData } from './events/verification.js';
@@ -211,9 +212,24 @@ export interface WorkflowState {
  * Create a fresh WorkflowState for a new session.
  *
  * Starts in the `idle` step with no substate, no eval config,
- * and a default feedback cap of 3 rounds.
+ * and a feedback cap derived from the resolved settings cascade
+ * (see {@link resolveMaxFeedbackRounds}). When `settings` is omitted
+ * — the common case in tests, replay paths, and any call site that
+ * does not have a cascade in hand — falls back to the historical
+ * default of 3.
+ *
+ * The `state.maxFeedbackRounds` field is a single session-wide cap
+ * (state-shape unchanged this Pass). `resolveMaxFeedbackRounds`
+ * collapses the per-step `workflow.{ideation,planning,execution}.maxIterations`
+ * values into one number using the `execution → planning → ideation`
+ * preference ladder — execution-step REVISE loops are the most common
+ * driver of the cap in practice. Per-step state extension is a
+ * deferred follow-up; see issue #134.
  */
-export function initialState(sessionId: string): WorkflowState {
+export function initialState(
+  sessionId: string,
+  settings?: ResolvedSettings,
+): WorkflowState {
   return {
     schemaVersion: 4,
     sessionId,
@@ -225,11 +241,33 @@ export function initialState(sessionId: string): WorkflowState {
     artifacts: {},
     violations: [],
     feedbackRound: 0,
-    maxFeedbackRounds: 3,
+    maxFeedbackRounds: resolveMaxFeedbackRounds(settings),
     lastVerdictOutcome: null,
     verificationResults: {},
     stepStartedAt: null,
   };
+}
+
+/**
+ * Resolve the session-wide `maxFeedbackRounds` from a resolved settings
+ * cascade. Reads the per-step `workflow.{step}.maxIterations` slots in
+ * the order `execution → planning → ideation`, returning the first
+ * defined value. Falls back to `3` when `settings` is `undefined` or
+ * none of the step slots carry a value.
+ *
+ * The state shape carries a single number this Pass — per-step state
+ * extension is deferred (see issue #134). Execution-step REVISE loops
+ * are the most common driver of the cap, so the execution slot wins
+ * the resolution race.
+ */
+function resolveMaxFeedbackRounds(settings: ResolvedSettings | undefined): number {
+  if (settings === undefined) return 3;
+  return (
+    settings.workflow?.execution?.maxIterations
+    ?? settings.workflow?.planning?.maxIterations
+    ?? settings.workflow?.ideation?.maxIterations
+    ?? 3
+  );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #134.

## Summary

\`initialState()\` now accepts an optional \`ResolvedSettings\` parameter and reads \`maxFeedbackRounds\` from \`workflow.execution.maxIterations\` (with fallback to planning, ideation, and finally the default of 3). \`init.ts\` threads the resolved settings through to \`initialState\`.

## Notes

- No state-shape change — \`maxFeedbackRounds\` field already existed
- No \`schemaVersion\` bump
- Property 9 (maxFeedbackRounds invariant after init) still holds
- Smoke test PASSED live; +5 test delta
- **Merge order advisory**: land #142 (fix/138) before this PR (non-overlapping init.ts hunks but cleaner semantic order)

🤖 Generated with [Claude Code](https://claude.com/claude-code)