### PR TITLE
feat: Wave C.1 — Prompts-as-data (#156)

### DIFF
--- a/.gobbi/projects/gobbi/design/v050-features/README.md
+++ b/.gobbi/projects/gobbi/design/v050-features/README.md
@@ -14,5 +14,5 @@ Feature description docs for gobbi v0.5.0 — read these to understand what the 
 | [claude-docs-management.md](claude-docs-management.md) | JSON source at `.gobbi/skills\|agents\|rules/` rendered to `.claude/` by the CLI. Evaluation rubrics travel with authoring skills. |
 | [cli-as-runtime-api.md](cli-as-runtime-api.md) | Agent-facing runtime API spanning workflow control, configuration, memory, rendering, and hard-for-agents helpers. |
 | [token-budget-and-cache.md](token-budget-and-cache.md) | Cache-prefix ordering invariant + token budget allocation with section minimums. |
-| [prompts-as-data.md](prompts-as-data.md) | Step specs as JSON data; transition conditions as predicate-registry names; the CLI compiles prompts, not humans. |
+| [prompts-as-data.md](prompts-as-data.md) | Step specs as JSON data; CQRS for spec evolution (state.db::events truth, prompt_patches projection, JSONL chain foldable to spec.json); operator-only `gobbi prompt render | patch | rebuild` mutation surface. |
 | [worktree-based-operation.md](worktree-based-operation.md) | One worktree per task under `.gobbi/worktrees/`. Branch exclusivity, base-branch verification, subagents commit / orchestrator pushes. |

--- a/.gobbi/projects/gobbi/design/v050-features/prompts-as-data.md
+++ b/.gobbi/projects/gobbi/design/v050-features/prompts-as-data.md
@@ -1,20 +1,214 @@
 # Prompts as Data
 
-Feature description for gobbi's step-spec model. Read this to understand why workflow prompts are structured data rather than authored text, and what that makes possible.
+Feature description for gobbi's step-spec model. Read this to understand why workflow prompts are structured data rather than authored text, what that makes possible, and how Wave C.1 ships the schema lock + JSON Patch tooling that lets operators evolve prompts without losing history.
 
 ---
 
-> **The prompt for every workflow step is a spec file, not a template someone wrote. It is structured, validated, and generated.**
+> **The prompt for every workflow step is a spec file, not a template someone wrote. It is structured, validated, generated — and evolvable through an audit-only patch flow.**
 
 In v0.4.x, orchestration is driven by skills the orchestrator reads and interprets. The prompt content is prose — instructions an LLM reads and follows as best it can. Changing the workflow means changing the prose and hoping the interpretation tracks.
 
 V0.5.0 moves workflow prompts to data. Each step is defined by a `spec.json` file in the CLI's spec library. The spec declares the step's metadata, valid exit transitions with predicate references, delegation topology (which agents, which stances, which artifacts they write), token budget allocation, and the static instructional blocks. The CLI reads the spec and generates the prompt programmatically; all dynamic data — session state, inlined artifacts, skill materials — is added by the CLI's compilation logic. The spec describes what the step does; the CLI decides what data to supply. When a step becomes active, the CLI reads the spec, assembles the prompt following the section ordering described in `token-budget-and-cache.md`, and hands it off at the moment of need per `just-in-time-prompt-injection.md`.
 
-This separation produces several concrete properties. Guards and static analysis tools can validate structured delegation data without parsing prose. The SubagentStop hook knows the expected artifacts from the spec's delegation config without inspecting the conversation. A static-analysis step (command name TBD — the CLI surface is being redesigned) performs this checking at build time: it verifies that every predicate name referenced in a spec has a registered implementation, catches dead steps and broken references, and validates the full workflow graph before a session begins.
+This separation produces several concrete properties. Guards and static analysis tools can validate structured delegation data without parsing prose. The SubagentStop hook knows the expected artifacts from the spec's delegation config without inspecting the conversation. Every spec is validated against a JSON Schema; the schema and the TypeScript `StepSpec` interface are bound together by an `ajv::JSONSchemaType<StepSpec>` annotation so divergence fails `tsc --noEmit` before any runtime test loads. A glob-validation CI gate (Wave C.1.1) rejects every `spec.json` in the source tree that does not satisfy the locked schema.
 
 The predicate registry is the key mechanism: transition conditions and guard conditions in specs are predicate names (strings in JSON), not inline logic. The CLI resolves predicate names to registered implementations. Adding a new workflow condition means adding an implementation to the registry and referencing its name — not modifying an expression parser or writing custom operator logic.
 
-Each spec is validated against a JSON schema — the schema itself is a future deliverable, but it is the mechanism by which structural errors are caught before the workflow graph is built. Spec authors cannot write a spec that violates the schema; spec authors cannot reference a predicate name that is not registered.
+---
+
+## 1. The schema lock (Wave C.1.1)
+
+The drift safety net stack:
+
+| Layer | Where | What it catches |
+|---|---|---|
+| Compile-time | `_schema/v1.ts:249` `JSONSchemaType<StepSpec>` annotation | A field added to `types.ts::StepSpec` without a matching entry in `StepSpecSchema` (or vice versa) — fails `tsc --noEmit`. |
+| JSON-mirror byte-equality | `specs/__tests__/schema.test.ts:399-406` | A hand-edit to `_schema/v1.json` that drifts from `JSON.stringify(StepSpecSchema, null, 2)`. |
+| **Glob-validation (NEW Wave C.1.1)** | `specs/__tests__/all-specs.test.ts` | Every on-disk `<step>/spec.json` validates against the schema at runtime, with `$schema` pinned to `STEP_SPEC_SCHEMA_ID`. Closed-set assertion guarantees the discovered step directories match `{ideation, planning, execution, evaluation, memorization, handoff}`. |
+| Custom keyword | `_schema/v1.ts::tokenBudgetSumEqualsOne` | The runtime-only invariant that token-budget proportions sum to 1.0 (± 1e-6). |
+
+The locked `$id` is `https://gobbi.dev/schemas/step-spec/v1.json`. Every spec carries the `$schema` field pointing at that URI; the glob test asserts the field equals the locked constant. A future schema-v2 wave bumps both the `$id` and the field's expected value; until then the schema is frozen — any change to its field shape, `additionalProperties: false`, `required` arrays, or `nullable` annotations routes to a future wave, not C.1.
+
+---
+
+## 2. The CQRS partition extended to prompts (Wave C.1.2 + C.1.3 + C.1.4)
+
+V0.5.0 already locks CQRS for events: `state.db::events` is truth, `gobbi.db::memories` is the projection. Wave C.1 applies the same split to prompts:
+
+```text
+                 ┌──────────────────────────────────────────────────────┐
+                 │  state.db::events (TRUTH)                            │
+                 │  one `prompt.patch.applied` row per applied patch    │
+                 │  Wave C.1.3 — audit-only event, bypasses reducer     │
+                 └──────────┬─────────────────────────┬─────────────────┘
+                            │ projection write        │ JSONL append
+                            ▼                         ▼
+        ┌────────────────────────────┐   ┌────────────────────────────────┐
+        │ state.db::prompt_patches   │   │ .gobbi/projects/<n>/prompt-    │
+        │ (READ PROJECTION)          │   │ evolution/<prompt-id>.jsonl    │
+        │ Wave C.1.2 — schema v7     │   │ (REPLAY-FOLDABLE LOG)          │
+        │ queryable history          │   │ Wave C.1.4 — genesis-line      │
+        └────────────────────────────┘   │ chain, foldable to spec.json   │
+                                         └─────────────────┬──────────────┘
+                                                           │ fold
+                                                           ▼
+                                  ┌──────────────────────────────────────┐
+                                  │ packages/cli/src/specs/<step>/       │
+                                  │ spec.json (MATERIALIZED SNAPSHOT)    │
+                                  │ derivable from the JSONL chain;      │
+                                  │ replay-equivalence CI gate locks     │
+                                  │ contentHash(folded) ≡ on-disk hash   │
+                                  └──────────────────────────────────────┘
+```
+
+### 2.1 The `prompt_patches` table (Wave C.1.2)
+
+Schema v7, additive. One row per applied RFC 6902 patch:
+
+| Column | Purpose |
+|---|---|
+| `seq INTEGER PRIMARY KEY AUTOINCREMENT` | Local row ordering (mirrors `events.seq`). |
+| `session_id`, `project_id` | Workspace partition keys (mirror v6 sibling tables). |
+| `prompt_id` (CHECK closed enum) | One of `{ideation, planning, execution, evaluation, memorization, handoff}` — locked to the user-locked prompt-id set. |
+| `parent_seq` (FK to self) | Chain causality (NULL = genesis row). |
+| `event_seq` (UNIQUE FK to `events(seq)`) | 1:1 row-event pairing. |
+| `patch_id` | `sha256(canonicalize(patch_json))` — content address. Reused as the `'content'` IdempotencyKind's `contentId`. |
+| `patch_json` | RFC 6902 ops array (JSON-encoded; includes any synthesized test op). |
+| `pre_hash`, `post_hash` | `sha256(canonicalize(spec.json))` before / after. |
+| `applied_at` | UNIX-ms wall clock. |
+| `applied_by` (CHECK = `'operator'`) | Patch flow is operator-only. Future widening (agent-proposed patches) requires v8. |
+
+Two unique indices: `idx_prompt_patches_event` on `event_seq` (1:1), and `idx_prompt_patches_content` on `(prompt_id, patch_id)` — the cross-session content-dedup safety net.
+
+`ensureSchemaV7` runs inside `EventStore.initSchema` after `ensureSchemaV6` and is idempotent. The maintenance command `gobbi maintenance migrate-state-db` runs both for operators who want a deterministic migration step.
+
+### 2.2 The `prompt.patch.applied` audit-only event (Wave C.1.3)
+
+Mirror of `step.advancement.observed` from Wave A.1.3. The event commits via `store.append()` directly — the reducer never sees it. The runtime fence at `reducer.ts:691` returns `ok(state)` for any `isPromptPatchAppliedEvent` to defend against serialise/deserialise replay paths that erase the type-level `Event ∪ AuditOnlyEvent` discriminator.
+
+The data shape carries audit hints — `promptId`, `patchId`, `parentPatchId`, `preHash`, `postHash`, `opCount`, `schemaId`, `appliedBy` — but **not** the full RFC 6902 ops array. The ops live in the JSONL log line and the `prompt_patches.patch_json` column. The event records the *fact*; the projection holds the *content*.
+
+A new `'content'` `IdempotencyKind` variant (synthesis lock 9) lands with this event. Formula: `${type}:${contentId}`. The `contentId` is the `patchId`. `sessionId` is intentionally **absent** from the formula, so the same patch content authored from two different sessions dedupes at the events table via the existing `ON CONFLICT(idempotency_key) DO NOTHING` gate. Cross-session content dedup, belt-and-braces with the `UNIQUE (prompt_id, patch_id)` projection index.
+
+Closed-enumeration count: 24 wire-level event types (22 reducer-typed + 2 audit-only).
+
+### 2.3 The JSONL evolution log (Wave C.1.4)
+
+Path: `<repoRoot>/.gobbi/projects/<project>/prompt-evolution/<prompt-id>.jsonl`. One file per prompt-id, six files total (one per step in the closed prompt-id set). Whitelisted by the existing `!.gobbi/projects/` rule in `.gitignore` — git-tracked.
+
+The first line of every file is the **genesis entry** (synthesis innovative addition #2): a synthetic `add op` at root path `''` whose `value` is the entire baseline `spec.json`. This makes the JSONL self-contained — any reader can fold the chain from line 1 and reproduce the on-disk `spec.json` byte-exactly. Without genesis, the JSONL is a delta-only log requiring the on-disk spec as external input.
+
+Per-line schema (synthesis §7):
+
+```json
+{
+  "v": 1,
+  "ts": "<ISO-8601>",
+  "promptId": "ideation",
+  "patchId": "sha256:<hex>",
+  "parentPatchId": "sha256:<hex>" | null,
+  "preHash": "sha256:<hex>",
+  "postHash": "sha256:<hex>",
+  "ops": [{"op":"test","path":"/version","value":1}, ...],
+  "validationStatus": "passed",
+  "appliedBy": "operator",
+  "eventSeq": 12345,
+  "schemaId": "https://gobbi.dev/schemas/step-spec/v1.json"
+}
+```
+
+Field-name convention: lowerCamelCase in JSONL (TS convention), snake_case in SQLite (SQL convention). Mapping at the writer/reader boundary, mirroring `EvalDecideData.plan ↔ state.evalConfig.planning`.
+
+**Canonicalization rule (synthesis Architecture F-7 fix):** `JSON.stringify(value, null, 2)` — insertion-order, 2-space indent. Matches the existing schema-mirror byte-equality test at `specs/__tests__/schema.test.ts:399-406`. A sorted-key variant would split the hash space; insertion-order is well-defined for `spec.json` files (the author's chosen key order is part of the file's byte identity), and `fast-json-patch::applyPatch` preserves key insertion order. The canonicalization is round-trip stable.
+
+The `lib/canonical-json.ts::canonicalize` helper is the single source of truth — `lib/prompt-evolution.ts::contentHash` returns `sha256:<hex>` over `canonicalize(value)` bytes, and every hash in the system (event payload, projection columns, JSONL line fields) hashes the same way.
+
+---
+
+## 3. Operator commands (Waves C.1.5 + C.1.6 + C.1.7)
+
+The `gobbi prompt` top-level dispatcher mirrors `gobbi maintenance` exactly (registry-based, dynamic-imported subhandlers). Three subcommands:
+
+### 3.1 `gobbi prompt render <prompt-id> --format=...` (Wave C.1.5)
+
+Three formats:
+
+- `--format=markdown` (default) — flat readable doc walking `StepBlocks` in source order. No session.state, no dynamic.context. Suitable for `gobbi prompt render <step> --format=markdown | less` reviews.
+- `--format=composed` — calls `assembly.compile()` directly, NOT a re-implementation. Output is byte-identical to what the runtime orchestrator produces for the same `CompileInput`. Includes the `staticPrefixHash` header line so operators can verify cache stability against `gobbi workflow status --cost`.
+- `--format=diff <baseline-patch-id>` — folds the JSONL chain twice (truncated to baseline, full to head), renders both as markdown, and shells out to `git --no-pager diff --no-index`. Zero new diff dependencies. `--allow-empty-diff` exits 0 on a genesis-only chain; default refuses with a clear message.
+
+### 3.2 `gobbi prompt patch <prompt-id> --patch <file>` (Wave C.1.6)
+
+The operator-only mutation surface. Single new production dependency: `fast-json-patch@3.1.1`.
+
+Validation pipeline (synthesis §9.2 fail-fast ladder):
+
+1. Parse JSON, reject non-array roots (RFC 6902 §3 requires top-level array).
+2. RFC 6902 shape check via `fast-json-patch::validate`.
+3. **Test-op merge logic** (synthesis §9.2 step 3, Overall F-7):
+   - No `test` op anywhere → synthesize `{op:'test',path:'/version',value:1}` at index 0; warn on stderr.
+   - Operator-authored `test` op already at index 0 testing `/version` → keep as-is.
+   - Operator-authored `test` op(s) elsewhere or testing other paths → prepend the synth `/version` test; preserve operator's tests in their original positions.
+4. Resolve baseline. `--baseline <hash>` enforces the operator's claimed baseline. No `--baseline`: refuse if on-disk `pre_hash` ≠ last patch row's `post_hash` — the operator-hand-edit / crash-mid-write detector. Operators override with `--baseline <hash>`.
+5. Simulate via `fast-json-patch::applyPatch` on a deep clone.
+6. Schema-validate the candidate via `validateStepSpec` (includes the `blockRef → blocks.delegation` cross-ref check).
+7. Compile-test the candidate via `assembly.compile()` (catches future content-lint regressions).
+8. Compute `post_hash` and `patch_id`.
+9. `--dry-run` / `--validate-only` → print summary, exit 0.
+10. **Commit phase** (atomic):
+
+    ```text
+    SQL transaction:
+      store.append(prompt.patch.applied event) → returns event_seq
+      INSERT INTO prompt_patches (event_seq, ...)
+
+    Filesystem (after SQL commit):
+      appendFileSync(<jsonl>, <line> + '\n')
+      writeFileSync(<spec.json>.tmp, canonicalize(<new spec>) + '\n')
+      renameSync(<spec.json>.tmp, <spec.json>)
+    ```
+
+`--allow-no-parent` opts the operator into bootstrapping a fresh chain by synthesizing a genesis line from the on-disk pre-patch spec.
+
+`SQLITE_BUSY` is caught and re-raised with `"another \`gobbi prompt\` invocation holds the write lock; retry"` (Planning routed-resolution).
+
+Cross-session content dedup: re-running the same patch from a second session hits the events idempotency key, surfaces a `"patch already applied (originating session: <sid>)"` message, and exits 0 without writing a duplicate row.
+
+### 3.3 `gobbi prompt rebuild <prompt-id>` (Wave C.1.7)
+
+Recovery command. Folds the JSONL chain via `lib/prompt-evolution.ts::foldChain`, validates the rebuilt spec via `validateStepSpec`, and writes the result via temp+rename. Pure recovery — does NOT mutate `prompt_patches` or `events`. The SQLite tables are the truth; this command makes the on-disk `spec.json` reflect them.
+
+Two recovery cases:
+1. Crash-mid-write — SQL committed, JSONL appended, but SIGKILL fired before the spec.json write.
+2. Operator hand-edit — someone edited spec.json directly. Detected by the same `pre_hash != last patch row's post_hash` check in `gobbi prompt patch`.
+
+Refuses to write if the chain produces a schema-invalid spec (a corrupted intermediate patch); emits a diagnostic naming the offending patchId.
+
+---
+
+## 4. The replay-equivalence CI gate
+
+The strongest invariant of the prompts-as-data system: `contentHash(foldChain(<jsonl>)) === contentHash(<on-disk spec.json>)` for every chain that exists.
+
+The CI test at `specs/__tests__/replay-equivalence.test.ts` enforces this for every prompt-id whose JSONL chain exists. When the chain is missing (a fresh repo, no patches applied), the test passes vacuously — the on-disk spec.json IS the baseline.
+
+Drift detection makes both failure modes visible:
+- JSONL corruption (a row's declared `postHash` disagrees with the computed one) — `foldChain` throws with the line number.
+- spec.json hand-edit (the on-disk file diverges from the chain) — the test fails with both hashes printed.
+
+---
+
+## 5. What's NOT in scope for Wave C.1
+
+Deferred items (synthesis §11):
+
+- Multi-spec atomic patch sets (cross-step renames). Operator handles via N independent patches today.
+- Content-addressable schema id (`v1#sha256-<digest>`). Useful when v1 → v2 migration arrives.
+- Typed-DSL author-time layer (TS function → RFC 6902). Ergonomic but orthogonal to correctness.
+- Bundled `dist/` semantics — patches apply to repo source; rebuild to pick up in installed CLI.
+- `gobbi prompt verify` consistency checker — detects orphan JSONL entries, hash mismatches.
+- `gobbi prompt log <prompt-id>` history view — `(prompt_id, seq)` index makes this trivial later.
+- RFC 6902 round-trip property test — recommended hardening; not yet required.
 
 ---
 
@@ -22,7 +216,8 @@ Each spec is validated against a JSON schema — the schema itself is a future d
 
 | Document | Covers |
 |----------|--------|
-| `deterministic-orchestration.md` | How step specs drive state transitions in the six-step workflow |
-| `token-budget-and-cache.md` | How spec-driven compilation preserves cache-prefix stability |
-| `just-in-time-prompt-injection.md` | How compiled prompts reach the orchestrator at the moment of need |
-| `cli-as-runtime-api.md` | The CLI surface that reads specs and compiles them |
+| `deterministic-orchestration.md` | How step specs drive state transitions in the six-step workflow. |
+| `token-budget-and-cache.md` | How spec-driven compilation preserves cache-prefix stability. |
+| `just-in-time-prompt-injection.md` | How compiled prompts reach the orchestrator at the moment of need. |
+| `cli-as-runtime-api.md` | The CLI surface that reads specs and compiles them. |
+| `orchestration/README.md` | The L0-L3 layering, state.db / gobbi.db partition, JIT framing. |

--- a/.gobbi/projects/gobbi/design/v050-features/prompts-as-data.md
+++ b/.gobbi/projects/gobbi/design/v050-features/prompts-as-data.md
@@ -158,15 +158,24 @@ Validation pipeline (synthesis §9.2 fail-fast ladder):
 10. **Commit phase** (atomic):
 
     ```text
-    SQL transaction:
+    SQL transaction (BEGIN IMMEDIATE — single bun:sqlite handle):
       store.append(prompt.patch.applied event) → returns event_seq
       INSERT INTO prompt_patches (event_seq, ...)
+    COMMIT
 
     Filesystem (after SQL commit):
       appendFileSync(<jsonl>, <line> + '\n')
       writeFileSync(<spec.json>.tmp, canonicalize(<new spec>) + '\n')
       renameSync(<spec.json>.tmp, <spec.json>)
     ```
+
+    The SQL transaction lives on the `EventStore` as
+    `appendWithProjection(input, projection)` (Wave C.1.6 R1 /
+    Architecture F-1 fix). Both writes share one connection — a
+    SIGKILL between them rolls both back rather than leaving an
+    orphan event row. The projection callback receives the same
+    underlying `Database` handle so it cannot accidentally open a
+    second connection that would defeat the atomicity guarantee.
 
 `--allow-no-parent` opts the operator into bootstrapping a fresh chain by synthesizing a genesis line from the on-disk pre-patch spec.
 

--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
       },
       "dependencies": {
         "ajv": "^8.18.0",
+        "fast-json-patch": "^3.1.1",
       },
       "devDependencies": {
         "bun-types": "^1.3.12",
@@ -44,6 +45,8 @@
     "fast-check": ["fast-check@4.6.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-json-patch": ["fast-json-patch@3.1.1", "", {}, "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="],
 
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,8 @@
     "prepack": "bun run sync:template-bundle"
   },
   "dependencies": {
-    "ajv": "^8.18.0"
+    "ajv": "^8.18.0",
+    "fast-json-patch": "^3.1.1"
   },
   "peerDependencies": {
     "playwright": ">=1.40.0",

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -257,10 +257,12 @@ describe('TOP_LEVEL_COMMANDS — canonical registry', () => {
     // `maintenance` namespace for out-of-session cleanup commands
     // (wipe-legacy-sessions). W5.5 added `install` (template-bundle
     // lay-down + 3-way merge) and `project` (list / create / switch)
-    // as top-level multi-project verbs. Workflow subcommands (Waves
-    // 2–8) extend the inner `workflow` registry and do not surface
-    // here. If this test fails, verify the change belongs in this PR
-    // before updating it.
+    // as top-level multi-project verbs. v0.5.0 Wave C.1.5 added
+    // `prompt` (render / patch / rebuild — operator-only spec.json
+    // mutation surface for the prompts-as-data feature). Workflow
+    // subcommands (Waves 2–8) extend the inner `workflow` registry
+    // and do not surface here. If this test fails, verify the change
+    // belongs in this PR before updating it.
     const expected: readonly CommandName[] = [
       'config',
       'session',
@@ -270,6 +272,7 @@ describe('TOP_LEVEL_COMMANDS — canonical registry', () => {
       'workflow',
       'gotcha',
       'maintenance',
+      'prompt',
       'install',
       'project',
       'image',

--- a/packages/cli/src/__tests__/cross-pass-invariant.test.ts
+++ b/packages/cli/src/__tests__/cross-pass-invariant.test.ts
@@ -479,12 +479,14 @@ describe('cross-pass invariant: init normalises legacy-shape session', () => {
       expect(legacySnap.stateSchemaVersion).toBe(4);
       expect(freshSnap.stateSchemaVersion).toBe(4);
 
-      // Layer 3 — gobbi.db schema (Wave A.1.3: v6 — workspace-partitioned
-      // audit + meta tables on top of the gobbi-memory Pass 2 v5 events
-      // columns). `CURRENT_SCHEMA_VERSION` is imported (not hardcoded
-      // literal) so a future schema bump localises the failure here rather
-      // than scattering bare integers across asserts.
-      expect(CURRENT_SCHEMA_VERSION).toBe(6);
+      // Layer 3 — gobbi.db schema (Wave C.1.2: v7 — `prompt_patches`
+      // workspace-partitioned audit table on top of v6's
+      // workspace-partitioned audit + meta tables, on top of the
+      // gobbi-memory Pass 2 v5 events columns). `CURRENT_SCHEMA_VERSION`
+      // is imported (not hardcoded literal) so a future schema bump
+      // localises the failure here rather than scattering bare integers
+      // across asserts.
+      expect(CURRENT_SCHEMA_VERSION).toBe(7);
       expect(legacySnap.dbColumnsHaveSessionAndProjectId).toBe(true);
       expect(freshSnap.dbColumnsHaveSessionAndProjectId).toBe(true);
 

--- a/packages/cli/src/__tests__/e2e/prompt-patch.test.ts
+++ b/packages/cli/src/__tests__/e2e/prompt-patch.test.ts
@@ -1,0 +1,239 @@
+/**
+ * End-to-end test for `gobbi prompt patch` (Wave C.1.6, issue #156).
+ *
+ * Exercises the validation pipeline via in-process `runPromptPatchOnFiles`
+ * calls against a scratch directory — full subprocess invocation would
+ * require copying the entire `packages/cli/src/specs/` tree, which is
+ * overkill for the failure-mode coverage. The unit tests in
+ * `commands/prompt/__tests__/patch.test.ts` cover `mergeTestOp`; this
+ * file covers:
+ *
+ *   - Patch file missing → exit 1.
+ *   - Patch file is not JSON → exit 1.
+ *   - Patch file root is not an array → exit 1.
+ *   - RFC 6902 shape violation (unknown op) → exit 1.
+ *   - --baseline mismatch → exit 1.
+ *   - Schema-violating patch → exit 1 at gate 6 (validateStepSpec).
+ *   - --dry-run with a passing patch → exits 0 + prints summary.
+ *
+ * Subprocess form (Bun.$) is preserved for the dry-run happy path so we
+ * verify the CLI binary entry point itself works.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { $ } from 'bun';
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const CLI_PATH = join(import.meta.dir, '..', '..', 'cli.ts');
+
+describe('gobbi prompt patch — argv + dry-run smoke (subprocess)', () => {
+  test('--help prints usage and exits 0', async () => {
+    const result = await $`bun run ${CLI_PATH} prompt patch --help`
+      .nothrow()
+      .quiet();
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString('utf8')).toContain(
+      'Usage: gobbi prompt patch',
+    );
+  });
+
+  test('missing <prompt-id> exits 2 with usage on stderr', async () => {
+    const result = await $`bun run ${CLI_PATH} prompt patch`.nothrow().quiet();
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr.toString('utf8')).toContain('missing <prompt-id>');
+  });
+
+  test('unknown prompt-id exits 1 with the closed-set message', async () => {
+    const result = await $`bun run ${CLI_PATH} prompt patch unknown-step --patch /dev/null`
+      .nothrow()
+      .quiet();
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString('utf8')).toContain('invalid prompt-id');
+  });
+
+  test('missing --patch exits 2 with a clear message', async () => {
+    const result = await $`bun run ${CLI_PATH} prompt patch ideation`
+      .nothrow()
+      .quiet();
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr.toString('utf8')).toContain(
+      '--patch <file> is required',
+    );
+  });
+
+  test('patch file does not exist → exit 1', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'gobbi-prompt-patch-e2e-'));
+    try {
+      const ghost = join(tmp, 'nope.json');
+      const result = await $`bun run ${CLI_PATH} prompt patch ideation --patch ${ghost}`
+        .nothrow()
+        .quiet();
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr.toString('utf8')).toContain('patch file not found');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('patch file is not JSON → exit 1', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'gobbi-prompt-patch-e2e-'));
+    try {
+      const file = join(tmp, 'bad.json');
+      writeFileSync(file, 'not json', 'utf8');
+      const result = await $`bun run ${CLI_PATH} prompt patch ideation --patch ${file}`
+        .nothrow()
+        .quiet();
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr.toString('utf8')).toContain('not valid JSON');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('patch file root is not an array → exit 1', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'gobbi-prompt-patch-e2e-'));
+    try {
+      const file = join(tmp, 'bad.json');
+      writeFileSync(file, '{"oops":true}', 'utf8');
+      const result = await $`bun run ${CLI_PATH} prompt patch ideation --patch ${file}`
+        .nothrow()
+        .quiet();
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr.toString('utf8')).toContain(
+        'patch file root must be a JSON array',
+      );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('schema-violating patch fails at validateStepSpec gate (--dry-run)', async () => {
+    // A valid RFC 6902 ops array that mutates the spec into a
+    // schema-violating shape: replace tokenBudget so the sum no longer
+    // hits 1.0.
+    const tmp = mkdtempSync(join(tmpdir(), 'gobbi-prompt-patch-e2e-'));
+    try {
+      const file = join(tmp, 'patch.json');
+      writeFileSync(
+        file,
+        JSON.stringify([
+          {
+            op: 'replace',
+            path: '/tokenBudget/staticPrefix',
+            value: 0.99, // sum will no longer equal 1.0
+          },
+        ]),
+        'utf8',
+      );
+      const result = await $`bun run ${CLI_PATH} prompt patch ideation --patch ${file} --dry-run`
+        .nothrow()
+        .quiet();
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr.toString('utf8')).toContain(
+        'fails schema validation',
+      );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('--baseline that does not match on-disk pre_hash exits 1', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'gobbi-prompt-patch-e2e-'));
+    try {
+      const file = join(tmp, 'patch.json');
+      writeFileSync(
+        file,
+        JSON.stringify([
+          { op: 'replace', path: '/meta/description', value: 'updated' },
+        ]),
+        'utf8',
+      );
+      const result = await $`bun run ${CLI_PATH} prompt patch ideation --patch ${file} --baseline sha256:wrong --dry-run`
+        .nothrow()
+        .quiet();
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr.toString('utf8')).toContain(
+        '--baseline sha256:wrong does not match',
+      );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('valid patch with --dry-run prints summary and exits 0 (no commit)', async () => {
+    // A valid patch: change meta.description (a leaf string field with
+    // no schema constraints beyond `string`).
+    const tmp = mkdtempSync(join(tmpdir(), 'gobbi-prompt-patch-e2e-'));
+    try {
+      const file = join(tmp, 'patch.json');
+      writeFileSync(
+        file,
+        JSON.stringify([
+          {
+            op: 'replace',
+            path: '/meta/description',
+            value: 'Ideation — updated description',
+          },
+        ]),
+        'utf8',
+      );
+      const result = await $`bun run ${CLI_PATH} prompt patch ideation --patch ${file} --dry-run`
+        .nothrow()
+        .quiet();
+      expect(result.exitCode).toBe(0);
+      const stdout = result.stdout.toString('utf8');
+      expect(stdout).toContain('gobbi prompt patch — dry-run');
+      expect(stdout).toContain('patchId:');
+      expect(stdout).toContain('pre_hash:');
+      expect(stdout).toContain('post_hash:');
+      expect(stdout).toContain('synthesized test:  yes');
+      // Synthesis warning landed on stderr.
+      expect(result.stderr.toString('utf8')).toContain(
+        "synthesized {op:'test', path:'/version', value:1}",
+      );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("dry-run preserves on-disk spec.json (no mutation)", async () => {
+    const specPath = join(
+      import.meta.dir,
+      '..',
+      '..',
+      'specs',
+      'ideation',
+      'spec.json',
+    );
+    const before = readFileSync(specPath, 'utf8');
+    const tmp = mkdtempSync(join(tmpdir(), 'gobbi-prompt-patch-e2e-'));
+    try {
+      const file = join(tmp, 'patch.json');
+      writeFileSync(
+        file,
+        JSON.stringify([
+          {
+            op: 'replace',
+            path: '/meta/description',
+            value: 'should-not-stick',
+          },
+        ]),
+        'utf8',
+      );
+      await $`bun run ${CLI_PATH} prompt patch ideation --patch ${file} --dry-run`
+        .nothrow()
+        .quiet();
+      const after = readFileSync(specPath, 'utf8');
+      expect(after).toBe(before);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -91,6 +91,7 @@ export const COMMAND_ORDER = [
   'workflow',
   'gotcha',
   'maintenance',
+  'prompt',
   'install',
   'project',
   'image',
@@ -179,6 +180,14 @@ export const COMMANDS_BY_NAME = {
     run: async (args: string[]): Promise<void> => {
       const { runMaintenance } = await import('./commands/maintenance.js');
       await runMaintenance(args);
+    },
+  },
+  prompt: {
+    name: 'prompt',
+    summary: 'Render / patch / rebuild per-step spec.json (operator-only)',
+    run: async (args: string[]): Promise<void> => {
+      const { runPrompt } = await import('./commands/prompt.js');
+      await runPrompt(args);
     },
   },
   install: {

--- a/packages/cli/src/commands/maintenance/migrate-state-db.ts
+++ b/packages/cli/src/commands/maintenance/migrate-state-db.ts
@@ -101,6 +101,7 @@ import {
   CURRENT_SCHEMA_VERSION,
   ensureSchemaV5,
   ensureSchemaV6,
+  ensureSchemaV7,
 } from '../../workflow/migrations.js';
 
 // ---------------------------------------------------------------------------
@@ -368,6 +369,10 @@ export function migrateStateDbAt(
     // Stamp v6 with the supplied `now` so the JSON output is
     // deterministic under a fixed clock.
     ensureSchemaV6(db, clock());
+    // v7 — Wave C.1.2 — additive `prompt_patches` table. Stamp with the
+    // same clock so the operator-visible `migrated_at` is the v7 stamp,
+    // matching the schema_meta.schema_version that this run advertises.
+    ensureSchemaV7(db, clock());
     const elapsedMs = clock() - startMs;
     return {
       path: dbPath,

--- a/packages/cli/src/commands/prompt.ts
+++ b/packages/cli/src/commands/prompt.ts
@@ -65,6 +65,14 @@ export const PROMPT_COMMANDS: readonly PromptCommand[] = [
       await runPromptRender(args);
     },
   },
+  {
+    name: 'patch',
+    summary: 'Apply an RFC 6902 patch to a per-step spec.json (operator-only)',
+    run: async (args: string[]): Promise<void> => {
+      const { runPromptPatch } = await import('./prompt/patch.js');
+      await runPromptPatch(args);
+    },
+  },
 ];
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/commands/prompt.ts
+++ b/packages/cli/src/commands/prompt.ts
@@ -1,0 +1,124 @@
+/**
+ * gobbi prompt — subcommand dispatcher for prompts-as-data operations.
+ *
+ * Mirrors `commands/maintenance.ts` exactly: a `readonly PromptCommand[]`
+ * registry, help derived from the registry, and a separate
+ * registry-parameterised dispatch for tests. Sub-handlers are
+ * dynamic-`import()`-ed so unrelated namespaces pay no cold-start cost.
+ *
+ * ## Scope (Wave C.1)
+ *
+ *   - `render`  (Wave C.1.5) — render a per-step `spec.json` in
+ *                              `markdown` / `composed` / `diff` form.
+ *   - `patch`   (Wave C.1.6) — apply an RFC 6902 patch to a per-step
+ *                              `spec.json` (operator-only, atomic).
+ *   - `rebuild` (Wave C.1.7) — materialize `spec.json` from the JSONL
+ *                              evolution chain (recovery path).
+ *
+ * Per the design synthesis lock 3, the patch flow is operator-only via
+ * CLI; the orchestrator never mutates prompts mid-session. This
+ * dispatcher and its three subcommands are the only authorised
+ * mutation surface for `spec.json` files.
+ *
+ * ## Source vs. installed CLI
+ *
+ * `gobbi prompt patch` and `gobbi prompt rebuild` mutate the source
+ * `spec.json` files at `packages/cli/src/specs/<step>/spec.json` —
+ * NOT the bundled `dist/` build output. Operators running the
+ * installed CLI cannot patch installed prompts; they must patch the
+ * source repo and rebuild. Each subcommand's `--help` text restates
+ * this constraint per Overall F-1's deferral.
+ *
+ * ## Exit codes
+ *
+ *   - `0` on `--help` / no subcommand.
+ *   - `1` when the subcommand is unknown.
+ *   - Subcommand handlers own their own exit codes.
+ */
+
+// ---------------------------------------------------------------------------
+// Registry shape
+// ---------------------------------------------------------------------------
+
+/**
+ * One entry in the `prompt` subcommand registry. `run` receives the
+ * argv slice AFTER the subcommand name. The handler owns its own flag
+ * parsing and is free to exit the process.
+ */
+export interface PromptCommand {
+  readonly name: string;
+  readonly summary: string;
+  readonly run: (args: string[]) => Promise<void>;
+}
+
+/**
+ * Canonical list of registered subcommands. Ordering controls `--help`
+ * output. Each handler is dynamic-imported to keep cold-starts lean.
+ */
+export const PROMPT_COMMANDS: readonly PromptCommand[] = [
+  {
+    name: 'render',
+    summary:
+      'Render a per-step spec.json (--format=markdown | composed | diff)',
+    run: async (args: string[]): Promise<void> => {
+      const { runPromptRender } = await import('./prompt/render.js');
+      await runPromptRender(args);
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Help rendering
+// ---------------------------------------------------------------------------
+
+function renderHelp(commands: readonly PromptCommand[]): string {
+  const header = `Usage: gobbi prompt <subcommand> [options]`;
+  const pad = commands.reduce((w, c) => Math.max(w, c.name.length), 0) + 2;
+  const commandsSection =
+    commands.length === 0
+      ? '  (no subcommands registered)'
+      : commands
+          .map((cmd) => `  ${cmd.name.padEnd(pad)}${cmd.summary}`)
+          .join('\n');
+  const optionsSection = `Options:\n  --help    Show this help message`;
+  return `${header}\n\nSubcommands:\n${commandsSection}\n\n${optionsSection}`;
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+export async function runPrompt(args: string[]): Promise<void> {
+  return runPromptWithRegistry(args, PROMPT_COMMANDS);
+}
+
+/**
+ * Registry-parameterised dispatch — exported for tests that need to
+ * exercise the dispatcher against a custom registry (unknown-command
+ * handling, `--help` rendering).
+ */
+export async function runPromptWithRegistry(
+  args: string[],
+  commands: readonly PromptCommand[],
+): Promise<void> {
+  const subcommand = args[0];
+
+  if (
+    subcommand === undefined ||
+    subcommand === '--help' ||
+    subcommand === '-h'
+  ) {
+    console.log(renderHelp(commands));
+    return;
+  }
+
+  const match = commands.find((cmd) => cmd.name === subcommand);
+  if (match === undefined) {
+    process.stderr.write(`Unknown subcommand: ${subcommand}\n`);
+    process.stderr.write(renderHelp(commands));
+    process.stderr.write('\n');
+    process.exit(1);
+  }
+
+  await match.run(args.slice(1));
+}

--- a/packages/cli/src/commands/prompt.ts
+++ b/packages/cli/src/commands/prompt.ts
@@ -73,6 +73,14 @@ export const PROMPT_COMMANDS: readonly PromptCommand[] = [
       await runPromptPatch(args);
     },
   },
+  {
+    name: 'rebuild',
+    summary: 'Materialize spec.json from the JSONL chain (recovery)',
+    run: async (args: string[]): Promise<void> => {
+      const { runPromptRebuild } = await import('./prompt/rebuild.js');
+      await runPromptRebuild(args);
+    },
+  },
 ];
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/commands/prompt/__tests__/__snapshots__/render.snap.test.ts.snap
+++ b/packages/cli/src/commands/prompt/__tests__/__snapshots__/render.snap.test.ts.snap
@@ -1,0 +1,621 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`renderMarkdown ideation markdown render matches snapshot 1`] = `
+"# Ideation — PI agents explore what to do across innovative and best-practice stances, then the orchestrator synthesizes a single direction.
+
+## role
+
+You are the orchestrator of the Ideation step. Your job is to coordinate two parallel PI (perspective-informed) agents — one innovative, one best-practice — and synthesize their findings into a single shared direction the user approves before the workflow moves to planning.
+
+You are not the ideator yourself. The PI agents ideate; you frame the problem, delegate, discuss the options with the user, and synthesize.
+
+## principles
+
+Ideation principles:
+
+- Two stances, not one. Innovative explores novel approaches; best-practice grounds the work in proven patterns. Neither is correct alone — the synthesis is where the direction emerges.
+- Discuss before delegating. Talk to the user about the problem shape, constraints, and priorities. Use AskUserQuestion for every decision point. A detailed prompt to the PI agents produces detailed ideation; a vague prompt produces vague options.
+- Synthesize, do not concatenate. The output \`ideation.md\` is one chosen direction, not both stances pasted together. When the stances conflict, surface the tradeoff to the user and decide together.
+- Never evaluate your own synthesis. If evaluation is enabled for this step, the CLI will transition to \`ideation_eval\` and spawn independent evaluator agents after your synthesis lands.
+
+## scope-boundary
+
+Scope boundary:
+
+- Stay within the Ideation step. Do not begin decomposition or implementation — that is the Plan and Execution steps' job.
+- Do not load orchestration, discussion, or ideation skills as content — their behavior is already encoded in this prompt. Load only domain skills the PI agents need for the specific problem.
+- Note adjacent improvements in the ideation artifact, but do not implement them now. The Plan step decides what belongs in scope.
+
+## feedback-context (conditional: feedbackRoundActive)
+
+Feedback round context:
+
+A prior evaluation of this step returned a revise verdict. Before re-running the PI agents, read the evaluator findings under \`evaluation/\` in the session directory. Ask the user which findings to address, which to defer, and which to disagree with. Re-run ideation only after the revision scope is clear — do not blindly re-spawn the PI agents on the original prompt.
+
+## evaluation-deciding (conditional: ideationSynthesized)
+
+Evaluation decision point:
+
+The PI agents have completed and you have synthesized \`ideation.md\`. Before exiting the step, ask the user whether to run Ideation evaluation. Use AskUserQuestion with two options: skip evaluation (recommended when the synthesis is clearly aligned with user intent) or run evaluation (recommended when the direction is novel, risky, or touches multiple architectural surfaces). Wait for the user decision before emitting the completion signal.
+
+## spawn-ready (conditional: piAgentsToSpawn)
+
+Spawn-readiness guidance:
+
+You are about to spawn the two PI agents in parallel. Before calling the Agent tool, confirm the delegation prompt contains the problem framing, constraints, user priorities, and the stance label. Spawn both agents in a single message — parallel dispatch is cheaper than sequential because their execution does not depend on each other.
+
+## delegation: pi.innovative
+
+You are a PI agent working the innovative stance.
+
+Your goal is to produce \`innovative.md\` — a depth-first, divergent exploration of what this problem could become if the most creative constraints were lifted. Challenge the default framing. Propose approaches that are unusual, novel, or that reshape the problem itself rather than solve its surface.
+
+Approach:
+
+- Question the problem statement before accepting it. What assumption is load-bearing? What would change if it were false?
+- Propose at least three distinct approaches. Each approach should have a clear first-order shape, an honest tradeoff note, and a sketched decision rationale.
+- Favor conceptual clarity over completeness. A strong idea explored halfway beats two shallow ideas each explored a quarter.
+- Do not optimize for compatibility with the current codebase. That is the best-practice agent's job. Your job is the frontier.
+
+Output: \`innovative.md\` under the session's ideation directory. Include a brief stance statement at the top so the synthesis step knows which perspective authored it.
+
+## delegation: pi.best
+
+You are a PI agent working the best-practice stance.
+
+Your goal is to produce \`best.md\` — a grounded exploration of what this problem becomes when proven patterns, established conventions, and reliability are the primary lens. Propose approaches that are safe, reversible, and aligned with how similar problems have been solved in the codebase or the wider ecosystem.
+
+Approach:
+
+- Name the pattern you are applying. Cite where the pattern is already used (codebase, upstream library, well-known reference).
+- Propose at least three distinct approaches. Each approach should name its pattern, show how it maps onto the problem, and state its operational tradeoff.
+- Favor reversibility. A change that can be rolled back in one commit beats a change that requires a migration to undo.
+- Do not optimize for novelty. The innovative agent handles the frontier. Your job is the steady baseline against which novelty is weighed.
+
+Output: \`best.md\` under the session's ideation directory. Include a brief stance statement at the top so the synthesis step knows which perspective authored it.
+
+## synthesis
+
+Synthesis instructions:
+
+After both PI agents complete, produce \`ideation.md\` — one chosen direction, not a concatenation of both stances. Your synthesis process:
+
+1. Read both \`innovative.md\` and \`best.md\` in full. Do not skim. Overlaps and conflicts are what the synthesis is actually about.
+2. Extract the options table. List every distinct approach across both artifacts with a one-line summary, a stance tag, and an honest tradeoff. Deduplicate near-identical approaches; keep the clearer articulation.
+3. Discuss the options with the user via AskUserQuestion. Recommend one option first with a clear rationale. The user decides which direction to take — never auto-select.
+4. Write \`ideation.md\` with the chosen direction, the reasoning that led there, and the options that were considered but not selected with their tradeoffs. Future steps read this file; it is the record of why this direction was taken over the alternatives.
+5. If the evaluation gate is enabled for this step, the CLI will spawn evaluator agents after your synthesis lands. Do not evaluate your own synthesis.
+
+## completion
+
+Emit the SubagentStop completion signal once \`ideation.md\` is written, the user has approved the chosen direction, and (if evaluation is enabled) the user has decided whether to run ideation_eval.
+
+1. innovative.md is written to the session's ideation directory by the innovative PI agent
+2. best.md is written to the session's ideation directory by the best-practice PI agent
+3. ideation.md is written by the orchestrator with a single chosen direction and a record of the options considered
+4. the user has approved the chosen direction via AskUserQuestion
+5. the user has decided whether to run ideation_eval (if the eval gate is enabled for this session)
+
+## footer
+
+---
+## Step completion protocol
+
+You have finished this step's work when the criteria above are satisfied. Once they are met, run EXACTLY this command as your last action:
+
+  gobbi workflow transition COMPLETE
+
+The CLI's output is the authoritative record of step completion. No other phrasing — prose, markdown headers, comments — advances the workflow. Run the command, observe the printed next step, and stop.
+
+"
+`;
+
+exports[`renderMarkdown planning markdown render matches snapshot 1`] = `
+"# Plan — decompose the chosen ideation direction into narrow, ordered tasks with clear scope and verification criteria. Orchestrator-authored artifact; no delegated agents.
+
+## role
+
+You are the orchestrator of the Plan step. Your job is to translate the single chosen direction from Ideation into an ordered list of narrow, specific tasks that Execution can run one at a time.
+
+Plan is orchestrator-authored. You do not delegate ideation here; you do not begin implementation. You read the approved ideation direction, decompose it into tasks the user agrees to, and commit the result as \`plan.md\`. Evaluation (if enabled at session start) runs separately — you never evaluate your own plan.
+
+## principles
+
+Plan principles:
+
+- Narrow each task. A task is narrow enough that its scope is unambiguous and its verification criterion is obvious. If a reasonable executor would have to guess, decompose further.
+- Fit one context window. A task that cannot fit in one executor context window is two tasks. Reason about the inputs, outputs, and intermediate artifacts each task needs; if any one task's delegation prompt would be oversized, split it.
+- Order tasks so earlier tasks unblock later ones. Plan is a contract Execution runs against — dependencies in the wrong order surface as rework.
+- Every task names its verification. How does Execution know the task is done? A runnable command, a passing test, a visible artifact, a reviewed diff. Vague completion criteria produce vague completion.
+- Discuss the decomposition with the user via AskUserQuestion before committing. Offer a recommended decomposition first with rationale. The user decides which tasks stay, merge, or split.
+
+## scope-boundary
+
+Scope boundary:
+
+- Planning produces a task list. Do not start implementation — Execution owns that step.
+- Do not re-open ideation. If a new option surfaces during planning, note it and ask the user whether to skip back to ideation rather than silently ideating inside planning.
+- Do not evaluate the plan. If the user enabled planning evaluation at session start, the CLI transitions to \`planning_eval\` after your exit; independent evaluator agents assess the plan then.
+- Do not expand tasks into adjacent work. A plan that grows to absorb "while we are at it" work is a plan that executes slowly and reviews poorly.
+
+## plan-artifact-shape
+
+Plan artifact shape:
+
+Write \`plan.md\` with the following structure so Execution and downstream evaluators can read it deterministically:
+
+1. \`Direction\` — a one-paragraph restatement of the chosen ideation direction this plan realizes. Grounds the plan in the approved intent.
+2. \`Tasks\` — an ordered list. Each task has:
+   - A short imperative title
+   - A scope statement in one or two sentences
+   - Inputs the task will consume (artifacts, references)
+   - Outputs the task will produce (files, commits, tests)
+   - Verification — the concrete check that proves the task done
+   - Agent — which agent type executes the task (\`__executor\`, \`_project-evaluator\`, etc.)
+3. \`Dependencies\` — a brief table mapping tasks to prerequisite tasks, if non-trivial.
+4. \`Out-of-scope\` — adjacent work that was considered and deliberately deferred, with a one-line rationale per item. This protects Execution from quietly absorbing deferred work.
+
+The shape is stable on purpose: \`gobbi workflow validate\` and downstream compilation read it structurally.
+
+## feedback-context (conditional: feedbackRoundActive)
+
+Feedback round context:
+
+A prior evaluation of this plan returned a revise verdict, or an execution_eval loop targeted the planning step. Before rewriting the plan, read the evaluator findings under \`evaluation/\` (for planning_eval loops) or the execution_eval summary (for execution_eval loops) in the session directory. Ask the user which findings to address, which to defer, and which to disagree with — the feedback is input, not instruction. Re-plan only after the revision scope is clear; do not rewrite tasks on a guess.
+
+## evaluation-deciding (conditional: evalPlanningEnabled)
+
+Evaluation pre-exit check:
+
+The user enabled Planning evaluation at session start (\`evalConfig.planning == true\`). Before emitting the completion signal, confirm the plan artifact is complete and the user has approved its shape. The CLI will transition to \`planning_eval\` on exit; do not ask the user again about running evaluation — that decision is locked. Your job at exit is to ensure \`plan.md\` is ready to be assessed by independent evaluator agents.
+
+## synthesis
+
+Synthesis instructions:
+
+Plan is orchestrator-authored — there are no delegated agents whose output you merge. Your synthesis is the plan itself:
+
+1. Read the approved \`ideation.md\` in full. Do not skim. The direction statement in your plan's first section must reflect the ideation decision faithfully — if you find yourself drifting, stop and re-read.
+2. Draft a task list as a first pass. Reason about task boundaries, input/output shapes, and dependencies. Aim for specificity over completeness — a vague task is worse than a task that obviously needs splitting.
+3. Discuss the decomposition with the user via AskUserQuestion. Offer one recommended shape first with rationale. The user decides which tasks stay, merge, split, or get deferred to out-of-scope.
+4. Commit the agreed decomposition as \`plan.md\` using the structure in the \`Plan artifact shape\` section. Include the out-of-scope list so Execution does not absorb adjacent work.
+5. If plan evaluation is enabled for this session, the CLI will spawn evaluator agents after your exit. Do not evaluate your own plan.
+
+## completion
+
+Emit the Stop completion signal once \`plan.md\` is written with the agreed decomposition and the user has approved the task list.
+
+1. plan.md is written to the session's plan directory with Direction, Tasks, Dependencies, and Out-of-scope sections
+2. every task names its scope, inputs, outputs, verification, and agent
+3. the user has approved the decomposition via AskUserQuestion
+4. no task is so large that its delegation prompt would overflow a single context window
+5. deferred adjacent work is captured in the Out-of-scope section with a one-line rationale per item
+
+## footer
+
+---
+## Step completion protocol
+
+You have finished this step's work when the criteria above are satisfied. Once they are met, run EXACTLY this command as your last action:
+
+  gobbi workflow transition COMPLETE
+
+The CLI's output is the authoritative record of step completion. No other phrasing — prose, markdown headers, comments — advances the workflow. Run the command, observe the printed next step, and stop.
+
+"
+`;
+
+exports[`renderMarkdown execution markdown render matches snapshot 1`] = `
+"# Execution — run one task at a time from the approved plan, verify against criteria, then move on. Delegates to __executor subagents per task; verification happens between tasks.
+
+## role
+
+You are the orchestrator of the Execution step. Your job is to run the approved plan one task at a time, verifying each task before the next begins, until the plan is complete or a failure surfaces that requires feedback.
+
+You delegate each task to an executor subagent; you do not implement tasks yourself. You do not evaluate the execution output — that is \`execution_eval\`'s job. You do not re-decompose tasks on the fly; if a task is structurally wrong, surface it to the user rather than silently reshaping the plan.
+
+## principles
+
+Execution principles:
+
+- One task at a time. Complete a task, verify it, then move to the next. Broad parallel execution produces broad shallow mistakes.
+- Verify against the plan's criteria, not against whether the code "looks right." The plan's verification column is the contract; satisfying it is the definition of done for that task.
+- Delegate with specificity. Every executor subagent prompt must include the task's scope, inputs, outputs, verification criteria, the relevant prior-step artifacts, and the skills to load. A subagent that has to guess is a subagent that guesses wrong.
+- Respect scope boundaries. If an executor notices adjacent improvements, they note them in their response — they do not implement them. Scope creep in Execution is scope creep everywhere downstream.
+- Record gotchas immediately after any correction. A correction not recorded is a correction repeated across sessions.
+
+## scope-boundary
+
+Scope boundary:
+
+- Execute the plan as written. Do not re-plan mid-step. If a task is blocked or malformed, stop and ask the user — skipping back to \`plan\` is a legitimate option.
+- Do not evaluate execution quality yourself. \`execution_eval\` runs after Execution exits; it is mandatory and non-skippable.
+- Stay inside the per-task scope when briefing executors. A subagent that executes task 3 must receive exactly the context task 3 requires — not the full history of tasks 1 and 2.
+- Write artifacts to the session's execution directory, not to the plan directory or the ideation directory. Each step owns its own artifact namespace.
+
+## verification-contract
+
+Verification contract:
+
+After each executor subagent completes, run the task's verification before dispatching the next task. Verification can be:
+
+- A shell command the plan specified (lint, test, typecheck)
+- A structural check on produced artifacts (file exists, required sections present)
+- A focused reading of a diff against the task's declared outputs
+
+A failing verification is not a silent regression — record the failure in the execution artifact, decide with the user whether to retry the task, skip to a focused fix, or escape the step and return to \`plan\`. Never mark a task complete on a failing verification just to keep the list moving.
+
+## feedback-context (conditional: feedbackRoundActive)
+
+Feedback round context:
+
+A prior execution_eval verdict targeted this step (or an upstream step) for revision and the workflow has looped back here. Before dispatching the next executor, read the evaluation findings under \`evaluation/\` in the session directory. Ask the user which findings to address and in what order — the revision scope is the input that shapes every delegation prompt this round. Do not blanket-re-execute every task; target the tasks the findings identified.
+
+## feedback-cap-warning (conditional: feedbackCapExceeded)
+
+Pre-cap warning:
+
+The feedback round counter has reached the maximum allowed for this session. The NEXT execution_eval revise verdict will route the workflow to \`error\` rather than looping back. Treat this round as the final focused attempt: read the accumulated pattern of revise findings from prior rounds, discuss with the user which findings are the highest-leverage remaining gaps, and prioritize those. If the gap is irreducible with the current plan, surface that to the user before burning the last round.
+
+## delegation: executor
+
+You are an executor subagent working a single task from the approved plan.
+
+Your goal is to complete ONE task: read its scope, inputs, outputs, and verification, implement the change, verify it, and report back. You are not the orchestrator; you do not decompose, delegate, or decide plan shape. You execute.
+
+Approach:
+
+- Study before acting. The codebase is the source of truth, not the briefing. Read the relevant code, understand existing patterns, and check gotchas before writing a single line.
+- Plan before coding. Outline which files you will modify, what patterns you will follow, and what the expected result looks like. A few minutes of planning prevents an hour of rework.
+- Implement minimally. Follow existing code patterns. Do not introduce new patterns when existing ones work. Do not add error handling, abstractions, or features beyond the task's declared outputs.
+- Verify before reporting done. Run the task's declared verification. A task is done when the verification passes, not when the code looks right to you.
+- Stay within scope. If you notice adjacent improvements, note them in your final response — do not implement them.
+
+Output: write your deliverable to the task's declared outputs. Write your execution notes to the session's execution directory as directed. Include in your final response: what was done, what changed, what was learned, any open items, and any scope-boundary notes. Your final response is the permanent record of this task — make it self-contained.
+
+## synthesis
+
+Synthesis instructions:
+
+After every task in the plan has a verified completion (or has been deliberately deferred with the user), produce \`execution.md\` — the step-level summary that downstream evaluation and memorization read. Your synthesis process:
+
+1. Read each executor subagent's final response in order. The per-task record is authoritative; do not rely on memory.
+2. For each task, record: the task title, the verification that ran, the verification result, the artifacts produced, and any scope-boundary notes the executor flagged.
+3. Aggregate any gotchas the executors surfaced. Gotchas belong in the gotcha system; record them there before synthesizing.
+4. Note any tasks that were skipped, re-ordered, or returned to \`plan\` mid-step — the evaluator needs the history, not just the endpoint.
+5. Commit \`execution.md\` with the above. Do not assess the work's quality — execution_eval does that. Your job is to produce a faithful ledger of what happened.
+
+## completion
+
+Emit the SubagentStop completion signal once every plan task has a verified completion (or a recorded deferral), \`execution.md\` is written, and any executor-surfaced gotchas have been recorded.
+
+1. every task in the approved plan has a verified completion recorded in execution.md, or a deliberate deferral recorded with the user's agreement
+2. execution.md is written to the session's execution directory with a per-task ledger of scope, verification, result, and artifacts
+3. gotchas surfaced during execution have been written to the appropriate gotcha location before the step exits
+4. no task was marked complete on a failing verification without explicit user agreement recorded in execution.md
+
+## footer
+
+---
+## Step completion protocol
+
+You have finished this step's work when the criteria above are satisfied. Once they are met, run EXACTLY this command as your last action:
+
+  gobbi workflow transition COMPLETE
+
+The CLI's output is the authoritative record of step completion. No other phrasing — prose, markdown headers, comments — advances the workflow. Run the command, observe the printed next step, and stop.
+
+"
+`;
+
+exports[`renderMarkdown evaluation markdown render matches snapshot 1`] = `
+"# Evaluation — independent evaluator agents assess the preceding step's output from distinct perspectives. Reused by ideation_eval, planning_eval, and execution_eval via index.json's evalFor indirection. The creating agent never participates. NOTE: The transitions array below declares ideation_eval defaults (verdictRevise → ideation, verdictPass → planning). For planning_eval and execution_eval, the authoritative routing lives in index.json graph edges (e.g., planning_eval verdictPass → execution, execution_eval verdictPass → memorization). Do not restructure this spec to hold per-eval-variant transitions — the shared-spec design is intentional.
+
+## role
+
+You are the orchestrator of an Evaluation step. Your job is to spawn independent evaluator agents across at least two perspectives (Project and Overall are mandatory; more perspectives are selected based on the step under evaluation), collect their findings, and produce a single consolidated verdict the user decides what to act on.
+
+You are not an evaluator yourself. The evaluators assess; you frame the evaluation scope, delegate, discuss the findings with the user, and record the verdict. The creating agent of the preceding step must not participate in its own evaluation — that isolation is the reason evaluation is a separate step.
+
+## principles
+
+Evaluation principles:
+
+- Evaluators find problems, not confirmations. An evaluator that reports only successes has not done the job. Instruct each evaluator to surface concrete defects with severity and location.
+- Minimum two perspectives. Project and Overall are always included; additional perspectives (Architecture, Security, Performance, UX) are selected based on what the step under evaluation produced. A single-perspective evaluation is structurally blind.
+- Discuss before deciding. Evaluator findings are input, not instruction. Use AskUserQuestion to walk the user through each finding — they decide what to address, defer, or disagree with. Never auto-apply findings.
+- The verdict belongs to the user. You synthesize the findings into a proposed verdict (pass or revise), but the user commits. Revise verdicts include a \`loopTarget\` when issued from execution_eval — the user picks which prior step to return to.
+- Evaluators run on fresh context. Do not pass the preceding step's orchestrator transcript to evaluators. Each evaluator receives the artifacts under assessment and their perspective skill; their independence is the point.
+
+## scope-boundary
+
+Scope boundary:
+
+- This spec is reused for ideation_eval, planning_eval, and execution_eval via \`index.json\`'s \`evalFor\` indirection. The preceding step under evaluation is identified by the session state, not by the spec — read \`state.currentStep\` and its \`evalFor\` target when assembling the delegation prompts.
+- The \`transitions\` array in this spec declares ideation_eval defaults. For planning_eval and execution_eval, the graph (\`index.json\`) is authoritative: planning_eval verdictPass routes to execution, execution_eval verdictPass routes to memorization. Do not rely on the spec-level transitions for non-ideation eval routing.
+- Do not modify the artifacts under evaluation. Evaluation is read-only. If a finding requires a fix, that fix belongs in the loop-back step (ideation, planning, or execution), not here.
+- Do not spawn more than \`maxParallelAgents\` evaluators in a single wave. Cap set conservatively at five to keep the parallel response channel observable and to keep per-call rate-limit exposure bounded.
+- Stay in evaluation. Do not ask the user to make planning or implementation decisions here — the verdict is what exits the step; the next step handles the response.
+
+## feedback-context (conditional: feedbackRoundActive)
+
+Feedback round context:
+
+This evaluation is running after a prior loop-back — \`feedbackRound > 0\`. The preceding step has been re-attempted and this evaluation decides whether the re-attempt resolved the prior findings. Instruct each evaluator to read the prior round's findings — filename-suffixed artifacts in the flat \`evaluation/\` directory (e.g., \`project-r{N-1}.md\`, \`overall-r{N-1}.md\`, \`evaluation-r{N-1}.md\`) — alongside the current artifacts: the question is not "is this good" in isolation, but "did the revision actually address the prior defects." A clean round on the current artifacts but unaddressed prior findings is still a revise verdict.
+
+## delegation: evaluator.project
+
+You are an evaluator working the Project perspective.
+
+Your goal is to produce \`project.md\` — an adversarial assessment of the preceding step's artifacts from the project-documentation angle. You look for gaps, stale references, structural problems, missing context, and incomplete handoffs. You find what is wrong; you do not confirm success.
+
+Approach:
+
+- Read the artifacts under evaluation in full. Do not skim — structural defects live in the parts that look boring.
+- Read the prior-step inputs the current artifacts depend on (ideation → plan → execution chain). A plan that does not realize its ideation, or an execution that does not implement its plan, is a structural defect.
+- Surface findings with severity (critical, major, minor), location (file + section), and a concrete description of what is wrong. Vague findings are noise; they do not help the orchestrator decide what to fix.
+- Do not implement fixes. Do not propose specific code. Your output is the finding list — the orchestrator and user decide the response.
+
+Output: \`project.md\` under the session's evaluation directory. Include a brief perspective statement at the top so the synthesis step knows which evaluator authored it, then a findings list ordered by severity.
+
+## delegation: evaluator.overall
+
+You are an evaluator working the Overall perspective.
+
+Your goal is to produce \`overall.md\` — an integrative assessment of whether the preceding step's artifacts, taken together, deliver a coherent whole. You look for contradictions between artifacts, shape mismatches between plan and execution, and places where the parts are individually fine but the whole does not add up.
+
+Approach:
+
+- Read every artifact under evaluation, not just the most recent. The whole is the object of your assessment; a whole is more than its last file.
+- Ask: does this step's output, taken with its prior steps' outputs, realize the direction set at ideation? A step that drifts from the direction is a structural defect even when each piece looks locally correct.
+- Surface findings with severity (critical, major, minor), location (across which artifacts), and a concrete description of the integration defect.
+- Do not implement fixes. Do not relitigate decisions that the user already approved — your job is to find integration gaps, not to re-ideate.
+
+Output: \`overall.md\` under the session's evaluation directory. Include a brief perspective statement at the top, then a findings list ordered by severity.
+
+## synthesis
+
+Synthesis instructions:
+
+After all evaluators complete, produce \`evaluation.md\` — the consolidated verdict the workflow acts on. Your synthesis process:
+
+1. Read every evaluator artifact in full. Do not summarize them without reading; the severity labels and locations are load-bearing.
+2. Deduplicate findings that multiple evaluators raised. A finding flagged by two perspectives is stronger evidence than two findings of equal severity from one perspective; note the cross-perspective agreement explicitly.
+3. Propose a verdict: \`pass\` if no critical or major findings remain, \`revise\` otherwise. For execution_eval revise verdicts, propose a \`loopTarget\` (ideation, plan, or execution) — the target is determined by where the findings point.
+4. Discuss every finding with the user via AskUserQuestion. The user decides what to address, defer, or disagree with. Record the decisions.
+5. Commit \`evaluation.md\` with: the verdict, the loop target (for execution_eval revise), the deduplicated findings with their user-agreed disposition, and the per-evaluator artifact list.
+6. The CLI emits the \`decision.eval.verdict\` event on your completion signal; the verdict payload is read from \`evaluation.md\`.
+
+## completion
+
+Emit the SubagentStop completion signal once every evaluator artifact is written, \`evaluation.md\` is written with the verdict and agreed dispositions, and the user has confirmed the verdict.
+
+1. at least two evaluator artifacts are written — Project and Overall — to the session's evaluation directory
+2. evaluation.md is written with a verdict (pass or revise) and, for execution_eval revise verdicts, a loopTarget
+3. every finding from every evaluator has a user-agreed disposition recorded in evaluation.md
+4. no evaluator assessed the artifacts it helped create — creator-evaluator isolation is preserved
+5. the user has confirmed the verdict via AskUserQuestion before the completion signal is emitted
+
+## footer
+
+---
+## Step completion protocol
+
+You have finished this evaluation when the criteria above are satisfied and the user has confirmed the verdict. Once they are met, run EXACTLY ONE of the following commands as your last action:
+
+  gobbi workflow transition PASS
+    — Use this when no critical or major findings remain after user discussion.
+
+  gobbi workflow transition REVISE [--loop-target <step>]
+    — Use this when findings require re-entering a prior step. For execution_eval, include --loop-target with the user-agreed target (ideation, planning, or execution). For ideation_eval and planning_eval, the loop target is the preceding productive step by default.
+
+  gobbi workflow transition ESCALATE
+    — Use this when a critical structural defect requires user intervention outside the workflow. Routes to the error step.
+
+You MUST run exactly one of these as your last action. COMPLETE is not valid for evaluation steps. The CLI's output is the authoritative record; no other phrasing advances the workflow.
+
+"
+`;
+
+exports[`renderMarkdown memorization markdown render matches snapshot 1`] = `
+"# Memorization — read the session conversation, the rawdata path-pointer manifest, and the prior-step artifacts; extract decisions, state, open questions, and gotchas; and write them where the next session can find them. Productive step before the workflow transitions to handoff. Rawdata reaches the agent as a manifest of paths, not inlined content (per Spike 3, 2026-04-25).
+
+## role
+
+You are the orchestrator of the Memorization step. Your job is to read the session's produced artifacts and conversation, extract what should persist beyond this session, and commit that to the places where the next session can discover it.
+
+Memorization is orchestrator-authored. You do not delegate; you do not evaluate. You collect, verify the collection is faithful, and write. The artifact you produce here is what a future session reads to resume without re-discovery.
+
+## principles
+
+Memorization principles:
+
+- Capture context for session continuity. Decisions made, state at completion, open questions, and gotchas recorded — the next session should be able to resume without re-discovering any of them.
+- Write gotchas before writing the memorization artifact. A gotcha not recorded before the session ends is a gotcha lost. Walk the conversation for corrections, platform quirks, and non-obvious constraints the user surfaced; commit them to the gotcha system first.
+- Ensure project documentation reflects what was done. If the session added files, changed conventions, or set precedent, the project README / design docs / gotcha index must reflect that before the step completes. A memorization artifact that references undocumented changes is a broken handoff.
+- Be faithful to the record, not to the intent. Memorize what happened, including what went wrong, what was deferred, and what the user chose differently from recommendations. Rewriting history optimistically is the failure mode memorization exists to prevent.
+- Read the rawdata manifest, do not assume inlined content. The artifact section of this prompt lists rawdata as path pointers — file paths plus one-line purpose tags — not the file contents themselves. For each section of \`memorization.md\` you write, decide which manifest entries are load-bearing and read those files with the Read tool. Do not assume the manifest exhausts what is needed; also consult \`git log\`, the project README, and any decisions/gotchas under \`.gobbi/projects/<name>/learnings/\` that the session touched.
+
+## scope-boundary
+
+Scope boundary:
+
+- Memorization does not evaluate the work. Execution_eval has already run (it is mandatory); do not re-litigate its verdict here.
+- Memorization does not re-open prior steps. If you find a gap while memorizing, record it as an open question in the memorization artifact — the user decides in the next session whether to loop back.
+- Memorization does not implement deferred work. The Out-of-scope list from the plan, plus any adjacent improvements surfaced during execution, belong in the memorization artifact as named open items, not as new edits.
+- Write only to memorization-scope locations: the session's \`memorization/\` directory, the project's \`learnings/decisions/\`, the project's \`learnings/gotchas/\`, and the project's README/design files when the session affected them. Do not touch artifacts of prior steps.
+
+## artifact-shape
+
+Memorization artifact shape:
+
+Write \`memorization.md\` with the following structure so the next session can read it deterministically:
+
+1. \`Summary\` — one paragraph: what this session accomplished, in the session's own terms.
+2. \`Decisions\` — ordered list of the decisions made this session (architectural choices, scope calls, deferrals). Each decision names what was chosen, what was rejected, and why.
+3. \`State at completion\` — the concrete state the next session inherits: files changed, branches created, PRs opened, tests added, features shipped.
+4. \`Open questions\` — named questions this session did not resolve, each with a one-line note on who is expected to resolve it and what the next step looks like.
+5. \`Gotchas recorded\` — a bulleted list pointing at gotcha files written this session, with a one-line summary per gotcha so the next session can grep for the one it needs.
+6. \`Pointers\` — references to the session's key artifacts (ideation.md, plan.md, execution.md, evaluation.md) so the next session can dive deeper without searching.
+
+The shape is stable on purpose: future sessions' first action is to read the most recent memorization artifact; a predictable shape keeps resumption fast.
+
+## rawdata-manifest-contract
+
+Rawdata is delivered as a path-pointer manifest, not as inlined content:
+
+The artifact slot of this prompt holds a manifest — a list of file paths, sizes, kinds, and one-line purpose tags — that names every rawdata source the memorization step considers in scope. The manifest does NOT carry the content of those files. You read the files yourself, with the Read tool, on demand and selectively per section of \`memorization.md\` you are writing.
+
+Why: inlining 30+ rawdata transcripts at a 0.3 artifacts budget caused the budget allocator to drop the entire dynamic-context section wholesale (whole-section atomic inclusion). The manifest pattern keeps the prompt small and predictable while still naming every source the agent must be able to reach. See \`learnings/decisions/2026-04-25-spike-3-memorization-compile-latency.md\` for the empirical record.
+
+Manifest format:
+
+The manifest renders as a markdown table with columns \`path | bytes | kind | purpose\`. Rows group by \`kind\`. Recognized \`kind\` values: \`subagent\` (subagent transcripts), \`main\` (orchestrator/main session transcript), \`state-snapshot\` (event-store extracts and \`state.db\` snapshots), \`learnings-decision\` (recent decisions written this session), \`learnings-gotcha\` (gotchas written this session), \`step-artifact\` (the durable per-step \`*.md\` files), \`exit-plan\` (ExitPlanMode captures), \`step-readme\` (per-step \`README.md\` if present).
+
+Reading rules:
+
+- Read selectively. Open a manifest file only when its \`kind\` and \`purpose\` are load-bearing for the section of \`memorization.md\` you are currently writing. A \`subagent\` transcript is load-bearing for \`Decisions\` and \`Gotchas recorded\`; a \`state-snapshot\` is load-bearing for \`State at completion\`; a \`learnings-decision\` is load-bearing for \`Pointers\` and may already capture what you would otherwise duplicate.
+- The manifest is not exhaustive. Also consult \`git log\` for the session's commit shape, the project's \`README.md\` and \`design/\` tree for convention changes, and any prior-session \`memorization.md\` linked from \`learnings/\`.
+- When the manifest is absent or empty (e.g. an early session, or a session run before the runtime manifest generator landed), fall back to a direct walk of the session's \`sessions/<id>/\` subtree and the orchestrator transcript path recorded in \`metadata.json\`.
+
+## force-memorization-context (conditional: feedbackCapExceeded)
+
+Force-memorization recovery context:
+
+This memorization run was entered via the force-memorization recovery pathway — the workflow hit the feedback-round cap at execution_eval and the user opted to persist partial work rather than abort. Treat the memorization artifact as a partial record: explicitly note which plan tasks converged, which did not, and what the accumulated evaluation findings say about the blocked tasks. Future sessions reading this artifact must see that the work is partial — do not smooth the unfinished state into a success narrative.
+
+## synthesis
+
+Synthesis instructions:
+
+Memorization is orchestrator-authored — no delegated agents contribute. Your synthesis is the memorization artifact itself, plus the durable extractions that flow out of it. Use the rawdata manifest in the artifact section as the path index; do not expect content to be inlined.
+
+Rawdata sources you may need to read (the manifest enumerates these as path pointers):
+
+1. Main session transcript — \`~/.claude/projects/-playinganalytics-git-gobbi/<session-id>.jsonl\`. The orchestrator's full conversation log; authoritative for user corrections, decisions, deferrals.
+2. Subagent transcripts — \`~/.claude/projects/-playinganalytics-git-gobbi/<session-id>/subagents/*.jsonl\`. Per-subagent runs, useful for verifying what each delegated agent actually did.
+3. Captured rawdata — \`.gobbi/projects/<name>/sessions/<session-id>/raw-data/transcripts/*.jsonl\`. Files copied into the session by \`gobbi capture-subagent\` / capture hooks.
+4. Recent project decisions — \`.gobbi/projects/<name>/learnings/decisions/*.md\`. The latest entries (including spike outcomes) often subsume what you would otherwise re-record.
+5. Mid-session gotchas — \`.gobbi/projects/<name>/learnings/gotchas/*.md\`. Gotchas written during the session you may need to escalate or cross-reference.
+6. Per-step durable artifacts — \`sessions/<session-id>/{ideation,planning,execution,execution_eval}/*.md\`. The committed records of each prior step.
+7. State-snapshot extracts — rows from the workspace event store for this session, available via \`gobbi workflow events\` and surfaced by the manifest as \`state-snapshot\` entries.
+
+Extraction destinations (where you write):
+
+1. \`.gobbi/projects/<name>/sessions/<session-id>/memorization/memorization.md\` — the per-session record (the artifact named in \`meta.expectedArtifacts\`). Use the structure from \`Memorization artifact shape\`.
+2. \`.gobbi/projects/<name>/learnings/decisions/<YYYY-MM-DD>-<slug>.md\` — one file per durable decision the session locked. Cross-link from \`memorization.md::Decisions\`.
+3. \`.gobbi/projects/<name>/learnings/gotchas/<slug>.md\` — one file per non-obvious correction the user surfaced. Write these BEFORE writing \`memorization.md\` so the artifact's \`Gotchas recorded\` section has real files to point at.
+4. Auto-memory updates — when a session's outcome warrants an entry in the user-level \`MEMORY.md\` index (e.g. a shipped PR, a phase milestone), update the index and add or update the per-topic memory file alongside it.
+5. Project documentation — README/design entries for any convention, precedent, or directory-structure change the session introduced.
+
+Pipeline:
+
+1. Read the rawdata manifest in the artifact section. Note which paths each section of \`memorization.md\` will need.
+2. Walk the session end-to-end via the manifest's main + subagent + captured-rawdata entries. Note every correction the user issued, every decision that replaced a recommended option, every deferral. These are the highest-value entries.
+3. Cross-check against each step's artifact (\`ideation.md\`, \`plan.md\`, \`execution.md\`, \`evaluation.md\`) — read them via the manifest's \`step-artifact\` rows — to confirm the decisions and state you are about to record match the durable artifacts.
+4. Write gotchas first under \`learnings/gotchas/\`. Every non-obvious correction becomes a gotcha entry. A correction not recorded is a correction repeated across sessions.
+5. Write durable decisions next under \`learnings/decisions/\`, one file per locked decision.
+6. Update project documentation and the user-level MEMORY index for any session-level change.
+7. Commit \`memorization.md\` at \`sessions/<session-id>/memorization/memorization.md\` using the structure in the \`Memorization artifact shape\` section. Cross-link the gotcha and decision files you just wrote in \`Gotchas recorded\` and \`Pointers\`.
+8. Emit the completion signal — the CLI transitions the workflow to the next step (\`handoff\`) on the \`always\` transition; handoff then writes the narrow cover-sheet artifact and finishes the workflow.
+
+## completion
+
+Emit the Stop completion signal once \`memorization.md\` is written, gotchas have been committed to the gotcha system, project documentation reflects the session's durable changes, and any new decisions or auto-memory entries the session warrants have been written.
+
+1. memorization.md is written at the session's memorization directory with Summary, Decisions, State at completion, Open questions, Gotchas recorded, and Pointers sections
+2. every non-obvious correction from the session has a corresponding entry under \`.gobbi/projects/<name>/learnings/gotchas/\`
+3. every durable decision the session locked has a corresponding entry under \`.gobbi/projects/<name>/learnings/decisions/<YYYY-MM-DD>-<slug>.md\`, cross-linked from memorization.md
+4. the user-level MEMORY.md index has been updated with any per-session entry the session warrants (e.g. shipped PR, phase milestone)
+5. project README and design docs reflect any convention, precedent, or scope change the session introduced
+6. no prior-step artifacts have been modified by this step — memorization is write-forward only
+
+## footer
+
+---
+## Step completion protocol
+
+You have finished this step's work when the criteria above are satisfied. Once they are met, run EXACTLY this command as your last action:
+
+  gobbi workflow transition COMPLETE
+
+The CLI's output is the authoritative record of step completion. No other phrasing — prose, markdown headers, comments — advances the workflow. Run the command, observe the printed next step, and stop.
+
+"
+`;
+
+exports[`renderMarkdown handoff markdown render matches snapshot 1`] = `
+"# Handoff — read the just-written memorization artifact and the session's terminal-state record, then write a tight hand-off note for the next session. Last productive step; the workflow transitions to done after it completes.
+
+## role
+
+You are the orchestrator of the Handoff step. Your job is to read the just-written memorization artifact and the session's terminal-state record, then produce a narrow, high-signal hand-off note that the next session can read first to resume without re-discovery.
+
+Handoff is orchestrator-authored. You do not delegate; you do not evaluate. You read the wider record memorization wrote, distill it to what the next session must know, and commit a single tight artifact. Memorization is the long record; handoff is the cover sheet that points into it.
+
+## principles
+
+Handoff principles:
+
+- Narrow over wide. Memorization captured everything that should persist; handoff captures only what the next session must read first. A reader who only opens \`handoff.md\` should know what shipped, what is still open, what locks not to re-litigate, and where to dig deeper. They should not need to skim the full memorization artifact to decide what to do next.
+- Faithful to the record, not to the intent. Quote the memorization artifact's language for decisions and open threads rather than restating optimistically. If memorization says a task did not converge, handoff says the same — never smooth an unfinished state into a success narrative.
+- Pointers, not duplication. The decisions, gotchas, and design notes live in their own files post-memorization. Handoff names the paths and the one-line gist; the next session reads the source when it needs the detail.
+- Tight by construction. The artifact targets ~5 sentences in \`What was shipped\`, bulleted lists elsewhere, and stops there. Handoff that grows to memorization size has lost its purpose.
+
+## scope-boundary
+
+Scope boundary:
+
+- Handoff does not re-do memorization's work. Memorization already wrote \`memorization.md\`, the per-class extraction files, and any project documentation updates. Handoff reads those outputs and synthesizes the cover sheet — it does not write new gotchas, decisions, or design entries.
+- Handoff does not re-open prior steps. If you find a gap while reading memorization, record it as an open thread in \`handoff.md\` — the next session decides whether to address it.
+- Handoff writes only to handoff-scope locations: the session's \`handoff/\` directory and the workspace \`gobbi.db::memories\` row of class \`'handoff'\`. Do not modify \`memorization.md\`, prior-step artifacts, or any project documentation.
+- One artifact. Handoff produces exactly \`handoff.md\` plus one memory row. No supplementary files, no second cover sheet — narrowness is the contract.
+
+## artifact-shape
+
+Handoff artifact shape:
+
+Write \`handoff.md\` at \`sessions/<id>/handoff/handoff.md\` with the following structure so the next session reads it deterministically:
+
+1. \`What was shipped\` — one paragraph, max ~5 sentences. The session's net deliverable in its own terms, with PR/commit references if any. If the session ended via the force-memorization recovery pathway, state that here — the partial-record framing must reach handoff, not be smoothed away.
+2. \`Open threads — read these first\` — bulleted list of unresolved items the next session needs to know about. Each bullet is a one-liner; pointers go to \`memorization.md\` or other files for detail.
+3. \`Decisions you should respect\` — bulleted list of locks made this session that the next session should not re-litigate. Quote the decision in the memorization artifact's language; do not paraphrase.
+4. \`Pointers\` — references to the session's load-bearing artifacts: \`memorization.md\` (always), key files changed, key issues filed or closed, the worktree path if relevant. The next session uses these to dive deeper without grepping the session tree.
+
+The shape is stable on purpose. Future sessions' first action is to read the most recent \`handoff.md\`; a predictable shape keeps resumption fast and the cover-sheet contract honest. A handoff longer than ~150 lines is over-budget — trim toward pointers.
+
+## synthesis
+
+Synthesis instructions:
+
+Handoff is orchestrator-authored — no delegated agents contribute. Your synthesis is the hand-off artifact itself:
+
+1. Read \`sessions/<id>/memorization/memorization.md\` end-to-end. This is the wider record; handoff is the cover sheet that points into it.
+2. Read the last-N events from the workspace event store for this session — terminal-state inspection. The events tell you whether the session reached \`done\` cleanly or via the force-memorization recovery pathway; that framing must reach the artifact.
+3. Distill \`memorization.md\` to the four-section shape in the \`Handoff artifact shape\` section. Quote the memorization artifact's language for decisions and open threads — paraphrase loses fidelity.
+4. Write \`handoff.md\` at \`sessions/<id>/handoff/handoff.md\`.
+5. Write one row into the workspace memories store with \`class='handoff', session_id=<id>, project_id=<resolved>\`, body equal to the rendered artifact. The next session's CLI pulls this row as ambient context for its first step.
+6. Emit the completion signal — the CLI transitions the workflow to \`done\` on the \`always\` transition.
+
+## completion
+
+Emit the Stop completion signal once \`handoff.md\` is written at \`sessions/<id>/handoff/handoff.md\` and a \`class='handoff'\` row has been added to the workspace memories store.
+
+1. handoff.md exists at sessions/<id>/handoff/handoff.md with What was shipped, Open threads, Decisions you should respect, and Pointers sections
+2. exactly one row of class='handoff' has been added to the workspace memories store with the rendered artifact body and the resolved session_id and project_id
+3. the artifact stays narrow — pointers replace duplication, no new gotchas/decisions/design entries are introduced (those belong to memorization)
+4. no prior-step artifacts have been modified — handoff is write-forward only into the session's handoff directory
+
+## footer
+
+---
+## Step completion protocol
+
+You have finished this step's work when the criteria above are satisfied. Once they are met, run EXACTLY this command as your last action:
+
+  gobbi workflow transition COMPLETE
+
+The CLI's output is the authoritative record of step completion. No other phrasing — prose, markdown headers, comments — advances the workflow. Run the command, observe the printed next step, and stop.
+
+"
+`;

--- a/packages/cli/src/commands/prompt/__tests__/patch.test.ts
+++ b/packages/cli/src/commands/prompt/__tests__/patch.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for `commands/prompt/patch.ts` — Wave C.1.6 (issue #156).
+ *
+ * Covers:
+ *
+ *   - `mergeTestOp` (synthesis §9.2 step 3 / Overall F-7) — the three
+ *     test-op merge cases and a few hand-picked edge cases.
+ *   - `runPromptPatchOnFiles` validation pipeline — fails at every gate
+ *     in the §9.2 fail-fast ladder. Uses scratch directory + `--dry-run`
+ *     to avoid touching real state.db / real spec.json files. The full
+ *     commit-phase test lives in the e2e test
+ *     (`__tests__/e2e/prompt-patch.test.ts`).
+ */
+
+import { describe, test, expect } from 'bun:test';
+import type { Operation } from 'fast-json-patch';
+
+import { mergeTestOp } from '../patch.js';
+
+describe('mergeTestOp', () => {
+  test('case 1 — no test op anywhere: synthesizes /version test at index 0', () => {
+    const operatorOps: Operation[] = [
+      { op: 'replace', path: '/meta/description', value: 'updated' },
+    ];
+    const result = mergeTestOp(operatorOps);
+    expect(result.synthesizedTestOp).toBe(true);
+    expect(result.mergedOps).toEqual([
+      { op: 'test', path: '/version', value: 1 },
+      { op: 'replace', path: '/meta/description', value: 'updated' },
+    ]);
+  });
+
+  test('case 2 — operator authored test-at-index-0-on-/version: keep as-is', () => {
+    const operatorOps: Operation[] = [
+      { op: 'test', path: '/version', value: 1 },
+      { op: 'replace', path: '/meta/description', value: 'updated' },
+    ];
+    const result = mergeTestOp(operatorOps);
+    expect(result.synthesizedTestOp).toBe(false);
+    expect(result.mergedOps).toEqual(operatorOps);
+  });
+
+  test('case 3 — operator test op elsewhere: prepend synth /version test, preserve operator tests', () => {
+    const operatorOps: Operation[] = [
+      { op: 'replace', path: '/meta/description', value: 'updated' },
+      { op: 'test', path: '/version', value: 1 },
+    ];
+    const result = mergeTestOp(operatorOps);
+    expect(result.synthesizedTestOp).toBe(true);
+    expect(result.mergedOps[0]).toEqual({
+      op: 'test',
+      path: '/version',
+      value: 1,
+    });
+    // Operator's test op preserved at original index (now offset by 1).
+    expect(result.mergedOps).toHaveLength(3);
+  });
+
+  test('case 3 — operator test on different path: prepend synth, preserve operator', () => {
+    const operatorOps: Operation[] = [
+      { op: 'test', path: '/meta/description', value: 'baseline' },
+      { op: 'replace', path: '/meta/description', value: 'updated' },
+    ];
+    const result = mergeTestOp(operatorOps);
+    expect(result.synthesizedTestOp).toBe(true);
+    expect(result.mergedOps[0]).toEqual({
+      op: 'test',
+      path: '/version',
+      value: 1,
+    });
+    // Operator's test on /meta/description preserved.
+    expect(result.mergedOps[1]).toEqual({
+      op: 'test',
+      path: '/meta/description',
+      value: 'baseline',
+    });
+  });
+
+  test('case 2 vs. case 3 boundary — test op at index 0 on a non-/version path triggers synth', () => {
+    const operatorOps: Operation[] = [
+      { op: 'test', path: '/version', value: 2 }, // wrong value but path matches
+      { op: 'replace', path: '/version', value: 2 },
+    ];
+    // Path matches /version so this stays as case 2: keep as-is. The
+    // test-op value mismatch is the operator's responsibility.
+    const result = mergeTestOp(operatorOps);
+    expect(result.synthesizedTestOp).toBe(false);
+    expect(result.mergedOps).toEqual(operatorOps);
+  });
+
+  test('empty operator ops: synthesizes a single /version test', () => {
+    const result = mergeTestOp([]);
+    expect(result.synthesizedTestOp).toBe(true);
+    expect(result.mergedOps).toEqual([
+      { op: 'test', path: '/version', value: 1 },
+    ]);
+  });
+
+  test('multiple operator test ops, none at index 0 on /version: prepend synth, all preserved', () => {
+    const operatorOps: Operation[] = [
+      { op: 'replace', path: '/meta/description', value: 'updated' },
+      { op: 'test', path: '/meta/description', value: 'baseline' },
+      { op: 'test', path: '/version', value: 1 },
+    ];
+    const result = mergeTestOp(operatorOps);
+    expect(result.synthesizedTestOp).toBe(true);
+    expect(result.mergedOps).toHaveLength(4);
+    expect(result.mergedOps[0]).toEqual({
+      op: 'test',
+      path: '/version',
+      value: 1,
+    });
+  });
+});

--- a/packages/cli/src/commands/prompt/__tests__/rebuild.test.ts
+++ b/packages/cli/src/commands/prompt/__tests__/rebuild.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for `commands/prompt/rebuild.ts` — Wave C.1.7 (issue #156).
+ *
+ * Subprocess-driven tests for the recovery command. Covers exit-code
+ * semantics for every failure mode plus the dry-run happy path.
+ *
+ * The pure-function `foldChain` is tested in
+ * `lib/__tests__/prompt-evolution.test.ts`. Here we test the CLI
+ * dispatch + flag parsing + exit-code surface.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { $ } from 'bun';
+import { join } from 'node:path';
+
+const CLI_PATH = join(import.meta.dir, '..', '..', '..', 'cli.ts');
+
+describe('gobbi prompt rebuild — argv + dry-run smoke (subprocess)', () => {
+  test('--help prints usage and exits 0', async () => {
+    const result = await $`bun run ${CLI_PATH} prompt rebuild --help`
+      .nothrow()
+      .quiet();
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString('utf8')).toContain(
+      'Usage: gobbi prompt rebuild',
+    );
+  });
+
+  test('missing <prompt-id> exits 2', async () => {
+    const result = await $`bun run ${CLI_PATH} prompt rebuild`.nothrow().quiet();
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr.toString('utf8')).toContain('missing <prompt-id>');
+  });
+
+  test('unknown prompt-id exits 1 with the closed-set message', async () => {
+    const result = await $`bun run ${CLI_PATH} prompt rebuild not-a-step`
+      .nothrow()
+      .quiet();
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString('utf8')).toContain('invalid prompt-id');
+  });
+
+  test('valid prompt-id with no JSONL chain exits 1 with a clear diagnostic', async () => {
+    // The repo has no JSONL chain (Wave C.1 ships no chain bootstrap;
+    // the chain is created on first `gobbi prompt patch
+    // --allow-no-parent`). So `gobbi prompt rebuild ideation` should
+    // refuse with the chain-not-found message.
+    const result = await $`bun run ${CLI_PATH} prompt rebuild ideation --dry-run`
+      .nothrow()
+      .quiet();
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString('utf8')).toContain(
+      'prompt-evolution chain not found',
+    );
+  });
+
+  test('dispatcher routes "rebuild" through the prompt registry', async () => {
+    // Verify `gobbi prompt --help` lists rebuild.
+    const result = await $`bun run ${CLI_PATH} prompt --help`.nothrow().quiet();
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString('utf8')).toContain('rebuild');
+  });
+});

--- a/packages/cli/src/commands/prompt/__tests__/render.snap.test.ts
+++ b/packages/cli/src/commands/prompt/__tests__/render.snap.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for `commands/prompt/render.ts` — the markdown + composed
+ * formatters used by `gobbi prompt render`.
+ *
+ * Wave C.1.5 (issue #156). Snapshot tests pin the markdown output;
+ * cache-stability tests assert that `composed` form's
+ * `staticPrefixHash` is reproducible across two compile passes.
+ *
+ * Diff form is exercised end-to-end in C.1.6's e2e test (after the
+ * patch command can populate the JSONL chain). Here we cover the
+ * formatters that do not require a live chain.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { renderComposed, renderMarkdown } from '../render.js';
+import { validateStepSpec } from '../../../specs/_schema/v1.js';
+import type { StepSpec } from '../../../specs/types.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SPECS_ROOT = resolve(HERE, '..', '..', '..', 'specs');
+
+function loadSpec(promptId: string): StepSpec {
+  const path = resolve(SPECS_ROOT, promptId, 'spec.json');
+  const raw = JSON.parse(readFileSync(path, 'utf8')) as unknown;
+  const result = validateStepSpec(raw);
+  if (!result.ok) {
+    throw new Error(`spec ${promptId} failed validation`);
+  }
+  return result.value;
+}
+
+const PROMPT_IDS = [
+  'ideation',
+  'planning',
+  'execution',
+  'evaluation',
+  'memorization',
+  'handoff',
+] as const;
+
+describe('renderMarkdown', () => {
+  for (const promptId of PROMPT_IDS) {
+    test(`${promptId} markdown render matches snapshot`, () => {
+      const spec = loadSpec(promptId);
+      const out = renderMarkdown(spec);
+      expect(out).toMatchSnapshot();
+    });
+  }
+
+  test('markdown ends with a single trailing newline', () => {
+    const spec = loadSpec('ideation');
+    const out = renderMarkdown(spec);
+    expect(out.endsWith('\n')).toBe(true);
+    // No double trailing newlines.
+    expect(out.endsWith('\n\n\n')).toBe(false);
+  });
+
+  test('markdown contains the description as the H1 heading', () => {
+    const spec = loadSpec('ideation');
+    const out = renderMarkdown(spec);
+    expect(out.startsWith(`# ${spec.meta.description}`)).toBe(true);
+  });
+
+  test('markdown contains every block.static id as an H2 heading', () => {
+    const spec = loadSpec('ideation');
+    const out = renderMarkdown(spec);
+    for (const block of spec.blocks.static) {
+      expect(out).toContain(`## ${block.id}`);
+    }
+  });
+
+  test('markdown contains every delegation key as an H2 with prefix', () => {
+    const spec = loadSpec('ideation');
+    const out = renderMarkdown(spec);
+    for (const key of Object.keys(spec.blocks.delegation)) {
+      expect(out).toContain(`## delegation: ${key}`);
+    }
+  });
+
+  test('markdown carries the footer as an H2 section', () => {
+    const spec = loadSpec('ideation');
+    const out = renderMarkdown(spec);
+    expect(out).toContain('## footer');
+    // The footer body is rendered too — assert one byte from the footer.
+    expect(out).toContain(spec.blocks.footer.trim().slice(0, 30));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// composed — cache stability invariant (synthesis §8.1)
+// ---------------------------------------------------------------------------
+
+describe('renderComposed', () => {
+  test('two consecutive composed renders for the same spec/promptId produce identical output', () => {
+    const spec = loadSpec('ideation');
+    const a = renderComposed(spec, 'ideation');
+    const b = renderComposed(spec, 'ideation');
+    expect(a).toBe(b);
+  });
+
+  test('composed output prefixes the staticPrefixHash header line', () => {
+    const spec = loadSpec('ideation');
+    const out = renderComposed(spec, 'ideation');
+    // The hash format is whatever assembly.ts emits; we accept the
+    // non-empty hex form and any optional algorithm prefix.
+    expect(out).toMatch(
+      /^# gobbi prompt render ideation --format=composed\n# staticPrefixHash: [\w:]+\n/,
+    );
+  });
+
+  test('composed output contains the footer text from the spec', () => {
+    const spec = loadSpec('planning');
+    const out = renderComposed(spec, 'planning');
+    expect(out).toContain(spec.blocks.footer.trim().slice(0, 30));
+  });
+});

--- a/packages/cli/src/commands/prompt/patch.ts
+++ b/packages/cli/src/commands/prompt/patch.ts
@@ -426,9 +426,18 @@ export async function runPromptPatchOnFiles(
       // Synthesize genesis from the pre-patch spec. Atomic — event +
       // projection share one transaction (Wave C.1.6 R1, Architecture
       // F-1 fix).
-      const genesisContentId = contentHash([
+      //
+      // The events idempotency `contentId` is namespaced by `promptId`
+      // (Architecture F-4 fix, Wave C.1.6 R1): the same RFC 6902 ops
+      // array applied across two prompts (e.g., the same `add /`
+      // synthesized from two different baseline specs) must produce
+      // two distinct event rows, not one. Without the prefix the
+      // events table would dedup at the second `gobbi prompt patch`
+      // and the projection insert would be skipped.
+      const genesisPatchId = contentHash([
         { op: 'add', path: '', value: specRaw },
       ]);
+      const genesisContentId = `${inputs.promptId}:${genesisPatchId}`;
       // `genesisEntryRef` is captured inside the projection callback so
       // the post-callback code can append the JSONL line and read the
       // projection seq without re-querying. TypeScript's flow analysis
@@ -448,7 +457,7 @@ export async function runPromptPatchOnFiles(
           sessionId,
           data: JSON.stringify({
             promptId: inputs.promptId,
-            patchId: genesisContentId,
+            patchId: genesisPatchId,
             parentPatchId: null,
             preHash: contentHash({}),
             postHash: preHash,
@@ -493,11 +502,14 @@ export async function runPromptPatchOnFiles(
         parentSeq = genesisProjectionSeq;
       } else {
         // Genesis event was deduped (someone else just wrote it). Read
-        // back the existing genesis row and continue.
+        // back the existing genesis row and continue. Note: the
+        // projection row's `patch_id` column stores the raw patch hash
+        // (NOT the events idempotency `contentId`, which is namespaced
+        // by promptId per Architecture F-4).
         const dedupedSeq = readPatchSeqByContent(
           store,
           inputs.promptId,
-          genesisContentId,
+          genesisPatchId,
         );
         if (dedupedSeq === null) {
           throw new Error(
@@ -520,13 +532,22 @@ export async function runPromptPatchOnFiles(
     // SQLite IMMEDIATE transaction. A SIGKILL between the events INSERT
     // and the prompt_patches INSERT rolls both back rather than leaving
     // an orphan event row (Wave C.1.6 R1 / Architecture F-1 fix).
+    //
+    // The events idempotency `contentId` is namespaced by `promptId`
+    // (Architecture F-4 fix, Wave C.1.6 R1): a byte-identical RFC 6902
+    // ops array applied across two prompts (e.g., a generic
+    // `add /meta/notes` op meaningful for both `ideation` and
+    // `planning`) must produce two distinct event rows. Without the
+    // prefix the second invocation would dedup at the events table
+    // and skip the projection write entirely.
+    const eventContentId = `${inputs.promptId}:${patchId}`;
     const eventRow = store.appendWithProjection(
       {
         ts,
         type: 'prompt.patch.applied',
         actor: 'operator',
         idempotencyKind: 'content',
-        contentId: patchId,
+        contentId: eventContentId,
         sessionId,
         data: JSON.stringify({
           promptId: inputs.promptId,

--- a/packages/cli/src/commands/prompt/patch.ts
+++ b/packages/cli/src/commands/prompt/patch.ts
@@ -609,7 +609,6 @@ export async function runPromptPatchOnFiles(
       preHash,
       postHash,
       ops: mergedOps,
-      validationStatus: 'passed',
       appliedBy: 'operator',
       eventSeq: eventRow.seq,
       schemaId: STEP_SPEC_SCHEMA_ID,

--- a/packages/cli/src/commands/prompt/patch.ts
+++ b/packages/cli/src/commands/prompt/patch.ts
@@ -1,0 +1,859 @@
+/**
+ * gobbi prompt patch — apply an RFC 6902 patch to a per-step `spec.json`.
+ *
+ * Wave C.1.6 (issue #156). Operator-only (synthesis lock 3); the
+ * orchestrator never mutates prompts mid-session. Atomic across SQLite
+ * (event row + prompt_patches projection row) and the filesystem
+ * (JSONL append + temp+rename spec.json overwrite).
+ *
+ * # Validation pipeline (synthesis §9.2 fail-fast ladder)
+ *
+ *   1. Parse patch JSON. Reject non-array roots (RFC 6902 §3).
+ *   2. JSON-shape check every op (op + path required, op enum closed).
+ *   3. Test-op merge logic (synthesis §9.2 step 3, Overall F-7 fix):
+ *      - No `test` op anywhere → synthesize `{op:'test', path:'/version',
+ *        value:1}` at index 0; warn on stderr.
+ *      - Operator-authored `test` op already at index 0 testing
+ *        `/version` → keep as-is, no synthesis.
+ *      - Operator-authored `test` op(s) elsewhere or testing other paths
+ *        → prepend the synthesized `/version` test; preserve operator's
+ *        tests in their original positions.
+ *   4. Resolve baseline. Read on-disk `spec.json`, compute `pre_hash`.
+ *      If `--baseline <hash>` is supplied, refuse unless on-disk hash
+ *      matches. Otherwise (no --baseline) refuse if the on-disk
+ *      `pre_hash` ≠ the last patch row's `post_hash` (Overall F-5 fix
+ *      via Planning routed-resolution).
+ *   5. Simulate via `fast-json-patch::applyPatch` on a deep clone.
+ *   6. Schema-validate the candidate via `validateStepSpec`.
+ *   7. Compile-test the candidate via `assembly.compile()` (synthetic
+ *      deterministic state).
+ *   8. Compute post_hash.
+ *   9. If --validate-only or --dry-run: print + exit 0, no writes.
+ *   10. Commit phase: SQL transaction (event + projection row) → JSONL
+ *       append → atomic temp+rename spec.json.
+ *
+ * # Crash recovery
+ *
+ *   - Crash after SQL commit, before JSONL: re-running the same patch
+ *     hits the events idempotency_key, hits the prompt_patches UNIQUE
+ *     event_seq, and JSONL append fires once — end state correct.
+ *   - Crash after JSONL append, before spec.json rename: JSONL has the
+ *     entry, DB has the row, spec.json is stale. Next `gobbi prompt
+ *     patch` invocation detects (`pre_hash` of on-disk spec ≠ last
+ *     patch row's post_hash) and refuses with the rebuild diagnostic.
+ *
+ * # Source vs. installed CLI
+ *
+ * Patches the source `packages/cli/src/specs/<step>/spec.json`, NOT
+ * the bundled `dist/`. Operators on the installed CLI cannot patch
+ * installed prompts; they patch the source repo and rebuild.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { parseArgs } from 'node:util';
+import { applyPatch, deepClone, validate } from 'fast-json-patch';
+import type { Operation } from 'fast-json-patch';
+
+import { Database } from 'bun:sqlite';
+
+import {
+  compile,
+  type CompileInput,
+  type CompilePredicateRegistry,
+  type DynamicContext,
+} from '../../specs/assembly.js';
+import { defaultBudgetAllocator } from '../../specs/budget.js';
+import { validateStepSpec } from '../../specs/_schema/v1.js';
+import {
+  STEP_SPEC_SCHEMA_ID,
+} from '../../specs/_schema/v1.js';
+import type { StepSpec } from '../../specs/types.js';
+import { initialState } from '../../workflow/state.js';
+import type { WorkflowStep } from '../../workflow/state.js';
+import { defaultPredicates } from '../../workflow/predicates.js';
+import { EventStore } from '../../workflow/store.js';
+import {
+  appendJsonlSync,
+  buildGenesisEntry,
+  contentHash,
+} from '../../lib/prompt-evolution.js';
+import type { PromptEvolutionEntry } from '../../lib/prompt-evolution.js';
+import { canonicalize } from '../../lib/canonical-json.js';
+import { getRepoRoot } from '../../lib/repo.js';
+import { workspaceRoot } from '../../lib/workspace-paths.js';
+import {
+  PROMPT_ID_VALUES,
+  ensurePromptEvolutionDir,
+  isPromptId,
+  promptEvolutionPath,
+  resolveProjectName,
+  specJsonPath,
+  type PromptId,
+} from './paths.js';
+
+// ---------------------------------------------------------------------------
+// Usage
+// ---------------------------------------------------------------------------
+
+const USAGE = `Usage: gobbi prompt patch <prompt-id> --patch <json-patch-file> [options]
+
+Apply an RFC 6902 patch to a per-step spec.json. Operator-only — the
+orchestrator never mutates prompts mid-session.
+
+Arguments:
+  <prompt-id>             One of: ${PROMPT_ID_VALUES.join(', ')}.
+
+Options:
+  --patch <file>          Path to a JSON file containing an RFC 6902 ops
+                          array. Required.
+  --baseline <hash>       Refuse to apply unless the on-disk spec's
+                          pre_hash matches this content address. When
+                          omitted: refuse if the on-disk pre_hash does
+                          not match the last patch row's post_hash.
+  --dry-run               Run the full validation pipeline but commit
+                          nothing. Prints the synthesized JSONL line +
+                          hashes and exits 0.
+  --validate-only         Synonym for --dry-run.
+  --allow-no-parent       Permit a fresh-chain (no genesis line yet)
+                          to bootstrap. Implies a synthesized genesis
+                          line written before this patch's line.
+  --help, -h              Show this help message.
+
+Notes:
+  - Patches the source packages/cli/src/specs/<prompt-id>/spec.json —
+    NOT the bundled dist/. Operators on the installed CLI cannot patch
+    installed prompts.
+  - Atomic. SQL transaction (event row + prompt_patches projection row)
+    runs before any filesystem write. spec.json is written via
+    temp+rename so partial-write SIGKILL leaves the on-disk file
+    intact.`;
+
+// ---------------------------------------------------------------------------
+// Public entry
+// ---------------------------------------------------------------------------
+
+export async function runPromptPatch(args: string[]): Promise<void> {
+  if (args.includes('--help') || args.includes('-h')) {
+    process.stdout.write(`${USAGE}\n`);
+    return;
+  }
+
+  let positionals: string[];
+  let patchFile: string | undefined;
+  let baseline: string | undefined;
+  let dryRun: boolean;
+  let validateOnly: boolean;
+  let allowNoParent: boolean;
+
+  try {
+    const parsed = parseArgs({
+      args,
+      allowPositionals: true,
+      options: {
+        patch: { type: 'string' },
+        baseline: { type: 'string' },
+        'dry-run': { type: 'boolean', default: false },
+        'validate-only': { type: 'boolean', default: false },
+        'allow-no-parent': { type: 'boolean', default: false },
+        help: { type: 'boolean', short: 'h', default: false },
+      },
+    });
+    positionals = parsed.positionals;
+    patchFile = parsed.values.patch;
+    baseline = parsed.values.baseline;
+    dryRun = parsed.values['dry-run'] === true;
+    validateOnly = parsed.values['validate-only'] === true;
+    allowNoParent = parsed.values['allow-no-parent'] === true;
+  } catch (err) {
+    process.stderr.write(
+      `gobbi prompt patch: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.stderr.write(`${USAGE}\n`);
+    process.exit(2);
+  }
+
+  const promptIdArg = positionals[0];
+  if (promptIdArg === undefined) {
+    process.stderr.write(`gobbi prompt patch: missing <prompt-id>\n`);
+    process.stderr.write(`${USAGE}\n`);
+    process.exit(2);
+  }
+  if (!isPromptId(promptIdArg)) {
+    process.stderr.write(
+      `gobbi prompt patch: invalid prompt-id '${promptIdArg}' ` +
+        `(valid: ${PROMPT_ID_VALUES.join(', ')})\n`,
+    );
+    process.exit(1);
+  }
+  const promptId: PromptId = promptIdArg;
+
+  if (patchFile === undefined) {
+    process.stderr.write(`gobbi prompt patch: --patch <file> is required\n`);
+    process.exit(2);
+  }
+
+  await runPromptPatchOnFiles({
+    promptId,
+    patchFile,
+    baseline,
+    dryRun: dryRun || validateOnly,
+    allowNoParent,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Core implementation (separated from argv parsing for testability)
+// ---------------------------------------------------------------------------
+
+export interface PromptPatchInputs {
+  readonly promptId: PromptId;
+  readonly patchFile: string;
+  readonly baseline?: string | undefined;
+  readonly dryRun: boolean;
+  readonly allowNoParent: boolean;
+}
+
+export interface PromptPatchResult {
+  readonly committed: boolean;
+  readonly patchId: string;
+  readonly preHash: string;
+  readonly postHash: string;
+  readonly opCount: number;
+  readonly eventSeq: number | null; // null on dry-run
+  readonly synthesizedTestOp: boolean;
+}
+
+export async function runPromptPatchOnFiles(
+  inputs: PromptPatchInputs,
+): Promise<PromptPatchResult> {
+  // ----- 1. Parse + 2. shape-check the patch JSON ------------------------
+  if (!existsSync(inputs.patchFile)) {
+    process.stderr.write(
+      `gobbi prompt patch: patch file not found: ${inputs.patchFile}\n`,
+    );
+    process.exit(1);
+  }
+  let opsRaw: unknown;
+  try {
+    opsRaw = JSON.parse(readFileSync(inputs.patchFile, 'utf8'));
+  } catch (err) {
+    process.stderr.write(
+      `gobbi prompt patch: patch file is not valid JSON: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.exit(1);
+  }
+  if (!Array.isArray(opsRaw)) {
+    process.stderr.write(
+      `gobbi prompt patch: patch file root must be a JSON array of RFC 6902 ops (got ${typeof opsRaw})\n`,
+    );
+    process.exit(1);
+  }
+  const operatorOps = opsRaw as Operation[];
+
+  // RFC 6902 shape via fast-json-patch::validate.
+  // `validate(ops)` returns a PatchError if invalid, or undefined if OK.
+  const validationError = validate(operatorOps);
+  if (validationError !== undefined) {
+    process.stderr.write(
+      `gobbi prompt patch: RFC 6902 validation failed: ${validationError.message}\n`,
+    );
+    process.exit(1);
+  }
+
+  // ----- 3. Test-op merge (synthesis §9.2 step 3 / Overall F-7) ----------
+  const { mergedOps, synthesizedTestOp } = mergeTestOp(operatorOps);
+  if (synthesizedTestOp) {
+    process.stderr.write(
+      `gobbi prompt patch: synthesized {op:'test', path:'/version', value:1} at index 0; ` +
+        `the universal floor test ensures the patch refuses to apply on a non-v1 spec.\n`,
+    );
+  }
+
+  // ----- 4. Load on-disk spec, compute pre_hash, baseline check ----------
+  const specPath = specJsonPath(inputs.promptId);
+  if (!existsSync(specPath)) {
+    process.stderr.write(
+      `gobbi prompt patch: source spec not found: ${specPath}\n`,
+    );
+    process.exit(1);
+  }
+  const specRaw: unknown = JSON.parse(readFileSync(specPath, 'utf8'));
+  const preHash = contentHash(specRaw);
+
+  if (inputs.baseline !== undefined && inputs.baseline !== preHash) {
+    process.stderr.write(
+      `gobbi prompt patch: --baseline ${inputs.baseline} does not match on-disk pre_hash ${preHash}; ` +
+        `refusing to apply against a stale spec.\n`,
+    );
+    process.exit(1);
+  }
+
+  const projectName = resolveProjectName();
+
+  // Open the workspace state.db. The `gobbi prompt` commands run from
+  // the main tree per the gotcha at `gobbi-workflow-cli-from-main-tree.md`,
+  // so the workspace `state.db` lives at `<repoRoot>/.gobbi/state.db`.
+  const repoRoot = getRepoRoot();
+  const stateDbPath = join(workspaceRoot(repoRoot), 'state.db');
+
+  // No-baseline guard (Overall F-5 routed-resolution): if the on-disk
+  // spec's pre_hash does not match the last patch row's post_hash, the
+  // operator authored against a stale spec or a crash-recovery is
+  // pending. Refuse with the rebuild diagnostic.
+  if (inputs.baseline === undefined && existsSync(stateDbPath) && !inputs.dryRun) {
+    const lastPostHash = readLastPostHash(stateDbPath, inputs.promptId);
+    if (lastPostHash !== null && lastPostHash !== preHash) {
+      process.stderr.write(
+        `gobbi prompt patch: on-disk spec.json pre_hash ${preHash} does not match the last patch row's post_hash ${lastPostHash}. ` +
+          `This usually means the spec was hand-edited, or a prior \`gobbi prompt patch\` crashed mid-write. ` +
+          `Run \`gobbi prompt rebuild ${inputs.promptId}\` to restore the spec to the chain head, or pass --baseline ${preHash} to override.\n`,
+      );
+      process.exit(1);
+    }
+  }
+
+  // ----- 5. Simulate the patch on a deep clone --------------------------
+  let candidate: unknown;
+  try {
+    const result = applyPatch(deepClone(specRaw), mergedOps);
+    candidate = result.newDocument;
+  } catch (err) {
+    process.stderr.write(
+      `gobbi prompt patch: applyPatch failed: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.exit(1);
+  }
+
+  // ----- 6. Schema-validate the candidate -------------------------------
+  const validationResult = validateStepSpec(candidate);
+  if (!validationResult.ok) {
+    process.stderr.write(
+      `gobbi prompt patch: candidate spec fails schema validation:\n` +
+        `${JSON.stringify(validationResult.errors, null, 2)}\n`,
+    );
+    process.exit(1);
+  }
+  const validatedSpec = validationResult.value;
+
+  // ----- 7. Compile-test the candidate ----------------------------------
+  try {
+    compileSpecForTest(validatedSpec, inputs.promptId);
+  } catch (err) {
+    process.stderr.write(
+      `gobbi prompt patch: candidate spec fails assembly.compile() smoke test: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.exit(1);
+  }
+
+  // ----- 8. Compute post_hash + patch_id --------------------------------
+  const postHash = contentHash(candidate);
+  const patchId = contentHash(mergedOps);
+
+  // ----- 9. Dry-run / validate-only -------------------------------------
+  const result: PromptPatchResult = {
+    committed: false,
+    patchId,
+    preHash,
+    postHash,
+    opCount: mergedOps.length,
+    eventSeq: null,
+    synthesizedTestOp,
+  };
+  if (inputs.dryRun) {
+    printPatchSummary(result);
+    return result;
+  }
+
+  // ----- 10. Commit phase ----------------------------------------------
+  const ts = new Date().toISOString();
+  const sessionId = `prompt-patch-${ts}`;
+
+  // Open the EventStore — auto-applies v5+v6+v7 schema.
+  let store: EventStore;
+  try {
+    store = new EventStore(stateDbPath, {
+      sessionId,
+      projectId: projectName,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes('SQLITE_BUSY')) {
+      process.stderr.write(
+        `gobbi prompt patch: another \`gobbi prompt\` invocation holds the write lock; retry.\n`,
+      );
+      process.exit(1);
+    }
+    throw err;
+  }
+
+  let eventSeq: number;
+  try {
+    // Genesis-line bootstrap: if the chain has no rows for this prompt,
+    // we synthesize a genesis line from the on-disk pre-patch spec
+    // before the new patch's line. This matches synthesis §7's
+    // "every JSONL has a genesis line" invariant.
+    ensurePromptEvolutionDir(projectName, inputs.promptId);
+    const jsonlPath = promptEvolutionPath(projectName, inputs.promptId);
+
+    let parentPatchId: string | null = null;
+    let parentSeq: number | null = null;
+    if (!existsSync(jsonlPath)) {
+      if (!inputs.allowNoParent) {
+        // Without an explicit opt-in, refuse. Synthesizing a genesis
+        // line silently could mask a missing-jsonl drift bug.
+        store.close();
+        process.stderr.write(
+          `gobbi prompt patch: no JSONL chain found at ${jsonlPath}. ` +
+            `Pass --allow-no-parent to bootstrap a fresh chain by synthesizing a genesis line from the current spec.json.\n`,
+        );
+        process.exit(1);
+      }
+      // Synthesize genesis from the pre-patch spec.
+      const genesisEvent = store.append({
+        ts,
+        type: 'prompt.patch.applied',
+        actor: 'operator',
+        idempotencyKind: 'content',
+        contentId: contentHash([{ op: 'add', path: '', value: specRaw }]),
+        sessionId,
+        data: JSON.stringify({
+          promptId: inputs.promptId,
+          patchId: contentHash([{ op: 'add', path: '', value: specRaw }]),
+          parentPatchId: null,
+          preHash: contentHash({}),
+          postHash: preHash,
+          opCount: 1,
+          schemaId: STEP_SPEC_SCHEMA_ID,
+          appliedBy: 'operator',
+        }),
+      });
+      if (genesisEvent !== null) {
+        const genesisEntry = buildGenesisEntry({
+          promptId: inputs.promptId,
+          baselineSpec: specRaw,
+          ts,
+          schemaId: STEP_SPEC_SCHEMA_ID,
+          eventSeq: genesisEvent.seq,
+        });
+        // Write the genesis row in prompt_patches.
+        insertPromptPatchRow(store, {
+          sessionId,
+          projectId: projectName,
+          promptId: inputs.promptId,
+          parentSeq: null,
+          eventSeq: genesisEvent.seq,
+          patchId: genesisEntry.patchId,
+          patchJson: canonicalize(genesisEntry.ops),
+          preHash: genesisEntry.preHash,
+          postHash: genesisEntry.postHash,
+          appliedAt: Date.parse(ts),
+        });
+        appendJsonlSync(jsonlPath, JSON.stringify(genesisEntry));
+        parentPatchId = genesisEntry.patchId;
+        parentSeq = readPatchSeqByEventSeq(store, genesisEvent.seq);
+      } else {
+        // Genesis event was deduped (someone else just wrote it). Read
+        // back the existing genesis row and continue.
+        const dedupedSeq = readPatchSeqByContent(
+          store,
+          inputs.promptId,
+          contentHash([{ op: 'add', path: '', value: specRaw }]),
+        );
+        if (dedupedSeq === null) {
+          throw new Error(
+            'unreachable: genesis event existed but no projection row found',
+          );
+        }
+        parentSeq = dedupedSeq.seq;
+        parentPatchId = dedupedSeq.patchId;
+      }
+    } else {
+      // Chain exists — link to the last row.
+      const last = readLastPatch(store, inputs.promptId);
+      if (last !== null) {
+        parentPatchId = last.patchId;
+        parentSeq = last.seq;
+      }
+    }
+
+    // Append the operator's patch as event + projection row.
+    const eventRow = store.append({
+      ts,
+      type: 'prompt.patch.applied',
+      actor: 'operator',
+      idempotencyKind: 'content',
+      contentId: patchId,
+      sessionId,
+      data: JSON.stringify({
+        promptId: inputs.promptId,
+        patchId,
+        parentPatchId,
+        preHash,
+        postHash,
+        opCount: mergedOps.length,
+        schemaId: STEP_SPEC_SCHEMA_ID,
+        appliedBy: 'operator',
+      }),
+    });
+
+    if (eventRow === null) {
+      // Cross-session content dedup hit — the same patch was already
+      // applied. Surface the originating session.
+      store.close();
+      const existing = readPatchByContent(stateDbPath, inputs.promptId, patchId);
+      if (existing !== null) {
+        process.stderr.write(
+          `gobbi prompt patch: patch ${patchId} was already applied (originating session: ${existing.session_id}). No new rows written.\n`,
+        );
+        process.exit(0);
+      }
+      process.stderr.write(
+        `gobbi prompt patch: event idempotency dedup hit but projection row not found — possible store corruption.\n`,
+      );
+      process.exit(1);
+    }
+    eventSeq = eventRow.seq;
+
+    insertPromptPatchRow(store, {
+      sessionId,
+      projectId: projectName,
+      promptId: inputs.promptId,
+      parentSeq,
+      eventSeq: eventRow.seq,
+      patchId,
+      patchJson: canonicalize(mergedOps),
+      preHash,
+      postHash,
+      appliedAt: Date.parse(ts),
+    });
+
+    // JSONL append (after SQL commit; crash-recovery covered by F-5
+    // diagnostic on next run).
+    const entry: PromptEvolutionEntry = {
+      v: 1,
+      ts,
+      promptId: inputs.promptId,
+      patchId,
+      parentPatchId,
+      preHash,
+      postHash,
+      ops: mergedOps,
+      validationStatus: 'passed',
+      appliedBy: 'operator',
+      eventSeq: eventRow.seq,
+      schemaId: STEP_SPEC_SCHEMA_ID,
+    };
+    appendJsonlSync(jsonlPath, JSON.stringify(entry));
+
+    // Atomic spec.json write (temp+rename).
+    const tmp = `${specPath}.tmp`;
+    writeFileSync(tmp, canonicalize(candidate) + '\n', { encoding: 'utf8' });
+    renameSync(tmp, specPath);
+  } finally {
+    store.close();
+  }
+
+  const finalResult: PromptPatchResult = { ...result, committed: true, eventSeq };
+  printPatchSummary(finalResult);
+  return finalResult;
+}
+
+// ---------------------------------------------------------------------------
+// Test-op merge (synthesis §9.2 step 3, Overall F-7 fix)
+// ---------------------------------------------------------------------------
+
+interface MergeResult {
+  readonly mergedOps: Operation[];
+  readonly synthesizedTestOp: boolean;
+}
+
+export function mergeTestOp(operatorOps: ReadonlyArray<Operation>): MergeResult {
+  const SYNTH: Operation = { op: 'test', path: '/version', value: 1 };
+
+  // Find the first test op.
+  const firstTestIndex = operatorOps.findIndex((op) => op.op === 'test');
+  if (firstTestIndex < 0) {
+    // Case 1 — no test op anywhere. Synthesize at index 0.
+    return { mergedOps: [SYNTH, ...operatorOps], synthesizedTestOp: true };
+  }
+  const firstTest = operatorOps[firstTestIndex]!;
+  if (
+    firstTestIndex === 0 &&
+    firstTest.op === 'test' &&
+    'path' in firstTest &&
+    firstTest.path === '/version'
+  ) {
+    // Case 2 — operator already authored test-at-index-0-on-/version.
+    return { mergedOps: [...operatorOps], synthesizedTestOp: false };
+  }
+  // Case 3 — operator has test ops, but not at index 0 on /version.
+  // Prepend the synth /version test; preserve operator's tests.
+  return { mergedOps: [SYNTH, ...operatorOps], synthesizedTestOp: true };
+}
+
+// ---------------------------------------------------------------------------
+// Compile smoke test
+// ---------------------------------------------------------------------------
+
+const FIXED_TIMESTAMP = '2026-04-26T12:00:00.000Z';
+const GENEROUS_WINDOW = 200_000;
+const predicates: CompilePredicateRegistry = defaultPredicates;
+
+function compileSpecForTest(spec: StepSpec, promptId: PromptId): void {
+  const currentStep: WorkflowStep = promptId as WorkflowStep;
+  const state = {
+    ...initialState(`session-patch-test-${promptId}`),
+    currentStep,
+  };
+  const dynamic: DynamicContext = {
+    timestamp: FIXED_TIMESTAMP,
+    activeSubagentCount: 0,
+    artifacts: [],
+  };
+  const input: CompileInput = {
+    spec,
+    state,
+    dynamic,
+    predicates,
+    activeAgent: null,
+  };
+  // Call compile to verify the candidate spec passes the lint and
+  // budget allocator. Result is discarded.
+  compile(input, {
+    allocator: defaultBudgetAllocator,
+    contextWindowTokens: GENEROUS_WINDOW,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// SQLite helpers — direct-SQL writes/reads against `prompt_patches`.
+// EventStore handles `events`; this helper handles the projection table.
+// ---------------------------------------------------------------------------
+
+interface InsertPromptPatchArgs {
+  readonly sessionId: string;
+  readonly projectId: string | null;
+  readonly promptId: PromptId;
+  readonly parentSeq: number | null;
+  readonly eventSeq: number;
+  readonly patchId: string;
+  readonly patchJson: string;
+  readonly preHash: string;
+  readonly postHash: string;
+  readonly appliedAt: number;
+}
+
+function insertPromptPatchRow(
+  store: EventStore,
+  args: InsertPromptPatchArgs,
+): void {
+  // EventStore exposes only the events table publicly; for the
+  // projection row we open the underlying db via the same path. Keep
+  // the call inside the store's transaction so SQL atomicity holds.
+  // Grab a typed query via `(store as unknown as { db: Database }).db`
+  // — store does not export the db. Workaround: use a separate raw
+  // Database instance opened on the same file. SQLite WAL mode supports
+  // cross-handle visibility; the EventStore's busy_timeout=5000 covers
+  // contention.
+  //
+  // NOTE: this works because the events table append already committed
+  // (immediate transaction inside store.append). The prompt_patches
+  // INSERT runs in its own micro-transaction. Crash semantics: an
+  // event without a matching projection row is a recoverable state —
+  // a future run sees the unique idempotency key collide and a
+  // post-processor can fill in the projection row. For C.1 the
+  // simpler "second handle, second transaction" model is sufficient
+  // (single-writer convention; SQLITE_BUSY surfaces loudly via the
+  // busy_timeout).
+  const db = new Database(stateDbPathFromStore(store));
+  try {
+    db.run('PRAGMA busy_timeout = 5000');
+    db.run(
+      `INSERT INTO prompt_patches (session_id, project_id, prompt_id, parent_seq, event_seq, patch_id, patch_json, pre_hash, post_hash, applied_at, applied_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        args.sessionId,
+        args.projectId,
+        args.promptId,
+        args.parentSeq,
+        args.eventSeq,
+        args.patchId,
+        args.patchJson,
+        args.preHash,
+        args.postHash,
+        args.appliedAt,
+        'operator',
+      ],
+    );
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Read the workspace state.db path from an EventStore. The path is
+ * not exposed on the public surface — use a process-environment hint
+ * via repoRoot resolution. For C.1 we already know the path
+ * (`workspaceRoot(repoRoot)/state.db`) so this helper just restates
+ * it.
+ */
+function stateDbPathFromStore(_store: EventStore): string {
+  return join(workspaceRoot(getRepoRoot()), 'state.db');
+}
+
+interface LastPatchRow {
+  readonly seq: number;
+  readonly patchId: string;
+  readonly postHash: string;
+}
+
+function readLastPatch(
+  store: EventStore,
+  promptId: PromptId,
+): LastPatchRow | null {
+  const db = new Database(stateDbPathFromStore(store), { readonly: true });
+  try {
+    interface Row {
+      readonly seq: number;
+      readonly patch_id: string;
+      readonly post_hash: string;
+    }
+    const row = db
+      .query<Row, [string]>(
+        `SELECT seq, patch_id, post_hash FROM prompt_patches WHERE prompt_id = ? ORDER BY seq DESC LIMIT 1`,
+      )
+      .get(promptId);
+    if (row === null) return null;
+    return { seq: row.seq, patchId: row.patch_id, postHash: row.post_hash };
+  } finally {
+    db.close();
+  }
+}
+
+function readLastPostHash(
+  stateDbPath: string,
+  promptId: PromptId,
+): string | null {
+  if (!existsSync(stateDbPath)) return null;
+  const db = new Database(stateDbPath, { readonly: true });
+  try {
+    interface Row {
+      readonly post_hash: string;
+    }
+    // Tolerate the prompt_patches table not yet existing (fresh
+    // workspace, never opened by a v7 store).
+    try {
+      const row = db
+        .query<Row, [string]>(
+          `SELECT post_hash FROM prompt_patches WHERE prompt_id = ? ORDER BY seq DESC LIMIT 1`,
+        )
+        .get(promptId);
+      return row === null ? null : row.post_hash;
+    } catch {
+      return null;
+    }
+  } finally {
+    db.close();
+  }
+}
+
+function readPatchSeqByEventSeq(
+  store: EventStore,
+  eventSeq: number,
+): number | null {
+  const db = new Database(stateDbPathFromStore(store), { readonly: true });
+  try {
+    interface Row {
+      readonly seq: number;
+    }
+    const row = db
+      .query<Row, [number]>(
+        `SELECT seq FROM prompt_patches WHERE event_seq = ?`,
+      )
+      .get(eventSeq);
+    return row === null ? null : row.seq;
+  } finally {
+    db.close();
+  }
+}
+
+function readPatchSeqByContent(
+  store: EventStore,
+  promptId: PromptId,
+  patchId: string,
+): { seq: number; patchId: string } | null {
+  const db = new Database(stateDbPathFromStore(store), { readonly: true });
+  try {
+    interface Row {
+      readonly seq: number;
+      readonly patch_id: string;
+    }
+    const row = db
+      .query<Row, [string, string]>(
+        `SELECT seq, patch_id FROM prompt_patches WHERE prompt_id = ? AND patch_id = ?`,
+      )
+      .get(promptId, patchId);
+    return row === null ? null : { seq: row.seq, patchId: row.patch_id };
+  } finally {
+    db.close();
+  }
+}
+
+function readPatchByContent(
+  stateDbPath: string,
+  promptId: PromptId,
+  patchId: string,
+): { session_id: string } | null {
+  if (!existsSync(stateDbPath)) return null;
+  const db = new Database(stateDbPath, { readonly: true });
+  try {
+    interface Row {
+      readonly session_id: string;
+    }
+    const row = db
+      .query<Row, [string, string]>(
+        `SELECT session_id FROM prompt_patches WHERE prompt_id = ? AND patch_id = ?`,
+      )
+      .get(promptId, patchId);
+    return row === null ? null : { session_id: row.session_id };
+  } finally {
+    db.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pretty-print
+// ---------------------------------------------------------------------------
+
+function printPatchSummary(result: PromptPatchResult): void {
+  const lines = [
+    `gobbi prompt patch — ${result.committed ? 'committed' : 'dry-run'}`,
+    `patchId:           ${result.patchId}`,
+    `pre_hash:          ${result.preHash}`,
+    `post_hash:         ${result.postHash}`,
+    `op_count:          ${result.opCount}`,
+    `synthesized test:  ${result.synthesizedTestOp ? 'yes' : 'no'}`,
+  ];
+  if (result.eventSeq !== null) {
+    lines.push(`event_seq:         ${result.eventSeq}`);
+  }
+  process.stdout.write(`${lines.join('\n')}\n`);
+}
+
+// ---------------------------------------------------------------------------
+// Re-export for tests
+// ---------------------------------------------------------------------------
+
+export { PROMPT_PATCH_USAGE };
+const PROMPT_PATCH_USAGE = USAGE;
+
+// Suppress unused warnings while keeping the imports above narrowed.
+void execFileSync;
+void createHash;

--- a/packages/cli/src/commands/prompt/patch.ts
+++ b/packages/cli/src/commands/prompt/patch.ts
@@ -29,14 +29,21 @@
  *      deterministic state).
  *   8. Compute post_hash.
  *   9. If --validate-only or --dry-run: print + exit 0, no writes.
- *   10. Commit phase: SQL transaction (event + projection row) → JSONL
- *       append → atomic temp+rename spec.json.
+ *   10. Commit phase: ONE SQLite IMMEDIATE transaction wraps the event
+ *       row + prompt_patches projection row INSERT (Wave C.1.6 R1 /
+ *       Architecture F-1 fix — both writes share one connection so a
+ *       SIGKILL between them rolls both back). After the SQL commits,
+ *       JSONL append → atomic temp+rename spec.json.
  *
  * # Crash recovery
  *
- *   - Crash after SQL commit, before JSONL: re-running the same patch
- *     hits the events idempotency_key, hits the prompt_patches UNIQUE
- *     event_seq, and JSONL append fires once — end state correct.
+ *   - Crash inside the SQL transaction: BEGIN IMMEDIATE rolls back —
+ *     no events row, no prompt_patches row. Next run re-applies cleanly.
+ *   - Crash after SQL commit, before JSONL append: events + projection
+ *     rows exist. Re-running the same patch hits the events idempotency
+ *     dedup; the patch.ts dedup-hit branch surfaces the existing
+ *     projection row and exits 0. The operator runs `gobbi prompt
+ *     rebuild` to materialize the missing JSONL line + spec.json.
  *   - Crash after JSONL append, before spec.json rename: JSONL has the
  *     entry, DB has the row, spec.json is stale. Next `gobbi prompt
  *     patch` invocation detects (`pre_hash` of on-disk spec ≠ last
@@ -416,56 +423,81 @@ export async function runPromptPatchOnFiles(
         );
         process.exit(1);
       }
-      // Synthesize genesis from the pre-patch spec.
-      const genesisEvent = store.append({
-        ts,
-        type: 'prompt.patch.applied',
-        actor: 'operator',
-        idempotencyKind: 'content',
-        contentId: contentHash([{ op: 'add', path: '', value: specRaw }]),
-        sessionId,
-        data: JSON.stringify({
-          promptId: inputs.promptId,
-          patchId: contentHash([{ op: 'add', path: '', value: specRaw }]),
-          parentPatchId: null,
-          preHash: contentHash({}),
-          postHash: preHash,
-          opCount: 1,
-          schemaId: STEP_SPEC_SCHEMA_ID,
-          appliedBy: 'operator',
-        }),
-      });
-      if (genesisEvent !== null) {
-        const genesisEntry = buildGenesisEntry({
-          promptId: inputs.promptId,
-          baselineSpec: specRaw,
+      // Synthesize genesis from the pre-patch spec. Atomic — event +
+      // projection share one transaction (Wave C.1.6 R1, Architecture
+      // F-1 fix).
+      const genesisContentId = contentHash([
+        { op: 'add', path: '', value: specRaw },
+      ]);
+      // `genesisEntryRef` is captured inside the projection callback so
+      // the post-callback code can append the JSONL line and read the
+      // projection seq without re-querying. TypeScript's flow analysis
+      // narrows the closure-mutated locals to `never`, so we capture
+      // the type explicitly here.
+      let genesisEntryRef: PromptEvolutionEntry | null = null as
+        | PromptEvolutionEntry
+        | null;
+      let genesisProjectionSeq: number | null = null as number | null;
+      const genesisEvent = store.appendWithProjection(
+        {
           ts,
-          schemaId: STEP_SPEC_SCHEMA_ID,
-          eventSeq: genesisEvent.seq,
-        });
-        // Write the genesis row in prompt_patches.
-        insertPromptPatchRow(store, {
+          type: 'prompt.patch.applied',
+          actor: 'operator',
+          idempotencyKind: 'content',
+          contentId: genesisContentId,
           sessionId,
-          projectId: projectName,
-          promptId: inputs.promptId,
-          parentSeq: null,
-          eventSeq: genesisEvent.seq,
-          patchId: genesisEntry.patchId,
-          patchJson: canonicalize(genesisEntry.ops),
-          preHash: genesisEntry.preHash,
-          postHash: genesisEntry.postHash,
-          appliedAt: Date.parse(ts),
-        });
+          data: JSON.stringify({
+            promptId: inputs.promptId,
+            patchId: genesisContentId,
+            parentPatchId: null,
+            preHash: contentHash({}),
+            postHash: preHash,
+            opCount: 1,
+            schemaId: STEP_SPEC_SCHEMA_ID,
+            appliedBy: 'operator',
+          }),
+        },
+        (db, row) => {
+          const genesisEntry = buildGenesisEntry({
+            promptId: inputs.promptId,
+            baselineSpec: specRaw,
+            ts,
+            schemaId: STEP_SPEC_SCHEMA_ID,
+            eventSeq: row.seq,
+          });
+          insertPromptPatchRowOnDb(db, {
+            sessionId,
+            projectId: projectName,
+            promptId: inputs.promptId,
+            parentSeq: null,
+            eventSeq: row.seq,
+            patchId: genesisEntry.patchId,
+            patchJson: canonicalize(genesisEntry.ops),
+            preHash: genesisEntry.preHash,
+            postHash: genesisEntry.postHash,
+            appliedAt: Date.parse(ts),
+          });
+          genesisEntryRef = genesisEntry;
+          genesisProjectionSeq = readPatchSeqByEventSeqOnDb(db, row.seq);
+        },
+      );
+      if (genesisEvent !== null) {
+        const genesisEntry: PromptEvolutionEntry | null = genesisEntryRef;
+        if (genesisEntry === null) {
+          throw new Error(
+            'unreachable: appendWithProjection succeeded but genesis entry was not captured',
+          );
+        }
         appendJsonlSync(jsonlPath, JSON.stringify(genesisEntry));
         parentPatchId = genesisEntry.patchId;
-        parentSeq = readPatchSeqByEventSeq(store, genesisEvent.seq);
+        parentSeq = genesisProjectionSeq;
       } else {
         // Genesis event was deduped (someone else just wrote it). Read
         // back the existing genesis row and continue.
         const dedupedSeq = readPatchSeqByContent(
           store,
           inputs.promptId,
-          contentHash([{ op: 'add', path: '', value: specRaw }]),
+          genesisContentId,
         );
         if (dedupedSeq === null) {
           throw new Error(
@@ -484,25 +516,44 @@ export async function runPromptPatchOnFiles(
       }
     }
 
-    // Append the operator's patch as event + projection row.
-    const eventRow = store.append({
-      ts,
-      type: 'prompt.patch.applied',
-      actor: 'operator',
-      idempotencyKind: 'content',
-      contentId: patchId,
-      sessionId,
-      data: JSON.stringify({
-        promptId: inputs.promptId,
-        patchId,
-        parentPatchId,
-        preHash,
-        postHash,
-        opCount: mergedOps.length,
-        schemaId: STEP_SPEC_SCHEMA_ID,
-        appliedBy: 'operator',
-      }),
-    });
+    // Append the operator's patch as event + projection row inside one
+    // SQLite IMMEDIATE transaction. A SIGKILL between the events INSERT
+    // and the prompt_patches INSERT rolls both back rather than leaving
+    // an orphan event row (Wave C.1.6 R1 / Architecture F-1 fix).
+    const eventRow = store.appendWithProjection(
+      {
+        ts,
+        type: 'prompt.patch.applied',
+        actor: 'operator',
+        idempotencyKind: 'content',
+        contentId: patchId,
+        sessionId,
+        data: JSON.stringify({
+          promptId: inputs.promptId,
+          patchId,
+          parentPatchId,
+          preHash,
+          postHash,
+          opCount: mergedOps.length,
+          schemaId: STEP_SPEC_SCHEMA_ID,
+          appliedBy: 'operator',
+        }),
+      },
+      (db, row) => {
+        insertPromptPatchRowOnDb(db, {
+          sessionId,
+          projectId: projectName,
+          promptId: inputs.promptId,
+          parentSeq,
+          eventSeq: row.seq,
+          patchId,
+          patchJson: canonicalize(mergedOps),
+          preHash,
+          postHash,
+          appliedAt: Date.parse(ts),
+        });
+      },
+    );
 
     if (eventRow === null) {
       // Cross-session content dedup hit — the same patch was already
@@ -522,21 +573,8 @@ export async function runPromptPatchOnFiles(
     }
     eventSeq = eventRow.seq;
 
-    insertPromptPatchRow(store, {
-      sessionId,
-      projectId: projectName,
-      promptId: inputs.promptId,
-      parentSeq,
-      eventSeq: eventRow.seq,
-      patchId,
-      patchJson: canonicalize(mergedOps),
-      preHash,
-      postHash,
-      appliedAt: Date.parse(ts),
-    });
-
-    // JSONL append (after SQL commit; crash-recovery covered by F-5
-    // diagnostic on next run).
+    // JSONL append (after SQL transaction commits; crash-recovery
+    // covered by F-5 diagnostic on next run).
     const entry: PromptEvolutionEntry = {
       v: 1,
       ts,
@@ -651,50 +689,55 @@ interface InsertPromptPatchArgs {
   readonly appliedAt: number;
 }
 
-function insertPromptPatchRow(
-  store: EventStore,
+/**
+ * Run the `INSERT INTO prompt_patches ...` projection write on the
+ * supplied `Database` handle. Used inside
+ * {@link EventStore.appendWithProjection} so the projection row shares
+ * the same transaction as the events row (Wave C.1.6 R1 /
+ * Architecture F-1 fix). The caller MUST pass the handle obtained
+ * from the projection callback — opening a separate `new Database(path)`
+ * here would defeat the atomicity guarantee.
+ */
+function insertPromptPatchRowOnDb(
+  db: Database,
   args: InsertPromptPatchArgs,
 ): void {
-  // EventStore exposes only the events table publicly; for the
-  // projection row we open the underlying db via the same path. Keep
-  // the call inside the store's transaction so SQL atomicity holds.
-  // Grab a typed query via `(store as unknown as { db: Database }).db`
-  // — store does not export the db. Workaround: use a separate raw
-  // Database instance opened on the same file. SQLite WAL mode supports
-  // cross-handle visibility; the EventStore's busy_timeout=5000 covers
-  // contention.
-  //
-  // NOTE: this works because the events table append already committed
-  // (immediate transaction inside store.append). The prompt_patches
-  // INSERT runs in its own micro-transaction. Crash semantics: an
-  // event without a matching projection row is a recoverable state —
-  // a future run sees the unique idempotency key collide and a
-  // post-processor can fill in the projection row. For C.1 the
-  // simpler "second handle, second transaction" model is sufficient
-  // (single-writer convention; SQLITE_BUSY surfaces loudly via the
-  // busy_timeout).
-  const db = new Database(stateDbPathFromStore(store));
-  try {
-    db.run('PRAGMA busy_timeout = 5000');
-    db.run(
-      `INSERT INTO prompt_patches (session_id, project_id, prompt_id, parent_seq, event_seq, patch_id, patch_json, pre_hash, post_hash, applied_at, applied_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      [
-        args.sessionId,
-        args.projectId,
-        args.promptId,
-        args.parentSeq,
-        args.eventSeq,
-        args.patchId,
-        args.patchJson,
-        args.preHash,
-        args.postHash,
-        args.appliedAt,
-        'operator',
-      ],
-    );
-  } finally {
-    db.close();
+  db.run(
+    `INSERT INTO prompt_patches (session_id, project_id, prompt_id, parent_seq, event_seq, patch_id, patch_json, pre_hash, post_hash, applied_at, applied_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      args.sessionId,
+      args.projectId,
+      args.promptId,
+      args.parentSeq,
+      args.eventSeq,
+      args.patchId,
+      args.patchJson,
+      args.preHash,
+      args.postHash,
+      args.appliedAt,
+      'operator',
+    ],
+  );
+}
+
+/**
+ * Read the `prompt_patches.seq` for a given `event_seq` using the
+ * supplied in-transaction `Database` handle. Co-located with
+ * {@link insertPromptPatchRowOnDb} so the genesis-bootstrap path can
+ * capture the projection row's seq inside the same transaction the
+ * INSERT just landed in.
+ */
+function readPatchSeqByEventSeqOnDb(
+  db: Database,
+  eventSeq: number,
+): number | null {
+  interface Row {
+    readonly seq: number;
   }
+  const row = db
+    .query<Row, [number]>(`SELECT seq FROM prompt_patches WHERE event_seq = ?`)
+    .get(eventSeq);
+  return row === null ? null : row.seq;
 }
 
 /**
@@ -759,26 +802,6 @@ function readLastPostHash(
     } catch {
       return null;
     }
-  } finally {
-    db.close();
-  }
-}
-
-function readPatchSeqByEventSeq(
-  store: EventStore,
-  eventSeq: number,
-): number | null {
-  const db = new Database(stateDbPathFromStore(store), { readonly: true });
-  try {
-    interface Row {
-      readonly seq: number;
-    }
-    const row = db
-      .query<Row, [number]>(
-        `SELECT seq FROM prompt_patches WHERE event_seq = ?`,
-      )
-      .get(eventSeq);
-    return row === null ? null : row.seq;
   } finally {
     db.close();
   }

--- a/packages/cli/src/commands/prompt/patch.ts
+++ b/packages/cli/src/commands/prompt/patch.ts
@@ -56,8 +56,6 @@
  * installed prompts; they patch the source repo and rebuild.
  */
 
-import { execFileSync } from 'node:child_process';
-import { createHash } from 'node:crypto';
 import {
   existsSync,
   readFileSync,
@@ -88,7 +86,7 @@ import type { WorkflowStep } from '../../workflow/state.js';
 import { defaultPredicates } from '../../workflow/predicates.js';
 import { EventStore } from '../../workflow/store.js';
 import {
-  appendJsonlSync,
+  appendPromptEvolutionEntry,
   buildGenesisEntry,
   contentHash,
 } from '../../lib/prompt-evolution.js';
@@ -497,7 +495,11 @@ export async function runPromptPatchOnFiles(
             'unreachable: appendWithProjection succeeded but genesis entry was not captured',
           );
         }
-        appendJsonlSync(jsonlPath, JSON.stringify(genesisEntry));
+        // Use the shared `appendPromptEvolutionEntry` helper rather
+        // than rebuilding the JSONL-line stringification at the call
+        // site (Wave C.1.6 R1 / Overall F-2 fix). One source of truth
+        // for the wire shape — `lib/prompt-evolution.ts`.
+        appendPromptEvolutionEntry(jsonlPath, genesisEntry);
         parentPatchId = genesisEntry.patchId;
         parentSeq = genesisProjectionSeq;
       } else {
@@ -595,7 +597,9 @@ export async function runPromptPatchOnFiles(
     eventSeq = eventRow.seq;
 
     // JSONL append (after SQL transaction commits; crash-recovery
-    // covered by F-5 diagnostic on next run).
+    // covered by F-5 diagnostic on next run). Uses the shared
+    // `appendPromptEvolutionEntry` helper so the JSONL wire shape
+    // lives in one place (Wave C.1.6 R1 / Overall F-2 fix).
     const entry: PromptEvolutionEntry = {
       v: 1,
       ts,
@@ -610,7 +614,7 @@ export async function runPromptPatchOnFiles(
       eventSeq: eventRow.seq,
       schemaId: STEP_SPEC_SCHEMA_ID,
     };
-    appendJsonlSync(jsonlPath, JSON.stringify(entry));
+    appendPromptEvolutionEntry(jsonlPath, entry);
 
     // Atomic spec.json write (temp+rename).
     const tmp = `${specPath}.tmp`;
@@ -897,7 +901,3 @@ function printPatchSummary(result: PromptPatchResult): void {
 
 export { PROMPT_PATCH_USAGE };
 const PROMPT_PATCH_USAGE = USAGE;
-
-// Suppress unused warnings while keeping the imports above narrowed.
-void execFileSync;
-void createHash;

--- a/packages/cli/src/commands/prompt/paths.ts
+++ b/packages/cli/src/commands/prompt/paths.ts
@@ -1,0 +1,140 @@
+/**
+ * Shared path + prompt-id helpers for the `gobbi prompt` subcommands.
+ *
+ * Wave C.1.5+ (issue #156). Centralises:
+ *
+ *   - The closed prompt-id set (`PROMPT_ID_VALUES`, `PromptId`,
+ *     `isPromptId`).
+ *   - The on-disk source `spec.json` location resolver
+ *     (`resolveSpecsRoot`).
+ *   - The on-disk JSONL evolution log location resolver
+ *     (`promptEvolutionPath`).
+ *   - The active project name resolver (`resolveProjectName`).
+ *
+ * Centralising these in one module rather than duplicating across the
+ * three subcommands prevents the inevitable drift if the same path
+ * convention is restated in three places.
+ */
+
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { getRepoRoot } from '../../lib/repo.js';
+
+// ---------------------------------------------------------------------------
+// PromptId — closed enumeration mirroring `events/prompt.ts::PromptId`
+// and the SQLite CHECK constraint at `migrations.ts::SQL_CREATE_PROMPT_PATCHES`.
+// ---------------------------------------------------------------------------
+
+export const PROMPT_ID_VALUES = [
+  'ideation',
+  'planning',
+  'execution',
+  'evaluation',
+  'memorization',
+  'handoff',
+] as const;
+
+export type PromptId = (typeof PROMPT_ID_VALUES)[number];
+
+export function isPromptId(value: string): value is PromptId {
+  return (PROMPT_ID_VALUES as readonly string[]).includes(value);
+}
+
+// ---------------------------------------------------------------------------
+// Source spec.json location
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the absolute directory containing the source step specs:
+ * `packages/cli/src/specs/` resolved from this module's import.meta.url.
+ *
+ * Operators on the installed CLI do NOT have a `packages/cli/src/specs/`
+ * tree under the install dir — patches against the bundled CLI are out
+ * of scope for Wave C.1 (synthesis §11 deferral 5). This resolver
+ * assumes the source repo layout; render/patch/rebuild commands
+ * surface a clear error if the source spec is missing.
+ */
+export function resolveSpecsRoot(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  // commands/prompt/<file>.ts → ../../specs
+  return resolve(here, '..', '..', 'specs');
+}
+
+/** Absolute path to a step's `spec.json`. */
+export function specJsonPath(promptId: PromptId): string {
+  return join(resolveSpecsRoot(), promptId, 'spec.json');
+}
+
+// ---------------------------------------------------------------------------
+// Project resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the active project name. v0.5.0 defaults the project to
+ * `basename(repoRoot)` when no workspace settings name an active project
+ * — matches the bootstrap logic in
+ * `__tests__/cross-pass-invariant.test.ts:500`. The full settings cascade
+ * is read by other commands, but for `gobbi prompt`'s narrow needs the
+ * basename fallback is sufficient and avoids loading the settings layer.
+ */
+export function resolveProjectName(): string {
+  const repoRoot = getRepoRoot();
+  const settingsPath = join(repoRoot, '.gobbi', 'settings.json');
+  if (existsSync(settingsPath)) {
+    try {
+      const raw = JSON.parse(readFileSync(settingsPath, 'utf8')) as {
+        projects?: { active?: unknown };
+      };
+      const active = raw.projects?.active;
+      if (typeof active === 'string' && active.length > 0) return active;
+    } catch {
+      // Fall through to basename.
+    }
+  }
+  // basename(repoRoot)
+  const parts = repoRoot.split(/[\\/]/).filter((p) => p.length > 0);
+  return parts[parts.length - 1] ?? 'gobbi';
+}
+
+// ---------------------------------------------------------------------------
+// JSONL evolution log location
+// ---------------------------------------------------------------------------
+
+/**
+ * Absolute path to a prompt's JSONL evolution log:
+ *
+ *   `<repoRoot>/.gobbi/projects/<project>/prompt-evolution/<prompt-id>.jsonl`
+ *
+ * Per synthesis §7 the path is project-scoped (one chain per project,
+ * per prompt). The directory is created on demand by callers that need
+ * to write — see {@link ensurePromptEvolutionDir}.
+ */
+export function promptEvolutionPath(
+  projectName: string,
+  promptId: PromptId,
+): string {
+  return join(
+    getRepoRoot(),
+    '.gobbi',
+    'projects',
+    projectName,
+    'prompt-evolution',
+    `${promptId}.jsonl`,
+  );
+}
+
+/**
+ * Ensure the parent directory of {@link promptEvolutionPath} exists.
+ * Idempotent.
+ */
+export function ensurePromptEvolutionDir(
+  projectName: string,
+  promptId: PromptId,
+): void {
+  const dir = dirname(promptEvolutionPath(projectName, promptId));
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}

--- a/packages/cli/src/commands/prompt/rebuild.ts
+++ b/packages/cli/src/commands/prompt/rebuild.ts
@@ -1,0 +1,197 @@
+/**
+ * gobbi prompt rebuild — materialize `spec.json` from the JSONL chain.
+ *
+ * Wave C.1.7 (issue #156). Recovery path for two cases (synthesis §12
+ * C.1.7):
+ *
+ *   1. Crash mid-write: `gobbi prompt patch` committed the SQL
+ *      transaction (event row + prompt_patches row) and appended the
+ *      JSONL line, but SIGKILL fired before the temp+rename
+ *      spec.json write. The next invocation refuses with the
+ *      diagnostic that names this command. `gobbi prompt rebuild
+ *      <prompt-id>` folds the chain and writes the post-fold spec
+ *      via temp+rename.
+ *
+ *   2. Operator hand-edit: someone edited spec.json directly,
+ *      diverging from the chain head. Detected by the same
+ *      `pre_hash != last patch row's post_hash` check;
+ *      `gobbi prompt rebuild <prompt-id>` restores the file.
+ *
+ * Pure recovery — does NOT mutate `prompt_patches` or `events`. The
+ * SQLite tables are the truth; this command makes the on-disk
+ * spec.json reflect them.
+ *
+ * # Validation
+ *
+ * Before writing, the rebuilt spec is `validateStepSpec`-checked. If
+ * the fold result fails schema validation (a corrupted intermediate
+ * patch produced an invalid spec earlier in the chain), the command
+ * refuses to write and emits a diagnostic naming the offending
+ * patchId. Operator's job to figure out next steps — typically
+ * `git revert` of the bad patch, then re-apply the clean tail.
+ */
+
+import { existsSync, renameSync, writeFileSync } from 'node:fs';
+import { parseArgs } from 'node:util';
+
+import { canonicalize } from '../../lib/canonical-json.js';
+import { foldChain } from '../../lib/prompt-evolution.js';
+import { validateStepSpec } from '../../specs/_schema/v1.js';
+import {
+  PROMPT_ID_VALUES,
+  isPromptId,
+  promptEvolutionPath,
+  resolveProjectName,
+  specJsonPath,
+  type PromptId,
+} from './paths.js';
+
+// ---------------------------------------------------------------------------
+// Usage
+// ---------------------------------------------------------------------------
+
+const USAGE = `Usage: gobbi prompt rebuild <prompt-id> [options]
+
+Materialize a per-step spec.json from the JSONL evolution chain.
+Recovery-only — does not mutate the chain or any SQLite table.
+
+Arguments:
+  <prompt-id>             One of: ${PROMPT_ID_VALUES.join(', ')}.
+
+Options:
+  --dry-run               Fold the chain and validate the result, but
+                          write nothing. Prints the post-fold hash and
+                          entry count.
+  --help, -h              Show this help message.
+
+Notes:
+  - Refuses to write if the rebuilt spec fails schema validation.
+  - Refuses to write if the JSONL chain is missing or corrupt.
+  - Writes via temp+rename so partial-write SIGKILL leaves the
+    on-disk spec.json intact.`;
+
+// ---------------------------------------------------------------------------
+// Public entry
+// ---------------------------------------------------------------------------
+
+export async function runPromptRebuild(args: string[]): Promise<void> {
+  if (args.includes('--help') || args.includes('-h')) {
+    process.stdout.write(`${USAGE}\n`);
+    return;
+  }
+
+  let positionals: string[];
+  let dryRun: boolean;
+
+  try {
+    const parsed = parseArgs({
+      args,
+      allowPositionals: true,
+      options: {
+        'dry-run': { type: 'boolean', default: false },
+        help: { type: 'boolean', short: 'h', default: false },
+      },
+    });
+    positionals = parsed.positionals;
+    dryRun = parsed.values['dry-run'] === true;
+  } catch (err) {
+    process.stderr.write(
+      `gobbi prompt rebuild: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.stderr.write(`${USAGE}\n`);
+    process.exit(2);
+  }
+
+  const promptIdArg = positionals[0];
+  if (promptIdArg === undefined) {
+    process.stderr.write(`gobbi prompt rebuild: missing <prompt-id>\n`);
+    process.stderr.write(`${USAGE}\n`);
+    process.exit(2);
+  }
+  if (!isPromptId(promptIdArg)) {
+    process.stderr.write(
+      `gobbi prompt rebuild: invalid prompt-id '${promptIdArg}' ` +
+        `(valid: ${PROMPT_ID_VALUES.join(', ')})\n`,
+    );
+    process.exit(1);
+  }
+  const promptId: PromptId = promptIdArg;
+
+  rebuildOne(promptId, dryRun);
+}
+
+// ---------------------------------------------------------------------------
+// Core
+// ---------------------------------------------------------------------------
+
+export interface RebuildResult {
+  readonly promptId: PromptId;
+  readonly entryCount: number;
+  readonly postHash: string;
+  readonly written: boolean;
+}
+
+export function rebuildOne(promptId: PromptId, dryRun: boolean): RebuildResult {
+  const projectName = resolveProjectName();
+  const jsonlPath = promptEvolutionPath(projectName, promptId);
+
+  if (!existsSync(jsonlPath)) {
+    process.stderr.write(
+      `gobbi prompt rebuild: prompt-evolution chain not found at ${jsonlPath}; nothing to rebuild from.\n`,
+    );
+    process.exit(1);
+  }
+
+  let folded;
+  try {
+    folded = foldChain(jsonlPath);
+  } catch (err) {
+    process.stderr.write(
+      `gobbi prompt rebuild: chain fold failed: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.exit(1);
+  }
+
+  // Schema-validate before writing.
+  const validation = validateStepSpec(folded.spec);
+  if (!validation.ok) {
+    process.stderr.write(
+      `gobbi prompt rebuild: rebuilt spec fails schema validation — refusing to write.\n` +
+        `The chain at ${jsonlPath} contains a patch that produced an invalid spec.\n` +
+        `Errors:\n${JSON.stringify(validation.errors, null, 2)}\n`,
+    );
+    process.exit(1);
+  }
+
+  const result: RebuildResult = {
+    promptId,
+    entryCount: folded.entryCount,
+    postHash: folded.lastPostHash,
+    written: false,
+  };
+
+  if (dryRun) {
+    printSummary(result);
+    return result;
+  }
+
+  // Atomic write via temp+rename.
+  const specPath = specJsonPath(promptId);
+  const tmp = `${specPath}.tmp`;
+  writeFileSync(tmp, canonicalize(folded.spec) + '\n', { encoding: 'utf8' });
+  renameSync(tmp, specPath);
+
+  const finalResult: RebuildResult = { ...result, written: true };
+  printSummary(finalResult);
+  return finalResult;
+}
+
+function printSummary(result: RebuildResult): void {
+  const lines = [
+    `gobbi prompt rebuild — ${result.written ? 'wrote' : 'dry-run'}`,
+    `prompt-id:     ${result.promptId}`,
+    `entry_count:   ${result.entryCount}`,
+    `post_hash:     ${result.postHash}`,
+  ];
+  process.stdout.write(`${lines.join('\n')}\n`);
+}

--- a/packages/cli/src/commands/prompt/render.ts
+++ b/packages/cli/src/commands/prompt/render.ts
@@ -1,0 +1,475 @@
+/**
+ * gobbi prompt render — render a per-step `spec.json` in one of three forms.
+ *
+ * Wave C.1.5 (issue #156). Operator-only — emits to stdout, no
+ * filesystem mutation. Three formats per synthesis §8:
+ *
+ *   - `--format=markdown`   Flat readable doc walking `StepBlocks` in
+ *                           source order. Suitable for `gobbi prompt
+ *                           render <step> --format=markdown | less`
+ *                           reviews. No session.state, no
+ *                           dynamic.context — this is the spec-as-spec.
+ *   - `--format=composed`   The byte-exact `CompiledPrompt.text` plus
+ *                           `staticPrefixHash`. Reuses
+ *                           `assembly.ts::compile()` directly, NOT a
+ *                           re-implementation, so the rendered output
+ *                           is byte-identical to what the runtime
+ *                           orchestrator would produce. Synthesis §8.1
+ *                           critical invariant.
+ *   - `--format=diff`       Unified diff between the markdown form at
+ *                           a baseline patch-id and the markdown form
+ *                           at HEAD. Folds the JSONL chain twice and
+ *                           shells out to `git --no-pager diff
+ *                           --no-index` so we ship zero new diff
+ *                           dependencies.
+ *
+ * # Source vs. installed CLI
+ *
+ * Reads from the source `packages/cli/src/specs/<step>/spec.json` —
+ * NOT the bundled `dist/`. Operators on the installed CLI cannot
+ * render an installed prompt; they render the source repo. The
+ * dispatcher comment in `commands/prompt.ts` carries this.
+ */
+
+import { execFileSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
+
+import {
+  compile,
+  type CompileInput,
+  type CompilePredicateRegistry,
+  type DynamicContext,
+} from '../../specs/assembly.js';
+import { defaultBudgetAllocator } from '../../specs/budget.js';
+import { validateStepSpec } from '../../specs/_schema/v1.js';
+import type {
+  StepSpec,
+  StepBlocks,
+  BlockContent,
+  ConditionalBlock,
+} from '../../specs/types.js';
+import { initialState } from '../../workflow/state.js';
+import type { WorkflowStep } from '../../workflow/state.js';
+import { defaultPredicates } from '../../workflow/predicates.js';
+import { foldChain } from '../../lib/prompt-evolution.js';
+import {
+  PROMPT_ID_VALUES,
+  type PromptId,
+  resolveSpecsRoot,
+  resolveProjectName,
+  promptEvolutionPath,
+  isPromptId,
+} from './paths.js';
+
+// ---------------------------------------------------------------------------
+// Usage
+// ---------------------------------------------------------------------------
+
+const USAGE = `Usage: gobbi prompt render <prompt-id> [options]
+
+Render a per-step spec.json in one of three forms.
+
+Arguments:
+  <prompt-id>             One of: ${PROMPT_ID_VALUES.join(', ')}.
+
+Options:
+  --format <format>       Render form. One of: markdown, composed, diff.
+                          Default: markdown.
+  --baseline <patch-id>   Required when --format=diff. The chain entry's
+                          patchId to diff HEAD against.
+  --allow-empty-diff      When --format=diff and the chain has only the
+                          genesis line: exit 0 instead of refusing.
+  --help, -h              Show this help message.
+
+Notes:
+  - Reads source spec.json at packages/cli/src/specs/<prompt-id>/spec.json.
+    Operators on the installed CLI cannot render installed prompts; they
+    render the source repo.
+  - composed-form output is byte-identical to what the runtime
+    orchestrator emits for the same CompileInput (synthesis §8.1).`;
+
+// ---------------------------------------------------------------------------
+// Public entry
+// ---------------------------------------------------------------------------
+
+export async function runPromptRender(args: string[]): Promise<void> {
+  if (args.includes('--help') || args.includes('-h')) {
+    process.stdout.write(`${USAGE}\n`);
+    return;
+  }
+
+  let positionals: string[];
+  let format: string;
+  let baseline: string | undefined;
+  let allowEmptyDiff: boolean;
+
+  try {
+    const parsed = parseArgs({
+      args,
+      allowPositionals: true,
+      options: {
+        format: { type: 'string', default: 'markdown' },
+        baseline: { type: 'string' },
+        'allow-empty-diff': { type: 'boolean', default: false },
+        help: { type: 'boolean', short: 'h', default: false },
+      },
+    });
+    positionals = parsed.positionals;
+    format = parsed.values.format ?? 'markdown';
+    baseline = parsed.values.baseline;
+    allowEmptyDiff = parsed.values['allow-empty-diff'] === true;
+  } catch (err) {
+    process.stderr.write(
+      `gobbi prompt render: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.stderr.write(`${USAGE}\n`);
+    process.exit(2);
+  }
+
+  const promptIdArg = positionals[0];
+  if (promptIdArg === undefined) {
+    process.stderr.write(`gobbi prompt render: missing <prompt-id>\n`);
+    process.stderr.write(`${USAGE}\n`);
+    process.exit(2);
+  }
+  if (!isPromptId(promptIdArg)) {
+    process.stderr.write(
+      `gobbi prompt render: invalid prompt-id '${promptIdArg}' ` +
+        `(valid: ${PROMPT_ID_VALUES.join(', ')})\n`,
+    );
+    process.exit(1);
+  }
+  const promptId: PromptId = promptIdArg;
+
+  if (format !== 'markdown' && format !== 'composed' && format !== 'diff') {
+    process.stderr.write(
+      `gobbi prompt render: unknown --format '${format}' ` +
+        `(valid: markdown, composed, diff)\n`,
+    );
+    process.exit(2);
+  }
+
+  // ----- Render dispatch -------------------------------------------------
+  if (format === 'markdown') {
+    const spec = loadSpec(promptId);
+    process.stdout.write(renderMarkdown(spec));
+    return;
+  }
+  if (format === 'composed') {
+    const spec = loadSpec(promptId);
+    const composed = renderComposed(spec, promptId);
+    process.stdout.write(composed);
+    return;
+  }
+  // format === 'diff'
+  if (baseline === undefined) {
+    process.stderr.write(
+      `gobbi prompt render: --baseline <patch-id> is required when --format=diff\n`,
+    );
+    process.exit(2);
+  }
+  await renderDiff(promptId, baseline, allowEmptyDiff);
+}
+
+// ---------------------------------------------------------------------------
+// Spec loading
+// ---------------------------------------------------------------------------
+
+function loadSpec(promptId: PromptId): StepSpec {
+  const here = dirname(fileURLToPath(import.meta.url));
+  // commands/prompt/render.ts → ../../specs/<promptId>/spec.json
+  const path = resolve(here, '..', '..', 'specs', promptId, 'spec.json');
+  if (!existsSync(path)) {
+    process.stderr.write(`gobbi prompt render: spec not found at ${path}\n`);
+    process.exit(1);
+  }
+  const raw: unknown = JSON.parse(readFileSync(path, 'utf8'));
+  const result = validateStepSpec(raw);
+  if (!result.ok) {
+    process.stderr.write(
+      `gobbi prompt render: ${promptId}/spec.json fails schema validation:\n` +
+        `${JSON.stringify(result.errors, null, 2)}\n`,
+    );
+    process.exit(1);
+  }
+  return result.value;
+}
+
+// ---------------------------------------------------------------------------
+// markdown rendering — flat readable doc walking StepBlocks in source order
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a `StepBlocks` payload as a flat markdown doc. No session.state,
+ * no dynamic.context — runtime-only sections are out of scope here.
+ *
+ * Section ordering matches `types.ts::StepBlocks`: static → conditional
+ * → delegation → synthesis → completion → footer. Each block is an H2
+ * `## <id>` heading.
+ *
+ * Exported for tests; the render command pipes it to stdout.
+ */
+export function renderMarkdown(spec: StepSpec): string {
+  const lines: string[] = [];
+  const meta = spec.meta;
+  lines.push(`# ${meta.description}`);
+  lines.push('');
+
+  const blocks: StepBlocks = spec.blocks;
+
+  for (const block of blocks.static) {
+    lines.push(...renderBlock(block));
+  }
+  for (const block of blocks.conditional) {
+    lines.push(...renderConditional(block));
+  }
+  for (const [key, block] of Object.entries(blocks.delegation)) {
+    lines.push(`## delegation: ${key}`);
+    lines.push('');
+    lines.push(block.content.trimEnd());
+    lines.push('');
+  }
+  for (const block of blocks.synthesis) {
+    lines.push(...renderBlock(block));
+  }
+
+  // Completion as an H2 with a numbered criteria list.
+  lines.push('## completion');
+  lines.push('');
+  lines.push(blocks.completion.instruction.trimEnd());
+  lines.push('');
+  if (blocks.completion.criteria.length > 0) {
+    blocks.completion.criteria.forEach((c, i) => {
+      lines.push(`${i + 1}. ${c}`);
+    });
+    lines.push('');
+  }
+
+  // Footer
+  lines.push('## footer');
+  lines.push('');
+  lines.push(blocks.footer.trimEnd());
+  lines.push('');
+
+  return `${lines.join('\n')}\n`;
+}
+
+function renderBlock(block: BlockContent): readonly string[] {
+  return [`## ${block.id}`, '', block.content.trimEnd(), ''];
+}
+
+function renderConditional(block: ConditionalBlock): readonly string[] {
+  return [
+    `## ${block.id} (conditional: ${block.when})`,
+    '',
+    block.content.trimEnd(),
+    '',
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// composed rendering — calls assembly.compile() and emits text +
+// staticPrefixHash header.
+// ---------------------------------------------------------------------------
+
+const FIXED_TIMESTAMP = '2026-04-26T12:00:00.000Z';
+const GENEROUS_WINDOW = 200_000;
+
+const predicates: CompilePredicateRegistry = defaultPredicates;
+
+function buildCompileInput(spec: StepSpec, promptId: PromptId): CompileInput {
+  // Match the deterministic-state convention from `footer.snap.test.ts`.
+  // `currentStep` matches the prompt-id by default; this makes the
+  // composed-render output reproducible across invocations.
+  const currentStep: WorkflowStep = promptId as WorkflowStep;
+  const state = {
+    ...initialState(`session-render-${promptId}`),
+    currentStep,
+  };
+  const dynamic: DynamicContext = {
+    timestamp: FIXED_TIMESTAMP,
+    activeSubagentCount: 0,
+    artifacts: [],
+  };
+  return { spec, state, dynamic, predicates, activeAgent: null };
+}
+
+/**
+ * Render the composed form. Produces:
+ *
+ *     # gobbi prompt render <promptId> --format=composed
+ *     # staticPrefixHash: <hash>
+ *
+ *     <CompiledPrompt.text>
+ *
+ * Exported for tests.
+ */
+export function renderComposed(spec: StepSpec, promptId: PromptId): string {
+  const input = buildCompileInput(spec, promptId);
+  const out = compile(input, {
+    allocator: defaultBudgetAllocator,
+    contextWindowTokens: GENEROUS_WINDOW,
+  });
+  return [
+    `# gobbi prompt render ${promptId} --format=composed`,
+    `# staticPrefixHash: ${out.staticPrefixHash}`,
+    '',
+    out.text,
+    '',
+  ].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// diff rendering — fold chain to baseline, fold chain to head, shell-diff.
+// ---------------------------------------------------------------------------
+
+async function renderDiff(
+  promptId: PromptId,
+  baselinePatchId: string,
+  allowEmptyDiff: boolean,
+): Promise<void> {
+  const projectName = resolveProjectName();
+  const specsRoot = resolveSpecsRoot();
+  const jsonlPath = promptEvolutionPath(projectName, promptId);
+
+  if (!existsSync(jsonlPath)) {
+    process.stderr.write(
+      `gobbi prompt render: prompt-evolution chain not found at ${jsonlPath}; ` +
+        `run \`gobbi prompt patch\` to seed the chain or \`gobbi prompt rebuild\` to recover.\n`,
+    );
+    process.exit(1);
+  }
+
+  let head;
+  try {
+    head = foldChain(jsonlPath);
+  } catch (err) {
+    process.stderr.write(
+      `gobbi prompt render: chain fold failed: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.exit(1);
+  }
+
+  // If the chain has only the genesis line, --format=diff has nothing
+  // to compare against. Per Planning routed-resolution: refuse with a
+  // clear message; --allow-empty-diff lets operators opt in.
+  if (head.entryCount <= 1) {
+    if (allowEmptyDiff) {
+      process.stdout.write('');
+      return;
+    }
+    process.stderr.write(
+      `gobbi prompt render: prompt has no patches beyond genesis; nothing to diff. ` +
+        `Use --allow-empty-diff to exit 0.\n`,
+    );
+    process.exit(1);
+  }
+
+  // Fold a truncated chain — every line up to AND INCLUDING the
+  // baseline patchId — to produce the baseline spec. Achieved by
+  // copying the JSONL up to the baseline line into a temp file and
+  // calling foldChain on that.
+  const baselineSpec = foldChainTruncated(jsonlPath, baselinePatchId);
+  if (baselineSpec === null) {
+    process.stderr.write(
+      `gobbi prompt render: --baseline ${baselinePatchId} not found in the chain at ${jsonlPath}.\n`,
+    );
+    process.exit(1);
+  }
+
+  // Render markdown for both, then diff.
+  const baselineMd = renderMarkdown(baselineSpec as StepSpec);
+  const headMd = renderMarkdown(head.spec as StepSpec);
+
+  const tmp = mkdtempSync(join(tmpdir(), 'gobbi-prompt-diff-'));
+  try {
+    const baselinePath = join(tmp, 'baseline.md');
+    const headPath = join(tmp, 'head.md');
+    writeFileSync(baselinePath, baselineMd, 'utf8');
+    writeFileSync(headPath, headMd, 'utf8');
+    let diff: string;
+    try {
+      const out = execFileSync(
+        'git',
+        ['--no-pager', 'diff', '--no-index', baselinePath, headPath],
+        { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+      );
+      // git diff exits 0 when files are identical
+      diff = out;
+    } catch (err) {
+      // git diff exits 1 when files differ — that is the expected path.
+      const e = err as NodeJS.ErrnoException & { stdout?: Buffer | string; status?: number };
+      if (e.status === 1 && e.stdout !== undefined) {
+        diff = typeof e.stdout === 'string' ? e.stdout : e.stdout.toString('utf8');
+      } else {
+        process.stderr.write(
+          `gobbi prompt render: git diff failed: ${e.message}\n`,
+        );
+        process.exit(1);
+      }
+    }
+    process.stdout.write(diff);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+    // Side-effect noted: specsRoot is read at fold time but no other
+    // mutation is performed here; the temp dir is the only filesystem
+    // touch.
+    void specsRoot;
+  }
+}
+
+/**
+ * Fold the chain up to and including the entry whose `patchId` equals
+ * `baselinePatchId`. Returns `null` when the patch-id is absent. Used
+ * by --format=diff to compute the baseline spec.
+ *
+ * Implementation: read the JSONL, truncate the line list at the match,
+ * write to a temp JSONL, call `foldChain` on that. Reuses the chain
+ * folder's diagnostics rather than reimplementing them.
+ */
+function foldChainTruncated(
+  path: string,
+  baselinePatchId: string,
+): unknown | null {
+  const raw = readFileSync(path, 'utf8');
+  const lines = raw.split('\n').filter((l) => l.length > 0);
+  let cutIndex = -1;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    let parsed: { patchId?: unknown };
+    try {
+      parsed = JSON.parse(line) as { patchId?: unknown };
+    } catch {
+      // foldChain will surface this; we are best-effort here.
+      continue;
+    }
+    if (parsed.patchId === baselinePatchId) {
+      cutIndex = i;
+      break;
+    }
+  }
+  if (cutIndex < 0) return null;
+
+  const tmp = mkdtempSync(join(tmpdir(), 'gobbi-prompt-fold-'));
+  try {
+    const truncatedPath = join(tmp, 'truncated.jsonl');
+    writeFileSync(
+      truncatedPath,
+      lines.slice(0, cutIndex + 1).join('\n') + '\n',
+      'utf8',
+    );
+    return foldChain(truncatedPath).spec;
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}

--- a/packages/cli/src/lib/__tests__/canonical-json.test.ts
+++ b/packages/cli/src/lib/__tests__/canonical-json.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests for `lib/canonical-json.ts` — the pure stringifier used by
+ * Wave C.1's content addressing.
+ *
+ * The function is a thin wrapper around `JSON.stringify(value, null, 2)`
+ * so the test surface focuses on (a) the rule we lock here matches the
+ * `_schema/v1.json` byte-mirror format used at
+ * `specs/__tests__/schema.test.ts:399-406`, and (b) edge cases that the
+ * rule must be robust against (round-trip stability under
+ * parse-and-re-stringify, key insertion-order preservation).
+ */
+
+import { describe, test, expect } from 'bun:test';
+
+import { canonicalize } from '../canonical-json.js';
+
+describe('canonicalize', () => {
+  test('matches the `JSON.stringify(value, null, 2)` reference shape', () => {
+    const value = { a: 1, b: [2, 3], c: { d: true } };
+    expect(canonicalize(value)).toBe(JSON.stringify(value, null, 2));
+  });
+
+  test('uses 2-space indent (the schema-mirror precedent)', () => {
+    const out = canonicalize({ a: 1 });
+    expect(out).toContain('\n  "a": 1');
+  });
+
+  test('preserves insertion order — NOT sorted-key', () => {
+    const out = canonicalize({ z: 1, a: 2, m: 3 });
+    // Insertion order: z first, then a, then m.
+    const idxZ = out.indexOf('"z"');
+    const idxA = out.indexOf('"a"');
+    const idxM = out.indexOf('"m"');
+    expect(idxZ).toBeLessThan(idxA);
+    expect(idxA).toBeLessThan(idxM);
+  });
+
+  test('round-trips JSON.parse → canonicalize for an object whose keys are already in insertion order', () => {
+    const original = { x: 1, y: 2, z: 3 };
+    const json = JSON.stringify(original, null, 2);
+    const reparsed = JSON.parse(json) as unknown;
+    expect(canonicalize(reparsed)).toBe(json);
+  });
+
+  test('handles primitives — number, string, boolean, null', () => {
+    expect(canonicalize(42)).toBe('42');
+    expect(canonicalize('hello')).toBe('"hello"');
+    expect(canonicalize(true)).toBe('true');
+    expect(canonicalize(null)).toBe('null');
+  });
+
+  test('handles empty object', () => {
+    expect(canonicalize({})).toBe('{}');
+  });
+
+  test('handles empty array', () => {
+    expect(canonicalize([])).toBe('[]');
+  });
+
+  test('nested objects emit 2-space indents at every level', () => {
+    const out = canonicalize({ a: { b: { c: 1 } } });
+    // Depth-3 c should have 6 leading spaces.
+    expect(out).toContain('      "c": 1');
+  });
+
+  test('byte-equal idempotent — canonicalize(canonicalize-parsed) === canonicalize', () => {
+    const value = { a: [1, { b: 2 }], c: 'x' };
+    const first = canonicalize(value);
+    const reparsed = JSON.parse(first) as unknown;
+    expect(canonicalize(reparsed)).toBe(first);
+  });
+});

--- a/packages/cli/src/lib/__tests__/prompt-evolution.test.ts
+++ b/packages/cli/src/lib/__tests__/prompt-evolution.test.ts
@@ -127,8 +127,11 @@ describe('buildGenesisEntry', () => {
       { op: 'add', path: '', value: BASELINE_SPEC },
     ]);
     expect(entry.appliedBy).toBe('operator');
-    expect(entry.validationStatus).toBe('passed');
     expect(entry.v).toBe(1);
+    // Wave C.1.6 R1 / Overall F-4: `validationStatus` was dropped from
+    // the JSONL wire shape. Existence of the line IS the "passed"
+    // signal.
+    expect('validationStatus' in entry).toBe(false);
   });
 
   test('preHash hashes the empty-object baseline (genesis convention)', () => {
@@ -249,7 +252,6 @@ describe('appendPromptEvolutionEntry', () => {
       preHash: genesis.postHash,
       postHash: contentHash({ ...BASELINE_SPEC, version: 1 }),
       ops,
-      validationStatus: 'passed',
       appliedBy: 'operator',
       eventSeq: 2,
       schemaId: SCHEMA_ID,
@@ -310,7 +312,6 @@ describe('foldChain', () => {
       preHash: genesis.postHash,
       postHash: contentHash(intermediate),
       ops: ops1,
-      validationStatus: 'passed',
       appliedBy: 'operator',
       eventSeq: 2,
       schemaId: SCHEMA_ID,
@@ -329,7 +330,6 @@ describe('foldChain', () => {
       preHash: entry1.postHash,
       postHash: contentHash(finalSpec),
       ops: ops2,
-      validationStatus: 'passed',
       appliedBy: 'operator',
       eventSeq: 3,
       schemaId: SCHEMA_ID,
@@ -352,7 +352,6 @@ describe('foldChain', () => {
       preHash: contentHash({}),
       postHash: contentHash(BASELINE_SPEC),
       ops: [{ op: 'add', path: '', value: BASELINE_SPEC }],
-      validationStatus: 'passed',
       appliedBy: 'operator',
       eventSeq: 1,
       schemaId: SCHEMA_ID,
@@ -382,7 +381,6 @@ describe('foldChain', () => {
       preHash: genesis.postHash,
       postHash: genesis.postHash,
       ops: [],
-      validationStatus: 'passed',
       appliedBy: 'operator',
       eventSeq: 2,
       schemaId: SCHEMA_ID,
@@ -461,7 +459,6 @@ describe('foldChain', () => {
       preHash: genesis.postHash,
       postHash: genesis.postHash,
       ops,
-      validationStatus: 'passed',
       appliedBy: 'operator',
       eventSeq: 2,
       schemaId: SCHEMA_ID,
@@ -469,5 +466,43 @@ describe('foldChain', () => {
     appendPromptEvolutionEntry(path, bogus);
 
     expect(() => foldChain(path)).toThrow(/applyPatch failed/);
+  });
+
+  test('accepts a legacy line carrying validationStatus: "passed" and ignores the field (Wave C.1.6 R1)', () => {
+    // Backward compatibility: chains written by the prior pass carry
+    // a `validationStatus: "passed"` field on every line. The reader
+    // accepts but ignores these (Overall F-4 fix).
+    const path = join(testDir, 'ideation.jsonl');
+    const genesis = buildGenesisEntry({
+      promptId: 'ideation',
+      baselineSpec: BASELINE_SPEC,
+      ts: '2026-04-26T00:00:00Z',
+      schemaId: SCHEMA_ID,
+      eventSeq: 1,
+    });
+    const legacy = { ...genesis, validationStatus: 'passed' };
+    appendJsonlSync(path, JSON.stringify(legacy));
+
+    const result = foldChain(path);
+    expect(result.entryCount).toBe(1);
+    expect(canonicalize(result.spec)).toBe(canonicalize(BASELINE_SPEC));
+  });
+
+  test('rejects a legacy line whose validationStatus carries an unexpected value', () => {
+    // The reader IGNORES `validationStatus` when 'passed', but a non-
+    // 'passed' value (which never legitimately existed) is corruption
+    // and must be rejected loudly.
+    const path = join(testDir, 'ideation.jsonl');
+    const genesis = buildGenesisEntry({
+      promptId: 'ideation',
+      baselineSpec: BASELINE_SPEC,
+      ts: '2026-04-26T00:00:00Z',
+      schemaId: SCHEMA_ID,
+      eventSeq: 1,
+    });
+    const corrupted = { ...genesis, validationStatus: 'failed' };
+    appendJsonlSync(path, JSON.stringify(corrupted));
+
+    expect(() => foldChain(path)).toThrow(/validationStatus.*must equal 'passed'/);
   });
 });

--- a/packages/cli/src/lib/__tests__/prompt-evolution.test.ts
+++ b/packages/cli/src/lib/__tests__/prompt-evolution.test.ts
@@ -1,0 +1,473 @@
+/**
+ * Tests for `lib/prompt-evolution.ts` — Wave C.1.4 (issue #156).
+ *
+ * Covers the two halves of the JSONL evolution log discipline:
+ *
+ *   (a) Writer side — `appendJsonlSync`, `buildGenesisEntry`,
+ *       `ensureGenesis`, `appendPromptEvolutionEntry`. Genesis line
+ *       shape per synthesis §7; every line ends with `\n`; existing-file
+ *       guard for ensureGenesis idempotency.
+ *
+ *   (b) Reader side — `foldChain`. Folds genesis-only chains, multi-
+ *       patch chains, asserts byte-equal to the on-disk spec, and
+ *       refuses corrupt chains (parent linkage broken, postHash drift,
+ *       malformed JSONL line, RFC 6902 op fail).
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  appendJsonlSync,
+  appendPromptEvolutionEntry,
+  buildGenesisEntry,
+  contentHash,
+  ensureGenesis,
+  foldChain,
+} from '../prompt-evolution.js';
+import type { PromptEvolutionEntry } from '../prompt-evolution.js';
+import { canonicalize } from '../canonical-json.js';
+
+// ---------------------------------------------------------------------------
+// Test scaffolding
+// ---------------------------------------------------------------------------
+
+let testDir: string;
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), 'gobbi-prompt-evolution-'));
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+const BASELINE_SPEC = {
+  $schema: 'https://gobbi.dev/schemas/step-spec/v1.json',
+  version: 1,
+  meta: { description: 'baseline', substates: [] },
+};
+
+const SCHEMA_ID = 'https://gobbi.dev/schemas/step-spec/v1.json';
+
+// ---------------------------------------------------------------------------
+// contentHash
+// ---------------------------------------------------------------------------
+
+describe('contentHash', () => {
+  test('returns a sha256: hex digest with stable prefix', () => {
+    const out = contentHash({ a: 1 });
+    expect(out).toMatch(/^sha256:[a-f0-9]{64}$/);
+  });
+
+  test('same input produces the same digest', () => {
+    expect(contentHash({ a: 1 })).toBe(contentHash({ a: 1 }));
+  });
+
+  test('different input produces different digest', () => {
+    expect(contentHash({ a: 1 })).not.toBe(contentHash({ a: 2 }));
+  });
+
+  test('hash is over canonicalize() bytes — insertion-order matters', () => {
+    // Different insertion-order objects produce different hashes.
+    expect(contentHash({ a: 1, b: 2 })).not.toBe(contentHash({ b: 2, a: 1 }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// appendJsonlSync
+// ---------------------------------------------------------------------------
+
+describe('appendJsonlSync', () => {
+  test('writes one line ending with \\n on a fresh file', () => {
+    const path = join(testDir, 'a.jsonl');
+    appendJsonlSync(path, '{"k":1}');
+    expect(readFileSync(path, 'utf8')).toBe('{"k":1}\n');
+  });
+
+  test('appends a second line preserving the prior content', () => {
+    const path = join(testDir, 'a.jsonl');
+    appendJsonlSync(path, '{"k":1}');
+    appendJsonlSync(path, '{"k":2}');
+    expect(readFileSync(path, 'utf8')).toBe('{"k":1}\n{"k":2}\n');
+  });
+
+  test('parsed back, both lines round-trip', () => {
+    const path = join(testDir, 'a.jsonl');
+    appendJsonlSync(path, JSON.stringify({ a: 1 }));
+    appendJsonlSync(path, JSON.stringify({ a: 2 }));
+    const lines = readFileSync(path, 'utf8').split('\n').filter((l) => l);
+    expect(lines.map((l) => JSON.parse(l))).toEqual([{ a: 1 }, { a: 2 }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildGenesisEntry / ensureGenesis
+// ---------------------------------------------------------------------------
+
+describe('buildGenesisEntry', () => {
+  test('produces a parentPatchId=null entry with the baseline spec as a single add op at root path', () => {
+    const entry = buildGenesisEntry({
+      promptId: 'ideation',
+      baselineSpec: BASELINE_SPEC,
+      ts: '2026-04-26T00:00:00Z',
+      schemaId: SCHEMA_ID,
+      eventSeq: 1,
+    });
+    expect(entry.parentPatchId).toBeNull();
+    expect(entry.ops).toEqual([
+      { op: 'add', path: '', value: BASELINE_SPEC },
+    ]);
+    expect(entry.appliedBy).toBe('operator');
+    expect(entry.validationStatus).toBe('passed');
+    expect(entry.v).toBe(1);
+  });
+
+  test('preHash hashes the empty-object baseline (genesis convention)', () => {
+    const entry = buildGenesisEntry({
+      promptId: 'ideation',
+      baselineSpec: BASELINE_SPEC,
+      ts: '2026-04-26T00:00:00Z',
+      schemaId: SCHEMA_ID,
+      eventSeq: 1,
+    });
+    expect(entry.preHash).toBe(contentHash({}));
+  });
+
+  test('postHash hashes the baseline spec', () => {
+    const entry = buildGenesisEntry({
+      promptId: 'ideation',
+      baselineSpec: BASELINE_SPEC,
+      ts: '2026-04-26T00:00:00Z',
+      schemaId: SCHEMA_ID,
+      eventSeq: 1,
+    });
+    expect(entry.postHash).toBe(contentHash(BASELINE_SPEC));
+  });
+
+  test('patchId hashes the canonicalized ops array', () => {
+    const entry = buildGenesisEntry({
+      promptId: 'ideation',
+      baselineSpec: BASELINE_SPEC,
+      ts: '2026-04-26T00:00:00Z',
+      schemaId: SCHEMA_ID,
+      eventSeq: 1,
+    });
+    expect(entry.patchId).toBe(
+      contentHash([{ op: 'add', path: '', value: BASELINE_SPEC }]),
+    );
+  });
+});
+
+describe('ensureGenesis', () => {
+  test('writes the genesis line to a fresh path', () => {
+    const path = join(testDir, 'ideation.jsonl');
+    expect(existsSync(path)).toBe(false);
+
+    const entry = ensureGenesis({
+      path,
+      promptId: 'ideation',
+      baselineSpec: BASELINE_SPEC,
+      ts: '2026-04-26T00:00:00Z',
+      schemaId: SCHEMA_ID,
+      eventSeq: 1,
+    });
+
+    expect(existsSync(path)).toBe(true);
+    const raw = readFileSync(path, 'utf8');
+    const parsed = JSON.parse(raw.trim()) as PromptEvolutionEntry;
+    expect(parsed.patchId).toBe(entry.patchId);
+    expect(parsed.parentPatchId).toBeNull();
+  });
+
+  test('idempotent — re-running on an existing file does NOT append a duplicate line', () => {
+    const path = join(testDir, 'ideation.jsonl');
+    const first = ensureGenesis({
+      path,
+      promptId: 'ideation',
+      baselineSpec: BASELINE_SPEC,
+      ts: '2026-04-26T00:00:00Z',
+      schemaId: SCHEMA_ID,
+      eventSeq: 1,
+    });
+    const second = ensureGenesis({
+      path,
+      promptId: 'ideation',
+      baselineSpec: BASELINE_SPEC,
+      ts: '2026-04-26T00:00:00Z',
+      schemaId: SCHEMA_ID,
+      eventSeq: 99,
+    });
+
+    // Same returned shape (computed from inputs, not from file read).
+    expect(second.patchId).toBe(first.patchId);
+
+    // File has exactly one line.
+    const raw = readFileSync(path, 'utf8');
+    expect(raw.split('\n').filter((l) => l).length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// appendPromptEvolutionEntry
+// ---------------------------------------------------------------------------
+
+describe('appendPromptEvolutionEntry', () => {
+  test('appends a non-genesis entry as a new line', () => {
+    const path = join(testDir, 'ideation.jsonl');
+    ensureGenesis({
+      path,
+      promptId: 'ideation',
+      baselineSpec: BASELINE_SPEC,
+      ts: '2026-04-26T00:00:00Z',
+      schemaId: SCHEMA_ID,
+      eventSeq: 1,
+    });
+    const genesis = buildGenesisEntry({
+      promptId: 'ideation',
+      baselineSpec: BASELINE_SPEC,
+      ts: '2026-04-26T00:00:00Z',
+      schemaId: SCHEMA_ID,
+      eventSeq: 1,
+    });
+
+    const ops = [{ op: 'replace' as const, path: '/version', value: 1 }];
+    const next: PromptEvolutionEntry = {
+      v: 1,
+      ts: '2026-04-26T00:01:00Z',
+      promptId: 'ideation',
+      patchId: contentHash(ops),
+      parentPatchId: genesis.patchId,
+      preHash: genesis.postHash,
+      postHash: contentHash({ ...BASELINE_SPEC, version: 1 }),
+      ops,
+      validationStatus: 'passed',
+      appliedBy: 'operator',
+      eventSeq: 2,
+      schemaId: SCHEMA_ID,
+    };
+
+    appendPromptEvolutionEntry(path, next);
+
+    const lines = readFileSync(path, 'utf8').split('\n').filter((l) => l);
+    expect(lines.length).toBe(2);
+    expect(JSON.parse(lines[1]!).parentPatchId).toBe(genesis.patchId);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// foldChain — replay-equivalence smoke
+// ---------------------------------------------------------------------------
+
+describe('foldChain', () => {
+  test('genesis-only chain folds back to the baseline spec byte-equal', () => {
+    const path = join(testDir, 'ideation.jsonl');
+    ensureGenesis({
+      path,
+      promptId: 'ideation',
+      baselineSpec: BASELINE_SPEC,
+      ts: '2026-04-26T00:00:00Z',
+      schemaId: SCHEMA_ID,
+      eventSeq: 1,
+    });
+
+    const result = foldChain(path);
+    expect(result.entryCount).toBe(1);
+    expect(canonicalize(result.spec)).toBe(canonicalize(BASELINE_SPEC));
+    expect(result.lastPostHash).toBe(contentHash(BASELINE_SPEC));
+  });
+
+  test('multi-patch chain folds to the same spec the patches produce when applied in sequence', () => {
+    const path = join(testDir, 'ideation.jsonl');
+    const genesis = ensureGenesis({
+      path,
+      promptId: 'ideation',
+      baselineSpec: BASELINE_SPEC,
+      ts: '2026-04-26T00:00:00Z',
+      schemaId: SCHEMA_ID,
+      eventSeq: 1,
+    });
+
+    // Patch 1 — change description.
+    const ops1 = [
+      { op: 'replace' as const, path: '/meta/description', value: 'updated' },
+    ];
+    const intermediate = { ...BASELINE_SPEC, meta: { ...BASELINE_SPEC.meta, description: 'updated' } };
+    const entry1: PromptEvolutionEntry = {
+      v: 1,
+      ts: '2026-04-26T00:01:00Z',
+      promptId: 'ideation',
+      patchId: contentHash(ops1),
+      parentPatchId: genesis.patchId,
+      preHash: genesis.postHash,
+      postHash: contentHash(intermediate),
+      ops: ops1,
+      validationStatus: 'passed',
+      appliedBy: 'operator',
+      eventSeq: 2,
+      schemaId: SCHEMA_ID,
+    };
+    appendPromptEvolutionEntry(path, entry1);
+
+    // Patch 2 — add a new field.
+    const ops2 = [{ op: 'add' as const, path: '/meta/note', value: 'hello' }];
+    const finalSpec = { ...intermediate, meta: { ...intermediate.meta, note: 'hello' } };
+    const entry2: PromptEvolutionEntry = {
+      v: 1,
+      ts: '2026-04-26T00:02:00Z',
+      promptId: 'ideation',
+      patchId: contentHash(ops2),
+      parentPatchId: entry1.patchId,
+      preHash: entry1.postHash,
+      postHash: contentHash(finalSpec),
+      ops: ops2,
+      validationStatus: 'passed',
+      appliedBy: 'operator',
+      eventSeq: 3,
+      schemaId: SCHEMA_ID,
+    };
+    appendPromptEvolutionEntry(path, entry2);
+
+    const result = foldChain(path);
+    expect(result.entryCount).toBe(3);
+    expect(canonicalize(result.spec)).toBe(canonicalize(finalSpec));
+  });
+
+  test('refuses a chain whose genesis carries a non-null parentPatchId', () => {
+    const path = join(testDir, 'ideation.jsonl');
+    const broken: PromptEvolutionEntry = {
+      v: 1,
+      ts: '2026-04-26T00:00:00Z',
+      promptId: 'ideation',
+      patchId: 'sha256:fake',
+      parentPatchId: 'sha256:not-null',
+      preHash: contentHash({}),
+      postHash: contentHash(BASELINE_SPEC),
+      ops: [{ op: 'add', path: '', value: BASELINE_SPEC }],
+      validationStatus: 'passed',
+      appliedBy: 'operator',
+      eventSeq: 1,
+      schemaId: SCHEMA_ID,
+    };
+    appendJsonlSync(path, JSON.stringify(broken));
+
+    expect(() => foldChain(path)).toThrow(/genesis line must have parentPatchId=null/);
+  });
+
+  test('refuses a chain whose subsequent line breaks parent linkage', () => {
+    const path = join(testDir, 'ideation.jsonl');
+    const genesis = ensureGenesis({
+      path,
+      promptId: 'ideation',
+      baselineSpec: BASELINE_SPEC,
+      ts: '2026-04-26T00:00:00Z',
+      schemaId: SCHEMA_ID,
+      eventSeq: 1,
+    });
+
+    const orphan: PromptEvolutionEntry = {
+      v: 1,
+      ts: '2026-04-26T00:01:00Z',
+      promptId: 'ideation',
+      patchId: 'sha256:orphan',
+      parentPatchId: 'sha256:wrong-parent',
+      preHash: genesis.postHash,
+      postHash: genesis.postHash,
+      ops: [],
+      validationStatus: 'passed',
+      appliedBy: 'operator',
+      eventSeq: 2,
+      schemaId: SCHEMA_ID,
+    };
+    appendPromptEvolutionEntry(path, orphan);
+
+    expect(() => foldChain(path)).toThrow(/parentPatchId=.*does not match prior/);
+  });
+
+  test('refuses a chain whose declared postHash drifts from the computed one', () => {
+    const path = join(testDir, 'ideation.jsonl');
+    const genesis = buildGenesisEntry({
+      promptId: 'ideation',
+      baselineSpec: BASELINE_SPEC,
+      ts: '2026-04-26T00:00:00Z',
+      schemaId: SCHEMA_ID,
+      eventSeq: 1,
+    });
+    // Mutate postHash to a wrong value.
+    const broken = { ...genesis, postHash: 'sha256:wrong' };
+    appendJsonlSync(path, JSON.stringify(broken));
+
+    expect(() => foldChain(path)).toThrow(/postHash mismatch/);
+  });
+
+  test('refuses a chain with malformed JSONL', () => {
+    const path = join(testDir, 'ideation.jsonl');
+    writeFileSync(path, 'not-json\n');
+    expect(() => foldChain(path)).toThrow();
+  });
+
+  test('refuses a missing file with a clear diagnostic', () => {
+    const path = join(testDir, 'never-existed.jsonl');
+    expect(() => foldChain(path)).toThrow(/file not found/);
+  });
+
+  test('refuses an empty file with a clear diagnostic', () => {
+    const path = join(testDir, 'empty.jsonl');
+    writeFileSync(path, '');
+    expect(() => foldChain(path)).toThrow(/file is empty/);
+  });
+
+  test('refuses a chain with an unknown promptId enum value', () => {
+    const path = join(testDir, 'ideation.jsonl');
+    const genesis = buildGenesisEntry({
+      promptId: 'ideation',
+      baselineSpec: BASELINE_SPEC,
+      ts: '2026-04-26T00:00:00Z',
+      schemaId: SCHEMA_ID,
+      eventSeq: 1,
+    });
+    const malformed = { ...genesis, promptId: 'unknown-step' };
+    appendJsonlSync(path, JSON.stringify(malformed));
+    expect(() => foldChain(path)).toThrow(/promptId is not a valid prompt-id/);
+  });
+
+  test('refuses a chain whose RFC 6902 op fails to apply', () => {
+    const path = join(testDir, 'ideation.jsonl');
+    const genesis = ensureGenesis({
+      path,
+      promptId: 'ideation',
+      baselineSpec: BASELINE_SPEC,
+      ts: '2026-04-26T00:00:00Z',
+      schemaId: SCHEMA_ID,
+      eventSeq: 1,
+    });
+
+    // RFC 6902 `test` op deliberately set to a failing value.
+    const ops = [{ op: 'test' as const, path: '/version', value: 999 }];
+    const bogus: PromptEvolutionEntry = {
+      v: 1,
+      ts: '2026-04-26T00:01:00Z',
+      promptId: 'ideation',
+      patchId: contentHash(ops),
+      parentPatchId: genesis.patchId,
+      preHash: genesis.postHash,
+      postHash: genesis.postHash,
+      ops,
+      validationStatus: 'passed',
+      appliedBy: 'operator',
+      eventSeq: 2,
+      schemaId: SCHEMA_ID,
+    };
+    appendPromptEvolutionEntry(path, bogus);
+
+    expect(() => foldChain(path)).toThrow(/applyPatch failed/);
+  });
+});

--- a/packages/cli/src/lib/canonical-json.ts
+++ b/packages/cli/src/lib/canonical-json.ts
@@ -1,0 +1,52 @@
+/**
+ * Canonical JSON stringifier for content addressing.
+ *
+ * One source of truth for "what bytes hash into a content address" across
+ * Wave C.1's prompts-as-data feature: the JSONL evolution log
+ * (`prompt-evolution/<prompt-id>.jsonl`), the SQLite `prompt_patches`
+ * row's `patch_id`/`pre_hash`/`post_hash` columns, and the
+ * replay-equivalence CI test all hash `canonicalize(value)`. Diverging
+ * the rule across these sites would split the hash space — operators
+ * could not reproduce a `patch_id` they observe in `prompt patches log`
+ * by canonicalizing the on-disk patch_json column.
+ *
+ * # Why insertion-order, not sorted-key
+ *
+ * The schema-mirror byte-equality test at
+ * `specs/__tests__/schema.test.ts:399-406` already pins the schema
+ * `_schema/v1.json` to `JSON.stringify(StepSpecSchema, null, 2)` — i.e.,
+ * insertion-order, 2-space indent, no trailing whitespace. Synthesis
+ * Architecture F-7 fix locks the same convention everywhere: introducing
+ * a sorted-key variant for `prompt_patches` content addressing would
+ * break the schema mirror test or produce two hash spaces. Insertion
+ * order is well-defined for `spec.json` files (the author's chosen key
+ * order is part of the file's byte identity); RFC 6902 `applyPatch`
+ * preserves key insertion order; the canonicalization is round-trip
+ * stable.
+ *
+ * # Trade-off accepted
+ *
+ * Reordering the keys of an existing `spec.json` (without changing
+ * meaning) produces a different hash even though the data is
+ * semantically identical. This is intentional — the file's byte
+ * identity IS the content. Operators preserve key order through normal
+ * editing; `fast-json-patch::applyPatch` preserves it through the patch
+ * apply. The only path that re-sorts is `JSON.parse + JSON.stringify`
+ * with a custom replacer, which is not part of the gobbi pipeline.
+ */
+
+/**
+ * Stringify a value to its canonical form for content-address hashing.
+ *
+ * Pure thin wrapper around `JSON.stringify(value, null, 2)`. Exists as a
+ * named function so the convention is greppable and so a future
+ * single-source-of-truth change (if forced) can update one definition
+ * rather than scatter `JSON.stringify(..., null, 2)` calls across the
+ * codebase.
+ *
+ * @param value any JSON-serializable value (must not contain cycles).
+ * @returns the canonical JSON string with 2-space indent.
+ */
+export function canonicalize(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}

--- a/packages/cli/src/lib/prompt-evolution.ts
+++ b/packages/cli/src/lib/prompt-evolution.ts
@@ -1,0 +1,419 @@
+/**
+ * Prompt-evolution JSONL log writer + chain folder.
+ *
+ * The append-only event log of `spec.json` evolution per Wave C.1.4
+ * (issue #156). Lives at:
+ *
+ *   `<project-root>/.gobbi/projects/<project>/prompt-evolution/<prompt-id>.jsonl`
+ *
+ * One file per closed prompt-id (`ideation`, `planning`, `execution`,
+ * `evaluation`, `memorization`, `handoff`). The first line is a
+ * synthetic genesis entry containing the full baseline `spec.json` as
+ * an `add` op at root path `''` — this makes every JSONL self-
+ * contained: any reader can fold the chain from line 1 and reproduce
+ * the on-disk `spec.json` byte-exactly. Without genesis, JSONL is a
+ * delta-only log requiring the on-disk spec as external input —
+ * collapses the "JSONL is authoritative" property.
+ *
+ * # CQRS partition
+ *
+ * Per design synthesis §2: `state.db::events` is truth (the audit
+ * event); `prompt_patches` table is the queryable read projection;
+ * `spec.json` on disk is the materialized snapshot, derivable from the
+ * JSONL chain. The replay-equivalence CI test at C.1.6 folds the JSONL
+ * chain in memory, canonicalizes the result, hashes it, and asserts
+ * byte-equality with `sha256(canonicalize(<on-disk spec.json>))`. Drift
+ * here means either JSONL is corrupt or `spec.json` was hand-edited —
+ * both detectable rather than silent.
+ *
+ * # Append discipline
+ *
+ * - Synchronous `appendFileSync` — `Bun.write` has no append mode
+ *   (`_bun/SKILL.md:48`, `_bun/gotchas.md:72-87`).
+ * - One call per line, line-buffered: the file stays valid even after
+ *   partial-write SIGKILL (everything before the last `\n` is
+ *   parseable JSONL).
+ * - Each line ends with `\n`. No trailing comma, no array brackets —
+ *   this is JSONL, not JSON.
+ *
+ * # Hashing
+ *
+ * Always hashes `canonicalize(value)` bytes — see `lib/canonical-json.ts`.
+ * Separating the canonicalize step from the hash makes the test surface
+ * straightforward (canonicalize is pure, hash is pure, the composition
+ * is two named functions).
+ */
+
+import { createHash } from 'node:crypto';
+import { appendFileSync, existsSync, readFileSync } from 'node:fs';
+import { applyPatch, deepClone } from 'fast-json-patch';
+import type { Operation } from 'fast-json-patch';
+
+import { canonicalize } from './canonical-json.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Closed prompt-id set — mirrors `events/prompt.ts::PromptId`. */
+export type PromptId =
+  | 'ideation'
+  | 'planning'
+  | 'execution'
+  | 'evaluation'
+  | 'memorization'
+  | 'handoff';
+
+/**
+ * One JSONL line — the wire shape per synthesis §7. `v` is the
+ * line-schema version (distinct from the per-event `schema_version` and
+ * from the StepSpec schema's `$id`).
+ *
+ * Keys mirror the SQLite `prompt_patches` columns (lowerCamelCase JSON,
+ * snake_case SQL — established gobbi precedent at
+ * `events/workflow.ts:73-86`). `eventSeq` back-links to
+ * `state.db::events.seq`.
+ */
+export interface PromptEvolutionEntry {
+  readonly v: 1;
+  readonly ts: string;
+  readonly promptId: PromptId;
+  readonly patchId: string;
+  readonly parentPatchId: string | null;
+  readonly preHash: string;
+  readonly postHash: string;
+  readonly ops: ReadonlyArray<Operation>;
+  readonly validationStatus: 'passed';
+  readonly appliedBy: 'operator';
+  readonly eventSeq: number;
+  readonly schemaId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Hashing
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the sha256 of `canonicalize(value)`. Returned as a hex
+ * `'sha256:<digest>'`-prefixed string so downstream tools (operator
+ * reading audit logs, replay-equivalence diagnostics) can spot the
+ * algorithm at a glance and a future algorithm change is unambiguous.
+ */
+export function contentHash(value: unknown): string {
+  const bytes = canonicalize(value);
+  return `sha256:${createHash('sha256').update(bytes).digest('hex')}`;
+}
+
+// ---------------------------------------------------------------------------
+// JSONL append (thin wrapper around appendFileSync)
+//
+// Architecture F-4 fix: there is no shared append-jsonl helper in
+// `state.ts` (the line referenced in the briefing is inside another
+// function, not a usable export). Synthesis §15 instructs us to
+// publish a thin helper here rather than reuse a non-existent one.
+// ---------------------------------------------------------------------------
+
+/**
+ * Append one well-formed JSONL line to `path`. The line is the
+ * argument's exact bytes plus a trailing `\n` — callers control the
+ * line-content shape (this helper does not stringify, validate, or
+ * canonicalize).
+ *
+ * The single `appendFileSync` call gives us POSIX-level append-atomic
+ * line semantics (under the small-write threshold) and recoverable
+ * partial-write semantics under SIGKILL: the file always parses up to
+ * the last `\n`. Mirrors `state.ts:464-465`'s temp+rename pattern in
+ * intent (least-surprising filesystem write) but for an append-only
+ * log, not a single-file overwrite.
+ */
+export function appendJsonlSync(path: string, line: string): void {
+  appendFileSync(path, line + '\n', { encoding: 'utf8' });
+}
+
+// ---------------------------------------------------------------------------
+// Genesis line — first JSONL entry per prompt-id
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the genesis `PromptEvolutionEntry` for a brand-new
+ * `<prompt-id>.jsonl` from the full baseline `spec.json`. Synthesis §7
+ * locks the shape: the ops array is a single RFC 6902 `add` at root
+ * path `''` whose `value` is the entire baseline.
+ *
+ * `parentPatchId` is `null` (chain head). `preHash` is the content
+ * hash of the empty-spec baseline (`{}`) — by convention the prior
+ * "state" before genesis is the empty object so subsequent
+ * replay-equivalence folds can bootstrap from it.
+ */
+export function buildGenesisEntry(args: {
+  readonly promptId: PromptId;
+  readonly baselineSpec: unknown;
+  readonly ts: string;
+  readonly schemaId: string;
+  readonly eventSeq: number;
+}): PromptEvolutionEntry {
+  const ops: ReadonlyArray<Operation> = [
+    { op: 'add', path: '', value: args.baselineSpec },
+  ];
+  const preHash = contentHash({});
+  const postHash = contentHash(args.baselineSpec);
+  const patchId = contentHash(ops);
+  return {
+    v: 1,
+    ts: args.ts,
+    promptId: args.promptId,
+    patchId,
+    parentPatchId: null,
+    preHash,
+    postHash,
+    ops,
+    validationStatus: 'passed',
+    appliedBy: 'operator',
+    eventSeq: args.eventSeq,
+    schemaId: args.schemaId,
+  };
+}
+
+/**
+ * Write the genesis entry to a fresh `<prompt-id>.jsonl` if it does
+ * not already exist; otherwise no-op. Returns the entry that was
+ * written (or would have been written, if the file already exists).
+ *
+ * Idempotent: re-running on an existing file is a read-and-return; the
+ * caller can grep the returned `patchId` to confirm the genesis matches
+ * what they expect.
+ */
+export function ensureGenesis(args: {
+  readonly path: string;
+  readonly promptId: PromptId;
+  readonly baselineSpec: unknown;
+  readonly ts: string;
+  readonly schemaId: string;
+  readonly eventSeq: number;
+}): PromptEvolutionEntry {
+  const entry = buildGenesisEntry(args);
+  if (!existsSync(args.path)) {
+    appendJsonlSync(args.path, JSON.stringify(entry));
+  }
+  return entry;
+}
+
+// ---------------------------------------------------------------------------
+// Append a non-genesis entry
+// ---------------------------------------------------------------------------
+
+/**
+ * Append a non-genesis `PromptEvolutionEntry` to `path`. The caller
+ * supplies the fully-formed entry; this function only writes. Existence
+ * of the parent file is not checked — callers MUST call
+ * {@link ensureGenesis} first.
+ */
+export function appendPromptEvolutionEntry(
+  path: string,
+  entry: PromptEvolutionEntry,
+): void {
+  appendJsonlSync(path, JSON.stringify(entry));
+}
+
+// ---------------------------------------------------------------------------
+// Chain fold — used by replay-equivalence test + `gobbi prompt rebuild`
+// ---------------------------------------------------------------------------
+
+export interface FoldResult {
+  /** The final spec produced by folding every op in the chain. */
+  readonly spec: unknown;
+  /** Number of entries folded (genesis counts as 1). */
+  readonly entryCount: number;
+  /** The last entry's `postHash` (must match `contentHash(spec)`). */
+  readonly lastPostHash: string;
+}
+
+/**
+ * Read every line of a `<prompt-id>.jsonl` file, parse each as a
+ * `PromptEvolutionEntry`, and fold the ops into a final spec. Genesis
+ * line's `add path:''` op materialises the baseline; subsequent ops
+ * mutate the in-memory clone via `fast-json-patch::applyPatch`.
+ *
+ * Throws with a clear diagnostic when:
+ *
+ *   - The file is empty or missing.
+ *   - A line fails to JSON-parse.
+ *   - A line fails the entry shape check (missing required field).
+ *   - A patch op fails to apply (RFC 6902 `test` op fail, invalid path).
+ *   - The fold produces a `postHash` that disagrees with the entry's
+ *     declared `postHash` — chain corruption.
+ *   - `parentPatchId` chains do not link end-to-end.
+ *
+ * Used by:
+ *   - `specs/__tests__/replay-equivalence.test.ts` (Wave C.1.6 — folds
+ *     every step's JSONL and byte-compares to on-disk spec.json).
+ *   - `commands/prompt/rebuild.ts` (Wave C.1.7 — recovers a missing /
+ *     out-of-sync `spec.json` from the JSONL chain).
+ */
+export function foldChain(path: string): FoldResult {
+  if (!existsSync(path)) {
+    throw new Error(`prompt-evolution: file not found: ${path}`);
+  }
+  const raw = readFileSync(path, 'utf8');
+  const lines = raw.split('\n').filter((l) => l.length > 0);
+  if (lines.length === 0) {
+    throw new Error(`prompt-evolution: file is empty: ${path}`);
+  }
+
+  let spec: unknown = {};
+  let lastPostHash: string | null = null;
+  let lastPatchId: string | null = null;
+
+  lines.forEach((line, index) => {
+    let entry: PromptEvolutionEntry;
+    try {
+      entry = parseEntry(JSON.parse(line));
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `prompt-evolution: ${path} line ${index + 1}: ${reason}`,
+      );
+    }
+
+    // Chain linkage check — every non-genesis line must point at the
+    // prior line's patchId.
+    if (index === 0) {
+      if (entry.parentPatchId !== null) {
+        throw new Error(
+          `prompt-evolution: ${path} line 1: genesis line must have parentPatchId=null (got ${String(
+            entry.parentPatchId,
+          )})`,
+        );
+      }
+    } else {
+      if (entry.parentPatchId !== lastPatchId) {
+        throw new Error(
+          `prompt-evolution: ${path} line ${index + 1}: parentPatchId=${String(
+            entry.parentPatchId,
+          )} does not match prior line's patchId=${String(lastPatchId)}`,
+        );
+      }
+    }
+
+    // Apply the ops to a deep clone of the current spec. This catches
+    // RFC 6902 `test` op failures and invalid-path errors.
+    let result: ReturnType<typeof applyPatch<unknown>>;
+    try {
+      result = applyPatch(deepClone(spec), [...entry.ops]);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `prompt-evolution: ${path} line ${index + 1}: applyPatch failed: ${reason}`,
+      );
+    }
+    spec = result.newDocument;
+
+    // Hash check — the entry's declared postHash must match the
+    // canonicalized post-apply spec. Drift here is corruption.
+    const computed = contentHash(spec);
+    if (computed !== entry.postHash) {
+      throw new Error(
+        `prompt-evolution: ${path} line ${index + 1}: postHash mismatch — ` +
+          `entry declares ${entry.postHash}, computed ${computed}`,
+      );
+    }
+
+    lastPostHash = entry.postHash;
+    lastPatchId = entry.patchId;
+  });
+
+  return {
+    spec,
+    entryCount: lines.length,
+    // Non-null after the forEach (lines.length > 0 was checked).
+    lastPostHash: lastPostHash as unknown as string,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Entry shape validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Narrow an unknown JSON value to a `PromptEvolutionEntry`. Throws on
+ * any missing or wrong-typed field — the JSONL line shape is our wire
+ * contract, so a malformed line is a corruption signal, not a soft
+ * error.
+ */
+function parseEntry(value: unknown): PromptEvolutionEntry {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('entry must be a JSON object');
+  }
+  const obj = value as Record<string, unknown>;
+
+  function requireString(key: string): string {
+    const v = obj[key];
+    if (typeof v !== 'string') {
+      throw new Error(`field ${key} must be a string (got ${typeof v})`);
+    }
+    return v;
+  }
+  function requireNumber(key: string): number {
+    const v = obj[key];
+    if (typeof v !== 'number') {
+      throw new Error(`field ${key} must be a number (got ${typeof v})`);
+    }
+    return v;
+  }
+
+  if (obj['v'] !== 1) {
+    throw new Error(`field v must equal 1 (got ${String(obj['v'])})`);
+  }
+  const promptId = requireString('promptId');
+  const PROMPT_IDS = new Set([
+    'ideation',
+    'planning',
+    'execution',
+    'evaluation',
+    'memorization',
+    'handoff',
+  ]);
+  if (!PROMPT_IDS.has(promptId)) {
+    throw new Error(`field promptId is not a valid prompt-id: ${promptId}`);
+  }
+
+  const parentPatchIdRaw = obj['parentPatchId'];
+  if (parentPatchIdRaw !== null && typeof parentPatchIdRaw !== 'string') {
+    throw new Error(
+      `field parentPatchId must be string or null (got ${typeof parentPatchIdRaw})`,
+    );
+  }
+
+  const opsRaw = obj['ops'];
+  if (!Array.isArray(opsRaw)) {
+    throw new Error('field ops must be an array');
+  }
+
+  if (obj['validationStatus'] !== 'passed') {
+    throw new Error(
+      `field validationStatus must be 'passed' (got ${String(
+        obj['validationStatus'],
+      )})`,
+    );
+  }
+  if (obj['appliedBy'] !== 'operator') {
+    throw new Error(
+      `field appliedBy must be 'operator' (got ${String(obj['appliedBy'])})`,
+    );
+  }
+
+  return {
+    v: 1,
+    ts: requireString('ts'),
+    promptId: promptId as PromptId,
+    patchId: requireString('patchId'),
+    parentPatchId: parentPatchIdRaw,
+    preHash: requireString('preHash'),
+    postHash: requireString('postHash'),
+    ops: opsRaw as ReadonlyArray<Operation>,
+    validationStatus: 'passed',
+    appliedBy: 'operator',
+    eventSeq: requireNumber('eventSeq'),
+    schemaId: requireString('schemaId'),
+  };
+}

--- a/packages/cli/src/lib/prompt-evolution.ts
+++ b/packages/cli/src/lib/prompt-evolution.ts
@@ -73,6 +73,15 @@ export type PromptId =
  * snake_case SQL — established gobbi precedent at
  * `events/workflow.ts:73-86`). `eventSeq` back-links to
  * `state.db::events.seq`.
+ *
+ * Wave C.1.6 R1 / Overall F-4: the field formerly known as
+ * `validationStatus` was removed. The prior pass dropped the
+ * SQLite column but kept the JSONL field, leaving an asymmetric
+ * wire shape (column gone, line constant carrying the same value).
+ * Existence of the row IS the "passed" signal; a future schema-v2
+ * status taxonomy will be a separate field. The fold-time reader
+ * accepts and IGNORES `validationStatus` if a legacy line carries
+ * it — see {@link parseEntry}.
  */
 export interface PromptEvolutionEntry {
   readonly v: 1;
@@ -83,7 +92,6 @@ export interface PromptEvolutionEntry {
   readonly preHash: string;
   readonly postHash: string;
   readonly ops: ReadonlyArray<Operation>;
-  readonly validationStatus: 'passed';
   readonly appliedBy: 'operator';
   readonly eventSeq: number;
   readonly schemaId: string;
@@ -167,7 +175,6 @@ export function buildGenesisEntry(args: {
     preHash,
     postHash,
     ops,
-    validationStatus: 'passed',
     appliedBy: 'operator',
     eventSeq: args.eventSeq,
     schemaId: args.schemaId,
@@ -389,9 +396,17 @@ function parseEntry(value: unknown): PromptEvolutionEntry {
     throw new Error('field ops must be an array');
   }
 
-  if (obj['validationStatus'] !== 'passed') {
+  // Wave C.1.6 R1 / Overall F-4: `validationStatus` was dropped from
+  // the wire shape. Legacy lines may carry `validationStatus: 'passed'`
+  // — accept and IGNORE so older JSONL chains keep folding cleanly.
+  // A line with a non-'passed' value (which never legitimately existed)
+  // is rejected as corruption.
+  if (
+    'validationStatus' in obj &&
+    obj['validationStatus'] !== 'passed'
+  ) {
     throw new Error(
-      `field validationStatus must be 'passed' (got ${String(
+      `field validationStatus, when present, must equal 'passed' (got ${String(
         obj['validationStatus'],
       )})`,
     );
@@ -411,7 +426,6 @@ function parseEntry(value: unknown): PromptEvolutionEntry {
     preHash: requireString('preHash'),
     postHash: requireString('postHash'),
     ops: opsRaw as ReadonlyArray<Operation>,
-    validationStatus: 'passed',
     appliedBy: 'operator',
     eventSeq: requireNumber('eventSeq'),
     schemaId: requireString('schemaId'),

--- a/packages/cli/src/specs/__tests__/all-specs.test.ts
+++ b/packages/cli/src/specs/__tests__/all-specs.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Glob-validate every on-disk `spec.json` against the locked StepSpec v1
+ * JSON Schema (Wave C.1.1).
+ *
+ * # Why this test exists
+ *
+ * The drift safety nets at `_schema/v1.ts:247-313` — `JSONSchemaType<StepSpec>`
+ * compile-time binding plus the `v1.json` byte-mirror test at
+ * `schema.test.ts:399-406` — keep `types.ts ↔ schema TS ↔ schema JSON` in
+ * lockstep. They do NOT, on their own, validate the actual on-disk
+ * `packages/cli/src/specs/<step>/spec.json` files. Whichever test happens
+ * to load a spec exercises its own slice; a spec edit that violates the
+ * schema (e.g., a token-budget sum that no longer hits 1.0, a missing
+ * `required` field, a stray top-level key) only surfaces if downstream
+ * code paths happen to load the offending step.
+ *
+ * This test closes that gap. It walks every step subdirectory under
+ * `packages/cli/src/specs/<step>/`, parses each `spec.json`, runs
+ * `validateStepSpec`, and asserts:
+ *
+ *   1. `validateStepSpec` returns `ok: true` (full schema + cross-ref
+ *      gates pass; AJV error list is empty).
+ *   2. The `$schema` field on the parsed JSON equals `STEP_SPEC_SCHEMA_ID`
+ *      — every spec self-identifies as v1, no stray version strings.
+ *
+ * # Discovery
+ *
+ * Uses `node:fs.readdirSync(specsRoot)` against the absolute path computed
+ * from `import.meta.url` so the test is location-independent and never
+ * accidentally globs into `__tests__/fixtures/`. The expected step set is
+ * pinned (`{ideation, planning, execution, evaluation, memorization,
+ * handoff}`) so a missing or extra directory fails the closed-set check
+ * — drift in either direction surfaces here.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, resolve, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  validateStepSpec,
+  STEP_SPEC_SCHEMA_ID,
+} from '../_schema/v1.js';
+
+// ---------------------------------------------------------------------------
+// Closed step-id set — matches the prompt-id set locked in
+// `design/v050-features/prompts-as-data.md` user lock 2.
+// ---------------------------------------------------------------------------
+
+const EXPECTED_STEP_IDS = [
+  'ideation',
+  'planning',
+  'execution',
+  'evaluation',
+  'memorization',
+  'handoff',
+] as const;
+
+// ---------------------------------------------------------------------------
+// Discovery — walk `packages/cli/src/specs/<step>/spec.json`
+// ---------------------------------------------------------------------------
+
+const here = dirname(fileURLToPath(import.meta.url));
+const specsRoot = resolve(here, '..');
+
+function discoverSpecDirs(): readonly string[] {
+  return readdirSync(specsRoot)
+    .filter((entry) => {
+      // Skip non-directories (sibling .ts files like `assembly.ts`,
+      // `types.ts`, `index.json`).
+      if (!statSync(join(specsRoot, entry)).isDirectory()) return false;
+      // Skip leading-underscore subdirs (`_schema`) — those are
+      // infrastructure, not steps. Skip the test-runner directory.
+      if (entry.startsWith('_') || entry.startsWith('__')) return false;
+      // Only count directories that contain a `spec.json`.
+      try {
+        statSync(join(specsRoot, entry, 'spec.json'));
+        return true;
+      } catch {
+        return false;
+      }
+    })
+    .sort();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('all spec.json files validate against StepSpec v1', () => {
+  const stepIds = discoverSpecDirs();
+
+  test('discovered step directories match the closed prompt-id set', () => {
+    expect(stepIds).toEqual([...EXPECTED_STEP_IDS].sort());
+  });
+
+  // One test per spec so failures point at a single file.
+  for (const stepId of stepIds) {
+    test(`${stepId}/spec.json: validateStepSpec returns ok=true`, () => {
+      const path = join(specsRoot, stepId, 'spec.json');
+      const raw = readFileSync(path, 'utf8');
+      const parsed: unknown = JSON.parse(raw);
+      const result = validateStepSpec(parsed);
+      // Surface the AJV error list verbatim so a regression points at the
+      // exact field/keyword combination.
+      if (!result.ok) {
+        // eslint-disable-next-line no-console
+        console.error(`${stepId}/spec.json validation errors:`, result.errors);
+      }
+      expect(result.ok).toBe(true);
+    });
+
+    test(`${stepId}/spec.json: $schema equals STEP_SPEC_SCHEMA_ID`, () => {
+      const path = join(specsRoot, stepId, 'spec.json');
+      const raw = readFileSync(path, 'utf8');
+      const parsed = JSON.parse(raw) as { $schema?: unknown };
+      expect(parsed.$schema).toBe(STEP_SPEC_SCHEMA_ID);
+    });
+  }
+});

--- a/packages/cli/src/specs/__tests__/replay-equivalence.test.ts
+++ b/packages/cli/src/specs/__tests__/replay-equivalence.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Replay-equivalence CI gate (Wave C.1.6, synthesis §7 + §10
+ * innovative addition #4).
+ *
+ * The CQRS invariant: folding the JSONL evolution chain in memory and
+ * canonicalize-hashing the result must equal `contentHash(<on-disk
+ * spec.json>)`. Drift here means either the JSONL is corrupt or
+ * `spec.json` was hand-edited — both detectable rather than silent.
+ *
+ * Scope of this CI gate (Wave C.1):
+ *
+ *   - For every prompt-id whose `<repoRoot>/.gobbi/projects/<project>/
+ *     prompt-evolution/<prompt-id>.jsonl` exists, fold the chain via
+ *     `lib/prompt-evolution.ts::foldChain` and assert
+ *     `contentHash(folded) === contentHash(<on-disk spec.json>)`.
+ *
+ *   - Skips silently when the chain file is absent — the chain is
+ *     bootstrapped on first `gobbi prompt patch <prompt-id>
+ *     --allow-no-parent` invocation. A prompt-id that has never been
+ *     patched produces no JSONL chain (synthesis §11 deferral 5: the
+ *     bundled `dist/` semantics). The on-disk spec.json IS the
+ *     baseline in that case.
+ *
+ * The test produces one assertion per existing JSONL chain. When any
+ * chain exists, the test enforces byte-equality. When no chains exist
+ * (the default state of a fresh repo), the test passes vacuously and
+ * emits a soft note.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { contentHash, foldChain } from '../../lib/prompt-evolution.js';
+import { getRepoRoot } from '../../lib/repo.js';
+import {
+  PROMPT_ID_VALUES,
+  promptEvolutionPath,
+  resolveProjectName,
+} from '../../commands/prompt/paths.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SPECS_ROOT = resolve(HERE, '..');
+
+describe('replay equivalence — JSONL chain fold ≡ on-disk spec.json', () => {
+  for (const promptId of PROMPT_ID_VALUES) {
+    test(`${promptId}.jsonl folds to byte-equal on-disk spec.json (or skips when chain absent)`, () => {
+      const projectName = resolveProjectName();
+      const jsonlPath = promptEvolutionPath(projectName, promptId);
+      if (!existsSync(jsonlPath)) {
+        // Chain not yet bootstrapped — vacuous pass. The on-disk
+        // spec.json IS the baseline; nothing to compare against.
+        // (Soft note suppressed; bun:test does not surface it well.)
+        expect(true).toBe(true);
+        return;
+      }
+
+      const folded = foldChain(jsonlPath);
+
+      const specPath = join(SPECS_ROOT, promptId, 'spec.json');
+      expect(existsSync(specPath)).toBe(true);
+      const specRaw: unknown = JSON.parse(readFileSync(specPath, 'utf8'));
+
+      const foldedHash = contentHash(folded.spec);
+      const onDiskHash = contentHash(specRaw);
+
+      // Byte-equal under the canonicalize() convention. If this fails,
+      // either the JSONL is corrupt (a patch row's postHash drifted
+      // and the fold produced a wrong spec, which foldChain would
+      // already have thrown on) or spec.json was hand-edited after
+      // the chain was last patched (operator should run
+      // `gobbi prompt rebuild <prompt-id>` to restore). The diagnostic
+      // names which side drifted by including both hashes.
+      expect(foldedHash).toBe(onDiskHash);
+    });
+  }
+
+  test('fold + canonicalize round-trip preserves byte-identity', () => {
+    // A small smoke test to lock the contract end-to-end without
+    // requiring an actual chain to exist. Use a synthetic in-memory
+    // chain for this assertion — the per-prompt-id tests above cover
+    // the on-disk contract.
+    void getRepoRoot; // ensure import is used
+    expect(true).toBe(true);
+  });
+});

--- a/packages/cli/src/specs/__tests__/replay-equivalence.test.ts
+++ b/packages/cli/src/specs/__tests__/replay-equivalence.test.ts
@@ -21,19 +21,30 @@
  *     bundled `dist/` semantics). The on-disk spec.json IS the
  *     baseline in that case.
  *
- * The test produces one assertion per existing JSONL chain. When any
- * chain exists, the test enforces byte-equality. When no chains exist
- * (the default state of a fresh repo), the test passes vacuously and
- * emits a soft note.
+ *   - The `synthetic in-memory chain` describe block at the bottom
+ *     (Wave C.1.6 R1 / Innovative F-8 + Overall F-11 fix) replaces
+ *     the prior pass's vacuous `expect(true).toBe(true)` placeholder.
+ *     A 3-line synthetic JSONL (genesis + 2 patches) is folded and
+ *     byte-compared to a hand-derived spec; a hand-edited divergent
+ *     spec is shown to fail. This locks the contract end-to-end at
+ *     CI time, independent of any on-disk JSONL chain existing.
  */
 
-import { describe, test, expect } from 'bun:test';
-import { existsSync, readFileSync } from 'node:fs';
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
-import { contentHash, foldChain } from '../../lib/prompt-evolution.js';
-import { getRepoRoot } from '../../lib/repo.js';
+import {
+  appendPromptEvolutionEntry,
+  buildGenesisEntry,
+  contentHash,
+  ensureGenesis,
+  foldChain,
+} from '../../lib/prompt-evolution.js';
+import type { PromptEvolutionEntry } from '../../lib/prompt-evolution.js';
+import { canonicalize } from '../../lib/canonical-json.js';
 import {
   PROMPT_ID_VALUES,
   promptEvolutionPath,
@@ -43,6 +54,8 @@ import {
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SPECS_ROOT = resolve(HERE, '..');
 
+const SCHEMA_ID = 'https://gobbi.dev/schemas/step-spec/v1.json';
+
 describe('replay equivalence — JSONL chain fold ≡ on-disk spec.json', () => {
   for (const promptId of PROMPT_ID_VALUES) {
     test(`${promptId}.jsonl folds to byte-equal on-disk spec.json (or skips when chain absent)`, () => {
@@ -51,7 +64,8 @@ describe('replay equivalence — JSONL chain fold ≡ on-disk spec.json', () => 
       if (!existsSync(jsonlPath)) {
         // Chain not yet bootstrapped — vacuous pass. The on-disk
         // spec.json IS the baseline; nothing to compare against.
-        // (Soft note suppressed; bun:test does not surface it well.)
+        // The synthetic-chain describe block below locks the contract
+        // end-to-end regardless of whether any on-disk chain exists.
         expect(true).toBe(true);
         return;
       }
@@ -75,13 +89,180 @@ describe('replay equivalence — JSONL chain fold ≡ on-disk spec.json', () => 
       expect(foldedHash).toBe(onDiskHash);
     });
   }
+});
 
-  test('fold + canonicalize round-trip preserves byte-identity', () => {
-    // A small smoke test to lock the contract end-to-end without
-    // requiring an actual chain to exist. Use a synthetic in-memory
-    // chain for this assertion — the per-prompt-id tests above cover
-    // the on-disk contract.
-    void getRepoRoot; // ensure import is used
-    expect(true).toBe(true);
+// ---------------------------------------------------------------------------
+// Synthetic in-memory chain — Wave C.1.6 R1 (Innovative F-8 / Overall F-11)
+//
+// The on-disk-chain tests above are gated by chain bootstrap (the file
+// must exist on disk for any contract to be locked). The synthetic
+// describe block below builds an in-memory chain (genesis + 2 patches)
+// in a tmp directory and exercises the actual fold-and-compare invariant
+// independently of repo state. This makes the replay-equivalence
+// contract testable at CI time on a fresh checkout.
+// ---------------------------------------------------------------------------
+
+describe('replay equivalence — synthetic in-memory chain (Wave C.1.6 R1)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'gobbi-replay-equiv-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // A small stand-in for a real spec.json — same shape, no schema
+  // validation (the replay-equivalence contract is byte-for-byte
+  // equality of the canonicalized fold and the on-disk file; the
+  // spec's schema validity is a separate concern handled by
+  // `validateStepSpec` at write time).
+  const BASELINE_SPEC = {
+    $schema: SCHEMA_ID,
+    version: 1,
+    meta: { description: 'synthetic baseline', substates: [] },
+  } as const;
+
+  /**
+   * Build a 3-entry synthetic chain:
+   *   - genesis line carrying the full BASELINE_SPEC.
+   *   - patch 1: `replace /meta/description` to `'updated'`.
+   *   - patch 2: `add /meta/note` with value `'hello'`.
+   * Returns the path and the final folded spec for byte-equality
+   * comparison.
+   */
+  function seedSyntheticChain(promptId: 'ideation' | 'planning'): {
+    readonly jsonlPath: string;
+    readonly finalSpec: Record<string, unknown>;
+  } {
+    const jsonlPath = join(tmpDir, `${promptId}.jsonl`);
+
+    const genesis = ensureGenesis({
+      path: jsonlPath,
+      promptId,
+      baselineSpec: BASELINE_SPEC,
+      ts: '2026-04-26T00:00:00.000Z',
+      schemaId: SCHEMA_ID,
+      eventSeq: 1,
+    });
+
+    const ops1 = [
+      { op: 'replace' as const, path: '/meta/description', value: 'updated' },
+    ];
+    const intermediate = {
+      ...BASELINE_SPEC,
+      meta: { ...BASELINE_SPEC.meta, description: 'updated' },
+    };
+    const entry1: PromptEvolutionEntry = {
+      v: 1,
+      ts: '2026-04-26T00:01:00.000Z',
+      promptId,
+      patchId: contentHash(ops1),
+      parentPatchId: genesis.patchId,
+      preHash: genesis.postHash,
+      postHash: contentHash(intermediate),
+      ops: ops1,
+      appliedBy: 'operator',
+      eventSeq: 2,
+      schemaId: SCHEMA_ID,
+    };
+    appendPromptEvolutionEntry(jsonlPath, entry1);
+
+    const ops2 = [
+      { op: 'add' as const, path: '/meta/note', value: 'hello' },
+    ];
+    const finalSpec = {
+      ...intermediate,
+      meta: { ...intermediate.meta, note: 'hello' },
+    };
+    const entry2: PromptEvolutionEntry = {
+      v: 1,
+      ts: '2026-04-26T00:02:00.000Z',
+      promptId,
+      patchId: contentHash(ops2),
+      parentPatchId: entry1.patchId,
+      preHash: entry1.postHash,
+      postHash: contentHash(finalSpec),
+      ops: ops2,
+      appliedBy: 'operator',
+      eventSeq: 3,
+      schemaId: SCHEMA_ID,
+    };
+    appendPromptEvolutionEntry(jsonlPath, entry2);
+
+    return { jsonlPath, finalSpec };
+  }
+
+  test('positive — folded chain byte-equals the hand-derived final spec', () => {
+    const { jsonlPath, finalSpec } = seedSyntheticChain('ideation');
+
+    const folded = foldChain(jsonlPath);
+    expect(folded.entryCount).toBe(3);
+
+    const foldedHash = contentHash(folded.spec);
+    const finalHash = contentHash(finalSpec);
+    expect(foldedHash).toBe(finalHash);
+
+    // Byte-equality under canonicalize() — the strongest form of the
+    // replay-equivalence contract.
+    expect(canonicalize(folded.spec)).toBe(canonicalize(finalSpec));
+  });
+
+  test('negative — a hand-edited divergent spec fails the byte-equality assertion', () => {
+    const { jsonlPath, finalSpec } = seedSyntheticChain('planning');
+
+    const folded = foldChain(jsonlPath);
+    // Simulate the operator hand-editing the on-disk spec to a
+    // semantically-different value. The replay-equivalence contract
+    // MUST detect this drift.
+    const handEdited = {
+      ...finalSpec,
+      meta: { ...(finalSpec['meta'] as Record<string, unknown>), note: 'tampered' },
+    };
+
+    const foldedHash = contentHash(folded.spec);
+    const tamperedHash = contentHash(handEdited);
+
+    expect(foldedHash).not.toBe(tamperedHash);
+    expect(canonicalize(folded.spec)).not.toBe(canonicalize(handEdited));
+  });
+
+  test('negative — postHash drift in the JSONL itself is caught at fold time', () => {
+    // This is the corruption mode foldChain catches BEFORE the
+    // replay-equivalence comparator runs. Build a chain whose entry's
+    // declared postHash disagrees with the canonicalized result.
+    const jsonlPath = join(tmpDir, 'evaluation.jsonl');
+    const genesis = buildGenesisEntry({
+      promptId: 'evaluation',
+      baselineSpec: BASELINE_SPEC,
+      ts: '2026-04-26T00:00:00.000Z',
+      schemaId: SCHEMA_ID,
+      eventSeq: 1,
+    });
+    // Mutate postHash to a wrong value — foldChain catches this.
+    const broken = { ...genesis, postHash: 'sha256:wrong' };
+    appendPromptEvolutionEntry(jsonlPath, broken as PromptEvolutionEntry);
+
+    expect(() => foldChain(jsonlPath)).toThrow(/postHash mismatch/);
+  });
+
+  test('positive — single-genesis chain folds to the baseline byte-equal', () => {
+    // The minimum-size chain. Locks the genesis-only invariant
+    // (`add /` op materializes the baseline; no further ops).
+    const jsonlPath = join(tmpDir, 'memorization.jsonl');
+    ensureGenesis({
+      path: jsonlPath,
+      promptId: 'memorization',
+      baselineSpec: BASELINE_SPEC,
+      ts: '2026-04-26T00:00:00.000Z',
+      schemaId: SCHEMA_ID,
+      eventSeq: 1,
+    });
+
+    const folded = foldChain(jsonlPath);
+    expect(folded.entryCount).toBe(1);
+    expect(canonicalize(folded.spec)).toBe(canonicalize(BASELINE_SPEC));
+    expect(contentHash(folded.spec)).toBe(contentHash(BASELINE_SPEC));
   });
 });

--- a/packages/cli/src/workflow/__tests__/migrations.test.ts
+++ b/packages/cli/src/workflow/__tests__/migrations.test.ts
@@ -64,8 +64,8 @@ const LEGACY_PARTITION: Pick<EventRow, 'session_id' | 'project_id'> = {
 // ---------------------------------------------------------------------------
 
 describe('CURRENT_SCHEMA_VERSION', () => {
-  test('is 6 — schema v6 landed in Wave A.1.3 (state_snapshots + tool_calls + config_changes + schema_meta tables, plus step.advancement.observed audit-only event)', () => {
-    expect(CURRENT_SCHEMA_VERSION).toBe(6);
+  test('is 7 — schema v7 landed in Wave C.1.2 (prompt_patches table + prompt.patch.applied audit-only event for prompts-as-data)', () => {
+    expect(CURRENT_SCHEMA_VERSION).toBe(7);
   });
 });
 
@@ -854,7 +854,7 @@ describe('v5 → v6 schema ensureSchemaV6', () => {
     }
   });
 
-  test('schema_meta is stamped at the current schema version with the supplied timestamp', async () => {
+  test('schema_meta is stamped at v6 with the supplied timestamp', async () => {
     const db = await buildV5Db();
     try {
       const { ensureSchemaV6 } = await import('../migrations.js');
@@ -870,7 +870,13 @@ describe('v5 → v6 schema ensureSchemaV6', () => {
         .query<MetaRow, [string]>('SELECT * FROM schema_meta WHERE id = ?')
         .get('state_db');
       expect(row).not.toBeNull();
-      expect(row?.schema_version).toBe(CURRENT_SCHEMA_VERSION);
+      // Wave C.1.2 — `ensureSchemaV6` stamps the literal `6`, not
+      // `CURRENT_SCHEMA_VERSION`. Once v7 landed, the per-version stamp
+      // moved into each `ensureSchemaVN` so re-running an older hop in
+      // isolation does not leave the DB advertising a future version.
+      // The full chain (ensureSchemaV6 + ensureSchemaV7) stamps 7 in the
+      // outer test; this isolated call stamps 6.
+      expect(row?.schema_version).toBe(6);
       expect(row?.migrated_at).toBe(fixedNow);
     } finally {
       db.close();
@@ -959,6 +965,371 @@ describe('v5 → v6 schema ensureSchemaV6', () => {
           ['s', 'workflow.foo', 'global', null, '"x"', 2],
         ),
       ).toThrow();
+    } finally {
+      db.close();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2g. v6 → v7 event round-trip — identity on event data; the new
+//     `prompt_patches` table + `prompt.patch.applied` audit-only event
+//     are strictly additive (Wave C.1.2).
+// ---------------------------------------------------------------------------
+
+describe('v6 → v7 event round-trip (identity on event data)', () => {
+  test('a v6 workflow.start migrates to v7 unchanged', () => {
+    const v6Event: EventRow = {
+      seq: 1,
+      ts: '2026-04-26T00:00:00Z',
+      schema_version: 6,
+      type: 'workflow.start',
+      step: 'ideation',
+      data: JSON.stringify({
+        sessionId: 'sess-v6',
+        timestamp: '2026-04-26T00:00:00Z',
+      }),
+      actor: 'system',
+      parent_seq: null,
+      idempotency_key: 'sess-v6:1745611200000:workflow.start',
+      ...LEGACY_PARTITION,
+      session_id: 'sess-v6',
+    };
+    const migrated = migrateEvent(v6Event, 7);
+    expect(migrated.schema_version).toBe(7);
+    // Byte-identical data string — v6→v7 is an identity transform on
+    // event data; only the wire-level type set widened.
+    expect(migrated.data).toBe(v6Event.data);
+    expect(migrated.type).toBe(v6Event.type);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2h. v6 → v7 schema CREATE — `prompt_patches` workspace-partitioned
+//     audit table (Wave C.1.2, issue #156).
+// ---------------------------------------------------------------------------
+
+describe('v6 → v7 schema ensureSchemaV7', () => {
+  // Build a v6-shape store (events + the four v6 tables already
+  // present) so ensureSchemaV7 runs against the realistic starting
+  // point — a v6 db that has already been opened by an A.1+ binary.
+  const buildV6Db = async () => {
+    const { Database } = await import('bun:sqlite');
+    const { ensureSchemaV6 } = await import('../migrations.js');
+    const db = new Database(':memory:');
+    db.run(`
+      CREATE TABLE events (
+        seq INTEGER PRIMARY KEY,
+        ts TEXT NOT NULL,
+        schema_version INTEGER NOT NULL,
+        type TEXT NOT NULL,
+        step TEXT,
+        data TEXT NOT NULL DEFAULT '{}',
+        actor TEXT NOT NULL,
+        parent_seq INTEGER REFERENCES events(seq),
+        idempotency_key TEXT NOT NULL UNIQUE,
+        session_id TEXT,
+        project_id TEXT
+      )
+    `);
+    ensureSchemaV6(db);
+    return db;
+  };
+
+  test('ensureSchemaV7 applies cleanly on a v6 store and creates the prompt_patches table', async () => {
+    const db = await buildV6Db();
+    try {
+      const {
+        ensureSchemaV7,
+        getTableNames,
+        SCHEMA_V7_TABLES,
+      } = await import('../migrations.js');
+
+      const before = getTableNames(db);
+      for (const t of SCHEMA_V7_TABLES) {
+        expect(before.has(t)).toBe(false);
+      }
+
+      ensureSchemaV7(db);
+
+      const after = getTableNames(db);
+      for (const t of SCHEMA_V7_TABLES) {
+        expect(after.has(t)).toBe(true);
+      }
+    } finally {
+      db.close();
+    }
+  });
+
+  test('prompt_patches carries every expected column', async () => {
+    const db = await buildV6Db();
+    try {
+      const { ensureSchemaV7 } = await import('../migrations.js');
+      ensureSchemaV7(db);
+
+      interface Pragma {
+        readonly name: string;
+      }
+      const cols = (table: string): Set<string> =>
+        new Set(
+          db
+            .query<Pragma, []>(`PRAGMA table_info(${table})`)
+            .all()
+            .map((r) => r.name),
+        );
+
+      const promptPatchesCols = cols('prompt_patches');
+      for (const expected of [
+        'seq',
+        'session_id',
+        'project_id',
+        'prompt_id',
+        'parent_seq',
+        'event_seq',
+        'patch_id',
+        'patch_json',
+        'pre_hash',
+        'post_hash',
+        'applied_at',
+        'applied_by',
+      ]) {
+        expect(promptPatchesCols.has(expected)).toBe(true);
+      }
+    } finally {
+      db.close();
+    }
+  });
+
+  test('every v7 index is created', async () => {
+    const db = await buildV6Db();
+    try {
+      const {
+        ensureSchemaV7,
+        getIndexNames,
+        SCHEMA_V7_INDICES,
+      } = await import('../migrations.js');
+      ensureSchemaV7(db);
+      const indices = getIndexNames(db);
+      for (const idx of SCHEMA_V7_INDICES) {
+        expect(indices.has(idx)).toBe(true);
+      }
+    } finally {
+      db.close();
+    }
+  });
+
+  test('schema_meta is stamped at v7 with the supplied timestamp', async () => {
+    const db = await buildV6Db();
+    try {
+      const { ensureSchemaV7 } = await import('../migrations.js');
+      const fixedNow = 1746000000000;
+      ensureSchemaV7(db, fixedNow);
+
+      interface MetaRow {
+        readonly schema_version: number;
+        readonly migrated_at: number;
+      }
+      const row = db
+        .query<MetaRow, [string]>(
+          'SELECT schema_version, migrated_at FROM schema_meta WHERE id = ?',
+        )
+        .get('state_db');
+      expect(row).not.toBeNull();
+      expect(row?.schema_version).toBe(CURRENT_SCHEMA_VERSION);
+      expect(row?.migrated_at).toBe(fixedNow);
+    } finally {
+      db.close();
+    }
+  });
+
+  test('ensureSchemaV7 is idempotent — re-running does not throw and refreshes migrated_at', async () => {
+    const db = await buildV6Db();
+    try {
+      const {
+        ensureSchemaV7,
+        getTableNames,
+        SCHEMA_V7_TABLES,
+      } = await import('../migrations.js');
+      const t0 = 1746000000000;
+      const t1 = 1746000001000;
+      ensureSchemaV7(db, t0);
+      ensureSchemaV7(db, t1);
+
+      const after = getTableNames(db);
+      for (const t of SCHEMA_V7_TABLES) {
+        expect(after.has(t)).toBe(true);
+      }
+
+      interface MetaRow {
+        readonly migrated_at: number;
+      }
+      const row = db
+        .query<MetaRow, [string]>(
+          'SELECT migrated_at FROM schema_meta WHERE id = ?',
+        )
+        .get('state_db');
+      expect(row?.migrated_at).toBe(t1);
+
+      // Single-row invariant — `id = 'state_db'` remains the only row.
+      const count = db
+        .query<{ cnt: number }, []>('SELECT count(*) as cnt FROM schema_meta')
+        .get();
+      expect(count?.cnt).toBe(1);
+    } finally {
+      db.close();
+    }
+  });
+
+  test('prompt_id CHECK constraint rejects values outside the closed enum', async () => {
+    const db = await buildV6Db();
+    try {
+      const { ensureSchemaV7 } = await import('../migrations.js');
+      ensureSchemaV7(db);
+
+      // Insert a parent event row first to satisfy the FK on event_seq.
+      db.run(
+        `INSERT INTO events (seq, ts, schema_version, type, data, actor, idempotency_key, session_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        [1, '2026-04-26T00:00:00Z', 7, 'prompt.patch.applied', '{}', 'operator', 'idem-1', 's'],
+      );
+
+      // Valid prompt_id passes.
+      db.run(
+        `INSERT INTO prompt_patches (session_id, prompt_id, event_seq, patch_id, patch_json, pre_hash, post_hash, applied_at, applied_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ['s', 'ideation', 1, 'p1', '[]', 'h0', 'h1', 1, 'operator'],
+      );
+      // Invalid prompt_id throws.
+      // Insert a second event row first because event_seq is UNIQUE.
+      db.run(
+        `INSERT INTO events (seq, ts, schema_version, type, data, actor, idempotency_key, session_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        [2, '2026-04-26T00:00:00Z', 7, 'prompt.patch.applied', '{}', 'operator', 'idem-2', 's'],
+      );
+      expect(() =>
+        db.run(
+          `INSERT INTO prompt_patches (session_id, prompt_id, event_seq, patch_id, patch_json, pre_hash, post_hash, applied_at, applied_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          ['s', 'unknown_step', 2, 'p2', '[]', 'h0', 'h1', 1, 'operator'],
+        ),
+      ).toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  test('applied_by CHECK constraint rejects anything other than "operator"', async () => {
+    const db = await buildV6Db();
+    try {
+      const { ensureSchemaV7 } = await import('../migrations.js');
+      ensureSchemaV7(db);
+
+      db.run(
+        `INSERT INTO events (seq, ts, schema_version, type, data, actor, idempotency_key, session_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        [1, '2026-04-26T00:00:00Z', 7, 'prompt.patch.applied', '{}', 'operator', 'idem-1', 's'],
+      );
+
+      expect(() =>
+        db.run(
+          `INSERT INTO prompt_patches (session_id, prompt_id, event_seq, patch_id, patch_json, pre_hash, post_hash, applied_at, applied_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          ['s', 'ideation', 1, 'p1', '[]', 'h0', 'h1', 1, 'agent'],
+        ),
+      ).toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  test('UNIQUE(prompt_id, patch_id) blocks cross-session duplicate writes', async () => {
+    const db = await buildV6Db();
+    try {
+      const { ensureSchemaV7 } = await import('../migrations.js');
+      ensureSchemaV7(db);
+
+      // Two separate sessions emit the same patch content (same patch_id).
+      db.run(
+        `INSERT INTO events (seq, ts, schema_version, type, data, actor, idempotency_key, session_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        [1, '2026-04-26T00:00:00Z', 7, 'prompt.patch.applied', '{}', 'operator', 'idem-1', 'sess-A'],
+      );
+      db.run(
+        `INSERT INTO events (seq, ts, schema_version, type, data, actor, idempotency_key, session_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        [2, '2026-04-26T01:00:00Z', 7, 'prompt.patch.applied', '{}', 'operator', 'idem-2', 'sess-B'],
+      );
+
+      db.run(
+        `INSERT INTO prompt_patches (session_id, prompt_id, event_seq, patch_id, patch_json, pre_hash, post_hash, applied_at, applied_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ['sess-A', 'ideation', 1, 'shared-patch-id', '[]', 'h0', 'h1', 1, 'operator'],
+      );
+      // Second session writing the same content-addressed patch_id must
+      // be blocked by `UNIQUE (prompt_id, patch_id)`.
+      expect(() =>
+        db.run(
+          `INSERT INTO prompt_patches (session_id, prompt_id, event_seq, patch_id, patch_json, pre_hash, post_hash, applied_at, applied_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          ['sess-B', 'ideation', 2, 'shared-patch-id', '[]', 'h0', 'h1', 1, 'operator'],
+        ),
+      ).toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  test('UNIQUE(event_seq) blocks two prompt_patches rows pointing at the same event', async () => {
+    const db = await buildV6Db();
+    try {
+      const { ensureSchemaV7 } = await import('../migrations.js');
+      ensureSchemaV7(db);
+
+      db.run(
+        `INSERT INTO events (seq, ts, schema_version, type, data, actor, idempotency_key, session_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        [1, '2026-04-26T00:00:00Z', 7, 'prompt.patch.applied', '{}', 'operator', 'idem-1', 's'],
+      );
+
+      db.run(
+        `INSERT INTO prompt_patches (session_id, prompt_id, event_seq, patch_id, patch_json, pre_hash, post_hash, applied_at, applied_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ['s', 'ideation', 1, 'p1', '[]', 'h0', 'h1', 1, 'operator'],
+      );
+      expect(() =>
+        db.run(
+          `INSERT INTO prompt_patches (session_id, prompt_id, event_seq, patch_id, patch_json, pre_hash, post_hash, applied_at, applied_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          ['s', 'planning', 1, 'p2', '[]', 'h0', 'h1', 1, 'operator'],
+        ),
+      ).toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  test('full v6 → v7 chain via ensureSchemaV6 + ensureSchemaV7 stamps v7 in schema_meta', async () => {
+    const { Database } = await import('bun:sqlite');
+    const { ensureSchemaV6, ensureSchemaV7 } = await import('../migrations.js');
+    const db = new Database(':memory:');
+    try {
+      db.run(`
+        CREATE TABLE events (
+          seq INTEGER PRIMARY KEY,
+          ts TEXT NOT NULL,
+          schema_version INTEGER NOT NULL,
+          type TEXT NOT NULL,
+          step TEXT,
+          data TEXT NOT NULL DEFAULT '{}',
+          actor TEXT NOT NULL,
+          parent_seq INTEGER REFERENCES events(seq),
+          idempotency_key TEXT NOT NULL UNIQUE,
+          session_id TEXT,
+          project_id TEXT
+        )
+      `);
+      ensureSchemaV6(db, 1);
+      ensureSchemaV7(db, 2);
+
+      interface MetaRow {
+        readonly schema_version: number;
+        readonly migrated_at: number;
+      }
+      const row = db
+        .query<MetaRow, [string]>(
+          'SELECT schema_version, migrated_at FROM schema_meta WHERE id = ?',
+        )
+        .get('state_db');
+      // v7 stamp wins after the chain runs.
+      expect(row?.schema_version).toBe(7);
+      expect(row?.migrated_at).toBe(2);
     } finally {
       db.close();
     }

--- a/packages/cli/src/workflow/__tests__/reducer.test.ts
+++ b/packages/cli/src/workflow/__tests__/reducer.test.ts
@@ -16,6 +16,10 @@ import {
   STEP_ADVANCEMENT_EVENTS,
   createStepAdvancementObserved,
 } from '../events/step-advancement.js';
+import {
+  PROMPT_EVENTS,
+  createPromptPatchApplied,
+} from '../events/prompt.js';
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -1068,5 +1072,109 @@ describe('audit-only events bypass the reducer (Wave A.1.3)', () => {
     // Sanity check — the test fixtures above use the typed factory; this
     // assertion documents the type-string the runtime fence checks for.
     expect(STEP_ADVANCEMENT_EVENTS.OBSERVED).toBe('step.advancement.observed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Audit-only event runtime fence — `prompt.patch.applied` (Wave C.1.6 R1)
+//
+// Architecture F-2 fix. The plan's C.1.3 verification criterion required:
+// "Replay of a `prompt.patch.applied` event through the reducer returns
+// `ok(state)` without throwing (regression test for the runtime-fence
+// fix)." The prior pass extended the fence at `reducer.ts:692` with
+// `isPromptPatchAppliedEvent(event)` but did NOT add a regression test.
+// A future refactor that narrowed the fence back to `step.advancement.
+// observed`-only would silently regress the same invariant the prior
+// architecture eval flagged — defense-in-depth code that nothing tests
+// gets trimmed in a cleanup pass.
+//
+// These tests mirror the four `step.advancement.observed` tests above:
+// active step, idle, terminal-state, does-not-throw. All assert the
+// reducer returns `ok(state)` referentially unchanged when handed a
+// `prompt.patch.applied` event through the wire-roundtrip cast.
+// ---------------------------------------------------------------------------
+
+describe('audit-only events bypass the reducer — prompt.patch.applied (Wave C.1.6 R1)', () => {
+  // The runtime fence treats audit-only events as observability-only:
+  // state is returned unchanged regardless of step. Cast through
+  // `unknown` to bypass the type-system separation — this simulates the
+  // on-the-wire replay path that discards the type-level discriminator.
+  const promptPatchAppliedEvent = createPromptPatchApplied({
+    promptId: 'planning',
+    patchId: 'sha256:test-patch-id',
+    parentPatchId: null,
+    preHash: 'sha256:pre',
+    postHash: 'sha256:post',
+    opCount: 1,
+    schemaId: 'https://gobbi.dev/schemas/step-spec/v1.json',
+    appliedBy: 'operator',
+  }) as unknown as Event;
+
+  it('returns ok with state unchanged when handed prompt.patch.applied at an active step', () => {
+    const state = stateAt('planning');
+    const result = reduce(state, promptPatchAppliedEvent);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.state).toEqual(state);
+    // Same identity reference — the fence skips the spread that
+    // sub-reducers use, so callers that depend on `===` for cache
+    // invalidation can rely on a referential no-op.
+    expect(result.state).toBe(state);
+  });
+
+  it('returns ok with state unchanged when handed prompt.patch.applied at idle', () => {
+    const state = stateAt('idle');
+    const result = reduce(state, promptPatchAppliedEvent);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.state).toBe(state);
+  });
+
+  it('returns ok with state unchanged even at terminal states (audit fence runs before terminal-state rejection)', () => {
+    // Audit-only events are observability-only — they have no business
+    // logic and must persist regardless of state. The `done` / `error`
+    // terminal-state guard would otherwise reject every event with a
+    // step error message; the audit fence must intercept BEFORE that
+    // guard. This is the architectural ordering invariant.
+    const doneState = stateAt('done');
+    const r1 = reduce(doneState, promptPatchAppliedEvent);
+    expect(r1.ok).toBe(true);
+    if (r1.ok) expect(r1.state).toBe(doneState);
+
+    const errorState = stateAt('error');
+    const r2 = reduce(errorState, promptPatchAppliedEvent);
+    expect(r2.ok).toBe(true);
+    if (r2.ok) expect(r2.state).toBe(errorState);
+  });
+
+  it('does not throw when handed prompt.patch.applied (defense-in-depth against silent-fail mode)', () => {
+    // The reducer's `assertNever` would throw a plain Error if the audit
+    // event reached the bottom of the dispatch chain. The fence at the
+    // top of `reduce()` is the runtime guarantee that this throw cannot
+    // surface — the test calls `reduce()` directly and asserts NO throw.
+    const state = stateAt('execution');
+    expect(() => reduce(state, promptPatchAppliedEvent)).not.toThrow();
+  });
+
+  it('PROMPT_EVENTS.PATCH_APPLIED is the constant the reducer fence narrows', () => {
+    // Sanity check — the test fixture above uses the typed factory;
+    // this assertion documents the type-string the runtime fence
+    // checks for.
+    expect(PROMPT_EVENTS.PATCH_APPLIED).toBe('prompt.patch.applied');
+  });
+
+  it('a JSON serialise/deserialise roundtrip still hits the fence (wire-replay regression)', () => {
+    // The fence's primary purpose: a serialised event read back from
+    // the wire (or from an `events` table replay) loses its TypeScript
+    // discriminator. The runtime check at `reducer.ts:692` MUST still
+    // recognize it via the `type` field's string value.
+    const wireForm = JSON.parse(
+      JSON.stringify(promptPatchAppliedEvent),
+    ) as unknown as Event;
+    const state = stateAt('execution');
+    const result = reduce(state, wireForm);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.state).toBe(state);
   });
 });

--- a/packages/cli/src/workflow/__tests__/store.test.ts
+++ b/packages/cli/src/workflow/__tests__/store.test.ts
@@ -1768,3 +1768,242 @@ describe('WAL checkpoint after workflow.step.exit (#146 A.1.9)', () => {
     expect(follow!.seq).toBe(2);
   });
 });
+
+// ===========================================================================
+// appendWithProjection — atomic event + projection write (Wave C.1.6 R1,
+// Architecture F-1 fix). The events INSERT and the projection callback
+// share one bun:sqlite IMMEDIATE transaction; a thrown projection rolls
+// the events row back, and a deduped event skips the projection entirely.
+// ===========================================================================
+
+describe('appendWithProjection — atomic event + projection write', () => {
+  /**
+   * Seed the v7 `prompt_patches` table on a fresh on-disk store. The
+   * table is created by `ensureSchemaV7` during EventStore construction;
+   * the helper here just opens a same-process connection to confirm the
+   * shape used by the atomicity tests below.
+   */
+  function withTmpStore<T>(fn: (store: EventStore, dbPath: string) => T): T {
+    const tmp = mkdtempSync(join(tmpdir(), 'store-aw-'));
+    const dbPath = join(tmp, 'state.db');
+    const store = new EventStore(dbPath, {
+      sessionId: 'sess-aw',
+      projectId: 'proj-aw',
+    });
+    try {
+      return fn(store, dbPath);
+    } finally {
+      store.close();
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  }
+
+  it('commits both writes when the projection callback succeeds', () => {
+    withTmpStore((store, dbPath) => {
+      const row = store.appendWithProjection(
+        makeContentInput({
+          contentId: 'sha256-aw-ok',
+          sessionId: 'sess-aw',
+          data: JSON.stringify({ promptId: 'ideation' }),
+        }),
+        (db, eventRow) => {
+          db.run(
+            `INSERT INTO prompt_patches (session_id, project_id, prompt_id, parent_seq, event_seq, patch_id, patch_json, pre_hash, post_hash, applied_at, applied_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            [
+              'sess-aw',
+              'proj-aw',
+              'ideation',
+              null,
+              eventRow.seq,
+              'sha256-aw-ok',
+              '[]',
+              'sha256:0',
+              'sha256:1',
+              Date.parse('2026-01-01T00:00:00.000Z'),
+              'operator',
+            ],
+          );
+        },
+      );
+
+      expect(row).not.toBeNull();
+      expect(row!.seq).toBe(1);
+
+      // Both rows persisted in the same transaction — verify via a
+      // separate read-only handle.
+      const reader = new Database(dbPath, { readonly: true });
+      try {
+        const eventCount = (
+          reader.query<{ cnt: number }, []>(`SELECT count(*) AS cnt FROM events`).get()
+        )?.cnt ?? 0;
+        const projectionCount = (
+          reader
+            .query<{ cnt: number }, []>(
+              `SELECT count(*) AS cnt FROM prompt_patches WHERE event_seq = ${row!.seq}`,
+            )
+            .get()
+        )?.cnt ?? 0;
+        expect(eventCount).toBe(1);
+        expect(projectionCount).toBe(1);
+      } finally {
+        reader.close();
+      }
+    });
+  });
+
+  it('rolls back the events row when the projection callback throws', () => {
+    withTmpStore((store, dbPath) => {
+      let threw = false;
+      try {
+        store.appendWithProjection(
+          makeContentInput({
+            contentId: 'sha256-aw-rollback',
+            sessionId: 'sess-aw',
+            data: JSON.stringify({ promptId: 'ideation' }),
+          }),
+          (_db, _row) => {
+            // Simulate a projection write failure (e.g. CHECK constraint
+            // violation, or a synthetic mid-transaction abort). bun:sqlite
+            // surfaces the throw as a rolled-back transaction.
+            throw new Error('synthetic projection failure');
+          },
+        );
+      } catch {
+        threw = true;
+      }
+
+      expect(threw).toBe(true);
+
+      // The events row MUST NOT exist — atomicity guarantee. If the
+      // events INSERT had committed independently of the projection
+      // callback (the pre-R1 two-handle bug), this row count would be 1.
+      const reader = new Database(dbPath, { readonly: true });
+      try {
+        const eventCount = (
+          reader.query<{ cnt: number }, []>(`SELECT count(*) AS cnt FROM events`).get()
+        )?.cnt ?? 0;
+        const projectionCount = (
+          reader.query<{ cnt: number }, []>(`SELECT count(*) AS cnt FROM prompt_patches`).get()
+        )?.cnt ?? 0;
+        expect(eventCount).toBe(0);
+        expect(projectionCount).toBe(0);
+      } finally {
+        reader.close();
+      }
+    });
+  });
+
+  it('skips the projection callback when the event was deduped', () => {
+    withTmpStore((store, dbPath) => {
+      // First append — both writes commit.
+      const first = store.appendWithProjection(
+        makeContentInput({
+          contentId: 'sha256-aw-dup',
+          sessionId: 'sess-aw',
+          data: JSON.stringify({ promptId: 'ideation' }),
+        }),
+        (db, row) => {
+          db.run(
+            `INSERT INTO prompt_patches (session_id, project_id, prompt_id, parent_seq, event_seq, patch_id, patch_json, pre_hash, post_hash, applied_at, applied_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            [
+              'sess-aw',
+              'proj-aw',
+              'ideation',
+              null,
+              row.seq,
+              'sha256-aw-dup',
+              '[]',
+              'sha256:0',
+              'sha256:1',
+              Date.parse('2026-01-01T00:00:00.000Z'),
+              'operator',
+            ],
+          );
+        },
+      );
+      expect(first).not.toBeNull();
+
+      // Second append — same content. Idempotency key collides; the
+      // projection callback MUST NOT be invoked (otherwise the
+      // UNIQUE(prompt_id, patch_id) index would throw, but more
+      // importantly the contract is "no projection write on dedup").
+      let projectionInvocations = 0;
+      const dup = store.appendWithProjection(
+        makeContentInput({
+          contentId: 'sha256-aw-dup',
+          sessionId: 'sess-aw-other',
+          data: JSON.stringify({ promptId: 'ideation' }),
+        }),
+        () => {
+          projectionInvocations += 1;
+        },
+      );
+
+      expect(dup).toBeNull();
+      expect(projectionInvocations).toBe(0);
+
+      // Only the original row exists.
+      const reader = new Database(dbPath, { readonly: true });
+      try {
+        const eventCount = (
+          reader.query<{ cnt: number }, []>(`SELECT count(*) AS cnt FROM events`).get()
+        )?.cnt ?? 0;
+        const projectionCount = (
+          reader.query<{ cnt: number }, []>(`SELECT count(*) AS cnt FROM prompt_patches`).get()
+        )?.cnt ?? 0;
+        expect(eventCount).toBe(1);
+        expect(projectionCount).toBe(1);
+      } finally {
+        reader.close();
+      }
+    });
+  });
+
+  it('events.seq matches prompt_patches.event_seq after a successful append', () => {
+    withTmpStore((store, dbPath) => {
+      const row = store.appendWithProjection(
+        makeContentInput({
+          contentId: 'sha256-aw-link',
+          sessionId: 'sess-aw',
+          data: JSON.stringify({ promptId: 'planning' }),
+        }),
+        (db, eventRow) => {
+          db.run(
+            `INSERT INTO prompt_patches (session_id, project_id, prompt_id, parent_seq, event_seq, patch_id, patch_json, pre_hash, post_hash, applied_at, applied_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            [
+              'sess-aw',
+              'proj-aw',
+              'planning',
+              null,
+              eventRow.seq,
+              'sha256-aw-link',
+              '[]',
+              'sha256:0',
+              'sha256:1',
+              Date.parse('2026-01-01T00:00:00.000Z'),
+              'operator',
+            ],
+          );
+        },
+      );
+      expect(row).not.toBeNull();
+
+      const reader = new Database(dbPath, { readonly: true });
+      try {
+        const eventSeq = reader
+          .query<{ seq: number }, []>(`SELECT seq FROM events ORDER BY seq DESC LIMIT 1`)
+          .get()?.seq;
+        const projectionEventSeq = reader
+          .query<{ event_seq: number }, []>(
+            `SELECT event_seq FROM prompt_patches ORDER BY seq DESC LIMIT 1`,
+          )
+          .get()?.event_seq;
+        expect(eventSeq).toBe(row!.seq);
+        expect(projectionEventSeq).toBe(row!.seq);
+        expect(eventSeq).toBe(projectionEventSeq);
+      } finally {
+        reader.close();
+      }
+    });
+  });
+});

--- a/packages/cli/src/workflow/__tests__/store.test.ts
+++ b/packages/cli/src/workflow/__tests__/store.test.ts
@@ -14,6 +14,7 @@ import { join } from 'node:path';
 import { EventStore } from '../store.js';
 import type {
   AppendInput,
+  AppendInputContent,
   AppendInputCounter,
   AppendInputSystem,
   AppendInputToolCall,
@@ -78,6 +79,23 @@ function makeCounterInput(
     parent_seq: null,
     idempotencyKind: 'counter',
     counter: 0,
+    sessionId: 'sess-1',
+    ...overrides,
+  };
+}
+
+function makeContentInput(
+  overrides: Partial<AppendInputContent> = {},
+): AppendInput {
+  return {
+    ts: '2026-01-01T00:00:00.000Z',
+    type: 'prompt.patch.applied',
+    step: null,
+    data: JSON.stringify({ patchId: 'p1' }),
+    actor: 'operator',
+    parent_seq: null,
+    idempotencyKind: 'content',
+    contentId: 'sha256-content-1',
     sessionId: 'sess-1',
     ...overrides,
   };
@@ -776,6 +794,114 @@ describe('counter idempotency key', () => {
     expect(sys).not.toBeNull();
     expect(cnt).not.toBeNull();
     expect(sys!.idempotency_key).not.toBe(cnt!.idempotency_key);
+  });
+});
+
+// ===========================================================================
+// 'content' idempotency key — Wave C.1.3 (issue #156)
+//
+// Cross-session content-addressed dedup. The formula is `${type}:${contentId}`
+// — `sessionId` is intentionally absent from the key so the same patch
+// content appended from two different sessions dedupes at the events table.
+// Synthesis lock 8 + 9.
+// ===========================================================================
+
+describe('content idempotency key', () => {
+  it('generates key from eventType and contentId only — sessionId is NOT in the formula', () => {
+    using store = new EventStore(':memory:');
+
+    const row = store.append(
+      makeContentInput({
+        type: 'prompt.patch.applied',
+        contentId: 'sha256-abc',
+      }),
+    );
+
+    expect(row).not.toBeNull();
+    expect(row!.idempotency_key).toBe('prompt.patch.applied:sha256-abc');
+  });
+
+  it('same (type, contentId) collides regardless of sessionId — cross-session dedup', () => {
+    using store = new EventStore(':memory:');
+
+    const first = store.append(
+      makeContentInput({ contentId: 'sha256-shared', sessionId: 'sess-A' }),
+    );
+    // Different session, same content. Must dedupe — the patch_id is
+    // a content address, not a session-scoped identifier.
+    const dup = store.append(
+      makeContentInput({ contentId: 'sha256-shared', sessionId: 'sess-B' }),
+    );
+
+    expect(first).not.toBeNull();
+    expect(dup).toBeNull();
+    expect(store.eventCount()).toBe(1);
+  });
+
+  it('different contentIds produce distinct keys — both persist', () => {
+    using store = new EventStore(':memory:');
+
+    const r0 = store.append(makeContentInput({ contentId: 'sha256-a' }));
+    const r1 = store.append(makeContentInput({ contentId: 'sha256-b' }));
+
+    expect(r0).not.toBeNull();
+    expect(r1).not.toBeNull();
+    expect(r0!.idempotency_key).toBe('prompt.patch.applied:sha256-a');
+    expect(r1!.idempotency_key).toBe('prompt.patch.applied:sha256-b');
+    expect(store.eventCount()).toBe(2);
+  });
+
+  it('same contentId across different event types is distinct', () => {
+    using store = new EventStore(':memory:');
+
+    const r0 = store.append(
+      makeContentInput({ type: 'prompt.patch.applied', contentId: 'sha256-x' }),
+    );
+    const r1 = store.append(
+      makeContentInput({ type: 'unknown.future', contentId: 'sha256-x' }),
+    );
+
+    expect(r0).not.toBeNull();
+    expect(r1).not.toBeNull();
+    expect(r0!.idempotency_key).not.toBe(r1!.idempotency_key);
+  });
+
+  it('content kind is rejected at compile time when contentId is omitted', () => {
+    using store = new EventStore(':memory:');
+
+    const bad = {
+      ts: '2026-01-01T00:00:00.000Z',
+      type: 'prompt.patch.applied',
+      actor: 'operator',
+      idempotencyKind: 'content' as const,
+      sessionId: 'sess-1',
+      // contentId intentionally omitted
+    };
+    // @ts-expect-error — contentId is required when kind === 'content'
+    const row = store.append(bad);
+    // Like the counter case: tsc is the gate. Runtime will produce a
+    // degenerate `prompt.patch.applied:undefined` key — clearly wrong but
+    // not a crash.
+    expect(row).not.toBeNull();
+    expect(row!.idempotency_key).toBe('prompt.patch.applied:undefined');
+  });
+
+  it('content row is still partitioned by session_id column even though sessionId is absent from the idempotency formula', () => {
+    using store = new EventStore(':memory:', { sessionId: 'sess-explicit' });
+
+    const row = store.append(
+      makeContentInput({
+        contentId: 'sha256-partition-check',
+        sessionId: 'sess-explicit',
+      }),
+    );
+
+    expect(row).not.toBeNull();
+    expect(row!.session_id).toBe('sess-explicit');
+    // Idempotency key omits the session — partition column does not.
+    expect(row!.idempotency_key).toBe(
+      'prompt.patch.applied:sha256-partition-check',
+    );
   });
 });
 

--- a/packages/cli/src/workflow/__tests__/store.test.ts
+++ b/packages/cli/src/workflow/__tests__/store.test.ts
@@ -886,6 +886,89 @@ describe('content idempotency key', () => {
     expect(row!.idempotency_key).toBe('prompt.patch.applied:undefined');
   });
 
+  it('byte-identical patches across DIFFERENT prompts produce distinct events when contentId is namespaced by promptId — Architecture F-4', () => {
+    // Wave C.1.6 R1 / Architecture F-4: the same RFC 6902 ops array
+    // applied to two different prompts (e.g., a generic
+    // `add /meta/notes "audited"` op meaningful for both `ideation` and
+    // `planning`) must produce TWO event rows, not one. The fix is to
+    // namespace `contentId` with `${promptId}:${patchId}` so the
+    // idempotency formula `${type}:${contentId}` resolves to distinct
+    // keys per prompt. This test locks the contract at the store layer.
+    using store = new EventStore(':memory:');
+
+    // The raw patch hash is identical across prompts; the namespaced
+    // `contentId` differs.
+    const rawPatchId = 'sha256-shared-ops';
+    const ideationContentId = `ideation:${rawPatchId}`;
+    const planningContentId = `planning:${rawPatchId}`;
+
+    const r1 = store.append(
+      makeContentInput({
+        type: 'prompt.patch.applied',
+        contentId: ideationContentId,
+        sessionId: 'sess-x',
+        data: JSON.stringify({ promptId: 'ideation', patchId: rawPatchId }),
+      }),
+    );
+    const r2 = store.append(
+      makeContentInput({
+        type: 'prompt.patch.applied',
+        contentId: planningContentId,
+        sessionId: 'sess-x',
+        data: JSON.stringify({ promptId: 'planning', patchId: rawPatchId }),
+      }),
+    );
+
+    expect(r1).not.toBeNull();
+    expect(r2).not.toBeNull();
+    expect(r1!.idempotency_key).toBe(`prompt.patch.applied:${ideationContentId}`);
+    expect(r2!.idempotency_key).toBe(`prompt.patch.applied:${planningContentId}`);
+    expect(r1!.idempotency_key).not.toBe(r2!.idempotency_key);
+    expect(store.eventCount()).toBe(2);
+
+    // Sanity check: the raw patchId on the JSON payload is the same
+    // (the operator's RFC 6902 ops array is byte-identical) — only the
+    // namespaced contentId differs.
+    const data1 = JSON.parse(r1!.data) as { patchId: string };
+    const data2 = JSON.parse(r2!.data) as { patchId: string };
+    expect(data1.patchId).toBe(rawPatchId);
+    expect(data2.patchId).toBe(rawPatchId);
+    expect(data1.patchId).toBe(data2.patchId);
+  });
+
+  it('byte-identical patches on the SAME prompt across two sessions still dedup — Architecture F-4 keeps the cross-session safety net', () => {
+    // The promptId-namespaced contentId must NOT break the original
+    // cross-session dedup contract: a patch hash applied twice on the
+    // same prompt from two different sessions still collapses to one
+    // event row (synthesis lock 8 + 9). The Architecture F-4 fix only
+    // changes the formula's INPUT (contentId now includes promptId),
+    // not its cross-session-collision semantics.
+    using store = new EventStore(':memory:');
+
+    const namespaced = 'ideation:sha256-same';
+
+    const first = store.append(
+      makeContentInput({
+        type: 'prompt.patch.applied',
+        contentId: namespaced,
+        sessionId: 'sess-A',
+        data: JSON.stringify({ promptId: 'ideation' }),
+      }),
+    );
+    const dup = store.append(
+      makeContentInput({
+        type: 'prompt.patch.applied',
+        contentId: namespaced,
+        sessionId: 'sess-B',
+        data: JSON.stringify({ promptId: 'ideation' }),
+      }),
+    );
+
+    expect(first).not.toBeNull();
+    expect(dup).toBeNull();
+    expect(store.eventCount()).toBe(1);
+  });
+
   it('content row is still partitioned by session_id column even though sessionId is absent from the idempotency formula', () => {
     using store = new EventStore(':memory:', { sessionId: 'sess-explicit' });
 

--- a/packages/cli/src/workflow/engine.ts
+++ b/packages/cli/src/workflow/engine.ts
@@ -367,6 +367,20 @@ function buildAppendInput(args: BuildAppendInputArgs): AppendInput {
         counter: args.counter,
       };
     }
+    case 'content': {
+      // Wave C.1.3 (issue #156) — `'content'` is the new audit-only
+      // dedup kind for `prompt.patch.applied`. Audit-only events bypass
+      // `appendEventAndUpdateState` (synthesis §6 + the runtime fence
+      // at `reducer.ts:691`); they commit via `store.append()` directly.
+      // Reaching this branch through the engine means a caller wired
+      // a content-addressed event into the reducer-routed path — that is
+      // a contract violation, not a runtime failure to handle. Fail
+      // loudly so the misuse surfaces during development rather than
+      // silently producing a non-functional event row.
+      throw new Error(
+        "appendEventAndUpdateState: 'content' idempotency kind is reserved for audit-only events that commit via store.append() directly; reducer-routed events must use 'tool-call', 'system', or 'counter'",
+      );
+    }
   }
 }
 

--- a/packages/cli/src/workflow/events/__tests__/events.test.ts
+++ b/packages/cli/src/workflow/events/__tests__/events.test.ts
@@ -55,6 +55,11 @@ import {
   isStepAdvancementEvent,
   createStepAdvancementObserved,
 
+  // Prompt (audit-only)
+  PROMPT_EVENTS,
+  isPromptPatchAppliedEvent,
+  createPromptPatchApplied,
+
   // Top-level
   ALL_EVENT_TYPES,
   isValidEventType,
@@ -104,6 +109,10 @@ describe('const objects', () => {
   it('STEP_ADVANCEMENT_EVENTS has 1 entry (audit-only)', () => {
     expect(Object.values(STEP_ADVANCEMENT_EVENTS)).toHaveLength(1);
   });
+
+  it('PROMPT_EVENTS has 1 entry (audit-only)', () => {
+    expect(Object.values(PROMPT_EVENTS)).toHaveLength(1);
+  });
 });
 
 // ===========================================================================
@@ -111,12 +120,13 @@ describe('const objects', () => {
 // ===========================================================================
 
 describe('ALL_EVENT_TYPES', () => {
-  it('contains exactly 23 entries (9 + 3 + 2 + 3 + 3 + 1 + 1 + 1) — wire-level (reducer + audit-only)', () => {
-    // Wave A.1.3 / orchestration Pass 4: 22 reducer-typed events + 1
-    // audit-only event (`step.advancement.observed`) = 23 wire-level
-    // event types. Closed-enumeration discipline per orchestration
-    // README §3.5 / §13 success criterion #5.
-    expect(ALL_EVENT_TYPES.size).toBe(23);
+  it('contains exactly 24 entries (9 + 3 + 2 + 3 + 3 + 1 + 1 + 1 + 1) — wire-level (reducer + audit-only)', () => {
+    // Wave C.1.3 (issue #156): 22 reducer-typed events + 2 audit-only
+    // events (`step.advancement.observed` from Wave A.1.3 +
+    // `prompt.patch.applied` from Wave C.1.3) = 24 wire-level event
+    // types. Closed-enumeration discipline per orchestration README
+    // §3.5 / §13 success criterion #5.
+    expect(ALL_EVENT_TYPES.size).toBe(24);
   });
 
   it('contains every workflow event type', () => {
@@ -171,6 +181,16 @@ describe('ALL_EVENT_TYPES', () => {
     expect(ALL_EVENT_TYPES.has('step.advancement.observed')).toBe(true);
   });
 
+  it('contains every prompt (audit-only) event type', () => {
+    for (const value of Object.values(PROMPT_EVENTS)) {
+      expect(ALL_EVENT_TYPES.has(value)).toBe(true);
+    }
+  });
+
+  it('contains prompt.patch.applied (Wave C.1.3 audit-only)', () => {
+    expect(ALL_EVENT_TYPES.has('prompt.patch.applied')).toBe(true);
+  });
+
   it('does not contain unknown event types', () => {
     expect(ALL_EVENT_TYPES.has('unknown.event')).toBe(false);
     expect(ALL_EVENT_TYPES.has('START')).toBe(false); // key, not value
@@ -191,6 +211,7 @@ describe('cross-category exclusivity', () => {
     Object.values(SESSION_EVENTS),
     Object.values(VERIFICATION_EVENTS),
     Object.values(STEP_ADVANCEMENT_EVENTS),
+    Object.values(PROMPT_EVENTS),
   ];
 
   it('no event type string appears in more than one category', () => {
@@ -219,6 +240,7 @@ describe('cross-category exclusivity', () => {
       [Object.values(SESSION_EVENTS), 'session.'],
       [Object.values(VERIFICATION_EVENTS), 'verification.'],
       [Object.values(STEP_ADVANCEMENT_EVENTS), 'step.advancement.'],
+      [Object.values(PROMPT_EVENTS), 'prompt.'],
     ];
 
     for (const [values, prefix] of prefixMap) {
@@ -868,6 +890,118 @@ describe('factory functions', () => {
 
     it('isValidEventType accepts the audit-only type', () => {
       expect(isValidEventType('step.advancement.observed')).toBe(true);
+    });
+  });
+
+  describe('prompt (audit-only) factories', () => {
+    // Wave C.1.3 / issue #156 — `prompt.patch.applied` is an audit-only
+    // event committed via `store.append()` directly by the
+    // `gobbi prompt patch` command (Wave C.1.6). These tests cover
+    // (a) factory shape, (b) type-guard accept/reject behaviour, and
+    // (c) the architectural fence: it must NOT be a member of `Event`
+    // (the reducer-typed union). The runtime fence at `reducer.ts:691`
+    // catches a serialise/deserialise replay before `assertNever`
+    // throws.
+
+    const basePromptData = {
+      promptId: 'ideation' as const,
+      patchId: 'sha256-abcdef',
+      parentPatchId: null,
+      preHash: 'sha256-pre',
+      postHash: 'sha256-post',
+      opCount: 2,
+      schemaId: 'https://gobbi.dev/schemas/step-spec/v1.json',
+      appliedBy: 'operator' as const,
+    };
+
+    it('createPromptPatchApplied produces a well-formed event', () => {
+      const event = createPromptPatchApplied(basePromptData);
+      expect(event.type).toBe(PROMPT_EVENTS.PATCH_APPLIED);
+      expect(event.data).toEqual(basePromptData);
+    });
+
+    it('PROMPT_EVENTS.PATCH_APPLIED matches the prefixed string', () => {
+      expect(PROMPT_EVENTS.PATCH_APPLIED).toBe('prompt.patch.applied');
+    });
+
+    it('isPromptPatchAppliedEvent narrows the audit-only event', () => {
+      const event = createPromptPatchApplied(basePromptData);
+      expect(isPromptPatchAppliedEvent(event)).toBe(true);
+    });
+
+    it('isPromptPatchAppliedEvent rejects every reducer-typed category', () => {
+      const reducerTypedSamples = [
+        { type: 'workflow.start' },
+        { type: 'delegation.spawn' },
+        { type: 'artifact.write' },
+        { type: 'decision.user' },
+        { type: 'guard.violation' },
+        { type: 'session.heartbeat' },
+        { type: 'verification.result' },
+        { type: 'step.advancement.observed' },
+        { type: 'unknown.event' },
+      ];
+      for (const sample of reducerTypedSamples) {
+        expect(isPromptPatchAppliedEvent(sample)).toBe(false);
+      }
+    });
+
+    it('audit-only event is rejected by every reducer-category guard (architectural fence)', () => {
+      // Same fence as `step.advancement.observed`: an audit-only event
+      // MUST NOT pass any reducer-category type guard. Synthesis §6.
+      const event = createPromptPatchApplied(basePromptData);
+      expect(isWorkflowEvent(event)).toBe(false);
+      expect(isDelegationEvent(event)).toBe(false);
+      expect(isArtifactEvent(event)).toBe(false);
+      expect(isDecisionEvent(event)).toBe(false);
+      expect(isGuardEvent(event)).toBe(false);
+      expect(isSessionEvent(event)).toBe(false);
+      expect(isVerificationEvent(event)).toBe(false);
+      // And rejected by the sibling audit-only guard so the two
+      // categories stay distinct.
+      expect(isStepAdvancementEvent(event)).toBe(false);
+    });
+
+    it('round-trips through JSON (wire-format invariant)', () => {
+      const event = createPromptPatchApplied(basePromptData);
+      const round = JSON.parse(JSON.stringify(event)) as unknown;
+      expect(round).toEqual(event);
+    });
+
+    it('isValidEventType accepts the audit-only type', () => {
+      expect(isValidEventType('prompt.patch.applied')).toBe(true);
+    });
+
+    it('PromptId enum covers the closed prompt-id set', () => {
+      const expected = [
+        'ideation',
+        'planning',
+        'execution',
+        'evaluation',
+        'memorization',
+        'handoff',
+      ] as const;
+      // The factory accepts every member; round-trip preserves them.
+      for (const promptId of expected) {
+        const event = createPromptPatchApplied({ ...basePromptData, promptId });
+        expect(event.data.promptId).toBe(promptId);
+      }
+    });
+
+    it('parentPatchId can be null (genesis row marker)', () => {
+      const event = createPromptPatchApplied({
+        ...basePromptData,
+        parentPatchId: null,
+      });
+      expect(event.data.parentPatchId).toBeNull();
+    });
+
+    it('parentPatchId can be a string (chained patch)', () => {
+      const event = createPromptPatchApplied({
+        ...basePromptData,
+        parentPatchId: 'sha256-prior',
+      });
+      expect(event.data.parentPatchId).toBe('sha256-prior');
     });
   });
 });

--- a/packages/cli/src/workflow/events/index.ts
+++ b/packages/cli/src/workflow/events/index.ts
@@ -1,5 +1,5 @@
 /**
- * Event type system — 8 categories, 23 event types.
+ * Event type system — 9 categories, 24 event types.
  *
  * Re-exports all category modules and assembles top-level union types.
  *
@@ -34,6 +34,7 @@ export * from './guard.js';
 export * from './session.js';
 export * from './verification.js';
 export * from './step-advancement.js';
+export * from './prompt.js';
 
 // Import const objects for ALL_EVENT_TYPES assembly
 import { WORKFLOW_EVENTS } from './workflow.js';
@@ -44,6 +45,7 @@ import { GUARD_EVENTS } from './guard.js';
 import { SESSION_EVENTS } from './session.js';
 import { VERIFICATION_EVENTS } from './verification.js';
 import { STEP_ADVANCEMENT_EVENTS } from './step-advancement.js';
+import { PROMPT_EVENTS } from './prompt.js';
 
 // Import category types for top-level unions
 import type { WorkflowEvent, WorkflowEventType } from './workflow.js';
@@ -60,6 +62,7 @@ import type {
   StepAdvancementEvent,
   StepAdvancementEventType,
 } from './step-advancement.js';
+import type { PromptEvent, PromptEventType } from './prompt.js';
 
 // ---------------------------------------------------------------------------
 // Reducer-typed Event union — discriminated on `type`
@@ -87,7 +90,7 @@ export type Event =
 // receive an audit-only event (and vice versa) without an explicit cast.
 // ---------------------------------------------------------------------------
 
-export type AuditOnlyEvent = StepAdvancementEvent;
+export type AuditOnlyEvent = StepAdvancementEvent | PromptEvent;
 
 // ---------------------------------------------------------------------------
 // Reducer-typed EventType union — all valid reducer event-type strings
@@ -106,7 +109,7 @@ export type EventType =
 // Audit-only EventType union — strings that MUST NOT reach the reducer
 // ---------------------------------------------------------------------------
 
-export type AuditOnlyEventType = StepAdvancementEventType;
+export type AuditOnlyEventType = StepAdvancementEventType | PromptEventType;
 
 // ---------------------------------------------------------------------------
 // Wire-level EventType union — every type string that may legitimately
@@ -128,6 +131,7 @@ export const ALL_EVENT_TYPES: ReadonlySet<string> = new Set<string>([
   ...Object.values(SESSION_EVENTS),
   ...Object.values(VERIFICATION_EVENTS),
   ...Object.values(STEP_ADVANCEMENT_EVENTS),
+  ...Object.values(PROMPT_EVENTS),
 ]);
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/workflow/events/prompt.ts
+++ b/packages/cli/src/workflow/events/prompt.ts
@@ -1,0 +1,188 @@
+/**
+ * Prompt (audit-only) event category — 1 event type.
+ *
+ * Events: `prompt.patch.applied`
+ *
+ * Introduced by Wave C.1.3 (issue #156) to back the prompts-as-data
+ * feature described in `.gobbi/projects/gobbi/design/v050-features/prompts-as-data.md`
+ * and the synthesis at `sessions/<sid>/ideation/ideation.md` §6. The
+ * `gobbi prompt patch` operator command (Wave C.1.6) commits one of
+ * these events per applied RFC 6902 patch on a per-step `spec.json`.
+ *
+ * The full RFC 6902 ops array is NOT in the event payload — it lives in
+ * the JSONL evolution log line (`prompt-evolution/<prompt-id>.jsonl`)
+ * and the `prompt_patches.patch_json` column. The event records the
+ * *fact* (one patch was applied, with these audit hints); the projection
+ * holds the *content*. Synthesis §6 calls this out explicitly: keeping
+ * the ops out of the events table preserves a small `data` column for
+ * the audit log while leaving the queryable projection unbounded.
+ *
+ * ---
+ *
+ * # Architecture invariant — bypass the reducer
+ *
+ * `prompt.patch.applied` is intentionally **not** a member of the
+ * reducer-typed `Event` union. It is an audit-only / observability-only
+ * event: state derives nothing from it (the reducer state has no
+ * spec-content fields), no transition fires from it, and the reducer
+ * must never see it. Per the same fence applied to
+ * `step.advancement.observed` (see `events/step-advancement.ts:14-41`)
+ * and the gotcha at `state-db-redesign.md` §1, routing this event
+ * through `appendEventAndUpdateState` would silently fail end-to-end:
+ *
+ *   1. `reducer.ts` uses `assertNever` to enforce exhaustiveness over
+ *      the seven reducer-typed categories. An unknown event reaches the
+ *      `assertNever` branch and throws a plain `Error`.
+ *   2. `engine.ts:~232`'s audit-on-rejection branch only fires when the
+ *      thrown value is a `ReducerRejectionError` — a plain `Error` is
+ *      treated as a filesystem-style failure and is NOT audited.
+ *   3. The PostToolUse capture path wraps the engine call in a
+ *      best-effort try/catch that swallows the throw, so the event
+ *      quietly disappears.
+ *
+ * The fix locked at design time: **commit via `store.append()` directly,
+ * outside any `appendEventAndUpdateState` call**. The reducer stays
+ * pure; this event never enters its switch. The `gobbi prompt patch`
+ * command implementer MUST call `store.append()` directly. The type
+ * system enforces the bypass by giving `PromptEvent` a separate,
+ * non-`Event`-assignable type.
+ *
+ * The runtime fence at `reducer.ts:691` extends to cover this category
+ * with a `isPromptPatchAppliedEvent` check: a serialise/deserialise
+ * roundtrip (e.g. event replay from the wire) erases the type-level
+ * discriminator and could otherwise drive an audit event into
+ * `assertNever`'s plain-`Error` throw.
+ *
+ * ---
+ *
+ * # Idempotency formula — `'content'` kind
+ *
+ * Wave C.1.3 introduces a new `IdempotencyKind` variant `'content'`
+ * (extends the discriminated union at `store.ts:50-94`) with the formula
+ * `${type}:${contentId}`. The `contentId` is the `patchId` (sha256 of
+ * canonicalized `patch_json`). No `sessionId` participates in the
+ * formula — same patch content across two sessions dedupes at the
+ * events table via the existing `ON CONFLICT(idempotency_key) DO
+ * NOTHING` gate (`store.ts:148-152`). Synthesis lock 8.
+ */
+
+// ---------------------------------------------------------------------------
+// 1. Const object — single source of truth for event type strings
+// ---------------------------------------------------------------------------
+
+export const PROMPT_EVENTS = {
+  PATCH_APPLIED: 'prompt.patch.applied',
+} as const;
+
+// ---------------------------------------------------------------------------
+// 2. Set for type guard — values, NOT keys
+// ---------------------------------------------------------------------------
+
+const PROMPT_EVENT_TYPES = new Set<string>(Object.values(PROMPT_EVENTS));
+
+// ---------------------------------------------------------------------------
+// 3. Category union type — derived from the const object
+// ---------------------------------------------------------------------------
+
+export type PromptEventType =
+  typeof PROMPT_EVENTS[keyof typeof PROMPT_EVENTS];
+
+// ---------------------------------------------------------------------------
+// 4. Per-event data interfaces
+// ---------------------------------------------------------------------------
+
+/**
+ * Closed prompt-id set — matches the user-locked enumeration in
+ * `prompts-as-data.md` user lock 2 and the SQLite CHECK constraint on
+ * `prompt_patches.prompt_id` (`migrations.ts:SQL_CREATE_PROMPT_PATCHES`).
+ * Re-exported here so callers (CLI commands, tests) narrow against a
+ * single source of truth rather than restating the literal union.
+ */
+export type PromptId =
+  | 'ideation'
+  | 'planning'
+  | 'execution'
+  | 'evaluation'
+  | 'memorization'
+  | 'handoff';
+
+/**
+ * Payload for `prompt.patch.applied`.
+ *
+ * - `promptId` — closed prompt-id set member (see {@link PromptId}).
+ * - `patchId` — sha256 of canonicalized `patch_json`. Reused as the
+ *   `contentId` in the `'content'` IdempotencyKind formula at
+ *   `store.ts:50-94`. Doubles as the cross-session dedup key on the
+ *   `prompt_patches.UNIQUE(prompt_id, patch_id)` index.
+ * - `parentPatchId` — prior patch's `patchId` in the chain, or `null`
+ *   for the genesis row. The JSONL line at
+ *   `prompt-evolution/<prompt-id>.jsonl` carries the same field; the
+ *   SQLite row's `parent_seq` is canonical (Architecture F-12 fix per
+ *   ideation §4).
+ * - `preHash` — sha256 of canonicalized `spec.json` BEFORE this patch
+ *   applied. Operators reading the audit trail can verify content
+ *   addressing end-to-end.
+ * - `postHash` — sha256 of canonicalized `spec.json` AFTER this patch
+ *   applied. The replay-equivalence CI test at C.1.6 folds the JSONL
+ *   chain and compares its final post-hash to `sha256(canonicalize(<on-disk
+ *   spec.json>))`.
+ * - `opCount` — RFC 6902 ops count after the C.1.6 test-op merge step.
+ *   Audit hint only — full ops live in the JSONL line and
+ *   `patch_json` column.
+ * - `schemaId` — `STEP_SPEC_SCHEMA_ID` at apply time. Non-empty
+ *   string. Pinning the schema id in every audit row makes a future
+ *   v2 schema migration auditable: every patch row before the cutover
+ *   advertises v1.
+ * - `appliedBy` — locked to `'operator'` per user lock 3. Future
+ *   widening (agent-proposed patches) requires a new variant + a v8
+ *   schema migration.
+ */
+export interface PromptPatchAppliedData {
+  readonly promptId: PromptId;
+  readonly patchId: string;
+  readonly parentPatchId: string | null;
+  readonly preHash: string;
+  readonly postHash: string;
+  readonly opCount: number;
+  readonly schemaId: string;
+  readonly appliedBy: 'operator';
+}
+
+// ---------------------------------------------------------------------------
+// 5. Discriminated union for category events
+// ---------------------------------------------------------------------------
+
+/**
+ * Audit-only event variant. Deliberately NOT a member of the top-level
+ * `Event` union exported from `events/index.ts` — the reducer's
+ * exhaustive switch must never see this type.
+ *
+ * Hook implementers narrow with {@link isPromptPatchAppliedEvent} when
+ * they need to type-guard a generic `{ type: string }` shape, then call
+ * `store.append()` directly. There is no reducer branch and no engine
+ * helper; that asymmetry is the architectural fence.
+ */
+export type PromptEvent = {
+  readonly type: typeof PROMPT_EVENTS.PATCH_APPLIED;
+  readonly data: PromptPatchAppliedData;
+};
+
+// ---------------------------------------------------------------------------
+// 6. Type guards — Set.has() on values, NEVER `in` operator on keys
+// ---------------------------------------------------------------------------
+
+export function isPromptPatchAppliedEvent(
+  event: { type: string },
+): event is PromptEvent {
+  return PROMPT_EVENT_TYPES.has(event.type);
+}
+
+// ---------------------------------------------------------------------------
+// 7. Factory functions
+// ---------------------------------------------------------------------------
+
+export function createPromptPatchApplied(
+  data: PromptPatchAppliedData,
+): PromptEvent {
+  return { type: PROMPT_EVENTS.PATCH_APPLIED, data };
+}

--- a/packages/cli/src/workflow/migrations.ts
+++ b/packages/cli/src/workflow/migrations.ts
@@ -72,6 +72,25 @@
  *   Note: `prompt_patches` is intentionally NOT in v6 — Wave C.1's
  *   prompts-as-data feature owns it via a future v7. See
  *   orchestration review DRIFT-9 for the rationale.
+ *
+ * - v7 — Wave C.1.2 (issue #156). Adds the `prompt_patches` workspace-
+ *   partitioned audit table for the prompts-as-data feature. The table
+ *   carries one row per applied RFC 6902 patch on a per-step `spec.json`
+ *   (closed prompt-id set: `ideation`, `planning`, `execution`,
+ *   `evaluation`, `memorization`, `handoff`). Columns mirror the v6
+ *   sibling-table conventions for queryability under the v6+ "every
+ *   workspace table is partitioned by `(session_id, project_id)`" rule.
+ *   The `event_seq` column is a UNIQUE FK to `events(seq)` — every patch
+ *   row pairs 1:1 with the `prompt.patch.applied` audit-only event that
+ *   committed it. The composite UNIQUE on `(prompt_id, patch_id)` is the
+ *   cross-session deduplication safety net (a patch with identical content
+ *   produces the same `patch_id` regardless of session, so two sessions
+ *   applying the same patch produce one row, not two). Event *data*
+ *   payloads are wire-compatible v6→v7 (the new event type is strictly
+ *   additive and the table is purely a read projection). The registered
+ *   v6 migration is an identity on event data; the schema CREATE runs in
+ *   {@link ensureSchemaV7}, wired into `EventStore.initSchema` after
+ *   {@link ensureSchemaV6} and into `gobbi maintenance migrate-state-db`.
  */
 
 import type { Database } from 'bun:sqlite';
@@ -111,7 +130,7 @@ export interface EventRow {
 // Schema version tracking
 // ---------------------------------------------------------------------------
 
-export const CURRENT_SCHEMA_VERSION = 6;
+export const CURRENT_SCHEMA_VERSION = 7;
 
 // ---------------------------------------------------------------------------
 // Migration registry
@@ -147,10 +166,17 @@ type MigrationFn = (eventData: unknown) => unknown;
  *   type. No transform on existing event data — the new event type and
  *   the new tables are strictly additive. Registered as an identity on
  *   event data so the walk path stays composable for a future v7.
+ * - v6→v7 (Wave C.1.2, issue #156): adds the `prompt_patches`
+ *   workspace-partitioned audit table and the `prompt.patch.applied`
+ *   audit-only event type for the prompts-as-data feature. No transform
+ *   on existing event data — the new event type is strictly additive
+ *   and the new table is a pure read projection. Registered as an
+ *   identity on event data so the walk path stays composable for a
+ *   future v8.
  *
  * Declaring each identity registers the hop so the composition walks the
- * full chain (v1→v2→v3→v4→v5→v6) rather than short-circuiting — the walk
- * path is what a future v7 migration will extend.
+ * full chain (v1→v2→v3→v4→v5→v6→v7) rather than short-circuiting — the
+ * walk path is what a future v8 migration will extend.
  */
 const migrations: Readonly<Record<number, MigrationFn>> = {
   1: (data) => data,
@@ -158,6 +184,7 @@ const migrations: Readonly<Record<number, MigrationFn>> = {
   3: (data) => data,
   4: (data) => data,
   5: (data) => data,
+  6: (data) => data,
 };
 
 // ---------------------------------------------------------------------------
@@ -586,6 +613,172 @@ export function ensureSchemaV6(
 
     db.run(SQL_CREATE_SCHEMA_META);
 
-    db.run(SQL_STAMP_SCHEMA_META_V6, [CURRENT_SCHEMA_VERSION, now]);
+    // Stamp v6 here, not v7 — `ensureSchemaV6` exists as the v5→v6 hop in
+    // isolation (it must remain valid when called by older binaries that
+    // do not yet know about v7). The v7 caller below stamps v7 over the
+    // v6 stamp inside the same transaction so no half-migrated state is
+    // observable.
+    db.run(SQL_STAMP_SCHEMA_META_V6, [6, now]);
+  }).immediate();
+}
+
+// ---------------------------------------------------------------------------
+// Schema v7 — `prompt_patches` workspace-partitioned audit table
+//                (Wave C.1.2, issue #156)
+//
+// ## Producer status
+//
+// The writer for `prompt_patches` ships in Wave C.1.6 alongside the
+// `gobbi prompt patch` command. Operators running `gobbi maintenance
+// migrate-state-db` against a v6 db, observing v7 stamped, then finding
+// `prompt_patches` empty are seeing the intended state — the table is
+// the read projection for the `prompt.patch.applied` audit-only event,
+// populated only when an operator authors a patch.
+//
+// The CREATE lands in this wave so a future wave does not need to add a
+// v8 migration purely to introduce the table — forward-compatible
+// schema is the cheaper choice.
+// ---------------------------------------------------------------------------
+
+/**
+ * Names of every table introduced in schema v7. Exported so tests and
+ * post-migration verification can iterate without duplicating the literal.
+ */
+export const SCHEMA_V7_TABLES = ['prompt_patches'] as const;
+
+export type SchemaV7TableName = typeof SCHEMA_V7_TABLES[number];
+
+/**
+ * Names of every index introduced in schema v7. Exported so tests can
+ * assert presence without duplicating the literal.
+ *
+ * - `idx_prompt_patches_prompt_seq` — accelerates per-prompt history
+ *   queries (`SELECT … WHERE prompt_id = ? ORDER BY seq`).
+ * - `idx_prompt_patches_session_seq` — accelerates per-session history
+ *   queries; DESC ordering matches the "most-recent-first" workflow of
+ *   `gobbi prompt log`.
+ * - `idx_prompt_patches_event` — UNIQUE FK projection on `event_seq`,
+ *   guarantees 1:1 row-event pairing.
+ * - `idx_prompt_patches_content` — UNIQUE on `(prompt_id, patch_id)`,
+ *   the cross-session content-dedup safety net (synthesis lock 8).
+ */
+export const SCHEMA_V7_INDICES = [
+  'idx_prompt_patches_prompt_seq',
+  'idx_prompt_patches_session_seq',
+  'idx_prompt_patches_event',
+  'idx_prompt_patches_content',
+] as const;
+
+export type SchemaV7IndexName = typeof SCHEMA_V7_INDICES[number];
+
+/**
+ * `prompt_patches` — one row per applied RFC 6902 patch on a per-step
+ * `spec.json`.
+ *
+ * Columns:
+ *   - seq             INTEGER PRIMARY KEY AUTOINCREMENT — local row
+ *                     ordering, mirrors `events.seq`.
+ *   - session_id      TEXT NOT NULL — workspace partition key.
+ *   - project_id      TEXT — project partition key (nullable).
+ *   - prompt_id       TEXT NOT NULL CHECK — closed enum
+ *                     `(ideation, planning, execution, evaluation,
+ *                       memorization, handoff)` mirroring the user-lock
+ *                     prompt-id set.
+ *   - parent_seq      INTEGER REFERENCES prompt_patches(seq) — chain
+ *                     causality (NULL = genesis row).
+ *   - event_seq       INTEGER NOT NULL REFERENCES events(seq) — 1:1 FK
+ *                     to the `prompt.patch.applied` audit event that
+ *                     committed this patch.
+ *   - patch_id        TEXT NOT NULL — `sha256(canonicalize(patch_json))`,
+ *                     content address. Reused as `contentId` in the
+ *                     `'content'` IdempotencyKind formula at
+ *                     `store.ts:50-94`.
+ *   - patch_json      TEXT NOT NULL — RFC 6902 ops array (JSON-encoded,
+ *                     including any synthesized `test`-op-at-head).
+ *   - pre_hash        TEXT NOT NULL — `sha256(canonicalize(spec.json))`
+ *                     before this patch applied.
+ *   - post_hash       TEXT NOT NULL — `sha256(canonicalize(spec.json))`
+ *                     after this patch applied.
+ *   - applied_at      INTEGER NOT NULL — UNIX-ms wall clock.
+ *   - applied_by      TEXT NOT NULL CHECK = 'operator' — patch flow is
+ *                     operator-only via CLI (synthesis lock 3). Future
+ *                     widening (agent-proposed patches) requires a v8
+ *                     migration.
+ *
+ * Indices: see {@link SCHEMA_V7_INDICES}.
+ */
+const SQL_CREATE_PROMPT_PATCHES = `
+CREATE TABLE IF NOT EXISTS prompt_patches (
+  seq         INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id  TEXT NOT NULL,
+  project_id  TEXT,
+  prompt_id   TEXT NOT NULL CHECK (prompt_id IN ('ideation','planning','execution','evaluation','memorization','handoff')),
+  parent_seq  INTEGER REFERENCES prompt_patches(seq),
+  event_seq   INTEGER NOT NULL REFERENCES events(seq),
+  patch_id    TEXT NOT NULL,
+  patch_json  TEXT NOT NULL,
+  pre_hash    TEXT NOT NULL,
+  post_hash   TEXT NOT NULL,
+  applied_at  INTEGER NOT NULL,
+  applied_by  TEXT NOT NULL CHECK (applied_by = 'operator')
+)`;
+
+const SQL_CREATE_INDEX_PROMPT_PATCHES_PROMPT_SEQ = `
+CREATE INDEX IF NOT EXISTS idx_prompt_patches_prompt_seq
+  ON prompt_patches (prompt_id, seq)`;
+
+const SQL_CREATE_INDEX_PROMPT_PATCHES_SESSION_SEQ = `
+CREATE INDEX IF NOT EXISTS idx_prompt_patches_session_seq
+  ON prompt_patches (session_id, seq DESC)`;
+
+const SQL_CREATE_INDEX_PROMPT_PATCHES_EVENT = `
+CREATE UNIQUE INDEX IF NOT EXISTS idx_prompt_patches_event
+  ON prompt_patches (event_seq)`;
+
+const SQL_CREATE_INDEX_PROMPT_PATCHES_CONTENT = `
+CREATE UNIQUE INDEX IF NOT EXISTS idx_prompt_patches_content
+  ON prompt_patches (prompt_id, patch_id)`;
+
+/**
+ * Stamp the `schema_meta` row at v7. Same INSERT OR REPLACE shape as the
+ * v6 stamp — re-running the migration refreshes `migrated_at` without
+ * leaving a stale lower version.
+ */
+const SQL_STAMP_SCHEMA_META_V7 = `
+INSERT OR REPLACE INTO schema_meta (id, schema_version, migrated_at)
+VALUES ('state_db', ?, ?)`;
+
+/**
+ * Ensure the schema-v7 table and indices exist.
+ *
+ * Idempotent: every CREATE uses `IF NOT EXISTS`, so re-running this on
+ * a v7-or-later DB is a no-op. Running it on a pre-v7 DB after
+ * {@link ensureSchemaV6} brings the DB to v7 in one pass.
+ *
+ * Caller is responsible for sequencing — the `EventStore` constructor
+ * runs `ensureSchemaV5(db)` then `ensureSchemaV6(db)` then
+ * `ensureSchemaV7(db)` inside `initSchema`.
+ *
+ * Stamps the `schema_meta` row at v7 with the current wall-clock; the
+ * caller can pass an explicit `now` to make tests deterministic.
+ *
+ * ## Atomicity
+ *
+ * The CREATE chain runs inside a single `db.transaction(...).immediate()`
+ * so a mid-chain failure rolls back any partial v7 schema rather than
+ * leaving the DB half-applied. Mirrors {@link ensureSchemaV6}.
+ */
+export function ensureSchemaV7(
+  db: Database,
+  now: number = Date.now(),
+): void {
+  db.transaction(() => {
+    db.run(SQL_CREATE_PROMPT_PATCHES);
+    db.run(SQL_CREATE_INDEX_PROMPT_PATCHES_PROMPT_SEQ);
+    db.run(SQL_CREATE_INDEX_PROMPT_PATCHES_SESSION_SEQ);
+    db.run(SQL_CREATE_INDEX_PROMPT_PATCHES_EVENT);
+    db.run(SQL_CREATE_INDEX_PROMPT_PATCHES_CONTENT);
+
+    db.run(SQL_STAMP_SCHEMA_META_V7, [CURRENT_SCHEMA_VERSION, now]);
   }).immediate();
 }

--- a/packages/cli/src/workflow/reducer.ts
+++ b/packages/cli/src/workflow/reducer.ts
@@ -25,6 +25,7 @@ import { SESSION_EVENTS, isSessionEvent } from './events/session.js';
 import type { VerificationEvent } from './events/verification.js';
 import { VERIFICATION_EVENTS, isVerificationEvent } from './events/verification.js';
 import { isStepAdvancementEvent } from './events/step-advancement.js';
+import { isPromptPatchAppliedEvent } from './events/prompt.js';
 import type { WorkflowState, WorkflowStep } from './state.js';
 import { TERMINAL_STEPS, ACTIVE_STEPS } from './state.js';
 import { findTransition } from './transitions.js';
@@ -688,7 +689,7 @@ export function reduce(
   //
   // The guard returns the input state unchanged — audit-only events are
   // observability-only and have no state projection by definition.
-  if (isStepAdvancementEvent(event)) {
+  if (isStepAdvancementEvent(event) || isPromptPatchAppliedEvent(event)) {
     return ok(state);
   }
 

--- a/packages/cli/src/workflow/store.ts
+++ b/packages/cli/src/workflow/store.ts
@@ -24,6 +24,7 @@ import {
   backfillSessionAndProjectIds,
   ensureSchemaV5,
   ensureSchemaV6,
+  ensureSchemaV7,
 } from './migrations.js';
 import type { EventRow } from './migrations.js';
 
@@ -511,6 +512,14 @@ export class EventStore implements WriteStore {
     // wires this here so `EventStore` callers get v6 tables without
     // running `gobbi maintenance migrate-state-db` explicitly.
     ensureSchemaV6(this.db);
+    // Additive v6 → v7 schema migration — creates the `prompt_patches`
+    // workspace-partitioned audit table for the prompts-as-data feature
+    // (Wave C.1.2, issue #156). Idempotent (every CREATE uses `IF NOT
+    // EXISTS`) so this is safe to call on every store open. The stamp
+    // inside `ensureSchemaV7` writes `CURRENT_SCHEMA_VERSION` (= 7),
+    // overwriting the v6 stamp from the line above so callers reading
+    // `schema_meta.schema_version` see the latest applied version.
+    ensureSchemaV7(this.db);
   }
 
   // -------------------------------------------------------------------------

--- a/packages/cli/src/workflow/store.ts
+++ b/packages/cli/src/workflow/store.ts
@@ -308,6 +308,29 @@ export interface ReadStore {
 export interface WriteStore extends ReadStore {
   append(input: AppendInput): EventRow | null;
   transaction<T>(fn: () => T): T;
+  /**
+   * Append an event AND run a projection write under a single SQLite
+   * `IMMEDIATE` transaction. The projection callback receives the same
+   * underlying `Database` handle the events table writes through, so
+   * both writes commit atomically — a SIGKILL between them rolls both
+   * back rather than leaving an orphan event row.
+   *
+   * Used by `commands/prompt/patch.ts` (Wave C.1.6 R1, Architecture F-1
+   * fix) to keep the `events` row + `prompt_patches` projection row
+   * in lockstep. The projection callback MUST use the supplied `Database`
+   * handle — opening a separate connection inside the callback would
+   * defeat the atomicity guarantee.
+   *
+   * Returns the appended row, or `null` if the event was deduped at the
+   * `idempotency_key` UNIQUE constraint. When `null` is returned the
+   * projection callback is NOT invoked — the caller decides how to
+   * handle the dedup hit (typically: query the existing projection and
+   * surface the originating session).
+   */
+  appendWithProjection(
+    input: AppendInput,
+    projection: (db: Database, row: EventRow) => void,
+  ): EventRow | null;
   close(): void;
 }
 
@@ -648,6 +671,46 @@ export class EventStore implements WriteStore {
    */
   transaction<T>(fn: () => T): T {
     return this.db.transaction(fn).immediate();
+  }
+
+  /**
+   * Atomic event-append + projection-write — Wave C.1.6 R1
+   * (Architecture F-1 fix). Both writes share a single bun:sqlite
+   * IMMEDIATE transaction on the same `Database` handle: a SIGKILL
+   * between the event INSERT and the projection INSERT rolls both
+   * back rather than leaving an orphan event row.
+   *
+   * The projection callback receives the underlying `Database` so it
+   * can prepare-and-run its own statement against the same connection
+   * (e.g. `db.run('INSERT INTO prompt_patches ...')`). Opening a
+   * separate `new Database(path)` inside the callback would defeat
+   * the atomicity guarantee — the helper only enforces single-handle
+   * semantics by passing the handle in.
+   *
+   * Returns the appended row, or `null` when the event was deduped at
+   * the `idempotency_key` UNIQUE constraint. On dedup the projection
+   * callback is NOT invoked — the caller decides whether to query the
+   * existing projection and surface a diagnostic.
+   *
+   * Implementation note: bun:sqlite's `transaction()` runs the wrapped
+   * function under a single `BEGIN IMMEDIATE / COMMIT` envelope, with
+   * automatic ROLLBACK on thrown errors. Since `append()` already runs
+   * under its own implicit per-statement transaction, wrapping it
+   * inside `transaction()` creates a SAVEPOINT — the outer envelope
+   * stays atomic across both writes.
+   */
+  appendWithProjection(
+    input: AppendInput,
+    projection: (db: Database, row: EventRow) => void,
+  ): EventRow | null {
+    return this.transaction(() => {
+      const row = this.append(input);
+      if (row === null) {
+        return null;
+      }
+      projection(this.db, row);
+      return row;
+    });
   }
 
   // -------------------------------------------------------------------------

--- a/packages/cli/src/workflow/store.ts
+++ b/packages/cli/src/workflow/store.ts
@@ -47,8 +47,16 @@ export type { EventRow } from './migrations.js';
  *   (heartbeats). The caller supplies a monotonically increasing counter
  *   per same-ms collision window so the UNIQUE constraint does not
  *   silently drop repeats.
+ * - 'content': `${eventType}:${contentId}` — for content-addressed
+ *   events whose payload is byte-stable across sessions (Wave C.1.3,
+ *   issue #156). The same content must dedupe even when authored from
+ *   two different sessions, so `sessionId` is intentionally absent
+ *   from the formula. Used by `prompt.patch.applied` with
+ *   `contentId = patchId` (sha256 of canonicalized RFC 6902 ops).
+ *   See synthesis lock 8 + 9 in
+ *   `sessions/<sid>/ideation/ideation.md`.
  */
-export type IdempotencyKind = 'tool-call' | 'system' | 'counter';
+export type IdempotencyKind = 'tool-call' | 'system' | 'counter' | 'content';
 
 /**
  * Fields shared across every `AppendInput` variant — excludes `seq`
@@ -70,6 +78,7 @@ export interface AppendInputToolCall extends AppendInputBase {
   readonly idempotencyKind: 'tool-call';
   readonly toolCallId: string;
   readonly counter?: never;
+  readonly contentId?: never;
 }
 
 /**
@@ -80,6 +89,7 @@ export interface AppendInputSystem extends AppendInputBase {
   readonly idempotencyKind: 'system';
   readonly toolCallId?: never;
   readonly counter?: never;
+  readonly contentId?: never;
 }
 
 /**
@@ -92,17 +102,40 @@ export interface AppendInputCounter extends AppendInputBase {
   readonly idempotencyKind: 'counter';
   readonly toolCallId?: never;
   readonly counter: number;
+  readonly contentId?: never;
+}
+
+/**
+ * Content-addressed variant — formula is `${type}:${contentId}`. The
+ * `sessionId` from the base type is still recorded on the row's
+ * `session_id` column for partition queries, but is intentionally NOT
+ * part of the idempotency key. This makes content-addressed events
+ * dedupe across sessions: two operators authoring the same patch from
+ * two different sessions produce one event row, not two.
+ *
+ * `contentId` is REQUIRED — discriminated-union enforcement at
+ * construction time. Used by `prompt.patch.applied` with `contentId =
+ * patchId` (sha256 of canonicalized RFC 6902 ops); the same content
+ * always produces the same key.
+ */
+export interface AppendInputContent extends AppendInputBase {
+  readonly idempotencyKind: 'content';
+  readonly toolCallId?: never;
+  readonly counter?: never;
+  readonly contentId: string;
 }
 
 /**
  * Discriminated union — TypeScript enforces the per-kind fields at
  * construction time. `toolCallId` is only legal when `kind === 'tool-call'`;
- * `counter` is only legal (and is REQUIRED) when `kind === 'counter'`.
+ * `counter` is only legal (and is REQUIRED) when `kind === 'counter'`;
+ * `contentId` is only legal (and is REQUIRED) when `kind === 'content'`.
  */
 export type AppendInput =
   | AppendInputToolCall
   | AppendInputSystem
-  | AppendInputCounter;
+  | AppendInputCounter
+  | AppendInputContent;
 
 // ---------------------------------------------------------------------------
 // SQLite binding type — compatible with bun:sqlite's SQLQueryBindings
@@ -546,6 +579,13 @@ export class EventStore implements WriteStore {
       case 'counter': {
         const timestampMs = Date.parse(input.ts);
         return `${input.sessionId}:${timestampMs}:${input.type}:${input.counter}`;
+      }
+      case 'content': {
+        // Content-addressed: same patch content across two sessions
+        // produces the same key, so the second writer hits ON CONFLICT
+        // and dedupes silently. `sessionId` is intentionally absent
+        // from the formula — see synthesis lock 8 + 9.
+        return `${input.type}:${input.contentId}`;
       }
     }
   }


### PR DESCRIPTION
## Summary

Wave C.1 — Prompts-as-data — schema lockdown + JSONL evolution + prompt CLI. 14 commits (8 wave + 6 R1 revisions + 1 docs commit overlapping). 1972/0/8 tests, +137 net new tests vs `develop` baseline (1835).

### Ships

- **Schema lock (C.1.1)** — glob-validation CI gate at `specs/__tests__/all-specs.test.ts` runs `validateStepSpec` against every on-disk `<step>/spec.json` and pins `$schema` to `STEP_SPEC_SCHEMA_ID`.
- **Schema v7 + `prompt_patches` table (C.1.2)** — workspace-partitioned audit table mirrors v6 sibling-table conventions. `event_seq UNIQUE FK` + `(prompt_id, patch_id) UNIQUE` for cross-session content dedup. Strictly additive migration; identity entry v6→v7 in the registry walk.
- **`prompt.patch.applied` audit-only event (C.1.3)** — mirror of `step.advancement.observed` (Wave A.1.3). Bypasses reducer; runtime fence at `reducer.ts:692` extended. Closed-enumeration bumped 23→24. New `'content'` `IdempotencyKind` variant.
- **Canonicalizer + JSONL evolution log + chain folder (C.1.4)** — `lib/canonical-json.ts::canonicalize` (insertion-order, 2-space indent, matching `schema.test.ts:399-406` precedent). `lib/prompt-evolution.ts` exports `appendPromptEvolutionEntry`, `ensureGenesis`, `foldChain`. Genesis-line invariant: every JSONL self-contained.
- **Three operator commands (C.1.5 + C.1.6 + C.1.7)** — `gobbi prompt render | patch | rebuild`. New top-level dispatcher mirrors `gobbi maintenance`. `render` supports `markdown | composed | diff`; `composed` calls `assembly.compile()` directly. `patch` runs the synthesis §9.2 fail-fast ladder with the test-op merge logic, refuses stale baselines, atomically commits across SQLite + filesystem (R1). `rebuild` folds the JSONL chain — recovery only.
- **Replay-equivalence CI gate** — `specs/__tests__/replay-equivalence.test.ts` folds chains and asserts byte-equality with on-disk spec.json. Synthetic in-memory fixture exercises positive (chain matches), negative (hand-edit detected), and round-trip cases (R1).

### REVISE round 1 (post-wave-eval, 6 commits)

Wave evaluators (Project + Architecture + Overall + Innovative-PI + Best-PI) surfaced 2 HIGH + 4 Medium findings. All addressed:

- **Atomicity (Arch F-1, Overall F-1, Innovative F-12, Best F-9)** — `EventStore.appendWithProjection(input, projection)` wraps event append + projection insert in a single `db.transaction(...).immediate()` envelope. Replaced the prior two-handle implementation. New regression tests verify rollback on projection-callback throw.
- **Vacuous replay-equivalence test (Overall F-11, Innovative F-8)** — placeholder `expect(true).toBe(true)` calls replaced with synthetic-chain fixture: 4 active tests covering positive fold byte-equality, negative hand-edited spec divergence, postHash drift, single-genesis fold.
- **Reducer-fence regression test (Architecture F-2)** — new describe block in `reducer.test.ts` mirroring the `step.advancement.observed` precedent (6 tests).
- **`contentId` includes `promptId` (Architecture F-4)** — `${promptId}:${patchId}` formula prevents cross-prompt idempotency collisions.
- **Dead code cleanup (Overall F-2)** — `commands/prompt/patch.ts` now uses shared `appendPromptEvolutionEntry` + `ensureGenesis` helpers from `lib/prompt-evolution.ts` instead of inlining.
- **`validationStatus` field dropped from JSONL (Overall F-4)** — half-resolved state cleaned up; `parseEntry` is transition-tolerant for legacy lines.

### New production dependency

`fast-json-patch@3.1.1` (~3 kB, zero deps) — second prod dep alongside `ajv`. Surfaced explicitly per `feedback_verify_deps_before_recommend`.

### Schema

state.db schema `v6` → `v7`. Migration is strictly additive (`IF NOT EXISTS` everywhere); `git revert` + retry on a v6 binary leaves the v7 tables on disk but unused.

### Closed-enumeration count

24 wire-level event types (22 reducer-typed + 2 audit-only).

### User locks honored (10)

1. Scope: 1 session — schema lock + footer-as-data + tooling.
2. prompt-id closed set: SQLite CHECK + TS const tuple + runtime resolver.
3. Patch flow: operator-only via CLI. `applied_by` CHECK = `'operator'`.
4. JSON Patch lib: `fast-json-patch@3.1.1`.
5. Idempotency formula: `'content'` kind, `contentId = ${promptId}:${patchId}` (R1 narrowed), formula `${type}:${contentId}` (no sessionId).
6. All four innovative additions shipped.
7. Recovery: `gobbi prompt rebuild` ships in C.1.7.
8. Cross-session dedup: sessionId dropped + UNIQUE on `(prompt_id, patch_id)`.
9. `IdempotencyKind` extension: `'content'` variant.
10. Revision scope honored — every routed-to-Planning resolution encoded.

### Followup issues filed (Innovative-PI structural blind spots)

- #157 — synthesized `/version` test op is structurally trivial
- #158 — git rebase squash on JSONL leaves orphan `prompt_patches` rows
- #159 — `parent_seq` vs `parentPatchId` tiebreaker undefined
- #160 — `--allow-no-parent` UX requires reading an error

## Test plan

- [x] `bun test` — 1972 pass, 0 fail, 8 todo, 65 snapshots, 12551 expect() calls.
- [x] `bun run typecheck` — clean.
- [x] `bun run regen-schema` — no diff against `_schema/v1.json`.
- [x] Replay-equivalence test passes for all 6 prompt-ids (vacuous on real chains until first patch; synthetic-chain fixture locks the contract).
- [x] `ALL_EVENT_TYPES.size === 24` assertion passing.
- [x] Cross-prompt content idempotency: same op array on different prompts produces TWO event rows (R1 fix verified).
- [x] Reducer fence regression: replaying `prompt.patch.applied` returns `ok(state)` without throwing (R1 fix verified).
- [x] Atomicity regression: projection-callback throw rolls back the events row (R1 fix verified).
- [ ] Manual smoke: `gobbi prompt render ideation --format=markdown | less` (operator)
- [ ] Manual smoke: `gobbi prompt patch ideation --patch <fixture> --dry-run` (operator)

## Closes

#156

## Auto-close caveat

Base branch is `develop`, not the default `main`. Closing keywords trigger only on PRs merged into the default branch — orchestrator must manually close #156 post-merge per `learnings/gotchas/issue-scope-verify-before-wave.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)