### PR TITLE
fix(workflow): D.1 blockers — handoff FINISH, escalate verdict, resume state.json (#162)

### DIFF
--- a/.gobbi/projects/gobbi/learnings/gotchas/codex-overall-perspective-hangs.md
+++ b/.gobbi/projects/gobbi/learnings/gotchas/codex-overall-perspective-hangs.md
@@ -1,0 +1,35 @@
+### Codex Overall perspective hangs on large diffs
+
+---
+priority: medium
+tech-stack: codex, claude-code, plugins
+enforcement: advisory
+---
+
+**What happened**
+
+When running adversarial reviews via `codex:rescue` on the v0.5.0 review campaign, three Codex passes with the **Overall** perspective focus hung past 20 minutes:
+- B-Foundation Codex Overall: ran 41 minutes before being canceled
+- B-Per-feature-pass Codex Innovation: 13 minutes (also canceled)
+- The Codex Overall pass on a 43k-line diff explored the codebase too broadly and never converged
+
+Codex passes with **Architecture** or **Innovation** perspectives on the same diffs finished in 5–7 minutes.
+
+**User feedback**
+
+User asked to cancel hung Codex jobs to free quota for the next batches. The pattern repeated across 3 of 4 batches.
+
+**Correct approach**
+
+When invoking `codex:rescue` for adversarial review:
+
+1. **Always include an explicit time-box** in the prompt: `**Time-box: aim to finish in under 10 minutes.** Quality over breadth — pick 3-5 strong findings, don't comprehensive-sweep.`
+2. **Avoid the "Overall" perspective for very large diffs (>30k lines)** — Codex burns too much exploration time. Use Architecture + Innovation perspectives on big diffs; defer Overall-class findings to Claude voices which have stronger heuristics for "the right level of breadth".
+3. **Cancel jobs that exceed 15 minutes** rather than waiting indefinitely — the per-batch synthesis can proceed with 5/6 or 6/7 voices; cross-batch validation still works at reduced count.
+4. **Spawn Codex jobs in background** via `codex:codex-rescue` agent (which uses `--background`) — collect job IDs, retrieve via `/codex:result <job-id>` once `/codex:status --wait` returns. Don't block the main thread waiting for slow Codex.
+
+**Why this matters**
+
+`codex:rescue`'s task runtime gives Codex unbounded latitude to explore. With a focused perspective (Architecture: invariants, Innovation: cross-domain), Codex converges fast. With a broad perspective (Overall: gaps + risk + over/under-engineering + observability + dead code) on a big diff, it never converges.
+
+The fix is in the prompt, not the tool — explicit time-box + narrower perspective per pass.

--- a/.gobbi/projects/gobbi/learnings/gotchas/codex-overall-perspective-hangs.md
+++ b/.gobbi/projects/gobbi/learnings/gotchas/codex-overall-perspective-hangs.md
@@ -1,4 +1,4 @@
-### Codex Overall perspective hangs on large diffs
+# Codex Overall perspective hangs on large diffs
 
 ---
 priority: medium

--- a/packages/cli/src/commands/prompt/__tests__/__snapshots__/render.snap.test.ts.snap
+++ b/packages/cli/src/commands/prompt/__tests__/__snapshots__/render.snap.test.ts.snap
@@ -613,9 +613,9 @@ Emit the Stop completion signal once \`handoff.md\` is written at \`sessions/<id
 
 You have finished this step's work when the criteria above are satisfied. Once they are met, run EXACTLY this command as your last action:
 
-  gobbi workflow transition COMPLETE
+  gobbi workflow transition FINISH
 
-The CLI's output is the authoritative record of step completion. No other phrasing — prose, markdown headers, comments — advances the workflow. Run the command, observe the printed next step, and stop.
+The CLI's output is the authoritative record of step completion. No other phrasing — prose, markdown headers, comments — advances the workflow. Run the command, observe the printed next step, and stop. Handoff is the terminal productive step; FINISH emits \`workflow.finish\` and transitions the session to \`done\`.
 
 "
 `;

--- a/packages/cli/src/commands/workflow/__tests__/resume.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/resume.test.ts
@@ -449,6 +449,19 @@ describe('runResumeWithOptions — --force-memorization', () => {
     } finally {
       store.close();
     }
+
+    // Backup invariant — `state.json.backup` must trail `state.json` by
+    // at most one state write. The `--force-memorization` branch calls
+    // `backupState` immediately before `writeState`, so the backup
+    // captures the pre-resume `error` state that lived in `state.json`
+    // before the explicit post-transaction projection. This mirrors the
+    // discipline in `appendEventAndUpdateState` (engine.ts).
+    const backupRaw = readFileSync(
+      join(sessionDir, 'state.json.backup'),
+      'utf8',
+    );
+    const backup = JSON.parse(backupRaw) as { readonly currentStep: string };
+    expect(backup.currentStep).toBe('error');
   });
 });
 

--- a/packages/cli/src/commands/workflow/__tests__/resume.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/resume.test.ts
@@ -20,7 +20,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 
@@ -391,6 +391,61 @@ describe('runResumeWithOptions — --force-memorization', () => {
       // `detectPathway`, so it is NOT part of the baseline; it lives on
       // the PriorErrorSnapshot envelope rather than the pathway itself.
       expect(reconstructed).toEqual(baselinePathway);
+    } finally {
+      store.close();
+    }
+  });
+
+  // CV-9 regression — issue #163. The pre-fix `--force-memorization`
+  // branch appended events via raw `store.transaction(...)` and never
+  // wrote `state.json`. `resolveWorkflowState`'s fast path read the
+  // stale state.json and returned the pre-resume `error` step on every
+  // subsequent invocation — events said `memorization`, state.json
+  // disagreed. The fix derives state via `deriveWorkflowState` and
+  // explicitly calls `writeState` after the transaction commits.
+  //
+  // This test asserts the on-disk state.json content directly, NOT the
+  // event-store rows (the pre-existing tests above already cover those).
+  test('writes state.json with currentStep=memorization after --force-memorization (issue #163)', async () => {
+    const sessionId = 'resume-force-statefile';
+    const { sessionDir } = await initScratchSession(sessionId);
+    await driveToErrorState(sessionDir, sessionId);
+
+    // Sanity baseline: state.json reflects the error state pre-resume.
+    {
+      const raw = readFileSync(join(sessionDir, 'state.json'), 'utf8');
+      const before = JSON.parse(raw) as { readonly currentStep: string };
+      expect(before.currentStep).toBe('error');
+    }
+
+    await captureExit(() =>
+      runResumeWithOptions(
+        ['--target', 'memorization', '--force-memorization'],
+        { sessionDir },
+      ),
+    );
+    expect(captured.exitCode).toBeNull();
+
+    // The actual regression assertion — state.json materialised the
+    // post-resume state, not just the event-store rows.
+    const raw = readFileSync(join(sessionDir, 'state.json'), 'utf8');
+    const after = JSON.parse(raw) as {
+      readonly currentStep: string;
+      readonly schemaVersion: number;
+    };
+    expect(after.currentStep).toBe('memorization');
+    // The fast-path readers (`resolveWorkflowState`) accept the file by
+    // schemaVersion gate — confirm the persisted shape passes that gate
+    // so downstream guard / status / next reads see the fresh state.
+    expect(after.schemaVersion).toBeGreaterThanOrEqual(4);
+
+    // Cross-check via the same code path the runtime uses — fast-path
+    // readState → resolveWorkflowState. Pre-fix, this returned 'error'
+    // because state.json was stale.
+    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    try {
+      const resolved = resolveWorkflowState(sessionDir, store, sessionId);
+      expect(resolved.currentStep).toBe('memorization');
     } finally {
       store.close();
     }

--- a/packages/cli/src/commands/workflow/__tests__/transition.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/transition.test.ts
@@ -20,7 +20,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 
@@ -304,6 +304,76 @@ describe('runTransitionWithOptions — happy paths', () => {
     } finally {
       store.close();
     }
+  });
+
+  // CV-10 / issue #188 regression — pre-fix the handoff footer
+  // instructed `gobbi workflow transition COMPLETE`, but the runtime
+  // routed `handoff → done` only on `workflow.finish` (FINISH). The
+  // session looped without terminating because COMPLETE from handoff
+  // emitted `workflow.invalid_transition` while the agent retried.
+  // This test drives the full workflow through to handoff and asserts
+  // FINISH terminates the session.
+  test('FINISH from handoff fires workflow.finish and reaches `done`', async () => {
+    const { sessionDir } = await initScratchSession('trans-handoff-finish');
+
+    // Drive ideation → planning → execution → execution_eval. The
+    // execution → execution_eval edge is unconditional in the
+    // transition graph (see `transitions.ts:176`), so even with eval
+    // disabled the workflow lands at execution_eval after three
+    // COMPLETEs.
+    for (let i = 0; i < 3; i += 1) {
+      captured = { stdout: '', stderr: '', exitCode: null };
+      await captureExit(() =>
+        runTransitionWithOptions(['COMPLETE'], { sessionDir }),
+      );
+      expect(captured.exitCode).toBeNull();
+    }
+
+    // execution_eval → memorization via PASS verdict.
+    captured = { stdout: '', stderr: '', exitCode: null };
+    await captureExit(() =>
+      runTransitionWithOptions(['PASS'], { sessionDir }),
+    );
+    expect(captured.exitCode).toBeNull();
+
+    // memorization → handoff via COMPLETE.
+    captured = { stdout: '', stderr: '', exitCode: null };
+    await captureExit(() =>
+      runTransitionWithOptions(['COMPLETE'], { sessionDir }),
+    );
+    expect(captured.exitCode).toBeNull();
+
+    // FINISH from handoff terminates. Pre-fix the handoff footer
+    // instructed COMPLETE which routed `workflow.step.exit` from
+    // `handoff` — there is no transition rule for that pair, so the
+    // reducer rejected and the agent looped retrying COMPLETE.
+    captured = { stdout: '', stderr: '', exitCode: null };
+    await captureExit(() =>
+      runTransitionWithOptions(['FINISH'], { sessionDir }),
+    );
+    expect(captured.exitCode).toBeNull();
+    expect(captured.stdout).toContain('workflow.finish');
+    // After FINISH the runtime transition graph routes handoff → done.
+    expect(captured.stdout).toContain('done');
+
+    const store = openStore(sessionDir);
+    try {
+      const finishRow = store.last('workflow.finish');
+      expect(finishRow).not.toBeNull();
+      // The finish event was emitted while still at the handoff step
+      // (the reducer transitions to `done` AFTER applying the event).
+      expect(finishRow!.step).toBe('handoff');
+    } finally {
+      store.close();
+    }
+
+    // state.json reflects the terminal `done` state via the same
+    // resolveWorkflowState fast path the runtime guards / status
+    // commands use.
+    const finalState = JSON.parse(
+      readFileSync(join(sessionDir, 'state.json'), 'utf8'),
+    ) as { readonly currentStep: string };
+    expect(finalState.currentStep).toBe('done');
   });
 
   test('REVISE with --loop-target carries the target to EvalVerdictData', async () => {

--- a/packages/cli/src/commands/workflow/init.ts
+++ b/packages/cli/src/commands/workflow/init.ts
@@ -303,6 +303,22 @@ export async function runInitWithOptions(
   // locking; composing two calls under `store.transaction` yields a single
   // outer SAVEPOINT (bun:sqlite promotes nested calls automatically), so a
   // crash between the two appends rolls the pair back together.
+  //
+  // Why no explicit `writeState` after this transaction:
+  // The inner calls go through `appendEventAndUpdateState`, which
+  // calls `backupState` + `writeState` itself on every append (see
+  // `engine.ts`). state.json is materialised twice during this block —
+  // once after `workflow.start`, once after `workflow.eval.decide` —
+  // and the final write reflects the post-decide state. No
+  // post-transaction projection is needed.
+  //
+  // Contrast with the `--force-memorization` branch in `resume.ts`:
+  // that path appends events directly via `store.append(...)` inside
+  // its raw transaction (NOT through `appendEventAndUpdateState`),
+  // bypassing the per-append state.json write. It therefore needs an
+  // explicit `backupState` + `writeState` after the commit to bring
+  // state.json forward. See CV-9 (issue #163) for the regression that
+  // motivated that pattern.
   const dbPath = join(sessionDir, 'gobbi.db');
   const partitionKeys = resolvePartitionKeys(sessionDir);
   const store = new EventStore(dbPath, partitionKeys);

--- a/packages/cli/src/commands/workflow/resume.ts
+++ b/packages/cli/src/commands/workflow/resume.ts
@@ -43,7 +43,7 @@ import {
   type PriorErrorSnapshot,
 } from '../../workflow/events/decision.js';
 import type { WorkflowState } from '../../workflow/state.js';
-import { writeState } from '../../workflow/state.js';
+import { backupState, writeState } from '../../workflow/state.js';
 import {
   compileResumePrompt,
   detectPathway,
@@ -320,7 +320,14 @@ export async function runResumeWithOptions(
       // The write happens OUTSIDE the SQLite transaction — the atomicity
       // boundary is the two-event append; state.json is a downstream
       // projection that follows the commit.
+      //
+      // `backupState` runs immediately before `writeState` to preserve
+      // the invariant that `state.json.backup` trails `state.json` by
+      // at most one state write — matching the discipline in
+      // `appendEventAndUpdateState` (engine.ts), which calls
+      // `backupState` as step 1 inside its transaction.
       const derived = deriveWorkflowState(sessionId, store);
+      backupState(sessionDir);
       writeState(sessionDir, derived);
     } else {
       const resumeEvent = createResume({

--- a/packages/cli/src/commands/workflow/resume.ts
+++ b/packages/cli/src/commands/workflow/resume.ts
@@ -34,6 +34,7 @@ import { join } from 'node:path';
 import { EventStore } from '../../workflow/store.js';
 import {
   appendEventAndUpdateState,
+  deriveWorkflowState,
   resolveWorkflowState,
 } from '../../workflow/engine.js';
 import { createResume } from '../../workflow/events/workflow.js';
@@ -42,6 +43,7 @@ import {
   type PriorErrorSnapshot,
 } from '../../workflow/events/decision.js';
 import type { WorkflowState } from '../../workflow/state.js';
+import { writeState } from '../../workflow/state.js';
 import {
   compileResumePrompt,
   detectPathway,
@@ -299,11 +301,27 @@ export async function runResumeWithOptions(
         process.exit(1);
       }
 
-      // Refresh state. The raw transaction bypassed the state.json
-      // write (that lives in `appendEventAndUpdateState`), so
-      // `resolveWorkflowState` falls through to `replayAll` and derives
-      // a fresh state — this materializes the updated state.json.
-      resolveWorkflowState(sessionDir, store, sessionId);
+      // Refresh state.json after the raw transaction.
+      //
+      // The raw transaction bypassed the `writeState` call that lives
+      // inside `appendEventAndUpdateState`, so the on-disk `state.json`
+      // is still the pre-resume state at this point. `resolveWorkflowState`
+      // ALONE would not fix that — its fast path (`readState`) returns
+      // whatever `state.json` currently holds without re-deriving from
+      // events. Without the explicit write below, every subsequent
+      // `workflow status / next / guard` invocation reads stale state
+      // (currentStep: 'error') even though the event log says
+      // 'memorization'. See CV-9 in the v0.5.0 adversarial review
+      // campaign synthesis (issue #163) for the failure mode.
+      //
+      // The fix: force a full replay via `deriveWorkflowState` (cold
+      // path, ignores state.json) and then `writeState` to materialise
+      // the result, mirroring `appendEventAndUpdateState`'s discipline.
+      // The write happens OUTSIDE the SQLite transaction — the atomicity
+      // boundary is the two-event append; state.json is a downstream
+      // projection that follows the commit.
+      const derived = deriveWorkflowState(sessionId, store);
+      writeState(sessionDir, derived);
     } else {
       const resumeEvent = createResume({
         targetStep: target,

--- a/packages/cli/src/specs/__tests__/__snapshots__/footer.snap.test.ts.snap
+++ b/packages/cli/src/specs/__tests__/__snapshots__/footer.snap.test.ts.snap
@@ -371,9 +371,9 @@ Criteria:
 
 You have finished this step's work when the criteria above are satisfied. Once they are met, run EXACTLY this command as your last action:
 
-  gobbi workflow transition COMPLETE
+  gobbi workflow transition FINISH
 
-The CLI's output is the authoritative record of step completion. No other phrasing — prose, markdown headers, comments — advances the workflow. Run the command, observe the printed next step, and stop.
+The CLI's output is the authoritative record of step completion. No other phrasing — prose, markdown headers, comments — advances the workflow. Run the command, observe the printed next step, and stop. Handoff is the terminal productive step; FINISH emits \`workflow.finish\` and transitions the session to \`done\`.
 
 session.schemaVersion=4
 session.currentStep=handoff

--- a/packages/cli/src/specs/__tests__/footer.snap.test.ts
+++ b/packages/cli/src/specs/__tests__/footer.snap.test.ts
@@ -4,14 +4,16 @@
  * Pins the data-driven `blocks.footer` payload that B.1.1 lifted from prose
  * into a first-class `StepBlocks` field. The footer carries the exact
  * `gobbi workflow transition <VERB>` invocation each agent must run as its
- * terminal action — productive steps name `COMPLETE`; the shared evaluation
- * spec names `PASS` / `REVISE` / `ESCALATE`. Operator-only verbs (SKIP,
- * TIMEOUT, FINISH, ABORT, RESUME) must never appear paired with the
- * `gobbi workflow transition` token, so the verb-partition assertions key on
- * the *token sequence*, not the bare verb. (The eval footer's prose body
- * legitimately contains the bare word "COMPLETE" in the sentence "COMPLETE is
- * not valid for evaluation steps" — the token-sequence test does not flag
- * that.)
+ * terminal action — productive steps name `COMPLETE` EXCEPT `handoff`, which
+ * is the terminal productive step and names `FINISH` (drives `handoff → done`
+ * via `workflow.finish`). The shared evaluation spec names `PASS` / `REVISE`
+ * / `ESCALATE`. Operator-only verbs (SKIP, TIMEOUT, ABORT, RESUME) must
+ * never appear paired with the `gobbi workflow transition` token in any
+ * footer; `FINISH` may appear paired only in `handoff`'s footer. The
+ * verb-partition assertions key on the *token sequence*, not the bare verb.
+ * (The eval footer's prose body legitimately contains the bare word
+ * "COMPLETE" in the sentence "COMPLETE is not valid for evaluation steps" —
+ * the token-sequence test does not flag that.)
  *
  * Test groups:
  *
@@ -22,8 +24,10 @@
  *        (i)   the footer section sits between `blocks.completion` and
  *              `session.state` in the section list,
  *        (ii)  the footer section's `kind` is `'static'`,
- *        (iii) `prompt.text` contains the COMPLETE-verb sequence and none of
- *              the verdict / operator-only verb sequences,
+ *        (iii) `prompt.text` contains the step's terminal verb sequence
+ *              (FINISH for `handoff`; COMPLETE for every other productive
+ *              step) and none of the other verdict / operator-only verb
+ *              sequences,
  *        (iv)  `prompt.text` matches the on-disk snapshot.
  *
  *   b. footer — renders for evaluation spec
@@ -138,17 +142,37 @@ function compileGenerous(input: CompileInput): ReturnType<typeof compile> {
 
 const TXN = 'gobbi workflow transition';
 
-const PRODUCTIVE_POSITIVE_SEQUENCES = [`${TXN} COMPLETE`] as const;
+// Productive-step terminal verb is `COMPLETE` for every step EXCEPT
+// `handoff`, which is the terminal productive step and must emit
+// `workflow.finish` to drive `handoff → done`. See `spec.json` of each
+// step + issue #188 (CV-10 in the v0.5.0 adversarial review campaign).
+const PRODUCTIVE_POSITIVE_SEQUENCES_DEFAULT = [`${TXN} COMPLETE`] as const;
+const HANDOFF_POSITIVE_SEQUENCES = [`${TXN} FINISH`] as const;
 
-// All verbs that must NOT pair with `gobbi workflow transition` in a
-// productive footer — every verdict verb plus every operator-only verb.
-const PRODUCTIVE_NEGATIVE_SEQUENCES = [
+// Verbs that must NOT pair with `gobbi workflow transition` in a
+// non-handoff productive footer — every verdict verb plus every
+// operator-only verb (FINISH included; only handoff names FINISH).
+const PRODUCTIVE_NEGATIVE_SEQUENCES_DEFAULT = [
   `${TXN} PASS`,
   `${TXN} REVISE`,
   `${TXN} ESCALATE`,
   `${TXN} SKIP`,
   `${TXN} TIMEOUT`,
   `${TXN} FINISH`,
+  `${TXN} ABORT`,
+  `${TXN} RESUME`,
+] as const;
+
+// Handoff-specific negatives — same as default minus `FINISH`, plus
+// `COMPLETE` (which is the productive default everywhere else and must
+// not appear paired with `gobbi workflow transition` in handoff).
+const HANDOFF_NEGATIVE_SEQUENCES = [
+  `${TXN} COMPLETE`,
+  `${TXN} PASS`,
+  `${TXN} REVISE`,
+  `${TXN} ESCALATE`,
+  `${TXN} SKIP`,
+  `${TXN} TIMEOUT`,
   `${TXN} ABORT`,
   `${TXN} RESUME`,
 ] as const;
@@ -213,12 +237,23 @@ describe('footer — renders for productive specs', () => {
       expect(footerSummary).toBeDefined();
       expect(footerSummary?.kind).toBe('static');
 
-      // (iii) — verb-partition: the COMPLETE invocation is present; no other
-      //          `gobbi workflow transition <VERB>` sequence is.
-      for (const seq of PRODUCTIVE_POSITIVE_SEQUENCES) {
+      // (iii) — verb-partition: the step's terminal verb is present; no
+      //          other `gobbi workflow transition <VERB>` sequence is.
+      //          `handoff` names FINISH (the terminal productive step
+      //          drives `handoff → done` via `workflow.finish`); every
+      //          other productive step names COMPLETE.
+      const positives =
+        step === 'handoff'
+          ? HANDOFF_POSITIVE_SEQUENCES
+          : PRODUCTIVE_POSITIVE_SEQUENCES_DEFAULT;
+      const negatives =
+        step === 'handoff'
+          ? HANDOFF_NEGATIVE_SEQUENCES
+          : PRODUCTIVE_NEGATIVE_SEQUENCES_DEFAULT;
+      for (const seq of positives) {
         expect(prompt.text).toContain(seq);
       }
-      for (const seq of PRODUCTIVE_NEGATIVE_SEQUENCES) {
+      for (const seq of negatives) {
         expect(prompt.text).not.toContain(seq);
       }
 

--- a/packages/cli/src/specs/handoff/__tests__/snapshot.test.ts
+++ b/packages/cli/src/specs/handoff/__tests__/snapshot.test.ts
@@ -171,6 +171,19 @@ describe('handoff/spec.json — validation', () => {
     const spec = loadSpec();
     expect(spec.meta.requiredSkills).toContain('_project');
   });
+
+  // CV-10 / issue #188 regression — pre-fix the handoff footer named
+  // `gobbi workflow transition COMPLETE` but the runtime drives
+  // `handoff → done` only via `workflow.finish` (FINISH). The footer
+  // and the transition graph must agree at the spec-file level so any
+  // future edit re-introducing COMPLETE fails fast at unit-test time
+  // rather than wedging an in-flight session.
+  test('footer instructs `gobbi workflow transition FINISH`, not COMPLETE', () => {
+    const spec = loadSpec();
+    const footer = spec.blocks.footer;
+    expect(footer).toContain('gobbi workflow transition FINISH');
+    expect(footer).not.toContain('gobbi workflow transition COMPLETE');
+  });
 });
 
 // ===========================================================================

--- a/packages/cli/src/specs/handoff/spec.json
+++ b/packages/cli/src/specs/handoff/spec.json
@@ -63,6 +63,6 @@
         "no prior-step artifacts have been modified — handoff is write-forward only into the session's handoff directory"
       ]
     },
-    "footer": "---\n## Step completion protocol\n\nYou have finished this step's work when the criteria above are satisfied. Once they are met, run EXACTLY this command as your last action:\n\n  gobbi workflow transition COMPLETE\n\nThe CLI's output is the authoritative record of step completion. No other phrasing — prose, markdown headers, comments — advances the workflow. Run the command, observe the printed next step, and stop."
+    "footer": "---\n## Step completion protocol\n\nYou have finished this step's work when the criteria above are satisfied. Once they are met, run EXACTLY this command as your last action:\n\n  gobbi workflow transition FINISH\n\nThe CLI's output is the authoritative record of step completion. No other phrasing — prose, markdown headers, comments — advances the workflow. Run the command, observe the printed next step, and stop. Handoff is the terminal productive step; FINISH emits `workflow.finish` and transitions the session to `done`."
   }
 }

--- a/packages/cli/src/workflow/__tests__/reducer.test.ts
+++ b/packages/cli/src/workflow/__tests__/reducer.test.ts
@@ -160,6 +160,13 @@ function verdictRevise(loopTarget?: string): Event {
   };
 }
 
+function verdictEscalate(): Event {
+  return {
+    type: DECISION_EVENTS.EVAL_VERDICT,
+    data: { verdict: 'escalate' },
+  };
+}
+
 function decisionUser(): Event {
   return {
     type: DECISION_EVENTS.USER,
@@ -527,6 +534,92 @@ describe('decision.eval.verdict revise', () => {
 });
 
 // ---------------------------------------------------------------------------
+// 10b. decision.eval.verdict (escalate): transitions eval step -> error,
+//      rejects from non-eval steps. CV-11 / issue #168 regression.
+// ---------------------------------------------------------------------------
+
+describe('decision.eval.verdict escalate', () => {
+  // Pre-fix, the escalate arm fell through to `ok(state)` — a committed
+  // event that recorded nothing and moved nowhere. The fix transitions
+  // any *_eval origin to the `error` step so the operator can choose
+  // resume / abort via `gobbi workflow resume`.
+  it('ideation_eval -> error on escalate', () => {
+    const state = stateAt('ideation_eval');
+    const next = expectOk(reduce(state, verdictEscalate()));
+    expect(next.currentStep).toBe('error');
+    expect(next.currentSubstate).toBeNull();
+  });
+
+  it('planning_eval -> error on escalate', () => {
+    const state = stateAt('planning_eval');
+    const next = expectOk(reduce(state, verdictEscalate()));
+    expect(next.currentStep).toBe('error');
+  });
+
+  it('execution_eval -> error on escalate', () => {
+    const state = stateAt('execution_eval');
+    const next = expectOk(reduce(state, verdictEscalate()));
+    expect(next.currentStep).toBe('error');
+  });
+
+  // The eval-step gate (issue #168) is the source-of-truth check —
+  // verdict events fired from non-eval steps are rejected at the
+  // verdict arm, NOT silently no-opped. The pass/revise arms relied on
+  // `findTransition` returning null; escalate has no transition rule
+  // and therefore needed an explicit gate.
+  it('rejects escalate from a non-eval productive step (execution)', () => {
+    const result = reduce(stateAt('execution'), verdictEscalate());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('requires an eval step');
+    }
+  });
+
+  it('rejects escalate from ideation', () => {
+    const result = reduce(stateAt('ideation'), verdictEscalate());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('requires an eval step');
+    }
+  });
+
+  it('rejects escalate from planning', () => {
+    const result = reduce(stateAt('planning'), verdictEscalate());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('requires an eval step');
+    }
+  });
+
+  it('rejects escalate from memorization', () => {
+    const result = reduce(stateAt('memorization'), verdictEscalate());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('requires an eval step');
+    }
+  });
+
+  it('rejects escalate from error (already-error fallthrough guard)', () => {
+    const result = reduce(stateAt('error'), verdictEscalate());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('requires an eval step');
+    }
+  });
+
+  // Escalate must NOT overwrite `lastVerdictOutcome` — that field's
+  // schema is `'pass' | 'revise' | null` and downstream predicates may
+  // still consult the prior outcome. The step transition + committed
+  // event are the witnesses that this branch fired.
+  it('preserves lastVerdictOutcome from a prior pass when escalate fires', () => {
+    const state = stateAt('execution_eval', { lastVerdictOutcome: 'pass' });
+    const next = expectOk(reduce(state, verdictEscalate()));
+    expect(next.currentStep).toBe('error');
+    expect(next.lastVerdictOutcome).toBe('pass');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 11. Feedback cap: revise with feedbackRound >= maxFeedbackRounds -> error
 // ---------------------------------------------------------------------------
 
@@ -758,7 +851,9 @@ describe('invalid transitions return error, not throw', () => {
     const result = reduce(stateAt('execution'), verdictPass());
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error).toContain('No valid transition');
+      // The eval-step gate (issue #168) rejects any verdict variant
+      // — pass / revise / escalate — fired from a non-eval step.
+      expect(result.error).toContain('requires an eval step');
     }
   });
 

--- a/packages/cli/src/workflow/reducer.ts
+++ b/packages/cli/src/workflow/reducer.ts
@@ -403,72 +403,109 @@ function reduceDecision(
     case DECISION_EVENTS.EVAL_VERDICT: {
       const { verdict } = event.data;
 
-      if (verdict === 'pass') {
-        const rule = findTransition(
-          state.currentStep,
-          event,
-          state,
-          predicates,
+      // Verdict events are only valid from `*_eval` steps. The pass/revise
+      // arms enforce this implicitly via `findTransition` (which returns
+      // null for non-eval origins because the transition table contains no
+      // verdict-triggered rules for productive or terminal steps). The
+      // escalate arm has no transition-table rule, so we enforce the same
+      // rule explicitly here for a single source of truth across all three
+      // verdict variants. See CV-11 in the v0.5.0 adversarial review
+      // campaign synthesis (issue #168) for the failure mode this guards
+      // against — pre-fix, escalate from any step fell through to
+      // `ok(state)` and silently committed a no-op event.
+      if (
+        state.currentStep !== 'ideation_eval' &&
+        state.currentStep !== 'planning_eval' &&
+        state.currentStep !== 'execution_eval'
+      ) {
+        return err(
+          `decision.eval.verdict requires an eval step (ideation_eval / planning_eval / execution_eval), got ${state.currentStep}`,
         );
-        if (rule === null) {
-          return err(
-            `No valid transition from ${state.currentStep} for pass verdict`,
-          );
-        }
-        return ok({
-          ...state,
-          currentStep: rule.to,
-          currentSubstate: rule.to === 'ideation' ? 'discussing' : null,
-          lastVerdictOutcome: 'pass',
-        });
       }
 
-      if (verdict === 'revise') {
-        // Check feedback cap first
-        const feedbackCapPredicate = predicates['feedbackCapExceeded'];
-        if (
-          state.currentStep === 'execution_eval' &&
-          feedbackCapPredicate !== undefined &&
-          feedbackCapPredicate(state)
-        ) {
+      switch (verdict) {
+        case 'pass': {
+          const rule = findTransition(
+            state.currentStep,
+            event,
+            state,
+            predicates,
+          );
+          if (rule === null) {
+            return err(
+              `No valid transition from ${state.currentStep} for pass verdict`,
+            );
+          }
           return ok({
             ...state,
-            currentStep: 'error',
-            currentSubstate: null,
+            currentStep: rule.to,
+            currentSubstate: rule.to === 'ideation' ? 'discussing' : null,
+            lastVerdictOutcome: 'pass',
+          });
+        }
+
+        case 'revise': {
+          // Check feedback cap first
+          const feedbackCapPredicate = predicates['feedbackCapExceeded'];
+          if (
+            state.currentStep === 'execution_eval' &&
+            feedbackCapPredicate !== undefined &&
+            feedbackCapPredicate(state)
+          ) {
+            return ok({
+              ...state,
+              currentStep: 'error',
+              currentSubstate: null,
+              lastVerdictOutcome: 'revise',
+            });
+          }
+
+          const rule = findTransition(
+            state.currentStep,
+            event,
+            state,
+            predicates,
+          );
+          if (rule === null) {
+            return err(
+              `No valid transition from ${state.currentStep} for revise verdict`,
+            );
+          }
+
+          // feedbackRound increments only on execution_eval revise loops
+          const nextFeedbackRound =
+            state.currentStep === 'execution_eval'
+              ? state.feedbackRound + 1
+              : state.feedbackRound;
+
+          return ok({
+            ...state,
+            currentStep: rule.to,
+            currentSubstate: rule.to === 'ideation' ? 'discussing' : null,
+            feedbackRound: nextFeedbackRound,
             lastVerdictOutcome: 'revise',
           });
         }
 
-        const rule = findTransition(
-          state.currentStep,
-          event,
-          state,
-          predicates,
-        );
-        if (rule === null) {
-          return err(
-            `No valid transition from ${state.currentStep} for revise verdict`,
-          );
+        case 'escalate': {
+          // Escalate transitions the active eval step to `error` so the
+          // operator can choose `gobbi workflow resume --target …` (or
+          // `--force-memorization`). `lastVerdictOutcome` remains
+          // 'pass' | 'revise' | null at the schema level — escalate is
+          // recorded by the step transition itself plus the committed
+          // event, not by overwriting the prior verdict outcome (which
+          // some predicates still consult). The `error` step is the
+          // authoritative witness that this branch fired.
+          return ok({
+            ...state,
+            currentStep: 'error',
+            currentSubstate: null,
+          });
         }
 
-        // feedbackRound increments only on execution_eval revise loops
-        const nextFeedbackRound =
-          state.currentStep === 'execution_eval'
-            ? state.feedbackRound + 1
-            : state.feedbackRound;
-
-        return ok({
-          ...state,
-          currentStep: rule.to,
-          currentSubstate: rule.to === 'ideation' ? 'discussing' : null,
-          feedbackRound: nextFeedbackRound,
-          lastVerdictOutcome: 'revise',
-        });
+        default:
+          return assertNever(verdict);
       }
-
-      // escalate — informational, leaves lastVerdictOutcome unchanged so the
-      // prior outcome (if any) stays visible to predicates.
-      return ok(state);
     }
 
     case DECISION_EVENTS.EVAL_SKIP: {


### PR DESCRIPTION
## Summary

Three small workflow fixes that block Wave D.1, surfaced by the prior session's adversarial review campaign (synthesis §2 CV-9/10/11):

- **#188** — `handoff/spec.json` instructed `gobbi workflow transition COMPLETE`; runtime requires `FINISH`. Spec footer + criteria updated; without this, sessions cannot terminate via handoff.
- **#168** — `decision.eval.verdict` reducer arm for `escalate` was a silent no-op (fell through to `return ok(state)`). Added explicit arm that transitions to `error` step; added an eval-step gate that uniformly rejects all verdict events from non-eval steps.
- **#163** — `--force-memorization` resume branch appended events via raw `store.transaction` and never wrote `state.json`, leaving the projection stale. Now derives state from the updated event log and calls `backupState` + `writeState` post-commit, matching `appendEventAndUpdateState` discipline.

Bundled: one untracked gotcha file (`codex-overall-perspective-hangs.md`) carried over from the prior session — bundled here because direct push to `develop` is blocked.

## Test plan

- [x] `bun test` — 1984 pass / 0 fail / 8 todo
- [x] `bun run typecheck` — clean
- [x] `bun run build` — clean
- [x] `gobbi workflow validate` — exit 0
- [x] 3 regression tests added (each fails pre-fix, passes post-fix):
  - `resume.test.ts`: `state.json` and `state.json.backup` reflect `currentStep: error` (pre-resume) and `memorization` (post-resume) after `--force-memorization`
  - `reducer.test.ts`: `escalate` from eval step → `error`; verdict from non-eval step → reducer error
  - `transition.test.ts` + `snapshot.test.ts`: `FINISH` from handoff reaches `done`; spec footer asserts the keyword
- [x] 3 perspective evaluators (Project, Architecture, Overall) — all PASS, 4 findings addressed in remediation pass

## Closes

Closes #163, #168, #188.

## Notes

- Adjacent finding (NOT in this PR): globally-installed `gobbi` binary in this environment looks for `packages/specs/index.json` (legacy path) and fails with `E003_INVALID_GRAPH`. Worktree's local CLI works correctly. May warrant a follow-up issue for install/path drift.
- Schema field `lastVerdictOutcome: 'pass' | 'revise' | null` deliberately not extended to include `'escalate'` — escalate is recorded by the step transition + the committed event; downstream predicates do not consume `'escalate'` from this field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)