### PR TITLE
docs(reality-sweep): D.1 blockers — CLAUDE.md DB-path + design + CHANGELOG + MIGRATION (#162)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -10,7 +10,7 @@ MUST load this at session start, resume, and compaction. MUST follow the core pr
 
 > **The logic of good work: Ideation → Planning → Execution → Memorization → Handoff.**
 
-Every non-trivial task follows these 5 productive steps. Evaluation runs as a sub-phase inside Ideation, Planning, and Execution — mandatory after Execution, optional at the earlier steps. The 6-step state machine (adding Configuration as the pre-loop step) lives in `packages/cli/src/specs/` and is driven by `gobbi workflow init`. Workflow state persists in `.gobbi/state.db` (event log); cross-session memory lives in `.gobbi/gobbi.db` (memories projection).
+Every non-trivial task follows these 5 productive steps. Evaluation runs as a sub-phase inside Ideation, Planning, and Execution — mandatory after Execution, optional at the earlier steps. The 6-step state machine (Configuration as the CLI init phase, plus the 5 productive steps) lives in `packages/cli/src/specs/` and is driven by `gobbi workflow init`. Workflow events write to per-session `gobbi.db` at `.gobbi/projects/<name>/sessions/<id>/gobbi.db`; cross-session memory lives in `.gobbi/gobbi.db` (workspace memories projection, git-tracked). Note: `prompt.patch.applied` events write to workspace `.gobbi/state.db` — full workspace consolidation of workflow events is Wave A.1 work, partially shipped.
 
 **Ideation** — Explore what to do. PI agents (innovative + best stances) investigate the problem space with the user. Discuss until the approach is concrete enough to plan against. Optional evaluation.
 
@@ -46,6 +46,6 @@ MUST decompose work into small, specific tasks and track them with TaskCreate. E
 |----------|--------|
 | [gobbi skill](skills/gobbi/SKILL.md) | Entry point, session setup questions, skill map |
 | [_claude skill](skills/_claude/SKILL.md) | Documentation standard for `.claude/` authoring |
-| [`v050-overview.md`](../../../.gobbi/projects/gobbi/design/v050-overview.md) | v0.5.0 state machine, 6-step state machine, two-DB workspace split — authoritative architecture doc |
+| [`v050-overview.md`](../../../.gobbi/projects/gobbi/design/v050-overview.md) | v0.5.0 state machine, 6-step workflow, per-session/workspace DB split — authoritative architecture doc |
 | [`v050-cli.md`](../../../.gobbi/projects/gobbi/design/v050-cli.md) | CLI command surface, `gobbi workflow *` and `gobbi project *` commands |
 | [rules/](rules/) | Naming conventions and project rules |

--- a/.gobbi/projects/gobbi/design/v050-features/orchestration/README.md
+++ b/.gobbi/projects/gobbi/design/v050-features/orchestration/README.md
@@ -14,7 +14,7 @@ The same architecture pattern is well-established at scale — Temporal, AWS Ste
 
 ## 1. The 6-step workflow
 
-Every workflow is six steps. Evaluation is a sub-phase **inside** Ideation, Planning, and Execution — not a standalone step. `handoff` is a **true state-machine step**, not a memorization sub-artifact. The 6-step model supersedes the 5-step cycle currently described in `../../v050-overview.md` and `.claude/CLAUDE.md`; reconciling those is in scope for Wave A.2.
+Every workflow is six steps. Evaluation is a sub-phase **inside** Ideation, Planning, and Execution — not a standalone step. `handoff` is a **true state-machine step**, not a memorization sub-artifact. The 6-step model is now the authoritative framing in `../../v050-overview.md` and `.claude/CLAUDE.md` (reconciled in Wave A.2).
 
 | Step | State literal in `index.json` | Purpose | Productive or terminal? |
 |---|---|---|---|
@@ -54,19 +54,19 @@ The four layers each own a distinct slice of the orchestration stack. The user a
 | **L3a** Orchestrator-in-step | The active agent runtime (Claude Code or `claude -p`) | Compiled JIT prompt from `specs/assembly.ts::compile()` ending with the standardized footer | Autonomy within a bounded contract |
 | **L3b** Subagent-in-task | A spawned subagent with `(role, specialties[])` composition | Composed delegation prompt — spec'd in deferred `roles-and-specialties` pass | Autonomy within a delegation contract |
 
-**End-to-end trace (Plan → Execution under Outer mode, post-Wave-E.2 target):** `gobbi workflow run` reads `state.db`, sees `currentStep == 'planning_eval'` with `verdictPass`, calls `transition.ts::buildEvent('PASS')` to advance to `currentStep == 'execution'`. `gobbi workflow next` compiles the execution prompt via `specs/assembly.ts`. L1 spawns `claude -p '<prompt>' --session-id $SID`. The agent works in the prompt and runs `gobbi workflow transition COMPLETE` per the footer. `transition.ts:335` emits `workflow.step.exit`; the reducer validates; the loop continues. Same flow runs in Inner mode under interactive Claude Code — the only differences are who spawns the runtime and where the prompt is delivered.
+**End-to-end trace (Plan → Execution under Outer mode, post-Wave-E.2 target):** `gobbi workflow run` reads the per-session `gobbi.db`, sees `currentStep == 'planning_eval'` with `verdictPass`, calls `transition.ts::buildEvent('PASS')` to advance to `currentStep == 'execution'`. `gobbi workflow next` compiles the execution prompt via `specs/assembly.ts`. L1 spawns `claude -p '<prompt>' --session-id $SID`. The agent works in the prompt and runs `gobbi workflow transition COMPLETE` per the footer. `transition.ts:335` emits `workflow.step.exit`; the reducer validates; the loop continues. Same flow runs in Inner mode under interactive Claude Code — the only differences are who spawns the runtime and where the prompt is delivered.
 
 ---
 
 ## 3. State.db and gobbi.db — the two-DB partition
 
-The two-DB split is a CQRS read-model partition (Greg Young / EventStoreDB canon): `state.db` is the append-only event log; `gobbi.db` is the cross-session memory projection. After Wave A.1 both DBs are workspace-scoped at `.gobbi/state.db` and `.gobbi/gobbi.db`.
+The two-DB split is a CQRS read-model partition (Greg Young / EventStoreDB canon): the per-session `gobbi.db` is the append-only workflow event log; the workspace `gobbi.db` is the cross-session memory projection; the workspace `state.db` holds prompt-patch events. Full workspace consolidation of workflow events is a Wave A.1 migration target, partially shipped.
 
 ### 3.1 Current state vs target state
 
-**Today** (per `init.ts:6`, `store.ts:26`, `transition.ts:228`): `gobbi.db` is opened **per session** at `.gobbi/projects/<name>/sessions/<id>/gobbi.db`. Schema v5 already added `session_id` and `project_id` columns (`store.ts:8-17`), so partitioning is mechanically ready. The path is per-session.
+**Today** (per `init.ts`): workflow events write to a per-session `gobbi.db` at `.gobbi/projects/<name>/sessions/<id>/gobbi.db`. The workspace `state.db` at `.gobbi/state.db` holds only `prompt.patch.applied` events (Wave C.1). The workspace `gobbi.db` at `.gobbi/gobbi.db` holds cross-session memories (git-tracked). Schema v7 applies to both DB openings.
 
-**Target after Wave A.1:** workspace-scoped `state.db` (events) + workspace-scoped `gobbi.db` (memories). Wave A.1 owns the rename + re-scope migration via `gobbi maintenance migrate-state-db`.
+**Target (post-Wave A.1, full consolidation pending):** workspace-scoped `state.db` for workflow events + workspace-scoped `gobbi.db` for memories. Wave A.1 partially shipped the migration infrastructure (`gobbi maintenance migrate-state-db`, explicit EventStore partition keys, schema v6); full workspace event-log consolidation remains in progress.
 
 ### 3.2 EventStore constructor must accept explicit partition keys
 
@@ -94,11 +94,11 @@ config_changes           -- gobbi config set audit (table-only)
 schema_meta              -- migration version + last-completed timestamp
 ```
 
-Note: `prompt_patches` is **deferred to Wave C** (prompts-as-data owns it via schema v7). Wave A.1 schema v6 does not include it.
+Note: `prompt_patches` shipped in Wave C.1 (schema v7). Wave A.1 schema v6 did not include it; v7 adds the `prompt_patches` table for tracking applied JSON Patch operations.
 
 `session_id` and `project_id` remain nullable `TEXT` (not `NOT NULL`) — SQLite cannot add `NOT NULL` columns via `ALTER TABLE` without a table rebuild, and the `store.ts:476` fallback (`this.sessionId ?? input.sessionId`) provides backward compatibility for any pre-v6 row that lacks the partition keys.
 
-**Indices added in v6:** `(session_id, seq)`, `(project_id, seq DESC)` for "most recent N", `(type, step, session_id)` for predicate matchers; UNIQUE `idempotency_key` already exists at `store.ts:130-134`.
+**Indices added in v6:** `(session_id, seq)`, `(project_id, seq DESC)` for "most recent N", `(type, step, session_id)` for predicate matchers; UNIQUE `idempotency_key` already exists at `store.ts:130-134`. Schema v7 (Wave C.1) added the `prompt_patches` table.
 
 ### 3.4 `.gobbi/gobbi.db` (workspace, **git-tracked**, project + session memories)
 
@@ -123,9 +123,9 @@ Memories live **both** in SQLite (queryable + FTS) and rendered to markdown unde
 
 The `.gitignore` exception is required: today `.gobbi/*` covers everything; Wave A.1 must add `!.gobbi/gobbi.db` immediately after the `.gobbi/*` line, following the existing `!.gobbi/projects/` pattern (System F-1). Without the exception the file silently stays gitignored, defeating the entire point of the cross-session memory store.
 
-### 3.5 Event types — 22 today + 1 new in this design = 23 post-Pass-4
+### 3.5 Event types — 24 total (current)
 
-Today (verified per `events/index.ts:1` "22 event types"; expanded via `events/{workflow,delegation,decision,artifact,guard,verification,session}.ts`):
+Current live count per `events/index.ts` header "9 categories, 24 event types" — expanded via `events/{workflow,delegation,decision,artifact,guard,verification,session,step-advancement,prompt}.ts`:
 
 - **9 `workflow.*`** — `start`, `step.exit`, `step.skip`, `step.timeout`, `eval.decide`, `finish`, `abort`, `resume`, `invalid_transition`
 - **3 `delegation.*`** — `spawn`, `complete`, `fail`
@@ -134,25 +134,19 @@ Today (verified per `events/index.ts:1` "22 event types"; expanded via `events/{
 - **3 `guard.*`** — `violation`, `override`, `warn` (`warn` added in schema v2 per `migrations.ts:16`)
 - **1 `verification.*`** — `result`
 - **1 `session.*`** — `heartbeat`
+- **1 `step.*`** — `step.advancement.observed` (audit-only, bypasses reducer; added Pass 4 / Wave A.1)
+- **1 `prompt.*`** — `prompt.patch.applied` (audit-only, writes to workspace `state.db`; added Wave C.1)
 
-= **22 events total**.
+= **24 events total**.
 
-**New in Pass 4 (1 event):**
+**Audit-only events** (`step.advancement.observed`, `prompt.patch.applied`) bypass the reducer. The hook and `gobbi prompt patch` commands call `store.append()` directly. The reducer's `assertNever` at `reducer.ts:688` throws plain `Error` (not `ReducerRejectionError`), so a reducer-routed audit event would silently fail. Direct `store.append()` is the only path that persists these reliably. The reducer remains pure — it never sees audit-only events.
 
-- `step.advancement.observed` — synthetic event emitted by PostToolUse on `Bash` calls whose command starts with `gobbi workflow transition`. Primes the Stop-hook safety net so it does not false-positive after a successful transition.
-
-**Architecture F-1 fix:** the hook **calls `store.append()` directly**, bypassing the reducer. The reducer's `assertNever` at `reducer.ts:688` throws plain `Error` (not `ReducerRejectionError`), so a reducer-routed audit event would silently fail — the audit gate at `engine.ts:232` doesn't fire and `capture-planning.ts:177`'s catch swallows the throw. Direct `store.append()` is the only path that persists the event reliably. The reducer remains pure — it simply never sees this audit-only event.
-
-**Idempotency formula:** `tool-call`, keyed on the PostToolUse payload's `tool_call_id`. Deduplicates across hook retries; preserves distinctness across distinct Bash invocations.
-
-**Spike before committing in Wave A.1:** confirm Claude Code's PostToolUse fires for `Bash` running `gobbi workflow transition`. If not, the hook source becomes either a thin `gobbi workflow advance-observed` wrapper command that agents call after `transition`, or Stop-hook log scraping. Branch the implementation on the spike outcome.
-
-= **23 events total post-Pass-4**.
+**Idempotency formula (step.advancement.observed):** `tool-call`, keyed on the PostToolUse payload's `tool_call_id`. Deduplicates across hook retries; preserves distinctness across distinct Bash invocations.
 
 **Not new event categories — table-only:**
-- `tool_calls`, `config_changes`, `prompt_patches` (Wave C), `memories` (CRUD on table; no `memory.*` events).
+- `tool_calls`, `config_changes`, `memories` (CRUD on table; no `memory.*` events).
 
-**Migration:** schema v5 → v6 lifts the new tables and the new event type. Existing event streams are a strict subset; backfill is a no-op. `migrations.ts:86`'s `CURRENT_SCHEMA_VERSION` constant is bumped to `6`; `migrations.ts:121-126`'s registry adds an identity entry `5: (data) => data` so the walk loop at `migrations.ts:156-165` traverses v5 → v6 cleanly. `gobbi maintenance migrate-state-db` is the explicit command (Best §3 — Flyway "baseline-on-migrate" pattern). `gobbi maintenance restore-state-db` is the companion revert command for one-commit reversibility.
+**Migration history:** schema v5 → v6 (Wave A.1) lifted new tables (`state_snapshots`, `tool_calls`, `config_changes`) and `step.advancement.observed`. Schema v6 → v7 (Wave C.1) added `prompt_patches` table and `prompt.patch.applied` event. `gobbi maintenance migrate-state-db` handles the migration; `gobbi maintenance restore-state-db` is the companion revert command.
 
 ---
 
@@ -172,7 +166,7 @@ Verbatim from `packages/cli/src/workflow/events/workflow.ts:21-31`:
 | `workflow.resume` | User invoked `gobbi workflow resume --target <step>`; sets `fromError` if from error |
 | `workflow.invalid_transition` | Reducer rejected an event; audit-emit-on-rejection in fresh transaction |
 
-Closed-enumeration discipline: every reducer-accepted event is in the 23-event set. Test scans every category constant and asserts `ALL_EVENT_TYPES.size === 23` post-Pass-4. (Today: 22.)
+Closed-enumeration discipline: every wire-level event (reducer-typed + audit-only) is in the 24-event set. Test scans every category constant and asserts `ALL_EVENT_TYPES.size === 24`.
 
 ---
 
@@ -376,7 +370,7 @@ For the orchestration core:
 2. **0 state losses** across `/compact` + one full Claude Code restart in 100 test cases.
 3. **Inner ↔ Outer parity** — same workflow definition produces byte-identical compiled prompts (modulo per-mode footer) in 100% of snapshot tests.
 4. **No prompt-cache regression** — `gobbi workflow status --cost` rollup post-redesign ≥ pre-redesign baseline.
-5. **23-event closed enumeration** post-Pass-4 — test scans every category constant and asserts `ALL_EVENT_TYPES.size === 23`.
+5. **24-event closed enumeration** post-Pass-4 + Wave C.1 — test scans every category constant and asserts `ALL_EVENT_TYPES.size === 24`.
 6. **State-derivation determinism** — 1,000 random event-log replays produce identical `state_snapshot` rows.
 7. **Hook latency p99 < 10 ms** for PreToolUse — k8s admission-webhook budget. The 5 s `busy_timeout` is the failure mode boundary, not the operating point; `wal_checkpoint(TRUNCATE)` at step.exit prevents writer queue buildup.
 8. **Handoff coverage** — for every session that reaches `done`, exactly one `class='handoff'` row exists in `gobbi.db::memories` AND `handoff.md` exists at `sessions/<id>/handoff/handoff.md`. Measured via integration test.

--- a/.gobbi/projects/gobbi/design/v050-features/orchestration/checklist.md
+++ b/.gobbi/projects/gobbi/design/v050-features/orchestration/checklist.md
@@ -162,7 +162,7 @@ Items tagged `[GAP]` describe what the verification will look like once the corr
 
 ---
 
-## SC-ORCH-13 — PostToolUse direct-append `step.advancement.observed` (post-Wave-A.1)
+## SC-ORCH-13 — PostToolUse direct-append `step.advancement.observed`
 
 - `[GAP]` `events/step.ts` defines `STEP_EVENTS.ADVANCEMENT_OBSERVED`; `events/index.ts::ALL_EVENT_TYPES` includes the new type.
   - Verify (post-A.1.3): `bun test packages/cli/src/workflow/events/__tests__/closed-enumeration.test.ts`.
@@ -227,7 +227,7 @@ Items tagged `[GAP]` describe what the verification will look like once the corr
 
 ---
 
-## SC-ORCH-20 — Handoff writes + emits workflow.finish (post-Wave-A.1)
+## SC-ORCH-20 — Handoff writes + emits workflow.finish
 
 - `[GAP]` `specs/handoff/spec.json` exists with the README §9.2 template; running through the step writes `sessions/<id>/handoff/handoff.md` and inserts a `gobbi.db::memories` row with `class='handoff', session_id=<id>, project_id=<resolved>`.
   - Verify (post-A.1.5): `specs/handoff/__tests__/spec.test.ts` (new) asserts artifact-write + memory-row insert.
@@ -238,7 +238,7 @@ Items tagged `[GAP]` describe what the verification will look like once the corr
 
 ---
 
-## SC-ORCH-21 — `migrate-state-db` reversibility (post-Wave-A.1)
+## SC-ORCH-21 — `migrate-state-db` reversibility
 
 - `[GAP]` `commands/maintenance.ts:48-59` registry includes `{ name: 'migrate-state-db', ... }` and `{ name: 'restore-state-db', ... }` — the dispatch loop routes both subcommands (Architecture P-A-1).
   - Verify (post-A.1.4): `bun test packages/cli/src/commands/__tests__/maintenance.test.ts -t 'registry'` plus a smoke run of `gobbi maintenance migrate-state-db --dry-run`.
@@ -249,7 +249,7 @@ Items tagged `[GAP]` describe what the verification will look like once the corr
 
 ---
 
-## SC-ORCH-22 — `.gitignore` boundary (post-Wave-A.1)
+## SC-ORCH-22 — `.gitignore` boundary
 
 - `[GAP]` `git check-ignore .gobbi/gobbi.db` returns nonzero (file is tracked); `git check-ignore .gobbi/state.db` returns 0 (file is ignored).
   - Verify (post-A.1.8): `bun test packages/cli/src/__tests__/gitignore-boundary.test.ts` (new) using `git check-ignore` shell-out.
@@ -258,7 +258,7 @@ Items tagged `[GAP]` describe what the verification will look like once the corr
 
 ---
 
-## SC-ORCH-23 — Path-resolution sweep complete (post-Wave-A.1)
+## SC-ORCH-23 — Path-resolution sweep complete
 
 - `[GAP]` Zero non-test matches for `join(sessionDir, 'gobbi.db')` across `packages/cli/src/`.
   - Verify (post-A.1.7): `rg -n "join\(sessionDir, 'gobbi\.db'\)" packages/cli/src/ --type ts` returns no lines.
@@ -267,7 +267,7 @@ Items tagged `[GAP]` describe what the verification will look like once the corr
 
 ---
 
-## SC-ORCH-24 — EventStore explicit partition keys (post-Wave-A.1)
+## SC-ORCH-24 — EventStore explicit partition keys
 
 - `[GAP]` `new EventStore(path, { sessionId, projectId })` writes events with the supplied partition keys (not path-derived).
   - Verify (post-A.1.2): `store.test.ts` constructor-with-options test; assert persisted row has supplied `session_id` and `project_id`.
@@ -278,7 +278,7 @@ Items tagged `[GAP]` describe what the verification will look like once the corr
 
 ---
 
-## SC-ORCH-25 — `wal_checkpoint(TRUNCATE)` after each `step.exit` (post-Wave-A.1)
+## SC-ORCH-25 — `wal_checkpoint(TRUNCATE)` after each `step.exit`
 
 - `[GAP]` `store.ts` runs `PRAGMA wal_checkpoint(TRUNCATE)` after every commit of a `workflow.step.exit` event.
   - Verify (post-A.1.9): `store.test.ts` checkpoint-after-step-exit test inspects WAL-file size after commit.

--- a/.gobbi/projects/gobbi/design/v050-features/orchestration/checklist.md
+++ b/.gobbi/projects/gobbi/design/v050-features/orchestration/checklist.md
@@ -289,12 +289,12 @@ Items tagged `[GAP]` describe what the verification will look like once the corr
 
 ---
 
-## SC-ORCH-26 — 23-event closed enumeration (post-Wave-A.1)
+## SC-ORCH-26 — 24-event closed enumeration
 
-- `[GAP]` `events/index.ts:1` event-count documentation reads "7 categories, 23 event types"; `ALL_EVENT_TYPES.size === 23`.
-  - Verify (post-A.1.3): closed-enumeration test asserts size and category breakdown.
-- `[GAP]` Every reducer-accepted event type appears in `ALL_EVENT_TYPES`; reducer-tested events outside the set fail the test.
-  - Verify (post-A.1.3): test enumerates reducer cases and cross-checks `ALL_EVENT_TYPES`.
+- `[GAP]` `events/index.ts:1` event-count documentation reads "9 categories, 24 event types"; `ALL_EVENT_TYPES.size === 24`.
+  - Verify (post-A.1.3 + C.1): closed-enumeration test asserts size and category breakdown.
+- `[GAP]` Every reducer-accepted event type appears in `ALL_EVENT_TYPES`; reducer-tested events outside the set fail the test. Audit-only events (`step.advancement.observed`, `prompt.patch.applied`) appear in `ALL_EVENT_TYPES` but are excluded from the reducer-typed `Event` union.
+  - Verify (post-A.1.3 + C.1): test enumerates reducer cases and cross-checks `ALL_EVENT_TYPES`.
 
 ---
 
@@ -303,7 +303,7 @@ Items tagged `[GAP]` describe what the verification will look like once the corr
 The Pass-4 PR itself adds no code, so its verification is documentation-only:
 
 - `[MANUAL]` `README.md` references the 6-step model with `handoff` as step 5/6 in the §1 step table.
-- `[MANUAL]` Event count is cited as 22 today and 23 post-Pass-4 in §3.5 and §13.5.
+- `[MANUAL]` Event count is cited as 24 total (22 base + 1 Pass-4 + 1 Wave C.1) in §3.5 and §13.5.
 - `[MANUAL]` `step.advancement.observed` is documented to commit via direct `store.append()` (not reducer-routed) in §3.5 and §6.
 - `[MANUAL]` Every `[GAP]` item above traces to a Wave A.1 / B.1 / E.1 / E.2 task in `review.md`'s multi-session execution plan.
 - `[MANUAL]` `scenarios.md` includes scenarios SC-ORCH-01 through SC-ORCH-26.

--- a/.gobbi/projects/gobbi/design/v050-features/orchestration/scenarios.md
+++ b/.gobbi/projects/gobbi/design/v050-features/orchestration/scenarios.md
@@ -275,7 +275,7 @@ Evidence: `specs/memorization/spec.json` (rewritten in Wave A.1.6), `events/arti
 ### SC-ORCH-20 — Handoff writes `handoff.md` + memory row + emits `workflow.finish`
 
 **Given** an active session at `currentStep = 'handoff'` with `memorization.md` already written
-**When** the handoff agent reads `memorization.md` plus the last-N events from `state.db` and writes `sessions/<id>/handoff/handoff.md`
+**When** the handoff agent reads `memorization.md` plus the last-N events from the per-session `gobbi.db` at `.gobbi/projects/<name>/sessions/<id>/gobbi.db` and writes `sessions/<id>/handoff/handoff.md`
 **Then** `artifact.write` is emitted; an `INSERT INTO memories` row is added with `class='handoff', session_id=<id>, project_id=<resolved>`; the agent runs `gobbi workflow transition COMPLETE` which on the handoff step maps to `workflow.finish` per `index.json` rule `{ from: "handoff", to: "done", trigger: "workflow.finish" }`; reducer transitions `currentStep` to `done`.
 
 Evidence: `specs/handoff/spec.json`, `index.json` (handoff transitions added Wave A.1.5), `events/workflow.ts:21` (workflow.finish), `events/artifact.ts`.

--- a/.gobbi/projects/gobbi/design/v050-features/orchestration/scenarios.md
+++ b/.gobbi/projects/gobbi/design/v050-features/orchestration/scenarios.md
@@ -16,7 +16,7 @@ See `README.md` for the feature overview.
 
 **Given** a fresh repo with `.gobbi/projects/<name>/` populated by `gobbi install`
 **When** `gobbi workflow init --task "<text>"` runs
-**Then** a new session directory `.gobbi/projects/<name>/sessions/<id>/` is created with `metadata.json`; the workspace `state.db` (post-Wave-A.1) or per-session `gobbi.db` (today) records exactly one `workflow.start` event with `actor='cli'`; reducer sets `currentStep = 'ideation'`; exit code is `0`.
+**Then** a new session directory `.gobbi/projects/<name>/sessions/<id>/` is created with `metadata.json`; the per-session `gobbi.db` records exactly one `workflow.start` event with `actor='cli'`; reducer sets `currentStep = 'ideation'`; exit code is `0`.
 
 Evidence: `commands/workflow/init.ts:281` (DB open), `transition.ts:74-84` (TRANSITION_KEYWORDS map), `events/workflow.ts:21` (event constants), `reducer.ts` (workflow.start case).
 
@@ -196,13 +196,13 @@ Evidence: `_schema/v1.ts::StepBlocksSchema` (source); `bun run regen-schema` scr
 
 ## Missed-advancement safety net
 
-### SC-ORCH-13 — PostToolUse on `gobbi workflow transition` Bash emits `step.advancement.observed` via direct `store.append()` (post-Wave-A.1)
+### SC-ORCH-13 — PostToolUse on `gobbi workflow transition` Bash emits `step.advancement.observed` via direct `store.append()`
 
 **Given** an active session and an agent runs a Bash tool with command starting `gobbi workflow transition`
 **When** the PostToolUse hook fires (`capture-planning.ts` extended path)
 **Then** the hook calls `store.append()` directly with `type='step.advancement.observed'`, `actor='hook'`, `idempotencyKind='tool-call'` keyed on the PostToolUse payload's `tool_call_id`; the event is persisted; the reducer never sees this audit-only event (bypass is intentional per Architecture F-1).
 
-Evidence (post-Wave-A.1): `capture-planning.ts:166-179` extended; `events/step.ts` new factory; `store.ts:36-48` idempotency formula; Architecture F-1 finding.
+Evidence: `capture-planning.ts:166-179` extended; `events/step-advancement.ts` event factory; `store.ts:36-48` idempotency formula; Architecture F-1 finding.
 
 ---
 
@@ -264,7 +264,7 @@ Evidence (post-Wave-E.2): `packages/cli/src/specs/__tests__/snapshot.test.ts` cr
 
 **Given** an active session at `currentStep = 'memorization'` with the productive steps' rawdata under `sessions/<id>/{ideation,planning,execution}/rawdata/` and per-step READMEs written
 **When** the memorization agent reads the rawdata sources (per README §8.1) and writes `sessions/<id>/memorization/memorization.md`
-**Then** `artifact.write` is emitted for the file; for each extraction class, the agent writes the markdown destination (`learnings/decisions/<slug>.md`, `learnings/gotchas/<slug>.md`, `design/<area>/*.md`, `learnings/backlogs/<slug>.md`) and an `INSERT INTO memories` row (post-Wave-A.1) with the matching `class`; the agent then runs `gobbi workflow transition COMPLETE`; `workflow.step.exit` advances `currentStep` to `handoff`.
+**Then** `artifact.write` is emitted for the file; for each extraction class, the agent writes the markdown destination (`learnings/decisions/<slug>.md`, `learnings/gotchas/<slug>.md`, `design/<area>/*.md`, `learnings/backlogs/<slug>.md`) and an `INSERT INTO memories` row with the matching `class`; the agent then runs `gobbi workflow transition COMPLETE`; `workflow.step.exit` advances `currentStep` to `handoff`.
 
 Evidence: `specs/memorization/spec.json` (rewritten in Wave A.1.6), `events/artifact.ts` (artifact.write), `transition.ts:335` (step.exit emission), README §8.
 
@@ -272,79 +272,79 @@ Evidence: `specs/memorization/spec.json` (rewritten in Wave A.1.6), `events/arti
 
 ## Handoff step
 
-### SC-ORCH-20 — Handoff writes `handoff.md` + memory row + emits `workflow.finish` (post-Wave-A.1)
+### SC-ORCH-20 — Handoff writes `handoff.md` + memory row + emits `workflow.finish`
 
-**Given** an active session at `currentStep = 'handoff'` (post-Wave-A.1.5 schema) with `memorization.md` already written
+**Given** an active session at `currentStep = 'handoff'` with `memorization.md` already written
 **When** the handoff agent reads `memorization.md` plus the last-N events from `state.db` and writes `sessions/<id>/handoff/handoff.md`
 **Then** `artifact.write` is emitted; an `INSERT INTO memories` row is added with `class='handoff', session_id=<id>, project_id=<resolved>`; the agent runs `gobbi workflow transition COMPLETE` which on the handoff step maps to `workflow.finish` per `index.json` rule `{ from: "handoff", to: "done", trigger: "workflow.finish" }`; reducer transitions `currentStep` to `done`.
 
-Evidence (post-Wave-A.1.5): `specs/handoff/spec.json` (new), `index.json` (new transitions), `events/workflow.ts:21` (workflow.finish), `events/artifact.ts`.
+Evidence: `specs/handoff/spec.json`, `index.json` (handoff transitions added Wave A.1.5), `events/workflow.ts:21` (workflow.finish), `events/artifact.ts`.
 
 ---
 
 ## Schema migration + path discipline
 
-### SC-ORCH-21 — `gobbi maintenance migrate-state-db` is reversible via `restore-state-db` (post-Wave-A.1)
+### SC-ORCH-21 — `gobbi maintenance migrate-state-db` is reversible via `restore-state-db`
 
 **Given** a workspace at schema v5 with per-session `gobbi.db` files under `.gobbi/projects/*/sessions/*/gobbi.db`
 **When** `gobbi maintenance migrate-state-db` runs
 **Then** events are migrated into a new workspace `.gobbi/state.db` at schema v6; partition keys (`session_id`, `project_id`) are preserved on every row; per-session `gobbi.db` files are renamed `.bak` (not deleted) for one-commit reversibility; `gobbi maintenance restore-state-db` reverses the operation; replay-equivalence integration test confirms identical state derivation pre- and post-migration.
 
-Evidence (post-Wave-A.1.4): `commands/maintenance/migrate-state-db.ts` (new), `commands/maintenance/restore-state-db.ts` (new), `commands/maintenance.ts:48-59` registry update (Architecture P-A-1), replay-equivalence test in Wave A.1.10.
+Evidence: `commands/maintenance/migrate-state-db.ts`, `commands/maintenance/restore-state-db.ts`, `commands/maintenance.ts:48-59` registry, replay-equivalence test in Wave A.1.10 integration tests.
 
 ---
 
-### SC-ORCH-22 — `.gobbi/gobbi.db` has `!.gitignore` exception so it is git-tracked (post-Wave-A.1)
+### SC-ORCH-22 — `.gobbi/gobbi.db` has `!.gitignore` exception so it is git-tracked
 
-**Given** a workspace at the post-Wave-A.1 layout with `.gitignore` containing `.gobbi/*`, `!.gobbi/projects/`, `!.gobbi/gobbi.db`
+**Given** a workspace with `.gitignore` containing `.gobbi/*`, `!.gobbi/projects/`, `!.gobbi/gobbi.db`
 **When** the user runs `git check-ignore .gobbi/gobbi.db` and `git check-ignore .gobbi/state.db`
 **Then** `.gobbi/gobbi.db` returns nonzero (file is tracked); `.gobbi/state.db` returns 0 (file is ignored); both states are validated by an integration test added in Wave A.1.8.
 
-Evidence (post-Wave-A.1.8): `.gitignore` update, integration test asserting check-ignore exit codes, System F-1 finding.
+Evidence: `.gitignore` Wave A.1.8 update (commit `cdaea69`), integration test asserting check-ignore exit codes, System F-1 finding.
 
 ---
 
-### SC-ORCH-23 — Path-resolution sweep: every `gobbi.db` open uses `resolveDbPath(sessionDir)` helper (post-Wave-A.1)
+### SC-ORCH-23 — Path-resolution sweep: every `gobbi.db` open uses explicit partition keys or `resolveDbPath(sessionDir)` helper
 
-**Given** the post-Wave-A.1.7 codebase
+**Given** the Wave-A.1.7 codebase
 **When** `grep -rn 'join(sessionDir, .gobbi.db.)' packages/cli/src/` runs
 **Then** zero non-test matches are returned; every callsite that previously hard-coded the per-session `gobbi.db` path now calls `resolveDbPath(sessionDir)` (or equivalent helper) defined in `commands/session.ts`; the workspace rename touches the helper only, not the 11 individual call sites.
 
-Evidence (post-Wave-A.1.7): `commands/session.ts` `resolveDbPath` helper, A.1.7 callsite list (`{guard,stop,init,next,status,resume,capture-subagent,capture-planning,transition}.ts` + `session.ts` + `gotcha/promote.ts`).
+Evidence: Wave A.1.7 explicit partition-key refactor (commit `8d71fa4`), callsite list (`{guard,stop,init,next,status,resume,capture-subagent,capture-planning,transition}.ts` + `session.ts` + `gotcha/promote.ts`).
 
 ---
 
-### SC-ORCH-24 — EventStore constructor accepts explicit partition keys (post-Wave-A.1)
+### SC-ORCH-24 — EventStore constructor accepts explicit partition keys
 
 **Given** a workspace with `.gobbi/state.db` and an active session whose `metadata.json` is at `.gobbi/projects/<name>/sessions/<id>/`
 **When** `new EventStore('.gobbi/state.db', { sessionId: <id>, projectId: <name> })` opens the store and writes an event
 **Then** the persisted row has `session_id === <id>` AND `project_id === <name>` (not the path-derived `'.gobbi'` and `null`); a per-session caller without explicit params still works via the path-derivation fallback.
 
-Evidence (post-Wave-A.1.2): `store.ts` constructor signature change, partition-key fallback at `store.ts:476-477`, Architecture F-2 finding.
+Evidence: `store.ts` constructor with `{ sessionId?, projectId? }` options (Wave A.1.2, commit `14f53d5`), partition-key fallback at `store.ts:476-477`, Architecture F-2 finding.
 
 ---
 
 ## Concurrency + durability
 
-### SC-ORCH-25 — `wal_checkpoint(TRUNCATE)` runs after every `workflow.step.exit` (post-Wave-A.1)
+### SC-ORCH-25 — `wal_checkpoint(TRUNCATE)` runs after every `workflow.step.exit`
 
 **Given** a session that has emitted three `workflow.step.exit` events under workspace-scoped `state.db`
 **When** the WAL file is inspected after each step.exit
 **Then** the WAL has been truncated to size 0 (or close to it) immediately after each step.exit commit; events written between adjacent step.exits remain in WAL until the next checkpoint; the existing `store.ts::close()` checkpoint at lines 588-590 still runs at session-end (additive, not replaced); SIGKILL between adjacent step.exits cannot lose events committed before the prior step.exit.
 
-Evidence (post-Wave-A.1.9): `store.ts` per-step-exit checkpoint hook, integration test fixture using SIGKILL between checkpoints, Architecture P-A-6 finding (additive coexistence note).
+Evidence: `store.ts` per-step-exit checkpoint hook (Wave A.1.9, commit `84f4c79`), integration test fixture using SIGKILL between checkpoints, Architecture P-A-6 finding (additive coexistence note).
 
 ---
 
 ## Closed-enumeration
 
-### SC-ORCH-26 — Event-set test asserts `ALL_EVENT_TYPES.size === 23` post-Pass-4 (post-Wave-A.1)
+### SC-ORCH-26 — Event-set test asserts `ALL_EVENT_TYPES.size === 24`
 
-**Given** the post-Wave-A.1.3 codebase with `step.advancement.observed` registered in `events/index.ts::ALL_EVENT_TYPES`
+**Given** the post-Wave-A.1.3 + Wave-C.1 codebase with `step.advancement.observed` and `prompt.patch.applied` registered in `events/index.ts::ALL_EVENT_TYPES`
 **When** the closed-enumeration test scans every category constant
-**Then** the union has exactly 23 entries: 9 `workflow.*`, 3 `delegation.*`, 3 `decision.*`, 2 `artifact.*`, 3 `guard.*`, 1 `verification.*`, 1 `session.*`, 1 `step.*`; any reducer-accepted event outside this set fails the test.
+**Then** the union has exactly 24 entries: 9 `workflow.*`, 3 `delegation.*`, 3 `decision.*`, 2 `artifact.*`, 3 `guard.*`, 1 `verification.*`, 1 `session.*`, 1 `step.*`, 1 `prompt.*`; any reducer-accepted event outside this set fails the test; audit-only events (`step.advancement.observed`, `prompt.patch.applied`) are in `ALL_EVENT_TYPES` but excluded from the `Event` reducer union.
 
-Evidence (post-Wave-A.1.3): `events/index.ts:1` event-count documentation update, `events/__tests__/closed-enumeration.test.ts` (new or extended), README §3.5 (23-event ledger).
+Evidence (post-Wave-A.1.3 + C.1): `events/index.ts:1` event-count documentation ("9 categories, 24 event types"), `events/__tests__/closed-enumeration.test.ts`, README §3.5 (24-event ledger).
 
 ---
 

--- a/.gobbi/projects/gobbi/design/v050-overview.md
+++ b/.gobbi/projects/gobbi/design/v050-overview.md
@@ -38,7 +38,7 @@ In v0.5.0, skills still teach agents how to think about specific domains — git
 
 ## The Workflow
 
-V0.5.0 collapsed the v0.4.x seven-step cycle into the current 6-step state machine (Configuration plus 5 productive steps: Ideation, Planning, Execution, Memorization, Handoff). Research is absorbed into Ideation as an internal loop. Collection and Memorization merge into a single Memorization step. Evaluation runs as a sub-phase inside Ideation, Planning, and Execution — mandatory after Execution, optional at the earlier steps. Handoff is a true state-machine step (not a memorization sub-artifact) that writes a tight next-session summary.
+V0.5.0 collapsed the v0.4.x seven-step cycle into the current 6-step workflow (Configuration as the CLI init phase, plus 5 productive steps: Ideation, Planning, Execution, Memorization, Handoff). Configuration is not a state-machine node — it is the one-shot `gobbi workflow init` run that seeds settings, captures the task statement, and emits `workflow.start`. The 5 productive steps are the actual state-machine states. Research is absorbed into Ideation as an internal loop. Collection and Memorization merge into a single Memorization step. Evaluation runs as a sub-phase inside Ideation, Planning, and Execution — mandatory after Execution, optional at the earlier steps. Handoff is a true state-machine step (not a memorization sub-artifact) that writes a tight next-session summary.
 
 ```
 ┌──────────────────────────────────────────────────────────────────┐
@@ -136,11 +136,12 @@ V0.5.0 resolves it with a hard directory split:
   Read-only during workflow         Runtime state — write freely
 
   CLAUDE.md                         settings.json              (workspace prefs — gitignored)
-  rules/          ← symlinks →      state.db                   (workspace event log — gitignored)
+  rules/          ← symlinks →      state.db                   (workspace prompt-patch journal — gitignored)
   skills/         from .gobbi/      gobbi.db                   (workspace memories projection — tracked)
   agents/         skills|agents|    projects/<name>/
   settings.json   rules               settings.json            (project config — tracked)
   hooks/                              sessions/<id>/           (per-session — gitignored)
+                                      sessions/<id>/gobbi.db   (per-session event log — gitignored)
                                     projects/<name>/learnings/ (gotchas, decisions)
 ```
 
@@ -167,8 +168,8 @@ The five components of v0.5.0 form a closed feedback loop:
 
               ┌─────────────────────────────┐
               │         SQLite              │
-              │   state.db (event log)      │
-              │  (source of truth)          │
+              │  per-session gobbi.db       │
+              │  (event log per session)    │
               └──────┬──────────────────────┘
                      │ reads state
                      ▼
@@ -201,7 +202,7 @@ The five components of v0.5.0 form a closed feedback loop:
                      ▼
               ┌─────────────────────────────┐
               │         SQLite              │
-              │   state.db (event log)      │
+              │  per-session gobbi.db       │
               └─────────────────────────────┘
 ```
 
@@ -209,7 +210,7 @@ The five components of v0.5.0 form a closed feedback loop:
 
 **Hooks** are the constraint layer. PreToolUse hooks enforce guards — blocking writes to `.claude/` during sessions, preventing scope violations, enforcing step preconditions. PostToolUse and SubagentStop hooks capture events — when a subagent finishes, its output is automatically recorded in the event store without the orchestrator needing to remember to collect it.
 
-**SQLite event store** (`state.db`) is the source of truth for workflow state. Every step completion, every subagent result, every evaluation verdict, every state transition is an event. The CLI reads events to determine what to generate next. The hooks write events. A separate `gobbi.db` holds the cross-session memories projection (decisions, gotchas, design notes, handoff rows) — git-tracked so it persists across sessions.
+**SQLite event store** is the source of truth for workflow state. Workflow events (step transitions, subagent results, evaluation verdicts) write to per-session `gobbi.db` at `.gobbi/projects/<name>/sessions/<id>/gobbi.db`. The workspace `state.db` at `.gobbi/state.db` currently holds only `prompt.patch.applied` events (Wave C.1); full workspace consolidation of workflow events is Wave A.1 work, partially shipped. The CLI reads the per-session event store to determine what to generate next; hooks write events. A separate workspace `gobbi.db` at `.gobbi/gobbi.db` holds the cross-session memories projection (decisions, gotchas, design notes, handoff rows) — git-tracked so it persists across sessions.
 
 **Skills** still exist and still matter. They provide domain knowledge that the CLI incorporates into generated prompts as materials — git conventions, evaluation perspectives, documentation standards. Skills no longer drive orchestration; they inform it.
 

--- a/.gobbi/projects/gobbi/design/v050-session.md
+++ b/.gobbi/projects/gobbi/design/v050-session.md
@@ -95,7 +95,7 @@ Three indexes cover the common access patterns: one on `type` for queries that f
 
 ### Event Type Enum
 
-Events are grouped into seven categories that reflect the things that can happen in a session. The closed-enumeration discipline: 23 event types total post-Pass-4 — any reducer-accepted event is in this set. The test suite asserts `ALL_EVENT_TYPES.size === 23`.
+Events are grouped into nine categories that reflect the things that can happen in a session. The closed-enumeration discipline: 24 event types total (22 reducer-typed + 2 audit-only) — the wire-level set that may appear in the `events` table. The test suite asserts `ALL_EVENT_TYPES.size === 24`. Reducer-typed events flow through `appendEventAndUpdateState`; audit-only events (`step.advancement.observed`, `prompt.patch.applied`) are committed via direct `store.append()`.
 
 **Workflow** events track the high-level session progression (9 events):
 
@@ -152,12 +152,23 @@ Cost data surfaces via `gobbi workflow status` only. It must NOT appear in compi
 |-------|---------|
 | `verification.result` | A verification command completed — exit code and summary in data |
 
-**Session** events track liveness and advancement (2 events):
+**Session** events track liveness (1 event):
 
 | Event | Meaning |
 |-------|---------|
 | `session.heartbeat` | Liveness signal — written by the Stop hook after each turn |
+
+**Step-advancement** events track transition observability (1 event, audit-only):
+
+| Event | Meaning |
+|-------|---------|
 | `step.advancement.observed` | Synthetic audit event emitted by PostToolUse when `gobbi workflow transition` runs — primes the missed-advancement safety net; committed via direct `store.append()`, NOT through the reducer |
+
+**Prompt** events track prompt-patch operations (1 event, audit-only):
+
+| Event | Meaning |
+|-------|---------|
+| `prompt.patch.applied` | A JSON Patch was applied to a prompt spec — written to workspace `state.db` by `gobbi prompt patch`; committed via direct `store.append()`, NOT through the reducer |
 
 ---
 

--- a/.gobbi/projects/gobbi/design/v050-session.md
+++ b/.gobbi/projects/gobbi/design/v050-session.md
@@ -35,9 +35,11 @@ Sessions are stored under `.gobbi/projects/{project-name}/sessions/{session-id}/
                 └── memorization/      step artifacts — flat directory
 ```
 
-Note: `.gobbi/config.db` does not exist in this layout. It was a SQLite session-config store used in an earlier design iteration. `ensureSettingsCascade` deletes it on first run if found. The workspace event store is `state.db` at the `.gobbi/` root — one file for all projects and sessions, with `project_id` and `session_id` columns on every event row for scoped queries. The workspace memories projection is `gobbi.db` at the `.gobbi/` root — git-tracked, holds decisions, gotchas, design notes, and handoff rows. See `v050-features/gobbi-config/README.md` for the three-level settings cascade (workspace → project → session).
+Note: `.gobbi/config.db` does not exist in this layout. It was a SQLite session-config store used in an earlier design iteration. `ensureSettingsCascade` deletes it on first run if found. The workspace memories projection is `gobbi.db` at the `.gobbi/` root — git-tracked, holds decisions, gotchas, design notes, and handoff rows. See `v050-features/gobbi-config/README.md` for the three-level settings cascade (workspace → project → session).
 
-Each file and directory has a single responsibility. `metadata.json` and `state.db` are the permanent record. `state.json` is a derived view — it can be rebuilt from `state.db` at any time. `events.jsonl` has been removed; `state.db` is the sole event store.
+**Today** (per `init.ts`): workflow events write to a per-session `gobbi.db` at `.gobbi/projects/<name>/sessions/<id>/gobbi.db`. The workspace `state.db` at `.gobbi/state.db` currently holds only `prompt.patch.applied` events (Wave C.1). Full workspace consolidation of workflow events into a shared `state.db` is Wave A.1 work, partially shipped. The descriptions below in File Responsibilities and SQLite Event Store describe the target architecture; current path reality follows the per-session layout above.
+
+Each file and directory has a single responsibility. `metadata.json` and the per-session `gobbi.db` are the permanent record. `state.json` is a derived view — it can be rebuilt from the session event store at any time. `events.jsonl` has been removed.
 
 ---
 
@@ -45,11 +47,11 @@ Each file and directory has a single responsibility. `metadata.json` and `state.
 
 **`metadata.json`** is written once when the session is created and never modified. It records the session ID, creation timestamp, the project root path, and the user configuration snapshot that was active at session start. Because it is immutable, it remains valid even if the rest of the session directory is corrupted.
 
-**`state.db`** is the authoritative event store — a single SQLite file at `.gobbi/state.db` shared across all projects and sessions in the workspace (gitignored). Every workflow event — step transitions, subagent completions, evaluation verdicts, user decisions, guard violations — is appended as a row. The CLI reads `state.db` to derive workflow state when generating the next prompt. The hooks write to `state.db` when events occur. Each row carries `project_id` and `session_id` columns so queries can be scoped to one project or session without scanning the full log.
+**`state.db`** (target architecture, Wave A.1 full consolidation) — the workspace-scoped event store at `.gobbi/state.db` (gitignored). Every workflow event — step transitions, subagent completions, evaluation verdicts, user decisions, guard violations — is appended as a row. The CLI reads `state.db` to derive workflow state when generating the next prompt. The hooks write to `state.db` when events occur. Each row carries `project_id` and `session_id` columns so queries can be scoped to one project or session without scanning the full log. Today (per `init.ts`): workflow events write to the per-session `gobbi.db` instead; only `prompt.patch.applied` events currently write to `state.db`.
 
 **`gobbi.db`** is the workspace memories projection — a single SQLite file at `.gobbi/gobbi.db` (git-tracked). It holds cross-session persistent records: decisions (`class='decision'`), gotchas (`class='gotcha'`), design notes (`class='design'`), backlogs (`class='backlog'`), and handoff summaries (`class='handoff'`). Written by Memorization and Handoff steps; readable by every subsequent session. The markdown tree under `.gobbi/projects/<name>/learnings/` is the source of truth for git; `gobbi.db` is the read-optimized projection, regenerable from the markdown.
 
-**`state.json`** is a materialized view of current workflow state, derived by reducing all events in `state.db` for the active session. It is written after every event append. Reading `state.json` is faster than replaying all events on each CLI invocation, but it is a cache, not a source. If `state.json` is absent or corrupted, it is rebuilt from `state.db`.
+**`state.json`** is a materialized view of current workflow state, derived by reducing all events in the session event store. It is written after every event append. Reading `state.json` is faster than replaying all events on each CLI invocation, but it is a cache, not a source. If `state.json` is absent or corrupted, it is rebuilt from the per-session `gobbi.db` (today) or from `state.db` (target after Wave A.1 consolidation).
 
 **`state.json.backup`** holds the state as it was before the most recent transition — the Terraform apply pattern. Before writing a new `state.json`, the CLI copies the current `state.json` to `state.json.backup`. If a transition corrupts `state.json`, the backup provides a known-good rollback point without requiring full event replay.
 
@@ -67,7 +69,7 @@ The SubagentStop capture hook reads `feedbackRound` from `state.json` to constru
 
 > **The event store is the source of truth. Everything else is derived from it.**
 
-SQLite with WAL mode is chosen over a pure JSONL approach for three reasons: indexed queries allow efficient filtering by event type and step without full scans; atomic writes with WAL mode survive mid-write crashes without partial records; built-in sequence numbers provide a reliable ordering guarantee. The implementation uses Bun's native `bun:sqlite` module — zero additional runtime dependencies. A single `state.db` at `.gobbi/state.db` serves the entire workspace; the `project_id` and `session_id` columns on each row provide the scoping that per-session files previously offered.
+SQLite with WAL mode is chosen over a pure JSONL approach for three reasons: indexed queries allow efficient filtering by event type and step without full scans; atomic writes with WAL mode survive mid-write crashes without partial records; built-in sequence numbers provide a reliable ordering guarantee. The implementation uses Bun's native `bun:sqlite` module — zero additional runtime dependencies. **Today** (per `init.ts`): each session has its own `gobbi.db` at `.gobbi/projects/<name>/sessions/<id>/gobbi.db`. **Target after Wave A.1 consolidation:** a single `state.db` at `.gobbi/state.db` serves the entire workspace; the `project_id` and `session_id` columns on each row provide the scoping that per-session files currently offer.
 
 ### Events Table
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Wave C.1 — Prompts-as-data: schema v7, `prompt_patches` table, `gobbi prompt patch` and `gobbi prompt render` commands, JSON Patch (RFC 6902) spec evolution, `fast-json-patch` library, `prompt.patch.applied` audit event written to workspace `state.db` (#156, #161)
+- Wave B.1 — JIT step-completion footer data-driven: `blocks.footer` field in step specs, `_schema/v1.ts::StepBlocks`, JSON Schema mirror in `_schema/v1.json`, `assembly.ts::renderSpec` pipeline, footer snap tests, operator/agent verb-partition enforcement (#153, #154)
+- Wave A.2 — 9-doc reconciliation: stub-redirect files for retired `deterministic-orchestration.md` and `just-in-time-prompt-injection.md`, reconciled `v050-prompts.md`, `v050-hooks.md`, `v050-cli.md`, `v050-session.md` to post-Wave-A.1 reality (#150, #151)
+- Wave A.1 — Orchestration core: schema v6, `step.advancement.observed` audit event, explicit `EventStore` partition-key constructor params, WAL checkpoint after `workflow.step.exit`, handoff state-machine step (`specs/handoff/spec.json`), `gobbi maintenance migrate-state-db` + `restore-state-db`, memorization path-pointer manifest, `.gobbi/gobbi.db` git-tracked via `.gitignore` exception, 10 Wave A.1 integration tests (#146, #147)
+
 ## [0.5.0] - 2026-04-19
 
 ### Breaking
 
 - Hook wiring replaced — `gobbi notify *` hooks removed; `gobbi workflow *` hooks registered in `plugins/gobbi/hooks/hooks.json` and `.claude/settings.json` (#83)
-- `_orchestration` skill deprecated — see `.claude/skills/_orchestration/ARCHIVED.md` for the 7-step → 5-step mapping (#83)
-- 7-step cycle replaced by 5-step state machine (Ideation → Plan → Execution → Evaluation → Memorization); see `design/v050-overview.md` (#78, #79, #80, #81, #82, #83)
+- `_orchestration` skill deprecated — see `.claude/skills/_orchestration/ARCHIVED.md` for the 7-step → 6-step mapping (#83)
+- 7-step cycle replaced by 6-step workflow (Configuration → Ideation → Planning → Execution → Memorization → Handoff); see `.gobbi/projects/gobbi/design/v050-overview.md` (#78, #79, #80, #81, #82, #83)
 - Directory split — `.claude/` is static knowledge (skills, rules, docs, gotchas); `.gobbi/` is runtime state (event store, sessions, heartbeats); `.gobbi/` is gitignored (#78, #83)
 
 ### Added
 
-- `gobbi workflow` command group — 11 subcommands: `init`, `next`, `transition`, `guard`, `capture-subagent`, `capture-plan`, `stop`, `resume`, `status`, `validate`, `events` (#78, #80)
+- `gobbi workflow` command group — 11 subcommands: `init`, `next`, `transition`, `guard`, `capture-subagent`, `capture-planning`, `stop`, `resume`, `status`, `validate`, `events` (#78, #80)
 - Predicate registry — typed TS functions replacing JsonLogic; `gobbi workflow validate` enforces coverage (#79)
-- Spec library — 5 step specs as validated JSON under `packages/cli/src/specs/{ideation,plan,execution,evaluation,memorization}/spec.json` (#79)
+- Spec library — step specs as validated JSON under `packages/cli/src/specs/{ideation,planning,execution,evaluation,memorization}/spec.json` (#79)
 - Event store + schema v1→v4 migrations — `packages/cli/src/workflow/migrations.ts` with lazy read-time migration (#78, #80, #81, #82)
 - State reducer — `packages/cli/src/workflow/reducer.ts`, pure function state evolution (#78)
 - Verification runner — synchronous serial execution wired into `next.ts`; results reduce to state (#82)
@@ -35,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Property-based tests — fast-check v4 reducer idempotency + transition exhaustiveness (#82)
 - End-to-end subprocess tests — `workflow-cycle.test.ts` (full cycle) + `migration-chain.test.ts` (v1→v4 replay) (#82, #83)
 - `MIGRATION.md` at repo root — v0.4.x → v0.5.0 upgrade guide (#83)
-- Phase 3 backlog — `.claude/project/gobbi/design/v050-phase3-backlog.md` (#83)
+- Phase 3 backlog — `.gobbi/projects/gobbi/design/v050-phase3-backlog.md` (#83)
 - `_orchestration/ARCHIVED.md` — pedagogical mapping of 7-step to v0.5.0 equivalents (#83)
 
 ### Changed

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -28,7 +28,7 @@ v0.4.5 remains installable from npm for archival purposes: `npm install -g @gobb
 |---|---|---|---|
 | Skill-based orchestration (`_orchestration` skill) | CLI state machine (`gobbi workflow init`) | Plugin auto-registers new hooks on install | n/a — conceptual change |
 | 8 v0.4.x hook entries (3×SessionStart + Stop + Notification + StopFailure + SubagentStop + SessionEnd — calling `gobbi notify *` and `gobbi session *`) | 5 `gobbi workflow *` hook entries (SessionStart, PreToolUse, PostToolUse, SubagentStop, Stop) | Breaking — see below | n/a — hook wiring |
-| Notes in `.claude/project/{name}/note/` (retrospective archive) | Active sessions in `.gobbi/sessions/{id}/` (runtime state) | Both coexist; no migration needed | Existing note archives remain valid |
+| Notes in `.claude/project/{name}/note/` (retrospective archive) | Active sessions in `.gobbi/projects/<name>/sessions/<id>/` (runtime state) | Both coexist; no migration needed | Existing note archives remain valid |
 | 7-step cycle (ideation → plan → research → execute → collect → memorize → review) | 5-step cycle (Ideation → Plan → Execution → Evaluation → Memorization) | Conceptual; no user action needed | n/a |
 | `_orchestration` skill as workflow entry | Deprecated — banner + `ARCHIVED.md` | Skill remains on disk for reference; no deletion | n/a |
 
@@ -44,7 +44,7 @@ v0.5.0 removes all 8 v0.4.x entries and replaces them with 5 `gobbi workflow *` 
 |---|---|
 | SessionStart | `gobbi workflow init` |
 | PreToolUse | `gobbi workflow guard` |
-| PostToolUse (ExitPlanMode) | `gobbi workflow capture-plan` |
+| PostToolUse (ExitPlanMode) | `gobbi workflow capture-planning` |
 | SubagentStop | `gobbi workflow capture-subagent` |
 | Stop | `gobbi workflow stop` |
 
@@ -85,11 +85,11 @@ Removal is not scheduled. The deprecated skill will remain in v0.5.x as an archi
 
 - `.claude/` — static knowledge layer. Skills, rules, agents, gotchas, CLAUDE.md, settings. Read-only during an active workflow session. A PreToolUse guard blocks writes to `.claude/` while a session is running.
 
-- `.gobbi/` — runtime layer. Active sessions (`sessions/{id}/`), event store (`gobbi.db`), heartbeats, and mid-session gotchas. Agents write freely here. Writing to `.gobbi/` does not trigger Claude Code context reload.
+- `.gobbi/` — runtime layer. Active sessions (`.gobbi/projects/<name>/sessions/<id>/`), per-session event store (`sessions/<id>/gobbi.db`), workspace memories projection (`.gobbi/gobbi.db`, git-tracked), workspace prompt-patch journal (`.gobbi/state.db`, gitignored), and mid-session gotchas. Agents write freely here. Writing to `.gobbi/` does not trigger Claude Code context reload.
 
 **Consumer impact.** The gobbi repo itself already has `.gobbi/` in `.gitignore` (line 7). If you are adopting the gobbi plugin in your own project, add `.gobbi/` to your project's `.gitignore`. The `.gobbi/` directory is created on first `gobbi workflow init` run.
 
-Gotchas recorded mid-session land in `.gobbi/project/gotchas/` and must be promoted to `.claude/skills/_gotcha/` via `gobbi gotcha promote` — run this outside an active session. The promotion step is a deliberate gate that prevents mid-session noise from polluting the permanent gotcha store.
+Gotchas recorded mid-session land in `.gobbi/projects/gobbi/learnings/gotchas/` and must be promoted to workspace-level skill storage via `gobbi gotcha promote` — run this outside an active session. The promotion step is a deliberate gate that prevents mid-session noise from polluting the permanent gotcha store.
 
 ---
 
@@ -117,9 +117,27 @@ grep -n "gobbi notify" plugins/gobbi/hooks/hooks.json
 # 5. Session directory is created on init
 cd /tmp && mkdir test-gobbi && cd test-gobbi
 gobbi workflow init --session-id smoke-test --task "verify install"
-ls .gobbi/sessions/smoke-test/
+ls .gobbi/projects/gobbi/sessions/smoke-test/
 # → metadata.json  gobbi.db
 ```
+
+---
+
+### Event store schema evolution
+
+The `events` table in `gobbi.db` (per-session) and `state.db` (workspace) uses lazy read-time migration. Events are never rewritten on disk; migration runs in memory at replay time. The `schema_version` column on each row records the version at write time.
+
+| Version | Shipped | Key changes |
+|---|---|---|
+| v1 | v0.5.0 | Initial schema — `events`, `state_snapshots`, `idempotency_key` unique constraint |
+| v2 | v0.5.0 | `guard.warn` event type |
+| v3 | v0.5.0 | `metadata.json` schema v3 shape |
+| v4 | v0.5.0 | Error-compiler pathway fields in event data |
+| v5 | v0.5.0 | `session_id` and `project_id` columns on `events` |
+| v6 | Wave A.1 | `tool_calls` and `config_changes` tables; `step.advancement.observed` audit event; WAL checkpoint after `step.exit` |
+| v7 | Wave C.1 | `prompt_patches` table (`id`, `prompt_id`, `patch_id`, `patch_json`, `applied_at`, `applied_by`); `prompt.patch.applied` audit event written to workspace `state.db` |
+
+Run `gobbi maintenance migrate-state-db` to apply pending migrations. Run `gobbi maintenance restore-state-db` to revert. Both commands are idempotent.
 
 ---
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -29,7 +29,7 @@ v0.4.5 remains installable from npm for archival purposes: `npm install -g @gobb
 | Skill-based orchestration (`_orchestration` skill) | CLI state machine (`gobbi workflow init`) | Plugin auto-registers new hooks on install | n/a — conceptual change |
 | 8 v0.4.x hook entries (3×SessionStart + Stop + Notification + StopFailure + SubagentStop + SessionEnd — calling `gobbi notify *` and `gobbi session *`) | 5 `gobbi workflow *` hook entries (SessionStart, PreToolUse, PostToolUse, SubagentStop, Stop) | Breaking — see below | n/a — hook wiring |
 | Notes in `.claude/project/{name}/note/` (retrospective archive) | Active sessions in `.gobbi/projects/<name>/sessions/<id>/` (runtime state) | Both coexist; no migration needed | Existing note archives remain valid |
-| 7-step cycle (ideation → plan → research → execute → collect → memorize → review) | 5-step cycle (Ideation → Plan → Execution → Evaluation → Memorization) | Conceptual; no user action needed | n/a |
+| 7-step cycle (ideation → plan → research → execute → collect → memorize → review) | 6-step workflow (Configuration → Ideation → Planning → Execution → Memorization → Handoff) | Conceptual; no user action needed | n/a |
 | `_orchestration` skill as workflow entry | Deprecated — banner + `ARCHIVED.md` | Skill remains on disk for reference; no deletion | n/a |
 
 ---
@@ -65,13 +65,13 @@ The `gobbi notify` subcommand (`gobbi notify session`, `gobbi notify completion`
 **Path C — Wait for Phase 3.**
 Best for: users who want the canonical gobbi notification setup restored and can tolerate a gap.
 
-Phase 3 may restore notification events over the v0.5.0 hook surface. No timeline is committed. See `CHANGELOG.md` for release history and the Phase 3 backlog doc at `.claude/project/gobbi/design/v050-phase3-backlog.md` for the tracked item.
+Phase 3 may restore notification events over the v0.5.0 hook surface. No timeline is committed. See `CHANGELOG.md` for release history and the Phase 3 backlog doc at `.gobbi/projects/gobbi/design/v050-phase3-backlog.md` for the tracked item.
 
 ---
 
 ### Breaking change 2 — `_orchestration` skill deprecated
 
-**What changed.** The `_orchestration` skill's SKILL.md, which contained the 7-step prose orchestration cycle, is deprecated in v0.5.0. The skill directory remains on disk (per CP6 locked decision — no deletion) and is marked with a deprecation banner. The authoritative deprecation context, including the 7-step → 5-step mapping, lives in `.claude/skills/_orchestration/ARCHIVED.md`.
+**What changed.** The `_orchestration` skill's SKILL.md, which contained the 7-step prose orchestration cycle, is deprecated in v0.5.0. The skill directory remains on disk (per CP6 locked decision — no deletion) and is marked with a deprecation banner. The authoritative deprecation context, including the 7-step → v0.5.0 mapping, lives in `.claude/skills/_orchestration/ARCHIVED.md`.
 
 **Consumer impact.** If you have muscle memory loading the `_orchestration` skill or following its 7-step cycle, read `ARCHIVED.md` first. The new entry point for v0.5.0 orchestration is the `gobbi` skill (`/gobbi`), which now bootstraps a `gobbi workflow init` session instead of driving the 7-step prose cycle. The `_orchestration` skill remains on disk for reference; you will see a deprecation banner if you load it directly.
 


### PR DESCRIPTION
## Summary

Reality-sweep across CLAUDE.md, design docs, CHANGELOG.md, and MIGRATION.md to align documentation with the post-Wave-C.1 state. Combines hand-off Doc-PR 1 + synthesis §6 Doc-PR A + Doc-PR B per user-confirmed bundling.

- **`CLAUDE.md:13`** — DB path: workflow events write to per-session `gobbi.db`; `prompt.patch.applied` writes to workspace `state.db`. Wave A.1 partial-shipped qualifier added.
- **`v050-overview.md`** — Match CLAUDE.md DB framing; Configuration as CLI init phase (not state-machine node).
- **`orchestration/{README,checklist,scenarios}.md`** — Drop `post-Wave-A.1` futurity tags from shipped scenarios; schema v6 → v7; event count 23 → 24; SC-ORCH-26 closed enumeration assertion updated.
- **`v050-session.md`** — Today/Target DB-architecture split; event-type catalog aligned with live `events/index.ts` (9 categories, 24 types).
- **`CHANGELOG.md`** — `[Unreleased]` Wave A.1 + A.2 + B.1 + C.1 entries; `[0.5.0]` corrections (5-step → 6-step, capture-plan → capture-planning, specs/plan → specs/planning, include Handoff); stale `.claude/project/` path fix.
- **`MIGRATION.md`** — Session path canonicalization (`.gobbi/projects/<name>/sessions/<id>/`); capture-planning rename; v7 schema evolution table with `prompt_patches`; gotcha path; upgrade table 5-step → 6-step with Handoff; 7-step → v0.5.0 mapping pointer.

## Test plan

- [x] Live-code reality verified before edits: schema v7, 24 events (9 categories), `capture-planning` command, `specs/planning/` directory
- [x] DB-path framing consistent across CLAUDE.md, v050-overview.md, orchestration/README.md, v050-session.md (Today/Target split)
- [x] `rg "5-step cycle" MIGRATION.md` — zero matches
- [x] `rg "post-Wave-A.1\)" .gobbi/projects/gobbi/design/v050-features/orchestration/checklist.md` — zero matches in headers
- [x] `rg "last-N events from .*state.db" scenarios.md` — zero matches in shipped scenarios
- [x] `rg ".claude/project/gobbi" MIGRATION.md` — zero matches
- [x] Cross-doc consistency: schema v7, event count 24, `capture-planning`, `specs/planning/` — same value everywhere
- [x] 2 perspective evaluators (Project + Overall) — Project REVISE → 3-commit remediation pass → all High/Medium findings resolved

## Closes

Synthesis §6 Doc-PR A and Doc-PR B clusters. CV-7 cluster from synthesis §2.

## Notes

- Adjacent residuals deferred to follow-up: `v050-hooks.md:190` still has `capture-plan`; CHANGELOG `[Unreleased]` Wave A.1 entry could be more concrete on DB-path change; MIGRATION v7 entry could clarify lazy-vs-explicit migration.
- Some `state.db` references remain in `scenarios.md` for future-wave (E.1/E.2) scenarios — those describe the legitimately-unshipped consolidation target and are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)