### PR TITLE
test(capture-subagent): stabilize env-bleed flake with scoped withEnv helper (#131)

### DIFF
--- a/packages/cli/src/__tests__/helpers/with-env.ts
+++ b/packages/cli/src/__tests__/helpers/with-env.ts
@@ -1,0 +1,91 @@
+/**
+ * Scoped `process.env` mutation helper for tests — captures the prior value
+ * of every key in the overlay, applies the overlay, runs the supplied
+ * function, and restores the prior values in `finally`. Restoration runs
+ * regardless of whether the function returns or throws, eliminating the
+ * env-bleed flake class where one test's mutation contaminates a sibling
+ * (issue #131).
+ *
+ * Overlay semantics — the value type is `string | undefined`:
+ *   - `string` (including `''`)  → assign `process.env[key] = value`
+ *   - `undefined`                → `delete process.env[key]`
+ *
+ * Restoration distinguishes "key was absent" from "key was present" using a
+ * tagged discriminant rather than the value alone — `process.env` values
+ * are always strings under the Node/Bun contract, so an absent key cannot
+ * be encoded as a `string | undefined` directly without conflating with
+ * a deliberate empty-string value the test author wanted to restore.
+ *
+ * Usage:
+ *   await withEnv({ CLAUDE_CODE_VERSION: '2.1.110' }, async () => {
+ *     // process.env.CLAUDE_CODE_VERSION === '2.1.110' inside the callback
+ *   });
+ *   // process.env.CLAUDE_CODE_VERSION is restored to its prior state here
+ *
+ * The helper is async-aware — the callback may return a Promise and the
+ * env restoration is correctly tied to that Promise's settlement. For
+ * synchronous callbacks the same body still runs the restore in `finally`.
+ *
+ * Anti-patterns this helper replaces:
+ *   - Hand-written `try { setenv; await fn() } finally { restore }`
+ *     blocks that drift across tests and forget the "was absent" case.
+ *   - Tests that assume `afterEach` will reset env — `bun:test` does not
+ *     reset `process.env` between tests, so leaks survive.
+ */
+
+type PriorValue =
+  | { readonly present: false }
+  | { readonly present: true; readonly value: string };
+
+export async function withEnv(
+  overlay: Readonly<Record<string, string | undefined>>,
+  fn: () => Promise<void> | void,
+): Promise<void> {
+  const env = process.env;
+  const keys = Object.keys(overlay);
+
+  // Capture prior values BEFORE applying the overlay. The "was present"
+  // check uses hasOwnProperty so that a prior empty-string value is
+  // restored to '' rather than deleted.
+  const prior = new Map<string, PriorValue>();
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(env, key)) {
+      const captured = env[key];
+      // process.env values are always strings under the Node/Bun
+      // contract; the runtime guard is defensive against a future
+      // platform that exposes a non-string slot.
+      if (typeof captured === 'string') {
+        prior.set(key, { present: true, value: captured });
+      } else {
+        prior.set(key, { present: false });
+      }
+    } else {
+      prior.set(key, { present: false });
+    }
+  }
+
+  // Apply the overlay.
+  for (const key of keys) {
+    const value = overlay[key];
+    if (value === undefined) {
+      delete env[key];
+    } else {
+      env[key] = value;
+    }
+  }
+
+  try {
+    await fn();
+  } finally {
+    // Restore — keys absent prior get deleted, keys present prior get
+    // their captured string reassigned (preserves '' as ''-not-deleted).
+    for (const key of keys) {
+      const priorValue = prior.get(key);
+      if (priorValue === undefined || !priorValue.present) {
+        delete env[key];
+      } else {
+        env[key] = priorValue.value;
+      }
+    }
+  }
+}

--- a/packages/cli/src/commands/workflow/__tests__/capture-subagent.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/capture-subagent.test.ts
@@ -41,6 +41,7 @@ import {
   resolveWorkflowState,
 } from '../../../workflow/engine.js';
 import { createDelegationSpawn } from '../../../workflow/events/delegation.js';
+import { withEnv } from '../../../__tests__/helpers/with-env.js';
 
 // ---------------------------------------------------------------------------
 // stdout/stderr capture + process.exit trap
@@ -695,12 +696,10 @@ describe('runCaptureSubagent — tool-call idempotency', () => {
 
 describe('delegation.spawn — CLAUDE_CODE_VERSION env capture (issue #92)', () => {
   test('env present → spawn event data carries claudeCodeVersion', async () => {
-    const { sessionDir } = await initScratchSession('cap-sub-ccv-present');
     const sessionId = 'cap-sub-ccv-present';
+    const { sessionDir } = await initScratchSession(sessionId);
 
-    const originalVersion = process.env['CLAUDE_CODE_VERSION'];
-    try {
-      process.env['CLAUDE_CODE_VERSION'] = '2.1.110';
+    await withEnv({ CLAUDE_CODE_VERSION: '2.1.110' }, () => {
       const envVersion = process.env['CLAUDE_CODE_VERSION'];
       // Emitters populate the field only when the env var is a non-empty
       // string — this is the documented pattern (see delegation.ts
@@ -738,33 +737,33 @@ describe('delegation.spawn — CLAUDE_CODE_VERSION env capture (issue #92)', () 
       } finally {
         store.close();
       }
-    } finally {
-      if (originalVersion === undefined) {
-        delete process.env['CLAUDE_CODE_VERSION'];
-      } else {
-        process.env['CLAUDE_CODE_VERSION'] = originalVersion;
-      }
-    }
+    });
   });
 
-  // TODO(#92): capture-subagent env-bleed flake — same-millisecond
-  // `new Date().toISOString()` between scenarios A and B collides on the
-  // `system` idempotency key, and `process.env['CLAUDE_CODE_VERSION']` leaks
-  // across parallel workers in full-suite runs. Quarantined at the TEST
-  // level (not `describe.skip`) so the env-present sibling above still
-  // exercises the happy path. See issue #131 for the detailed repro and
-  // fix options (idempotency-key salt / sleep-1ms / per-test store
-  // isolation / env-cleanup).
-  test.skip('env unset or empty → spawn event data omits claudeCodeVersion', async () => {
-    const { sessionDir } = await initScratchSession('cap-sub-ccv-absent');
-    const sessionId = 'cap-sub-ccv-absent';
+  // Issue #131 stabilization: the original test merged scenarios A
+  // (`CLAUDE_CODE_VERSION` unset) and B (empty string) into one body,
+  // sharing a single sessionId and event store. Two flake sources
+  // collided in full-suite runs:
+  //
+  //   1. The `system` idempotency key is `${sessionId}:${ms}:${type}` —
+  //      same-millisecond `new Date().toISOString()` between the two
+  //      append calls produced an ON-CONFLICT no-op for scenario B,
+  //      then the `store.last(...)` read returned scenario A's row.
+  //   2. `process.env['CLAUDE_CODE_VERSION']` leaked across parallel
+  //      bun-test workers because the prior try/finally only ran inside
+  //      the test body.
+  //
+  // The fix splits the two scenarios into separate `test(...)` blocks
+  // (each with its own `initScratchSession` + scratch DB → distinct
+  // sessionId → idempotency keys cannot collide) and routes every env
+  // mutation through `withEnv` (scoped capture-set-restore in `finally`).
+  test('env unset → spawn event data omits claudeCodeVersion', async () => {
+    const sessionId = 'cap-sub-ccv-unset';
+    const { sessionDir } = await initScratchSession(sessionId);
 
-    const originalVersion = process.env['CLAUDE_CODE_VERSION'];
-    try {
-      // Scenario A — env var unset.
-      delete process.env['CLAUDE_CODE_VERSION'];
-      let envVersion = process.env['CLAUDE_CODE_VERSION'];
-      let claudeCodeVersion =
+    await withEnv({ CLAUDE_CODE_VERSION: undefined }, () => {
+      const envVersion = process.env['CLAUDE_CODE_VERSION'];
+      const claudeCodeVersion =
         envVersion !== undefined && envVersion !== '' ? envVersion : undefined;
 
       const store = new EventStore(join(sessionDir, 'gobbi.db'));
@@ -777,64 +776,64 @@ describe('delegation.spawn — CLAUDE_CODE_VERSION env capture (issue #92)', () 
           createDelegationSpawn({
             agentType: 'executor',
             step: state.currentStep,
-            subagentId: 'agent-ccv-absent-1',
+            subagentId: 'agent-ccv-unset',
             timestamp: new Date().toISOString(),
             ...(claudeCodeVersion !== undefined ? { claudeCodeVersion } : {}),
           }),
           'cli',
           sessionId,
           'system',
-          undefined,
         );
 
-        const rowA = store.last('delegation.spawn');
-        expect(rowA).not.toBeNull();
-        const dataA = JSON.parse(rowA!.data) as Record<string, unknown>;
-        expect(dataA['subagentId']).toBe('agent-ccv-absent-1');
+        const row = store.last('delegation.spawn');
+        expect(row).not.toBeNull();
+        const data = JSON.parse(row!.data) as Record<string, unknown>;
+        expect(data['subagentId']).toBe('agent-ccv-unset');
         // Emitter MUST omit the field, not write an empty string.
-        expect('claudeCodeVersion' in dataA).toBe(false);
-
-        // Scenario B — env var explicitly empty string. Same contract:
-        // emitter must omit the field rather than writing ''.
-        process.env['CLAUDE_CODE_VERSION'] = '';
-        envVersion = process.env['CLAUDE_CODE_VERSION'];
-        claudeCodeVersion =
-          envVersion !== undefined && envVersion !== ''
-            ? envVersion
-            : undefined;
-
-        const stateB = resolveWorkflowState(sessionDir, store, sessionId);
-        appendEventAndUpdateState(
-          store,
-          sessionDir,
-          stateB,
-          createDelegationSpawn({
-            agentType: 'executor',
-            step: stateB.currentStep,
-            subagentId: 'agent-ccv-absent-2',
-            timestamp: new Date().toISOString(),
-            ...(claudeCodeVersion !== undefined ? { claudeCodeVersion } : {}),
-          }),
-          'cli',
-          sessionId,
-          'system',
-          undefined,
-        );
-
-        const rowB = store.last('delegation.spawn');
-        expect(rowB).not.toBeNull();
-        const dataB = JSON.parse(rowB!.data) as Record<string, unknown>;
-        expect(dataB['subagentId']).toBe('agent-ccv-absent-2');
-        expect('claudeCodeVersion' in dataB).toBe(false);
+        expect('claudeCodeVersion' in data).toBe(false);
       } finally {
         store.close();
       }
-    } finally {
-      if (originalVersion === undefined) {
-        delete process.env['CLAUDE_CODE_VERSION'];
-      } else {
-        process.env['CLAUDE_CODE_VERSION'] = originalVersion;
+    });
+  });
+
+  test('env empty string → spawn event data omits claudeCodeVersion', async () => {
+    const sessionId = 'cap-sub-ccv-empty';
+    const { sessionDir } = await initScratchSession(sessionId);
+
+    await withEnv({ CLAUDE_CODE_VERSION: '' }, () => {
+      const envVersion = process.env['CLAUDE_CODE_VERSION'];
+      const claudeCodeVersion =
+        envVersion !== undefined && envVersion !== '' ? envVersion : undefined;
+
+      const store = new EventStore(join(sessionDir, 'gobbi.db'));
+      try {
+        const state = resolveWorkflowState(sessionDir, store, sessionId);
+        appendEventAndUpdateState(
+          store,
+          sessionDir,
+          state,
+          createDelegationSpawn({
+            agentType: 'executor',
+            step: state.currentStep,
+            subagentId: 'agent-ccv-empty',
+            timestamp: new Date().toISOString(),
+            ...(claudeCodeVersion !== undefined ? { claudeCodeVersion } : {}),
+          }),
+          'cli',
+          sessionId,
+          'system',
+        );
+
+        const row = store.last('delegation.spawn');
+        expect(row).not.toBeNull();
+        const data = JSON.parse(row!.data) as Record<string, unknown>;
+        expect(data['subagentId']).toBe('agent-ccv-empty');
+        // Emitter MUST omit the field, not write an empty string.
+        expect('claudeCodeVersion' in data).toBe(false);
+      } finally {
+        store.close();
       }
-    }
+    });
   });
 });


### PR DESCRIPTION
Closes #131.

## Summary

Two scenarios in the previously-skipped \`CLAUDE_CODE_VERSION\` env-absent test had nondeterministic full-suite failures from two collisions:

1. **Idempotency-key collision** — system idempotency key is \`\${sessionId}:\${ms}:\${type}\`. Both scenarios ran under one sessionId; same-millisecond \`new Date().toISOString()\` calls produced an ON-CONFLICT no-op for scenario B and a wrong-row read for the assertion.
2. **Env-bleed across parallel workers** — \`process.env['CLAUDE_CODE_VERSION']\` mutations leaked across parallel bun-test workers because the prior try/finally only covered the test body.

## Fix

Introduces \`packages/cli/src/__tests__/helpers/with-env.ts\` — a scoped env-overlay helper that captures prior values via \`hasOwnProperty\` (so absent-vs-empty-string is distinguishable on restore), applies the overlay, runs an async-or-sync callback, and restores prior values in finally.

## Verification

- Determinism verified across 10 iterations
- +1 unskip + 1 new = +2 test delta

🤖 Generated with [Claude Code](https://claude.com/claude-code)