### PR TITLE
fix(note): guard against doubled subagent path in CLAUDE_TRANSCRIPT_PATH (#132)

### DIFF
--- a/packages/cli/src/commands/__tests__/note.test.ts
+++ b/packages/cli/src/commands/__tests__/note.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Unit tests for `gobbi note collect` — focused on the path-doubling
+ * regression in issue #132.
+ *
+ * Coverage:
+ *   - Main-transcript layout (canonical case): when `CLAUDE_TRANSCRIPT_PATH`
+ *     points at the per-session main transcript
+ *     (`<projects-root>/<slug>/<session>.jsonl`), the subagent directory is
+ *     resolved by joining the dirname with `<sessionId>/subagents` — the
+ *     pre-fix behaviour, asserted as a non-regression.
+ *   - Subagent-transcript layout (issue #132): when `CLAUDE_TRANSCRIPT_PATH`
+ *     already lives inside `<projects-root>/<slug>/<session>/subagents/`,
+ *     the resolver must NOT re-append `<sessionId>/subagents` — naive
+ *     concatenation produced a doubled path
+ *     (`.../<session>/subagents/<session>/subagents/agent-X.meta.json`)
+ *     and the meta-file lookup failed.
+ *
+ * Both tests synthesise the on-disk layout under a scratch directory, write
+ * a minimal subagent meta + JSONL pair, run `runNote(['collect', ...])`,
+ * and assert the output JSON lands under the note-dir's
+ * `<phase>/subtasks/` directory. The doubled-path bug previously surfaced
+ * as `Error: Meta file not found: …` and a non-zero exit; the fix turns
+ * both branches into a successful collection.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { runNote } from '../note.js';
+
+// ---------------------------------------------------------------------------
+// stdout/stderr capture + process.exit trap
+// ---------------------------------------------------------------------------
+
+interface Captured {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+}
+
+class ExitCalled extends Error {
+  constructor(readonly code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+let captured: Captured;
+let origStdoutWrite: typeof process.stdout.write;
+let origStderrWrite: typeof process.stderr.write;
+let origExit: typeof process.exit;
+let origEnv: NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  captured = { stdout: '', stderr: '', exitCode: null };
+  origStdoutWrite = process.stdout.write;
+  origStderrWrite = process.stderr.write;
+  origExit = process.exit;
+  origEnv = { ...process.env };
+
+  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+    captured.stdout +=
+      typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+    captured.stderr +=
+      typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    return true;
+  }) as typeof process.stderr.write;
+  process.exit = ((code?: number | string | null): never => {
+    captured.exitCode = typeof code === 'number' ? code : 0;
+    throw new ExitCalled(captured.exitCode);
+  }) as typeof process.exit;
+});
+
+afterEach(() => {
+  process.stdout.write = origStdoutWrite;
+  process.stderr.write = origStderrWrite;
+  process.exit = origExit;
+  // Reset env to the pre-test snapshot — every test sets CLAUDE_*
+  // variables, and leaving them set leaks across tests in the same file.
+  for (const key of Object.keys(process.env)) {
+    if (!(key in origEnv)) delete process.env[key];
+  }
+  for (const key of Object.keys(origEnv)) {
+    process.env[key] = origEnv[key];
+  }
+});
+
+async function captureExit(fn: () => Promise<void>): Promise<void> {
+  try {
+    await fn();
+  } catch (err) {
+    if (err instanceof ExitCalled) return;
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scratch directory bookkeeping
+// ---------------------------------------------------------------------------
+
+const scratchDirs: string[] = [];
+
+afterEach(() => {
+  while (scratchDirs.length > 0) {
+    const d = scratchDirs.pop();
+    if (d !== undefined) {
+      try {
+        rmSync(d, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    }
+  }
+});
+
+function makeScratchRoot(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gobbi-note-collect-'));
+  scratchDirs.push(dir);
+  return dir;
+}
+
+// ---------------------------------------------------------------------------
+// Fixture builder
+// ---------------------------------------------------------------------------
+
+interface CollectFixture {
+  /** Root dir under which the canonical transcripts layout lives. */
+  readonly transcriptsRoot: string;
+  /** Per-session subagent dir holding the meta + jsonl files. */
+  readonly subagentDir: string;
+  /** Note dir whose `execution/subtasks/` is the collect target. */
+  readonly noteDir: string;
+  /** Subtasks directory the collect output must land in. */
+  readonly subtasksDir: string;
+  /** Agent id used in the meta + jsonl file basenames. */
+  readonly agentId: string;
+  /** Session id wired into env + path structure. */
+  readonly sessionId: string;
+}
+
+/**
+ * Build the on-disk layout that mirrors the real Claude Code transcripts
+ * directory:
+ *
+ *   <root>/projects/<slug>/<session-id>.jsonl                      (main)
+ *   <root>/projects/<slug>/<session-id>/subagents/agent-<id>.meta.json
+ *   <root>/projects/<slug>/<session-id>/subagents/agent-<id>.jsonl
+ *
+ * Plus a parallel note-dir tree
+ *   <root>/notes/<datetime>-<slug>-<session>/execution/subtasks/
+ * which `runNoteCollect` writes the result file into.
+ *
+ * Both transcripts paths are returned so each test can wire
+ * `CLAUDE_TRANSCRIPT_PATH` to the variant it exercises (main vs subagent).
+ */
+function buildFixture(): CollectFixture {
+  const root = makeScratchRoot();
+  const sessionId = 'sess-fixture-1234';
+  const projectSlug = '-tmp-test-project';
+  const agentId = 'agent42';
+
+  // Transcripts tree
+  const transcriptsRoot = join(root, 'projects', projectSlug);
+  const subagentDir = join(transcriptsRoot, sessionId, 'subagents');
+  mkdirSync(subagentDir, { recursive: true });
+
+  // Main transcript file (path used in the canonical case)
+  const mainTranscript = join(transcriptsRoot, `${sessionId}.jsonl`);
+  writeFileSync(
+    mainTranscript,
+    `${JSON.stringify({ type: 'summary', sessionId })}\n`,
+    'utf8',
+  );
+
+  // Subagent meta + jsonl
+  const metaFile = join(subagentDir, `agent-${agentId}.meta.json`);
+  const jsonlFile = join(subagentDir, `agent-${agentId}.jsonl`);
+  writeFileSync(
+    metaFile,
+    JSON.stringify({
+      agentType: 'gobbi:test-agent',
+      description: 'Issue #132 fixture subagent',
+    }) + '\n',
+    'utf8',
+  );
+  // First line: user prompt (delegationPrompt source).
+  // Last line: assistant final message (finalResult source).
+  const firstLine = JSON.stringify({
+    type: 'user',
+    timestamp: '2026-04-25T00:00:00Z',
+    message: { role: 'user', content: 'Fix the path-doubling bug.' },
+  });
+  const lastLine = JSON.stringify({
+    type: 'assistant',
+    message: {
+      role: 'assistant',
+      model: 'claude-opus-4-7',
+      content: [{ type: 'text', text: 'Fix landed and tests pass.' }],
+    },
+  });
+  writeFileSync(jsonlFile, `${firstLine}\n${lastLine}\n`, 'utf8');
+
+  // Note dir tree
+  const noteDirName = `20260425-0000-issue-132-fixture-${sessionId}`;
+  const noteDir = join(root, 'notes', noteDirName);
+  const subtasksDir = join(noteDir, 'execution', 'subtasks');
+  mkdirSync(subtasksDir, { recursive: true });
+
+  return {
+    transcriptsRoot,
+    subagentDir,
+    noteDir,
+    subtasksDir,
+    agentId,
+    sessionId,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('gobbi note collect — CLAUDE_TRANSCRIPT_PATH path resolution', () => {
+  test('main-transcript layout: derives <transcriptDir>/<session>/subagents and collects', async () => {
+    const fx = buildFixture();
+    const mainTranscript = join(fx.transcriptsRoot, `${fx.sessionId}.jsonl`);
+
+    process.env['CLAUDE_SESSION_ID'] = fx.sessionId;
+    process.env['CLAUDE_TRANSCRIPT_PATH'] = mainTranscript;
+
+    await captureExit(() =>
+      runNote([
+        'collect',
+        fx.agentId,
+        '01',
+        'wave-fixture',
+        fx.noteDir,
+        '--phase',
+        'execution',
+      ]),
+    );
+
+    // Successful collect: exit 0 (or null — runNoteCollect does not call
+    // process.exit on success), no error message, output file present.
+    expect(captured.stderr).toBe('');
+    const outputFile = join(fx.subtasksDir, '01-wave-fixture.json');
+    const written = JSON.parse(readFileSync(outputFile, 'utf8')) as {
+      readonly sessionId: string;
+      readonly agentId: string;
+      readonly agentType: string;
+      readonly delegationPrompt: string;
+      readonly finalResult: string;
+    };
+    expect(written.sessionId).toBe(fx.sessionId);
+    expect(written.agentId).toBe(fx.agentId);
+    expect(written.agentType).toBe('gobbi:test-agent');
+    expect(written.delegationPrompt).toBe('Fix the path-doubling bug.');
+    expect(written.finalResult).toBe('Fix landed and tests pass.');
+  });
+
+  test('subagent-transcript layout: idempotent — does NOT double-append <session>/subagents (issue #132)', async () => {
+    const fx = buildFixture();
+    // CLAUDE_TRANSCRIPT_PATH points at a subagent transcript that already
+    // lives inside `<session>/subagents/`. The pre-fix code computed
+    // dirname → `.../<session>/subagents` and joined `<session>/subagents`
+    // again, yielding a doubled path and a "Meta file not found" error.
+    const subagentTranscript = join(fx.subagentDir, `agent-${fx.agentId}.jsonl`);
+
+    process.env['CLAUDE_SESSION_ID'] = fx.sessionId;
+    process.env['CLAUDE_TRANSCRIPT_PATH'] = subagentTranscript;
+
+    await captureExit(() =>
+      runNote([
+        'collect',
+        fx.agentId,
+        '02',
+        'wave-fixture-subagent-env',
+        fx.noteDir,
+        '--phase',
+        'execution',
+      ]),
+    );
+
+    // The bug surfaced as a non-empty stderr with "Meta file not found"
+    // and a doubled path. The fix yields a clean collect.
+    expect(captured.stderr).not.toContain('Meta file not found');
+    expect(captured.stderr).not.toContain(`${fx.sessionId}/subagents/${fx.sessionId}/subagents`);
+    expect(captured.stderr).toBe('');
+
+    const outputFile = join(fx.subtasksDir, '02-wave-fixture-subagent-env.json');
+    const written = JSON.parse(readFileSync(outputFile, 'utf8')) as {
+      readonly sessionId: string;
+      readonly agentId: string;
+      readonly finalResult: string;
+    };
+    expect(written.sessionId).toBe(fx.sessionId);
+    expect(written.agentId).toBe(fx.agentId);
+    expect(written.finalResult).toBe('Fix landed and tests pass.');
+  });
+});

--- a/packages/cli/src/commands/note.ts
+++ b/packages/cli/src/commands/note.ts
@@ -397,9 +397,29 @@ async function runNoteCollect(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  // Derive subagent transcript paths
+  // Derive subagent transcript paths.
+  //
+  // `CLAUDE_TRANSCRIPT_PATH` is set by the SessionStart hook to the path
+  // Claude Code reports as `transcript_path`. The canonical layout is the
+  // *main session* transcript at `<projects-root>/<slug>/<session-id>.jsonl`
+  // — its dirname is the per-project root, and joining `<sessionId>/subagents`
+  // resolves to the per-session subagent directory.
+  //
+  // Some hook contexts (notably SubagentStop) may instead supply a path that
+  // already lives inside `<projects-root>/<slug>/<session-id>/subagents/`.
+  // Naively re-appending `<sessionId>/subagents` then yields a doubled path
+  // (`.../<session>/subagents/<session>/subagents`) and the meta-file lookup
+  // fails — see issue #132. Make the derivation idempotent by detecting when
+  // the dirname already matches the canonical subagent directory and using
+  // it directly; otherwise derive it from the project root as before.
   const transcriptDir = path.dirname(transcriptPath);
-  const subagentDir = path.join(transcriptDir, sessionId, 'subagents');
+  const expectedSubagentSuffix = path.join(sessionId, 'subagents');
+  const dirnameIsSubagentDir =
+    transcriptDir === expectedSubagentSuffix ||
+    transcriptDir.endsWith(`${path.sep}${expectedSubagentSuffix}`);
+  const subagentDir = dirnameIsSubagentDir
+    ? transcriptDir
+    : path.join(transcriptDir, sessionId, 'subagents');
   const metaFile = path.join(subagentDir, `agent-${agentId}.meta.json`);
   const jsonlFile = path.join(subagentDir, `agent-${agentId}.jsonl`);
 


### PR DESCRIPTION
Closes #132.

## Summary

\`runNoteCollect\` derived the per-session subagent directory by joining \`<sessionId>/subagents\` onto \`path.dirname(CLAUDE_TRANSCRIPT_PATH)\`. The canonical case — env var set to the main session transcript at \`<projects-root>/<slug>/<session-id>.jsonl\` — works as intended. But when the env var is set to a *subagent* transcript whose dirname already ends with \`<sessionId>/subagents\`, the join doubled the path (\`.../<session>/subagents/<session>/subagents/agent-<id>.meta.json\`) and the meta-file lookup failed with \`Error: Meta file not found: …\`.

## Fix

Make the derivation idempotent: detect when the dirname already matches the canonical subagent suffix and use it directly; otherwise derive from the project root as before.

## Verification

- Tests cover both branches (canonical main-transcript layout and subagent-transcript layout from the issue repro)
- Explicit assertions that the doubled-path substring is absent from stderr
- +2 test delta

🤖 Generated with [Claude Code](https://claude.com/claude-code)