### PR TITLE
feat(config): gobbi config init + init.ts session-id fix (PR-FIN-1a)

### DIFF
--- a/.gobbi/projects/gobbi/design/v050-features/gobbi-config/README.md
+++ b/.gobbi/projects/gobbi/design/v050-features/gobbi-config/README.md
@@ -1,6 +1,6 @@
 # gobbi-config — Unified Settings Cascade
 
-Feature description for gobbi's three-level configuration cascade. Read this to understand where settings live at each scope, how levels override one another, the unified `settings.json` shape, and the two-verb CLI surface. This is the design-of-record for Pass 3 (session `dfd4ff66`) updated in PR-FIN-1c (session `c34ea7e6`) for the GitSettings reshape and ProjectsRegistry removal.
+Feature description for gobbi's three-level configuration cascade. Read this to understand where settings live at each scope, how levels override one another, the unified `settings.json` shape, and the three-verb CLI surface. This is the design-of-record for Pass 3 (session `dfd4ff66`) updated in PR-FIN-1c (session `c34ea7e6`) for the GitSettings reshape and ProjectsRegistry removal, and PR-FIN-1a (session `c34ea7e6`) for the `gobbi config init` verb and session-id resolution hard-error.
 
 ---
 
@@ -14,11 +14,11 @@ Gobbi resolves every setting by composing three `settings.json` files — worksp
 
 | Level | Path | Git | Written by |
 |---|---|---|---|
-| workspace | `.gobbi/settings.json` | gitignored | `ensureSettingsCascade` seed on first run; manual edit |
-| project | `.gobbi/projects/<name>/settings.json` | tracked | `ensureSettingsCascade` seed; manual edit |
-| session | `.gobbi/projects/<name>/sessions/{id}/settings.json` | gitignored (inherits `.gobbi/projects/<name>/sessions/`) | `/gobbi` setup FIFTH step; `gobbi config set` |
+| workspace | `.gobbi/settings.json` | gitignored | `ensureSettingsCascade` seed on first run; `gobbi config init`; manual edit |
+| project | `.gobbi/projects/<name>/settings.json` | tracked | `ensureSettingsCascade` seed; `gobbi config init --level project`; manual edit |
+| session | `.gobbi/projects/<name>/sessions/{id}/settings.json` | gitignored (inherits `.gobbi/projects/<name>/sessions/`) | `/gobbi` setup FIFTH step; `gobbi config set`; `gobbi config init --level session` |
 
-Session-id resolution: `$CLAUDE_SESSION_ID` env is the CLI-level primary; `--session-id` flag is the override.
+**Session-id resolution (PR-FIN-1a):** `--session-id` flag takes priority over `$CLAUDE_SESSION_ID` env. When neither is present, CLI commands that require a session id exit 2 with a remediation hint — no silent UUID fallback (removed in PR-FIN-1a). `gobbi workflow init` follows the same ladder: flag → env → hard error.
 
 **Project-name resolution (PR-FIN-1c):** Project name resolves in priority order:
 1. `--project <name>` flag — passed explicitly by CLI commands
@@ -94,7 +94,18 @@ Violation raises `ConfigCascadeError('parse', …)` without a `tier` (the violat
 
 ## CLI surface
 
-Two verbs. No `init`, `list`, `delete`, `cleanup`, `resolve`, or `--with-sources`.
+Three verbs. No `list`, `delete`, `cleanup`, `resolve`, or `--with-sources`.
+
+### `gobbi config init [--level workspace|project|session] [--session-id <id>] [--project <name>] [--force]` (PR-FIN-1a)
+
+Scaffolds the minimum-valid `{schemaVersion: 1}` seed at the target level. Workspace is the default level.
+
+- Default `--level workspace`
+- Project resolves via `--project <name>` flag → `basename(repoRoot)` (same ladder as `gobbi config set`)
+- Session level requires `--session-id` flag or `$CLAUDE_SESSION_ID` env; missing both exits 2 with recovery hint suggesting `--level workspace` or `--level project`
+- Refuses with exit 2 if the target `settings.json` already exists; with `--force`, overwrites and emits a stderr WARN line naming the path
+- Seed is minimum-valid only — the cascade supplies all other defaults at resolve time
+- Exit codes: `0` success; `2` parse/validation/IO error, refuse-without-force, or missing session id
 
 ### `gobbi config get <key> [--level workspace|project|session] [--session-id <id>]`
 

--- a/.gobbi/projects/gobbi/design/v050-features/gobbi-config/checklist.md
+++ b/.gobbi/projects/gobbi/design/v050-features/gobbi-config/checklist.md
@@ -202,12 +202,75 @@ All items target behaviour shipped in Pass 3 (Wave B–D, SHAs cited in `review.
 
 ---
 
+## CFG-19 — `gobbi config init --level workspace` (PR-FIN-1a)
+
+- [EP] `gobbi config init` (no `--level`) writes `{schemaVersion: 1}` to `.gobbi/settings.json`; exit 0; stderr empty.
+  - Verify: `bun test packages/cli/src/__tests__/features/gobbi-config.test.ts -t 'CFG-19'`
+- [EP] `gobbi config init --level workspace` with existing file: exit 2; stderr contains `settings.json already exists at` and `--force`; file not modified.
+  - Verify: CFG-19c test asserts exit 2 and file content unchanged
+- [EP] `gobbi config init --level workspace --force` with existing file: exit 0; file overwritten with `{schemaVersion: 1}`.
+  - Verify: CFG-19d test asserts overwrite and minimum-valid content
+- [BVA] Seed is exactly `{schemaVersion: 1}` — no other keys written.
+  - Verify: CFG-19a test asserts `toEqual({ schemaVersion: 1 })`
+
+---
+
+## CFG-20 — `gobbi config init --level project` (PR-FIN-1a)
+
+- [EP] `gobbi config init --level project --project foo` creates `.gobbi/projects/foo/settings.json` with `{schemaVersion: 1}`; exit 0; stderr empty.
+  - Verify: `bun test packages/cli/src/__tests__/features/gobbi-config.test.ts -t 'CFG-20'`
+- [EP] Without `--project` flag, project name falls back to `basename(repoRoot)`.
+  - Verify: CFG-20b test asserts file exists at `.gobbi/projects/<basename>/settings.json`
+- [EP] Existing project file without `--force`: exit 2; stderr contains `--force`; file not modified.
+  - Verify: CFG-20c test asserts exit 2 and file unchanged
+- [ST] `--project` flag takes priority over `basename(repoRoot)` — consistent with `runSet` resolution.
+  - Verify: CFG-20a and CFG-20b together confirm both branches
+
+---
+
+## CFG-21 — `gobbi config init --level session` (PR-FIN-1a)
+
+- [EP] `--session-id sess-21` seeds `.gobbi/projects/<basename>/sessions/sess-21/settings.json`; exit 0; stderr empty.
+  - Verify: `bun test packages/cli/src/__tests__/features/gobbi-config.test.ts -t 'CFG-21'`
+- [EP] `$CLAUDE_SESSION_ID=env-sess-21` (no flag) seeds the env-supplied path; exit 0.
+  - Verify: CFG-21b test confirms env-based session id
+- [EP] Neither flag nor env: exit 2; stderr contains `requires CLAUDE_SESSION_ID env or --session-id` and `use --level workspace or --level project to bypass`.
+  - Verify: CFG-21c test asserts exit 2 and both recovery hint fragments
+- [EP] `--force` with existing session file: exit 0; file overwritten with minimum-valid seed.
+  - Verify: CFG-21d test asserts `{schemaVersion: 1}` after overwrite
+- [DT] Session-id resolution: `--session-id` flag → `$CLAUDE_SESSION_ID` env → exit 2. Flag takes priority when both present.
+  - Verify: CFG-21a and CFG-21b confirm the two happy-path branches; CFG-21c confirms the error branch
+
+---
+
+## CFG-22 — `--force` WARN on overwrite (PR-FIN-1a)
+
+- [EP] `--force` on existing file emits stderr line containing `WARN`, `overwriting existing settings.json`, the full file path, and `--force`.
+  - Verify: `bun test packages/cli/src/__tests__/features/gobbi-config.test.ts -t 'CFG-22'`
+- [EP] `--force` on absent file is silent — no WARN emitted; stderr is empty string.
+  - Verify: CFG-22b test asserts `captured.stderr === ''`
+- [BVA] WARN fires ONLY when the file existed before the overwrite — not on fresh creates.
+  - Verify: CFG-22a (overwrite) and CFG-22b (fresh) distinguish the WARN condition
+
+---
+
+## CFG-23 — Fresh-setup ordering invariant (#185 lock) (PR-FIN-1a)
+
+- [ST] Pre-init `config set --level session` + `workflow init` land under the same `.gobbi/projects/<basename>/sessions/<id>/` slot; `config get` returns the pre-init value after `workflow init`.
+  - Verify: `bun test packages/cli/src/__tests__/features/gobbi-config.test.ts -t 'CFG-23'`
+- [ST] `metadata.projectName` in the session directory equals `basename(repoRoot)` — confirming `workflow init` resolved the same project as `config set`.
+  - Verify: CFG-23 test asserts `meta.projectName === basename(repo)`
+- [EP] `ensureSettingsCascade` called by `workflow init` does NOT overwrite a pre-existing session file — the pre-init value survives.
+  - Verify: CFG-23 final step asserts `workflow.ideation.evaluate.mode === 'always'` after `workflow init`
+
+---
+
 ## Verification procedure
 
-1. `bun test packages/cli/src/__tests__/features/gobbi-config.test.ts` — exercises CFG-1 through CFG-17
+1. `bun test packages/cli/src/__tests__/features/gobbi-config.test.ts` — exercises CFG-1 through CFG-23
 2. `bun test packages/cli/src/__tests__/features/q2-evalconfig-e2e.test.ts` — exercises CFG-15 (4×3 matrix)
 3. `bun test packages/cli/src/__tests__/` — exercises CFG-18 (project list)
 4. For structural items, use the grep hints in each section to confirm cited code patterns exist
-5. `[GAP]` items represent aspirational behaviour — no items are GAP in Pass 3 or PR-FIN-1c
+5. `[GAP]` items represent aspirational behaviour — no items are GAP in Pass 3, PR-FIN-1c, or PR-FIN-1a
 
 See `scenarios.md` for full Given/When/Then bodies and `review.md` for DRIFT/NOTE/GAP resolutions.

--- a/.gobbi/projects/gobbi/design/v050-features/gobbi-config/review.md
+++ b/.gobbi/projects/gobbi/design/v050-features/gobbi-config/review.md
@@ -4,10 +4,13 @@
 |------------|--------------------------|------------|--------|
 | 2026-04-21 | `dfd4ff66-a2d4-456f-8fa4-ddd843e4e58b` | shipped | #123 (draft) |
 | 2026-04-28 | `c34ea7e6-d5c3-4174-b61e-5176efc8d39b` | shipped | PR-FIN-1c (TBD) |
+| 2026-04-28 | `c34ea7e6-d5c3-4174-b61e-5176efc8d39b` | shipped | PR (TBD) |
 
 Pass-3 finalization replaced the T1/T2 JSON + T3 SQLite + provenance architecture with a unified three-level `settings.json` shape and a two-verb CLI. Waves B through D landed on `feat/120-gobbi-config-pass-3` atop 6 prior commits.
 
 PR-FIN-1c (session `c34ea7e6`) reshaped `GitSettings` around always-on worktrees with independent opt-in fields (`issue.create`, `pr.open`, `pr.draft`), removed the `mode`/`workflow`/`cleanup` sub-objects, and removed the `ProjectsRegistry` interface + `Settings.projects` field entirely. Project resolution is now `basename(repoRoot)` + `--project` flag. The T2-v1 upgrader was extended to handle both the original T2-v1 shape and Pass-3 current-shape files. Commits `362217c` + `954f889` on branch `feat/212-pr-fin-1c-schema-redesign`.
+
+PR-FIN-1a (session `c34ea7e6`) added the `gobbi config init` verb (three levels, minimum-valid seed, `--force` overwrite with stderr WARN), replaced `init.ts::resolveSessionId`'s `randomUUID()` fallback with a hard error and remediation hint, added the `#182` recovery hint to `config get/set/init` missing-session-id errors, and locked the `#185` fresh-setup ordering invariant via CFG-23 integration test. Commit `6909fec` on branch `feat/214-pr-fin-1a-config-init-session-id`.
 
 This review documents what drifted from the originally-shipped Pass-3 design, notable implementation decisions (NOTEs), and open gaps deferred to follow-up Passes (GAPs). Entries marked **[superseded by DRIFT-9]** describe changes now themselves changed by PR-FIN-1c.
 
@@ -129,6 +132,20 @@ All SHAs below exist on the branch (`git log --oneline` verified).
 
 ---
 
+### DRIFT-10 — PR-FIN-1a: `randomUUID()` fallback removed from `init.ts::resolveSessionId`; `gobbi config init` verb added
+
+**Finding:** `init.ts::resolveSessionId` silently generated a `randomUUID()` UUID when neither `--session-id` flag nor `$CLAUDE_SESSION_ID` env was present. This created orphan session directories under `.gobbi/projects/<name>/sessions/<random>/` that no subsequent command referenced. PR-FIN-1a removes the fallback and replaces it with a hard error (exit 2) plus a remediation hint pointing the user at `--session-id` and `$CLAUDE_SESSION_ID`. Additionally, `gobbi config init` is added as the third CLI verb — an explicit scaffold command for the minimum-valid seed, replacing the implicit "first `ensureSettingsCascade` run creates the file" pattern with an intentional user action.
+
+**Evidence:** Round-3 ideation memo §Item 4a, §Item 1; plan §1a.1 deliverables B and A; `packages/cli/src/commands/workflow/init.ts` at `6909fec` — `resolveSessionId` rewrite; `packages/cli/src/commands/config.ts` at `6909fec` — `runInit` verb.
+
+**Severity:** Medium — prior to this fix, any invocation of `gobbi workflow init` outside a Claude Code session context (e.g., manual testing, CI without `CLAUDE_SESSION_ID`) silently created an unreferenced session directory. The orphan dirs were not harmful but generated noise and consumed disk space.
+
+**Resolution:** fix code + doc — resolved at `6909fec` (PR-FIN-1a). All three verbs now documented in README, scenarios CFG-19..23 added, checklist updated, CHANGELOG + MIGRATION updated.
+
+**Owner:** PR-FIN-1a (session `c34ea7e6`).
+
+---
+
 ### DRIFT-9 — PR-FIN-1c: `GitSettings` reshaped; `ProjectsRegistry` removed (F2 + F3)
 
 **Finding:** PR-FIN-1c (session `c34ea7e6`) reshaped `GitSettings` and removed `ProjectsRegistry`. The Pass-3 shape (`git.workflow.{mode,baseBranch}`, `git.pr.{draft}`, `git.cleanup.{worktree,branch}`) is replaced with a flat shape where each concern owns its own sub-object: `git.baseBranch`, `git.issue.{create}`, `git.worktree.{autoRemove}`, `git.branch.{autoRemove}`, `git.pr.{open,draft}`. The `mode` enum (and concept of worktree-vs-direct-commit dispatch) is removed — worktrees are always created; PR and issue creation are independent opt-in fields. `Settings.projects` and the `ProjectsRegistry` interface are deleted; project resolution is `basename(repoRoot)` + `--project` flag.
@@ -178,6 +195,16 @@ Supersedes the git-related portions of DRIFT-7 (which described the intermediate
 **Evidence:** ideation.md §10.10 — "model/effort override vs core-rule tension"; `settings.ts` `AgentModel` / `AgentEffort` types exist; no spawn-pipeline reader yet.
 
 **Owner:** deferred to a future Pass when orchestrator reads per-step model/effort overrides.
+
+---
+
+### NOTE-5 — `gobbi config init --force` emits a stderr WARN line (non-silent overwrite)
+
+**Finding:** When `gobbi config init --force` overwrites an existing `settings.json`, it emits a warning line to stderr naming the overwritten path. This is a deliberate usability decision: `--force` is potentially destructive (it replaces user-edited settings with the minimum-valid seed), so the operator must be notified even on exit 0. The WARN line is on stderr so it does not pollute stdout-piped workflows. When `--force` is used on an absent file, no WARN is emitted (no overwrite occurred).
+
+**Evidence:** plan §1a.1 deliverable A ("Refuses if file exists; with `--force`, overwrites and emits a stderr warning"); `packages/cli/src/commands/config.ts` at `6909fec` — `runInit` WARN branch; `packages/cli/src/__tests__/features/gobbi-config.test.ts` — CFG-22a vs CFG-22b distinction.
+
+**Owner:** PR-FIN-1a (session `c34ea7e6`).
 
 ---
 
@@ -242,10 +269,12 @@ Supersedes the git-related portions of DRIFT-7 (which described the intermediate
 | DRIFT-7 | drift | medium | `f9b3925` + `cf7733c` + Wave E | fix code + doc (superseded by DRIFT-9) |
 | DRIFT-8 | drift | high | `f9b3925` + `b671b02` | fix code + doc |
 | DRIFT-9 | drift | high | `362217c` + `954f889` (PR-FIN-1c) | fix code + doc |
+| DRIFT-10 | drift | medium | `6909fec` (PR-FIN-1a) | fix code + doc |
 | NOTE-1 | note | — | `f9b3925` (Wave A→B decision) | design decision |
 | NOTE-2 | note | — | `ff20702` | test discipline |
 | NOTE-3 | note | — | — (no code change) | scope boundary |
 | NOTE-4 | note | — | `b671b02` (schema-only) | scope boundary |
+| NOTE-5 | note | — | `6909fec` (PR-FIN-1a) | usability decision |
 | GAP-1 | gap | — | — | deferred; follow-up Pass |
 | GAP-2 | gap | — | — | deferred; gobbi-rule update |
 | GAP-3 | gap | — | — | deferred; issue #130 post-#119 |

--- a/.gobbi/projects/gobbi/design/v050-features/gobbi-config/scenarios.md
+++ b/.gobbi/projects/gobbi/design/v050-features/gobbi-config/scenarios.md
@@ -353,4 +353,138 @@ Evidence:
 
 ---
 
+---
+
+## CLI — init (PR-FIN-1a)
+
+### CFG-19 — `gobbi config init --level workspace` seeds + refuses without `--force`
+
+**Given** no `.gobbi/settings.json` exists
+**When** `gobbi config init` runs (default level is `workspace`)
+**Then** `.gobbi/settings.json` exists with content `{schemaVersion: 1}` and exit code is `0`
+And stderr is empty
+
+**Given** `.gobbi/settings.json` already exists with any content
+**When** `gobbi config init --level workspace` runs (no `--force`)
+**Then** exit code is `2` and stderr contains `settings.json already exists at` and `--force`
+And the existing file is not modified
+
+**Given** `.gobbi/settings.json` already exists
+**When** `gobbi config init --level workspace --force` runs
+**Then** exit code is `0` and `.gobbi/settings.json` content is `{schemaVersion: 1}` (minimum-valid seed)
+And the prior content is overwritten
+
+State trace:
+- `runInit` resolves level to `workspace`; calls `writeSettingsAtLevel` with seed `{schemaVersion: 1}`
+- File-existence check fires before write: if exists and no `--force` → stderr diagnostic + exit 2
+- `--force` path calls `writeSettingsAtLevel` unconditionally after emitting the WARN line
+
+Evidence:
+- `packages/cli/src/commands/config.ts` — `runInit` verb, refuse-without-force branch
+- `packages/cli/src/__tests__/features/gobbi-config.test.ts` — `describe('CFG-19')`
+
+---
+
+### CFG-20 — `gobbi config init --level project` resolves project via `--project` flag → `basename(repoRoot)`
+
+**Given** no `.gobbi/projects/foo/settings.json` exists
+**When** `gobbi config init --level project --project foo` runs
+**Then** `.gobbi/projects/foo/settings.json` exists with content `{schemaVersion: 1}` and exit code is `0`
+And stderr is empty
+
+**Given** no `--project` flag is supplied
+**When** `gobbi config init --level project` runs
+**Then** project name resolves to `basename(repoRoot)` and `.gobbi/projects/<basename>/settings.json` is created
+
+**Given** `.gobbi/projects/foo/settings.json` already exists
+**When** `gobbi config init --level project --project foo` runs (no `--force`)
+**Then** exit code is `2`, stderr contains `--force`, and the existing file is not modified
+
+State trace:
+- Project-name resolution: `--project <name>` flag → `basename(repoRoot)` — same ladder as `runSet`
+- `writeSettingsAtLevel` creates intermediate directories if absent
+
+Evidence:
+- `packages/cli/src/commands/config.ts` — `runInit`, project resolution
+- `packages/cli/src/__tests__/features/gobbi-config.test.ts` — `describe('CFG-20')`
+
+---
+
+### CFG-21 — `gobbi config init --level session` requires `--session-id` flag or `$CLAUDE_SESSION_ID` env
+
+**Given** `--session-id sess-21` flag is provided
+**When** `gobbi config init --level session --session-id sess-21` runs
+**Then** `.gobbi/projects/<basename>/sessions/sess-21/settings.json` exists with `{schemaVersion: 1}` and exit code is `0`
+And stderr is empty
+
+**Given** no `--session-id` flag but `$CLAUDE_SESSION_ID=env-sess-21` is set
+**When** `gobbi config init --level session` runs
+**Then** `.gobbi/projects/<basename>/sessions/env-sess-21/settings.json` is created and exit code is `0`
+
+**Given** neither `--session-id` flag nor `$CLAUDE_SESSION_ID` env is present
+**When** `gobbi config init --level session` runs
+**Then** exit code is `2` and stderr contains `requires CLAUDE_SESSION_ID env or --session-id`
+And stderr contains `use --level workspace or --level project to bypass`
+
+**Given** a session settings file already exists
+**When** `gobbi config init --level session --session-id sess-force --force` runs
+**Then** exit code is `0` and the file is overwritten with `{schemaVersion: 1}`
+
+State trace:
+- Session-id resolution: `--session-id` flag → `$CLAUDE_SESSION_ID` env → exit 2 with recovery hint
+- Recovery hint text mirrors the hint added to `runGet`/`runSet` by #182
+
+Evidence:
+- `packages/cli/src/commands/config.ts` — `runInit`, session-id resolution branch
+- `packages/cli/src/__tests__/features/gobbi-config.test.ts` — `describe('CFG-21')`
+
+---
+
+### CFG-22 — `--force` on existing file emits stderr WARN line; `--force` on absent file is silent
+
+**Given** `.gobbi/settings.json` already exists
+**When** `gobbi config init --level workspace --force` runs
+**Then** exit code is `0` and stderr contains `WARN` and `overwriting existing settings.json`
+And stderr contains the full path of the overwritten file and `--force`
+
+**Given** `.gobbi/settings.json` does not exist
+**When** `gobbi config init --level workspace --force` runs
+**Then** exit code is `0` and stderr is empty (no WARN when nothing was overwritten)
+And `.gobbi/settings.json` is created
+
+State trace:
+- `runInit` checks existence before writing: if file exists + `--force` → emit WARN to `process.stderr`, then write
+- If file is absent + `--force` → no WARN, just write
+
+Evidence:
+- `packages/cli/src/commands/config.ts` — `runInit` WARN branch
+- `packages/cli/src/__tests__/features/gobbi-config.test.ts` — `describe('CFG-22')`
+
+---
+
+### CFG-23 — Fresh-setup `config set --level session` + `workflow init` ordering invariant (#185 lock)
+
+**Given** a fresh repo with no `.gobbi/` directory and `$CLAUDE_SESSION_ID=sess1`
+**When** `gobbi config set workflow.ideation.evaluate.mode always --level session --session-id sess1` runs
+**Then** `.gobbi/projects/<basename>/sessions/sess1/settings.json` exists with the written value
+And exit code is `0`
+
+**When** `gobbi workflow init --session-id sess1` subsequently runs
+**Then** exit code is `0` and `metadata.projectName` in `.gobbi/projects/<basename>/sessions/sess1/metadata.json` equals `basename(repoRoot)`
+
+**When** `gobbi config get workflow.ideation.evaluate.mode --level session --session-id sess1` runs
+**Then** output is `"always"` — the value written before `workflow init` is preserved
+
+State trace:
+- Both `config set` and `workflow init` resolve project via `basename(repoRoot)` (post-PR-FIN-1c — no `projects.active` to diverge on)
+- `ensureSettingsCascade` called by `workflow init` does NOT overwrite the pre-existing session file
+- The ordering invariant holds because both commands land under the same `.gobbi/projects/<basename>/sessions/<id>/` slot
+
+Evidence:
+- `packages/cli/src/lib/settings-io.ts` — `writeSettingsAtLevel` project resolution
+- `packages/cli/src/commands/workflow/init.ts` — `resolveProjectNameForInit`
+- `packages/cli/src/__tests__/features/gobbi-config.test.ts` — `describe('CFG-23')`
+
+---
+
 See `README.md` for the prose overview. `checklist.md` turns each scenario ID into ISTQB-tagged verifiable items; `review.md` reports Pass-3 DRIFT/NOTE/GAP findings with pinned commit SHAs.

--- a/.gobbi/projects/gobbi/skills/gobbi/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/gobbi/SKILL.md
@@ -114,8 +114,6 @@ CLAUDE_SESSION_ID=$DISCOVERED gobbi config set notify.slack.enabled true
 
 Discussion modes are NOT asked. Defaults apply: `workflow.ideation.discuss.mode` = `user`, `workflow.planning.discuss.mode` = `user`, `workflow.execution.discuss.mode` = `agent`. Users override these manually via `gobbi config set` if they want different behavior.
 
-Note: the settings field is named `planning` to match the loop name in `deterministic-orchestration.md` ("Planning Loop") and the state-machine literal (aligned post-Wave-4). `resolveEvalDecision` accepts only `'planning'` — the `'plan'` backward-compat bridge was removed at Pass 3.
-
 **SIXTH — project context detection.** This runs automatically at session start without asking. Load [project-setup.md](project-setup.md) to execute detection.
 
 This skill defines the agent principles, rules, and skill map you must follow.

--- a/.gobbi/projects/gobbi/skills/gobbi/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/gobbi/SKILL.md
@@ -121,7 +121,9 @@ For explicit one-time scaffolding (e.g., first setup in a fresh repo before runn
 ```
 gobbi config init                            # workspace seed — .gobbi/settings.json
 gobbi config init --level project            # project seed — .gobbi/projects/<basename>/settings.json
+gobbi config init --level project --project foo   # project seed for a non-basename project name
 gobbi config init --level session --session-id $DISCOVERED   # session seed
+gobbi config init --level workspace --force  # force re-seed if file already exists
 ```
 
 Refuses without `--force` if the file already exists. Seed is `{schemaVersion: 1}` only.

--- a/.gobbi/projects/gobbi/skills/gobbi/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/gobbi/SKILL.md
@@ -22,6 +22,8 @@ In v0.5.0, `/gobbi` is the session-bootstrap front door. It completes the setup 
 2. **Fallback:** if `$CODEX_COMPANION_SESSION_ID` is empty, list `~/.claude/projects/{slug}/*.jsonl` and take the most recently modified file. The filename minus `.jsonl` is the session ID. The slug is derived from the project path (e.g., `-playinganalytics-git-gobbi` for `/playinganalytics/git/gobbi`).
 3. **Do NOT generate a `manual-*` fallback.** A fake session ID writes orphan entries under `.gobbi/projects/<name>/sessions/manual-*/` that need manual cleanup.
 
+**PR-FIN-1a change:** `gobbi workflow init` no longer falls back to `randomUUID()` when session id is missing. If `$CLAUDE_SESSION_ID` is absent and `--session-id` is not passed, the command exits 2 with a remediation hint. Agents MUST resolve the session ID (via one of the two discovery steps above) before calling `gobbi workflow init` or the command will fail.
+
 Once discovered, store the ID in a local variable (`DISCOVERED`). Pass it to every CLI call via inline env assignment or the explicit flag — the CLI is plugin-neutral and reads only `$CLAUDE_SESSION_ID` and `--session-id`:
 
 ```
@@ -113,6 +115,16 @@ CLAUDE_SESSION_ID=$DISCOVERED gobbi config set notify.slack.enabled true
 ```
 
 Discussion modes are NOT asked. Defaults apply: `workflow.ideation.discuss.mode` = `user`, `workflow.planning.discuss.mode` = `user`, `workflow.execution.discuss.mode` = `agent`. Users override these manually via `gobbi config set` if they want different behavior.
+
+For explicit one-time scaffolding (e.g., first setup in a fresh repo before running `gobbi workflow init`), `gobbi config init` is also available:
+
+```
+gobbi config init                            # workspace seed — .gobbi/settings.json
+gobbi config init --level project            # project seed — .gobbi/projects/<basename>/settings.json
+gobbi config init --level session --session-id $DISCOVERED   # session seed
+```
+
+Refuses without `--force` if the file already exists. Seed is `{schemaVersion: 1}` only.
 
 **SIXTH — project context detection.** This runs automatically at session start without asking. Load [project-setup.md](project-setup.md) to execute detection.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- PR-FIN-1a — `gobbi config init [--level workspace|project|session] [--session-id <id>] [--project <name>] [--force]` verb: scaffolds the minimum-valid `{schemaVersion: 1}` seed at the target level; refuses without `--force` if file exists; `--force` overwrites with a stderr WARN line. (#214)
+- PR-FIN-1a — CFG-19..CFG-23 integration tests: workspace init, project init, session init, `--force` WARN assertion, and fresh-setup ordering invariant (#185 lock). (#214)
+
 ### Changed
+
+- PR-FIN-1a — `init.ts::resolveSessionId` no longer falls back to `randomUUID()`. Resolution ladder: `--session-id` flag → `$CLAUDE_SESSION_ID` env → exit 2 with remediation hint. Pre-PR-FIN-1a sessions created with a random UUID fallback are now orphaned; see `MIGRATION.md` for cleanup guidance. (#214)
+- PR-FIN-1a — `gobbi config get/set/init --level session` error message now includes the recovery hint: `(outside a session, use --level workspace or --level project to bypass)`. Closes #182. (#214)
+- PR-FIN-1a — `GET_USAGE`/`SET_USAGE` help text corrected: `--session-id` flag takes priority over `$CLAUDE_SESSION_ID` env when both are present. (#214)
+- PR-FIN-1a — SKILL.md stale `resolveEvalDecision` note removed (the `'plan'` backward-compat bridge was removed in Pass 3; the note was factually wrong post-PR-FIN-1c). (#214)
+- PR-FIN-1a — `lib/settings.ts` module docstring T1/T3 historical narrative trimmed; current three-level cascade is described instead. (#214)
 
 - PR-FIN-1c — `GitSettings` reshaped: `mode`/`workflow`/`cleanup` sub-objects removed; flat shape with per-concern sub-objects (`baseBranch`, `issue.create`, `worktree.autoRemove`, `branch.autoRemove`, `pr.open`, `pr.draft`). Worktrees always created; PR and issue creation are independent opt-in fields. Cross-field check updated to `pr.open=true` requires `baseBranch !== null`; check exempts DEFAULTS-only case (fresh repos). `ProjectsRegistry` interface and `Settings.projects` field removed; project resolution is `basename(repoRoot)` + `--project` flag. `gobbi project list` runs filesystem scan; `gobbi project switch` removed. T2-v1 upgrader extended to also handle Pass-3-current-shape files in place. Workspace seed simplified to `{schemaVersion: 1}`. Closes #179, #212. (#212)
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,6 +4,82 @@ This guide documents breaking changes and upgrade steps for major version bumps.
 
 ---
 
+## PR-FIN-1a: gobbi config init verb + session-id resolution change
+
+### Summary
+
+PR-FIN-1a adds the `gobbi config init` verb and removes the `randomUUID()` fallback from `init.ts::resolveSessionId`. The session-id resolution ladder is now: `--session-id` flag → `$CLAUDE_SESSION_ID` env → exit 2 with remediation hint.
+
+---
+
+### Session directories from prior `randomUUID()` runs
+
+Before PR-FIN-1a, `gobbi workflow init` called without `--session-id` or `$CLAUDE_SESSION_ID` silently created session directories with a random UUID name (e.g., `.gobbi/projects/<name>/sessions/3f7a1b2c-.../`). These directories are unreferenced — no subsequent command knows their names.
+
+No automated cleanup is provided. Solo-user trust: manual removal is acceptable and encouraged:
+
+```bash
+# List session dirs under a project (all are legitimate if they match a real session id)
+ls .gobbi/projects/<project-name>/sessions/
+
+# Remove a specific orphan UUID session dir
+rm -rf .gobbi/projects/<project-name>/sessions/<random-uuid>/
+
+# Remove all session dirs older than 30 days (review the list before deleting)
+find .gobbi/projects/*/sessions -maxdepth 1 -mindepth 1 -type d -mtime +30
+```
+
+---
+
+### `gobbi config init` usage
+
+The new verb scaffolds a minimum-valid `{schemaVersion: 1}` seed at the target level. It is the explicit alternative to the implicit "first `ensureSettingsCascade` run seeds the workspace file" behavior.
+
+```bash
+# Workspace level (default) — writes .gobbi/settings.json
+gobbi config init
+
+# Project level — writes .gobbi/projects/<basename>/settings.json
+gobbi config init --level project
+
+# Project level with explicit name
+gobbi config init --level project --project myproject
+
+# Session level — requires session id
+gobbi config init --level session --session-id <id>
+
+# Overwrite an existing file (adds stderr WARN line)
+gobbi config init --force
+gobbi config init --level project --force
+```
+
+The seed is `{schemaVersion: 1}` only — all other defaults are applied at resolve time by `resolveSettings`. Existing content is NOT merged into the seed; `--force` replaces the file completely.
+
+---
+
+### Session-id resolution ladder (updated)
+
+| Priority | Source | Behavior |
+|---|---|---|
+| 1 | `--session-id <id>` flag | Use directly; takes priority over env |
+| 2 | `$CLAUDE_SESSION_ID` env | Use directly |
+| 3 | (none) | Exit 2 with remediation hint |
+
+**Before PR-FIN-1a:** step 3 was `randomUUID()` — a silent UUID was generated.
+
+**After PR-FIN-1a:** step 3 is a hard error with the message:
+
+```
+gobbi: cannot resolve session id.
+  Tried: --session-id flag, CLAUDE_SESSION_ID env.
+  Pass --session-id explicitly or set CLAUDE_SESSION_ID.
+  (SessionStart hook integration arrives in PR-FIN-1b.)
+```
+
+For commands that accept `--level session` (e.g., `gobbi config get/set/init`), the error also includes: `(outside a session, use --level workspace or --level project to bypass)`. Closes #182.
+
+---
+
 ## PR-FIN-1c: GitSettings reshape + ProjectsRegistry removal
 
 ### Summary

--- a/packages/cli/src/__tests__/features/gobbi-config.test.ts
+++ b/packages/cli/src/__tests__/features/gobbi-config.test.ts
@@ -1079,3 +1079,344 @@ describe('CFG-18: gobbi project list — filesystem scan replaces registry', () 
     expect(active).toBe(`*\t${repoBase}`);
   });
 });
+
+// ===========================================================================
+// CFG-19 (PR-FIN-1a): gobbi config init --level workspace
+// ===========================================================================
+//
+// `gobbi config init` is the explicit scaffold verb for the three-level
+// cascade. Default level is `workspace`; the seed is the minimum-valid
+// shape `{schemaVersion: 1}` (the cascade supplies all other defaults at
+// resolve time). Refuses without `--force` when the file exists.
+
+describe('CFG-19: gobbi config init --level workspace seeds + refuses + --force overwrites', () => {
+  test('CFG-19a: fresh init writes minimum-valid workspace seed', async () => {
+    const repo = makeScratchRepo();
+    await captureExit(async () => {
+      await runConfig(['init']);
+    });
+    expect(captured.exitCode).toBeNull();
+    expect(captured.stderr).toBe('');
+
+    const filePath = join(repo, '.gobbi', 'settings.json');
+    expect(existsSync(filePath)).toBe(true);
+    const onDisk = JSON.parse(readFileSync(filePath, 'utf8')) as unknown;
+    expect(onDisk).toEqual({ schemaVersion: 1 });
+  });
+
+  test('CFG-19b: --level workspace explicit seeds the same workspace path', async () => {
+    const repo = makeScratchRepo();
+    await captureExit(async () => {
+      await runConfig(['init', '--level', 'workspace']);
+    });
+    expect(captured.exitCode).toBeNull();
+
+    const filePath = join(repo, '.gobbi', 'settings.json');
+    expect(existsSync(filePath)).toBe(true);
+  });
+
+  test('CFG-19c: existing workspace settings.json refuses without --force', async () => {
+    const repo = makeScratchRepo();
+    // Pre-seed a non-trivial workspace settings file — init must not clobber.
+    writeJson(join(repo, '.gobbi', 'settings.json'), {
+      schemaVersion: 1,
+      workflow: { ideation: { discuss: { mode: 'agent' } } },
+    });
+    const before = readFileSync(join(repo, '.gobbi', 'settings.json'), 'utf8');
+
+    await captureExit(async () => {
+      await runConfig(['init', '--level', 'workspace']);
+    });
+    expect(captured.exitCode).toBe(2);
+    expect(captured.stderr).toContain('settings.json already exists at');
+    expect(captured.stderr).toContain('--force');
+
+    // File untouched.
+    expect(readFileSync(join(repo, '.gobbi', 'settings.json'), 'utf8')).toBe(before);
+  });
+
+  test('CFG-19d: --force overwrites the existing workspace file', async () => {
+    const repo = makeScratchRepo();
+    writeJson(join(repo, '.gobbi', 'settings.json'), {
+      schemaVersion: 1,
+      workflow: { ideation: { discuss: { mode: 'agent' } } },
+    });
+
+    await captureExit(async () => {
+      await runConfig(['init', '--level', 'workspace', '--force']);
+    });
+    expect(captured.exitCode).toBeNull();
+
+    const onDisk = JSON.parse(
+      readFileSync(join(repo, '.gobbi', 'settings.json'), 'utf8'),
+    ) as unknown;
+    expect(onDisk).toEqual({ schemaVersion: 1 });
+  });
+});
+
+// ===========================================================================
+// CFG-20 (PR-FIN-1a): gobbi config init --level project
+// ===========================================================================
+
+describe('CFG-20: gobbi config init --level project seeds via --project flag + basename fallback', () => {
+  test('CFG-20a: --project foo seeds .gobbi/projects/foo/settings.json', async () => {
+    const repo = makeScratchRepo();
+    await captureExit(async () => {
+      await runConfig(['init', '--level', 'project', '--project', 'foo']);
+    });
+    expect(captured.exitCode).toBeNull();
+    expect(captured.stderr).toBe('');
+
+    const filePath = join(projectDirForName(repo, 'foo'), 'settings.json');
+    expect(existsSync(filePath)).toBe(true);
+    const onDisk = JSON.parse(readFileSync(filePath, 'utf8')) as unknown;
+    expect(onDisk).toEqual({ schemaVersion: 1 });
+  });
+
+  test('CFG-20b: no --project flag falls back to basename(repoRoot)', async () => {
+    const repo = makeScratchRepo();
+    await captureExit(async () => {
+      await runConfig(['init', '--level', 'project']);
+    });
+    expect(captured.exitCode).toBeNull();
+
+    const filePath = join(projectDirForName(repo, basename(repo)), 'settings.json');
+    expect(existsSync(filePath)).toBe(true);
+  });
+
+  test('CFG-20c: existing project file refuses without --force', async () => {
+    const repo = makeScratchRepo();
+    writeJson(join(projectDirForName(repo, 'foo'), 'settings.json'), {
+      schemaVersion: 1,
+      git: { baseBranch: 'develop' },
+    });
+    const before = readFileSync(
+      join(projectDirForName(repo, 'foo'), 'settings.json'),
+      'utf8',
+    );
+
+    await captureExit(async () => {
+      await runConfig(['init', '--level', 'project', '--project', 'foo']);
+    });
+    expect(captured.exitCode).toBe(2);
+    expect(captured.stderr).toContain('--force');
+
+    expect(
+      readFileSync(join(projectDirForName(repo, 'foo'), 'settings.json'), 'utf8'),
+    ).toBe(before);
+  });
+});
+
+// ===========================================================================
+// CFG-21 (PR-FIN-1a): gobbi config init --level session
+// ===========================================================================
+
+describe('CFG-21: gobbi config init --level session seeds + requires session id + --force overwrites', () => {
+  test('CFG-21a: --session-id flag seeds .gobbi/projects/<name>/sessions/<id>/settings.json', async () => {
+    const repo = makeScratchRepo();
+    await captureExit(async () => {
+      await runConfig([
+        'init',
+        '--level',
+        'session',
+        '--session-id',
+        'sess-21',
+      ]);
+    });
+    expect(captured.exitCode).toBeNull();
+    expect(captured.stderr).toBe('');
+
+    const filePath = join(
+      sessionDirForProject(repo, basename(repo), 'sess-21'),
+      'settings.json',
+    );
+    expect(existsSync(filePath)).toBe(true);
+    const onDisk = JSON.parse(readFileSync(filePath, 'utf8')) as unknown;
+    expect(onDisk).toEqual({ schemaVersion: 1 });
+  });
+
+  test('CFG-21b: CLAUDE_SESSION_ID env supplies the session id when no flag', async () => {
+    const repo = makeScratchRepo();
+    process.env['CLAUDE_SESSION_ID'] = 'env-sess-21';
+    await captureExit(async () => {
+      await runConfig(['init', '--level', 'session']);
+    });
+    expect(captured.exitCode).toBeNull();
+
+    const filePath = join(
+      sessionDirForProject(repo, basename(repo), 'env-sess-21'),
+      'settings.json',
+    );
+    expect(existsSync(filePath)).toBe(true);
+  });
+
+  test('CFG-21c: missing both flag and env exits 2 with recovery hint', async () => {
+    makeScratchRepo();
+    delete process.env['CLAUDE_SESSION_ID'];
+    await captureExit(async () => {
+      await runConfig(['init', '--level', 'session']);
+    });
+    expect(captured.exitCode).toBe(2);
+    expect(captured.stderr).toContain(
+      'requires CLAUDE_SESSION_ID env or --session-id',
+    );
+    expect(captured.stderr).toContain(
+      'use --level workspace or --level project to bypass',
+    );
+  });
+
+  test('CFG-21d: --force overwrites the existing session file', async () => {
+    const repo = makeScratchRepo();
+    writeJson(
+      join(sessionDirForProject(repo, basename(repo), 'sess-force'), 'settings.json'),
+      { schemaVersion: 1, workflow: { ideation: { discuss: { mode: 'agent' } } } },
+    );
+
+    await captureExit(async () => {
+      await runConfig([
+        'init',
+        '--level',
+        'session',
+        '--session-id',
+        'sess-force',
+        '--force',
+      ]);
+    });
+    expect(captured.exitCode).toBeNull();
+
+    const onDisk = JSON.parse(
+      readFileSync(
+        join(
+          sessionDirForProject(repo, basename(repo), 'sess-force'),
+          'settings.json',
+        ),
+        'utf8',
+      ),
+    ) as unknown;
+    expect(onDisk).toEqual({ schemaVersion: 1 });
+  });
+});
+
+// ===========================================================================
+// CFG-22 (PR-FIN-1a): --force emits stderr WARN line on overwrite
+// ===========================================================================
+//
+// Explicit assertion that `--force` overwriting an existing file emits a
+// WARN line to stderr (not silent). The line names the path so the
+// operator can rollback if the overwrite was unintentional.
+
+describe('CFG-22: --force on existing file emits stderr WARN line', () => {
+  test('CFG-22a: workspace --force emits stderr WARN line containing the path', async () => {
+    const repo = makeScratchRepo();
+    writeJson(join(repo, '.gobbi', 'settings.json'), {
+      schemaVersion: 1,
+      workflow: { ideation: { discuss: { mode: 'agent' } } },
+    });
+
+    await captureExit(async () => {
+      await runConfig(['init', '--level', 'workspace', '--force']);
+    });
+    expect(captured.exitCode).toBeNull();
+    expect(captured.stderr).toContain('WARN');
+    expect(captured.stderr).toContain('overwriting existing settings.json');
+    expect(captured.stderr).toContain(join(repo, '.gobbi', 'settings.json'));
+    expect(captured.stderr).toContain('--force');
+  });
+
+  test('CFG-22b: --force on non-existent file is silent (no WARN)', async () => {
+    const repo = makeScratchRepo();
+    await captureExit(async () => {
+      await runConfig(['init', '--level', 'workspace', '--force']);
+    });
+    expect(captured.exitCode).toBeNull();
+    expect(captured.stderr).toBe('');
+    // The file lands either way.
+    expect(existsSync(join(repo, '.gobbi', 'settings.json'))).toBe(true);
+  });
+});
+
+// ===========================================================================
+// CFG-23 (PR-FIN-1a): fresh-setup config + workflow init ordering invariant
+// ===========================================================================
+//
+// Locks the #185 invariant: post-PR-FIN-1c project resolution is
+// consistent across `gobbi config set` and `gobbi workflow init` because
+// both walk `--project flag → basename(repoRoot)`. A pre-init `config
+// set` lands at the same project path that `workflow init` later
+// resolves, so a subsequent `config get` returns the value the user wrote.
+//
+// On a fresh repo (no `.gobbi/`), this exercises the entire ladder:
+// `ensureSettingsCascade` runs from `workflow init`, but the pre-init
+// `config set` already created the session-level file at the basename
+// slot — both must agree on the slot name.
+
+describe('CFG-23: fresh-setup config set + workflow init resolve to the same project', () => {
+  test('CFG-23: pre-init config set on session level + workflow init reads back the same value', async () => {
+    const repo = makeScratchRepo();
+    process.env['CLAUDE_SESSION_ID'] = 'sess1';
+    const expectedProject = basename(repo);
+
+    // Step 1: pre-init `config set` at session level — lands at
+    // .gobbi/projects/<basename>/sessions/sess1/settings.json. With no
+    // `.gobbi/` yet, this also creates the directory tree.
+    await captureExit(async () => {
+      await runConfig([
+        'set',
+        'workflow.ideation.evaluate.mode',
+        'always',
+        '--level',
+        'session',
+        '--session-id',
+        'sess1',
+      ]);
+    });
+    expect(captured.exitCode).toBeNull();
+
+    const expectedFile = join(
+      sessionDirForProject(repo, expectedProject, 'sess1'),
+      'settings.json',
+    );
+    expect(existsSync(expectedFile)).toBe(true);
+
+    // Step 2: workflow init — `ensureSettingsCascade` must NOT clobber the
+    // pre-existing session file, and it must resolve the project to the
+    // same `basename(repoRoot)` slot.
+    const { runInitWithOptions } = await import('../../commands/workflow/init.js');
+    resetCapture();
+    await captureExit(async () => {
+      await runInitWithOptions(
+        ['--session-id', 'sess1'],
+        { repoRoot: repo },
+      );
+    });
+    expect(captured.exitCode).toBeNull();
+
+    // The metadata.projectName must match the project the pre-init `set`
+    // landed under.
+    const metaPath = join(
+      sessionDirForProject(repo, expectedProject, 'sess1'),
+      'metadata.json',
+    );
+    expect(existsSync(metaPath)).toBe(true);
+    const meta = JSON.parse(readFileSync(metaPath, 'utf8')) as {
+      readonly projectName: string;
+    };
+    expect(meta.projectName).toBe(expectedProject);
+
+    // Step 3: read the value back via `config get --level session` — it
+    // must still be the value we set in step 1.
+    resetCapture();
+    await captureExit(async () => {
+      await runConfig([
+        'get',
+        'workflow.ideation.evaluate.mode',
+        '--level',
+        'session',
+        '--session-id',
+        'sess1',
+      ]);
+    });
+    expect(captured.exitCode).toBeNull();
+    expect(captured.stdout).toBe('"always"\n');
+  });
+});

--- a/packages/cli/src/commands/__tests__/config.test.ts
+++ b/packages/cli/src/commands/__tests__/config.test.ts
@@ -237,8 +237,9 @@ describe('runConfig top-level dispatch', () => {
       await runConfig([]);
     });
     expect(captured.stdout).toContain('Usage: gobbi config <verb> [options]');
-    expect(captured.stdout).toContain('get <key>');
-    expect(captured.stdout).toContain('set <key> <value>');
+    expect(captured.stdout).toContain('get');
+    expect(captured.stdout).toContain('set');
+    expect(captured.stdout).toContain('init');
     expect(captured.stderr).toBe('');
     expect(captured.exitCode).toBeNull();
   });

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -556,14 +556,6 @@ async function runInit(args: string[]): Promise<void> {
   const envSessionId = process.env['CLAUDE_SESSION_ID'];
   const sessionId = resolveSessionId(flagSessionId, envSessionId);
 
-  if (level === 'session' && (sessionId === undefined || sessionId === '')) {
-    process.stderr.write(
-      `gobbi config init: --level session requires CLAUDE_SESSION_ID env or --session-id\n` +
-        `  (outside a session, use --level workspace or --level project to bypass)\n`,
-    );
-    process.exit(2);
-  }
-
   const force = values.force === true;
   const projectFlag =
     typeof values['project'] === 'string' && values['project'] !== ''
@@ -576,14 +568,22 @@ async function runInit(args: string[]): Promise<void> {
   // Compute the on-disk path BEFORE writing so the refuse-without-force
   // gate can inspect the existing file and the WARN line / error message
   // can name the exact path the operator would touch.
+  //
+  // `requireSessionIdForInit` exits 2 when `level === 'session'` and the
+  // resolved id is absent. Returning `string` (never `string | undefined`)
+  // narrows naturally for the session branch — no `as string` cast needed.
+  // Matches the `emitCascadeError: never` convention (see line 786 below).
   let filePath: string;
   if (level === 'workspace') {
     filePath = workspaceSettingsPath(repoRoot);
   } else if (level === 'project') {
     filePath = projectSettingsPath(repoRoot, projectName);
   } else {
-    // session — sessionId is non-empty per the gate above.
-    filePath = sessionSettingsPath(repoRoot, projectName, sessionId as string);
+    filePath = sessionSettingsPath(
+      repoRoot,
+      projectName,
+      requireSessionIdForInit(sessionId),
+    );
   }
 
   if (existsSync(filePath)) {
@@ -613,7 +613,7 @@ async function runInit(args: string[]): Promise<void> {
         repoRoot,
         'session',
         seed,
-        sessionId as string,
+        requireSessionIdForInit(sessionId),
         projectName,
       );
     }
@@ -766,6 +766,27 @@ function resolveSessionId(
   if (flagValue !== undefined && flagValue !== '') return flagValue;
   if (envValue !== undefined && envValue !== '') return envValue;
   return undefined;
+}
+
+/**
+ * Narrow an optional session id to a definite `string` for the `init`
+ * verb's `--level session` branch, or exit 2 with a remediation hint.
+ *
+ * Returning `string` (never `string | undefined`) lets call sites in
+ * `runInit` consume the result directly without `as string` casts —
+ * TypeScript narrows naturally through the function signature. The
+ * `: never`-returning failure path mirrors `emitCascadeError`'s
+ * convention so process-exit helpers stay consistent across this file.
+ */
+function requireSessionIdForInit(sessionId: string | undefined): string {
+  if (sessionId === undefined || sessionId === '') {
+    process.stderr.write(
+      `gobbi config init: --level session requires CLAUDE_SESSION_ID env or --session-id\n` +
+        `  (outside a session, use --level workspace or --level project to bypass)\n`,
+    );
+    process.exit(2);
+  }
+  return sessionId;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,10 +1,12 @@
 /**
  * gobbi config — unified settings CLI.
  *
- * Two verbs only (per ideation §5):
+ * Three verbs:
  *
- *   gobbi config get <key> [--level workspace|project|session] [--session-id <id>]
- *   gobbi config set <key> <value> [--level workspace|project|session] [--session-id <id>]
+ *   gobbi config get  <key>         [--level workspace|project|session] [--session-id <id>]
+ *   gobbi config set  <key> <value> [--level workspace|project|session] [--session-id <id>]
+ *   gobbi config init               [--level workspace|project|session] [--session-id <id>]
+ *                                   [--project <name>] [--force]
  *
  * `get` without `--level` returns the cascade-resolved value (see
  * `lib/settings-io.ts::resolveSettings`). `get` with `--level` reads ONLY
@@ -23,22 +25,35 @@
  * against the single AJV validator in `settings-validator.ts`, and atomic-
  * write via `writeSettingsAtLevel`.
  *
+ * `init` writes the minimum-valid seed `{schemaVersion: 1}` to the chosen
+ * level's `settings.json`. Default level is `workspace`. Refuses with
+ * exit 2 when the file already exists; `--force` overwrites with a
+ * stderr WARN line. Validates the seed via the AJV validator before
+ * writing (atomic temp+rename, same pattern as `set`). The cascade
+ * supplies all other defaults at resolve time, so the seed stays
+ * minimum-shape on disk.
+ *
  * Exit codes:
- *   - `0` — success (get: key found + JSON value on stdout; set: written).
+ *   - `0` — success (get: key found + JSON value on stdout; set/init: written).
  *   - `1` — get-only: key not found at the selected level / path. Silent
  *           stdout, no stderr line (matches `jq` / `kubectl get -o
  *           jsonpath` conventions for missing keys).
- *   - `2` — parse, validation, I/O, or invalid-argument error. Diagnostic
- *           line on stderr.
+ *   - `2` — parse, validation, I/O, or invalid-argument error. Also: init
+ *           refuses to overwrite without `--force`. Diagnostic line on
+ *           stderr.
  *
  * Session-id resolution is plugin-neutral per the
  * `cli-vs-skill-session-id` gotcha: the CLI reads `$CLAUDE_SESSION_ID`
  * and accepts `--session-id <id>` explicitly. It does NOT know about
  * `$CODEX_COMPANION_SESSION_ID`; that discovery logic belongs to the
  * `/gobbi` orchestrator skill, which passes the resolved id through.
+ * The `--session-id` flag takes priority over the env var when both are
+ * present — explicit input overrides the ambient env.
  */
 
 import { parseArgs } from 'node:util';
+import { existsSync } from 'node:fs';
+import { basename } from 'node:path';
 
 import { isRecord } from '../lib/guards.js';
 import { getRepoRoot } from '../lib/repo.js';
@@ -49,7 +64,10 @@ import {
 } from '../lib/settings.js';
 import {
   loadSettingsAtLevel,
+  projectSettingsPath,
   resolveSettings,
+  sessionSettingsPath,
+  workspaceSettingsPath,
   writeSettingsAtLevel,
 } from '../lib/settings-io.js';
 import {
@@ -64,28 +82,39 @@ import {
 const USAGE = `Usage: gobbi config <verb> [options]
 
 Verbs:
-  get <key>            Read a dot-path key from the resolved cascade (or a
-                       single level with --level).
-  set <key> <value>    Write a dot-path key at one level (session by
-                       default). Validates the full resulting tree before
-                       atomic write.
+  get  <key>            Read a dot-path key from the resolved cascade (or a
+                        single level with --level).
+  set  <key> <value>    Write a dot-path key at one level (session by
+                        default). Validates the full resulting tree before
+                        atomic write.
+  init                  Seed the minimum-valid settings file at one level
+                        (workspace by default). Refuses without --force
+                        when the file already exists.
 
 Options:
-  --level <lvl>        Target level: workspace | project | session.
-  --session-id <id>    Session id for --level session. Falls back to the
-                       CLAUDE_SESSION_ID env var.
-  --help, -h           Show this help message.
+  --level <lvl>         Target level: workspace | project | session.
+  --session-id <id>     Session id for --level session. Takes priority over
+                        CLAUDE_SESSION_ID env when both are present.
+  --project <name>      Project name (init only). Defaults to
+                        basename(repoRoot).
+  --force               Overwrite an existing file (init only). Emits a
+                        stderr WARN line.
+  --help, -h            Show this help message.
 
 Examples:
   gobbi config get git.pr.open
   gobbi config get workflow.ideation.discuss.mode --level workspace
   gobbi config set workflow.ideation.discuss.mode user
   gobbi config set notify.slack.events '["workflow.complete","error"]' --level workspace
+  gobbi config init
+  gobbi config init --level project --project foo
+  gobbi config init --level session --session-id abc123 --force
 
 Exit codes:
   0  success
   1  get: key not found at selected level / path (silent stdout)
-  2  parse / validation / I/O / invalid-argument error (stderr diagnostic)`;
+  2  parse / validation / I/O / invalid-argument error (stderr diagnostic);
+     init: file already exists without --force`;
 
 const GET_USAGE = `Usage: gobbi config get <key> [--level workspace|project|session] [--session-id <id>]
 
@@ -95,8 +124,9 @@ level's file — no cascade fallthrough, no default fallback.
 
 Options:
   --level <lvl>        workspace | project | session.
-  --session-id <id>    Required for --level session when CLAUDE_SESSION_ID
-                       is empty; also accepted for cascade resolution.
+  --session-id <id>    Session id for --level session. Takes priority over
+                       CLAUDE_SESSION_ID env when both are present; either
+                       source is accepted for cascade resolution.
   --help, -h           Show this help message.
 
 Examples:
@@ -127,7 +157,8 @@ values exit 2 with the validator errors on stderr and never touch disk.
 Options:
   --level <lvl>        workspace | project | session (default: session).
   --session-id <id>    Session id for --level session (default target).
-                       Falls back to the CLAUDE_SESSION_ID env var.
+                       Takes priority over CLAUDE_SESSION_ID env when both
+                       are present.
   --help, -h           Show this help message.
 
 Examples:
@@ -140,6 +171,40 @@ Exit codes:
   0  success
   2  parse / validation / I/O / invalid-argument error`;
 
+const INIT_USAGE = `Usage: gobbi config init [--level workspace|project|session] [--session-id <id>] [--project <name>] [--force]
+
+Seed the minimum-valid \`{schemaVersion: 1}\` settings file at the chosen
+level. The cascade supplies all other defaults at resolve time, so the
+seed stays minimum-shape on disk.
+
+Default level is \`workspace\` (no --session-id required). For \`session\`,
+either --session-id or CLAUDE_SESSION_ID env is required. For \`project\`,
+project name resolves via --project flag, then basename(repoRoot).
+
+Refuses with exit 2 when the target file already exists. \`--force\`
+overwrites and emits a stderr WARN line so the operator notices.
+
+Options:
+  --level <lvl>        workspace | project | session (default: workspace).
+  --session-id <id>    Session id for --level session. Takes priority over
+                       CLAUDE_SESSION_ID env when both are present.
+  --project <name>     Project name for --level project | session. Defaults
+                       to basename(repoRoot).
+  --force              Overwrite an existing file. Emits a stderr WARN line.
+  --help, -h           Show this help message.
+
+Examples:
+  gobbi config init
+  gobbi config init --level workspace --force
+  gobbi config init --level project --project foo
+  gobbi config init --level session --session-id abc123
+
+Exit codes:
+  0  success
+  2  parse / validation / I/O / invalid-argument error;
+     refuse-without-force on existing file;
+     missing session id when --level session is required`;
+
 // ---------------------------------------------------------------------------
 // parseArgs options — shared between get and set
 // ---------------------------------------------------------------------------
@@ -147,6 +212,14 @@ Exit codes:
 const VERB_PARSE_OPTIONS = {
   level: { type: 'string' },
   'session-id': { type: 'string' },
+  help: { type: 'boolean', short: 'h', default: false },
+} as const;
+
+const INIT_PARSE_OPTIONS = {
+  level: { type: 'string' },
+  'session-id': { type: 'string' },
+  project: { type: 'string' },
+  force: { type: 'boolean', default: false },
   help: { type: 'boolean', short: 'h', default: false },
 } as const;
 
@@ -175,6 +248,11 @@ export async function runConfig(args: string[]): Promise<void> {
 
   if (first === 'set') {
     await runSet(args.slice(1));
+    return;
+  }
+
+  if (first === 'init') {
+    await runInit(args.slice(1));
     return;
   }
 
@@ -245,7 +323,8 @@ async function runGet(args: string[]): Promise<void> {
 
   if (level === 'session' && (sessionId === undefined || sessionId === '')) {
     process.stderr.write(
-      `gobbi config get: --level session requires CLAUDE_SESSION_ID env or --session-id\n`,
+      `gobbi config get: --level session requires CLAUDE_SESSION_ID env or --session-id\n` +
+        `  (outside a session, use --level workspace or --level project to bypass)\n`,
     );
     process.exit(2);
   }
@@ -349,7 +428,8 @@ async function runSet(args: string[]): Promise<void> {
 
   if (level === 'session' && (sessionId === undefined || sessionId === '')) {
     process.stderr.write(
-      `gobbi config set: --level session requires CLAUDE_SESSION_ID env or --session-id\n`,
+      `gobbi config set: --level session requires CLAUDE_SESSION_ID env or --session-id\n` +
+        `  (outside a session, use --level workspace or --level project to bypass)\n`,
     );
     process.exit(2);
   }
@@ -400,6 +480,145 @@ async function runSet(args: string[]): Promise<void> {
     writeSettingsAtLevel(repoRoot, level, updatedUnknown, sessionId);
   } catch (err) {
     emitCascadeError('set', err);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// gobbi config init
+// ---------------------------------------------------------------------------
+
+/**
+ * Seed the minimum-valid `{schemaVersion: 1}` settings file at the chosen
+ * level. The cascade supplies all other defaults at resolve time so the
+ * on-disk seed stays minimum-shape — adding more here would just create
+ * future drift between the seed and `DEFAULTS`.
+ *
+ * Refuses without `--force` when the target file already exists. `--force`
+ * overwrites and emits a stderr WARN line so an operator who runs init
+ * twice notices that they clobbered prior content.
+ *
+ * Project name (for `--level project | session`) resolves via the same
+ * ladder used by `workflow init` and `writeSettingsAtLevel`:
+ *
+ *   1. `--project <name>` flag.
+ *   2. `basename(repoRoot)`.
+ *
+ * Session id (for `--level session`) resolves via the standard
+ * flag → env ladder; both absent is exit 2 with the same recovery hint
+ * `runGet` / `runSet` use.
+ */
+async function runInit(args: string[]): Promise<void> {
+  let values: ReturnType<typeof parseArgs>['values'];
+  let positionals: readonly string[];
+  try {
+    const parsed = parseArgs({
+      args,
+      options: INIT_PARSE_OPTIONS,
+      allowPositionals: true,
+      strict: true,
+    });
+    values = parsed.values;
+    positionals = parsed.positionals;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`gobbi config init: ${message}\n`);
+    process.stderr.write(`${INIT_USAGE}\n`);
+    process.exit(2);
+  }
+
+  if (values.help === true) {
+    process.stdout.write(`${INIT_USAGE}\n`);
+    return;
+  }
+
+  if (positionals.length > 0) {
+    process.stderr.write(
+      `gobbi config init: unexpected extra arguments: ${positionals.join(' ')}\n`,
+    );
+    process.stderr.write(`${INIT_USAGE}\n`);
+    process.exit(2);
+  }
+
+  // Default level is `workspace` — init is the scaffold verb, and the
+  // workspace file is the most common bootstrap target. Session-level
+  // init is the niche case (per-session overrides).
+  const parsedLevel = parseLevel(values['level']);
+  if (parsedLevel === 'invalid') {
+    process.stderr.write(
+      `gobbi config init: --level must be one of workspace, project, session\n`,
+    );
+    process.exit(2);
+  }
+  const level: SettingsLevel = parsedLevel ?? 'workspace';
+
+  const flagSessionId =
+    typeof values['session-id'] === 'string' ? values['session-id'] : undefined;
+  const envSessionId = process.env['CLAUDE_SESSION_ID'];
+  const sessionId = resolveSessionId(flagSessionId, envSessionId);
+
+  if (level === 'session' && (sessionId === undefined || sessionId === '')) {
+    process.stderr.write(
+      `gobbi config init: --level session requires CLAUDE_SESSION_ID env or --session-id\n` +
+        `  (outside a session, use --level workspace or --level project to bypass)\n`,
+    );
+    process.exit(2);
+  }
+
+  const force = values.force === true;
+  const projectFlag =
+    typeof values['project'] === 'string' && values['project'] !== ''
+      ? values['project']
+      : undefined;
+
+  const repoRoot = getRepoRoot();
+  const projectName = projectFlag ?? basename(repoRoot);
+
+  // Compute the on-disk path BEFORE writing so the refuse-without-force
+  // gate can inspect the existing file and the WARN line / error message
+  // can name the exact path the operator would touch.
+  let filePath: string;
+  if (level === 'workspace') {
+    filePath = workspaceSettingsPath(repoRoot);
+  } else if (level === 'project') {
+    filePath = projectSettingsPath(repoRoot, projectName);
+  } else {
+    // session — sessionId is non-empty per the gate above.
+    filePath = sessionSettingsPath(repoRoot, projectName, sessionId as string);
+  }
+
+  if (existsSync(filePath)) {
+    if (!force) {
+      process.stderr.write(
+        `gobbi config init: settings.json already exists at ${filePath}; pass --force to re-seed\n`,
+      );
+      process.exit(2);
+    }
+    process.stderr.write(
+      `gobbi config init: WARN — overwriting existing settings.json at ${filePath} (--force)\n`,
+    );
+  }
+
+  // Minimum-valid seed — everything else lands via the cascade at resolve
+  // time. AJV validation runs inside `writeSettingsAtLevel`; we don't
+  // duplicate it here.
+  const seed: Settings = { schemaVersion: 1 };
+
+  try {
+    if (level === 'workspace') {
+      writeSettingsAtLevel(repoRoot, 'workspace', seed);
+    } else if (level === 'project') {
+      writeSettingsAtLevel(repoRoot, 'project', seed, undefined, projectName);
+    } else {
+      writeSettingsAtLevel(
+        repoRoot,
+        'session',
+        seed,
+        sessionId as string,
+        projectName,
+      );
+    }
+  } catch (err) {
+    emitCascadeError('init', err);
   }
 }
 
@@ -558,13 +777,13 @@ function resolveSessionId(
  * on `ConfigCascadeError.code` so the message tells the user what went
  * wrong at which tier (when known).
  *
- * The `verb` prefix (`get` / `set`) disambiguates CLI error lines when
- * users chain commands in a shell script.
+ * The `verb` prefix (`get` / `set` / `init`) disambiguates CLI error
+ * lines when users chain commands in a shell script.
  *
  * Returns `never` — the call always exits the process — so callers can
  * narrow control flow after invoking it.
  */
-function emitCascadeError(verb: 'get' | 'set', err: unknown): never {
+function emitCascadeError(verb: 'get' | 'set' | 'init', err: unknown): never {
   if (err instanceof ConfigCascadeError) {
     const tier = err.tier !== undefined ? ` [${err.tier}]` : '';
     process.stderr.write(`gobbi config ${verb}${tier}: ${err.message}\n`);

--- a/packages/cli/src/commands/workflow/__tests__/init.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/init.test.ts
@@ -128,11 +128,26 @@ describe('resolveSessionId', () => {
     delete process.env['CLAUDE_SESSION_ID'];
   });
 
-  test('generates a UUID when neither override nor env', () => {
+  test('flag override takes priority over env', () => {
+    process.env['CLAUDE_SESSION_ID'] = 'env-id';
+    try {
+      expect(resolveSessionId('flag-wins')).toBe('flag-wins');
+    } finally {
+      delete process.env['CLAUDE_SESSION_ID'];
+    }
+  });
+
+  test('exits 2 with remediation when neither override nor env', async () => {
     delete process.env['CLAUDE_SESSION_ID'];
-    const id = resolveSessionId(undefined);
-    expect(id.length).toBeGreaterThan(10);
-    expect(id.split('-').length).toBe(5);
+    await captureExit(async () => {
+      // Wrap in a promise so the captureExit harness intercepts the
+      // ExitCalled throw thrown inside `process.exit`.
+      resolveSessionId(undefined);
+    });
+    expect(captured.exitCode).toBe(2);
+    expect(captured.stderr).toContain('cannot resolve session id');
+    expect(captured.stderr).toContain('--session-id');
+    expect(captured.stderr).toContain('CLAUDE_SESSION_ID');
   });
 });
 

--- a/packages/cli/src/commands/workflow/init.ts
+++ b/packages/cli/src/commands/workflow/init.ts
@@ -19,8 +19,11 @@
  * ## Session id resolution
  *
  *   1. Explicit `--session-id <id>` flag (CLI direct mode).
- *   2. `CLAUDE_SESSION_ID` env var (hook context — set by Claude Code).
- *   3. Fallback — generate a fresh UUID.
+ *   2. `CLAUDE_SESSION_ID` env var (hook context — set by Claude Code via
+ *      the SessionStart hook + `$CLAUDE_ENV_FILE` mechanism in PR-FIN-1b).
+ *   3. Hard error — exit 2 with remediation. No `randomUUID()` fallback;
+ *      a fabricated id orphans `.gobbi/projects/<name>/sessions/<random>/`
+ *      directories that nothing references.
  *
  * ## Project name resolution (PR-FIN-1c)
  *
@@ -43,7 +46,6 @@
 import { parseArgs } from 'node:util';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
-import { randomUUID } from 'node:crypto';
 
 import { getRepoRoot } from '../../lib/repo.js';
 import { isRecord, isString, isNumber, isBoolean, isArray } from '../../lib/guards.js';
@@ -73,7 +75,8 @@ const USAGE = `Usage: gobbi workflow init [options]
 Initialise the workflow session directory and emit the opening events.
 
 Options:
-  --session-id <id>     Session id (overrides CLAUDE_SESSION_ID, generates UUID if neither set)
+  --session-id <id>     Session id (takes priority over CLAUDE_SESSION_ID env;
+                        exits 2 with remediation when neither is set)
   --project <name>      Bind this session to project <name> (per-invocation override)
   --task <text>         Free-text description of the task
   --eval-ideation       Enable evaluation after ideation (default: off)
@@ -371,14 +374,28 @@ function dedup(items: readonly string[]): readonly string[] {
 }
 
 /**
- * Resolve the session id using the three-tier priority described in the
- * module docblock. Exported so tests can exercise the fallback chain.
+ * Resolve the session id using the priority described in the module
+ * docblock — `--session-id` flag → `$CLAUDE_SESSION_ID` env → hard error.
+ *
+ * No silent UUID fabrication: a randomly-generated id orphans
+ * `.gobbi/projects/<name>/sessions/<random>/` directories that nothing
+ * else references, contaminating the workspace and breaking idempotent
+ * re-init. Fail loudly with remediation instead.
+ *
+ * Exits 2 (and never returns) when both sources are absent. Exported so
+ * tests can exercise both the success branches and the abort branch.
  */
 export function resolveSessionId(override: string | undefined): string {
   if (override !== undefined && override !== '') return override;
   const env = process.env['CLAUDE_SESSION_ID'];
   if (env !== undefined && env !== '') return env;
-  return randomUUID();
+  process.stderr.write(
+    'gobbi: cannot resolve session id.\n' +
+      '  Tried: --session-id flag, CLAUDE_SESSION_ID env.\n' +
+      '  Pass --session-id explicitly or set CLAUDE_SESSION_ID.\n' +
+      '  (SessionStart hook integration arrives in PR-FIN-1b.)\n',
+  );
+  process.exit(2);
 }
 
 /**

--- a/packages/cli/src/commands/workflow/init.ts
+++ b/packages/cli/src/commands/workflow/init.ts
@@ -382,10 +382,15 @@ function dedup(items: readonly string[]): readonly string[] {
  * else references, contaminating the workspace and breaking idempotent
  * re-init. Fail loudly with remediation instead.
  *
+ * Return type `string | never` makes the abort path explicit at the
+ * signature level — `string | never` simplifies to `string` for assignable
+ * callers, but the `never` annotation signals the process-exit branch and
+ * matches the `emitCascadeError: never` convention in `commands/config.ts`.
+ *
  * Exits 2 (and never returns) when both sources are absent. Exported so
  * tests can exercise both the success branches and the abort branch.
  */
-export function resolveSessionId(override: string | undefined): string {
+export function resolveSessionId(override: string | undefined): string | never {
   if (override !== undefined && override !== '') return override;
   const env = process.env['CLAUDE_SESSION_ID'];
   if (env !== undefined && env !== '') return env;

--- a/packages/cli/src/lib/settings.ts
+++ b/packages/cli/src/lib/settings.ts
@@ -2,12 +2,11 @@
  * Unified `settings.json` schema — the single TypeScript shape for all three
  * settings levels (workspace / project / session) plus the built-in defaults.
  *
- * Pass 3 finalization collapsed the historical split (T1 user-settings JSON +
- * T2 project-config JSON + T3 SQLite session rows + provenance) into a
- * single unified shape. Every level reads and writes the same interface;
- * `settings-io.ts::resolveSettings` composes them with last-wins semantics
- * (session > project > workspace > default). Unknown keys fail validation
- * at write time — see `settings-validator.ts`.
+ * The unified three-level cascade: workspace, project, session. Each level
+ * uses the same `Settings` shape; resolution folds session over project
+ * over workspace via `deepMerge` (see `settings-io.ts::resolveSettings`)
+ * with last-wins semantics (session > project > workspace > default).
+ * Unknown keys fail validation at write time — see `settings-validator.ts`.
  *
  * ## Module boundary
  *


### PR DESCRIPTION
## Summary

PR-FIN-1a — second PR in the gobbi-config finalization cluster. Adds the `gobbi config init` verb, replaces `init.ts::resolveSessionId` `randomUUID()` fallback with a hard error + remediation hint, ships the #182 recovery hint, locks the #185 fresh-setup ordering invariant, deletes a stale SKILL.md note, and trims T1/T3 historical narrative from `lib/settings.ts`.

3 commits on top of `develop` (`8cd2a0d`, post-PR-FIN-1c):
- `6909fec` feat(config): gobbi config init + init.ts session-id fix
- `b9cafce` docs(config): design docs + CHANGELOG + MIGRATION + SKILL.md additions
- `c8a171d` chore(config): R1 remediation — TS narrowing + SKILL.md examples

Diff: 13 files / +1007 / -53.

## What changed

### `gobbi config init` verb (Item 1)

```
gobbi config init [--level workspace|project|session] [--session-id <id>] [--project <name>] [--force]
```

- Three levels (workspace default; project resolves via `--project` flag → `basename(repoRoot)`; session requires `--session-id` flag or `$CLAUDE_SESSION_ID` env).
- Each level writes the minimum-valid `{schemaVersion: 1}` seed. Inheritance via existing resolve-time cascade.
- Refuses if file exists; with `--force`, overwrites + emits stderr `WARN — overwriting existing settings.json at <path> (--force)`.
- AJV-validated, atomic temp+rename.

### `init.ts::resolveSessionId` rewrite (Item 4a)

`randomUUID()` fallback is gone. New ladder: `--session-id` flag → `$CLAUDE_SESSION_ID` env → abort with remediation. Return type annotated `string | never` to match the `emitCascadeError` convention.

### #182 recovery hint

Missing-session-id error in `runGet`/`runSet`/`runInit` now appends `(outside a session, use --level workspace or --level project to bypass)`. Help text priority inversion fixed in `GET_USAGE`/`SET_USAGE` — flag takes priority over env.

### #185 fresh-setup ordering

Post-PR-FIN-1c, `config set --level session` and `workflow init` already resolve project consistently via `basename(repoRoot)` + `--project` flag (no `projects.active` to diverge on). `CFG-23` integration test locks the invariant.

### Doc cleanups

- SKILL.md stale `resolveEvalDecision accepts both 'plan' and 'planning'` note deleted (Item 3e — bridge was removed in Pass-3 finalization).
- T1/T3 historical narrative trimmed from `lib/settings.ts` module docstring (Item 3f).
- `lib/ensure-settings-cascade.ts` already current-state focused (no T1/T3 narrative to remove — executor's accurate observation).

## Closes

- Closes #214 (this PR's tracker)
- Closes #182 (recovery hint to `config set` missing-session-id error)
- Closes #185 (fresh-setup config ordering — locked by CFG-23)

## Out of scope (deferred to subsequent PRs)

- `gobbi config env` + `gobbi hook` namespace + `$CLAUDE_ENV_FILE` (PR-FIN-1b)
- `HookTrigger` enum expansion + dispatch (PR-FIN-1d)
- `model`/`effort`/`maxIterations` wiring (PR-FIN-1e)
- `--project` flag validation (PR-FIN-2)
- `_orchestration/` skill, `note.ts:438`, `verification.ts:53`, `gobbi workflow next` ENOENT (PR-FIN-5)

## Evaluation

- Round 1 — both perspectives PASS
  - Project: PASS (4 low — transitional remediation message, `cli-vs-skill-session-id` PR-FIN-1b cleanup tracker, CFG-23 plan deviation already documented, SKILL.md `--project` example missing)
  - Overall: PASS (2 minor — `as string` casts in `runInit`, `resolveSessionId` `: never` annotation)
- R1 remediation in `c8a171d` — fixed all 3 actionable findings (extracted `requireSessionIdForInit` helper instead of cast, annotated `string | never`, added `--project` + `--force` SKILL.md examples)

Reports in `.claude/project/gobbi/note/20260428-0311-finalize-gobbi-config-c34ea7e6-d5c3-4174-b61e-5176efc8d39b/execution/evaluation/`.

## Test plan

- [x] `bun test packages/cli/src/__tests__/features/gobbi-config.test.ts -t 'CFG-19'` → 4 pass / 0 fail
- [x] `bun test … -t 'CFG-20'` → 3 pass / 0 fail
- [x] `bun test … -t 'CFG-21'` → 4 pass / 0 fail
- [x] `bun test … -t 'CFG-22'` → 2 pass / 0 fail
- [x] `bun test … -t 'CFG-23'` → 1 pass / 0 fail (#185 ordering invariant)
- [x] `bun test` (full suite) → 1979 pass / 0 fail / 9 skip / 8 todo
- [x] `bun run build` → clean (`cli.js` 0.75 MB)

## References

- Round-3 ideation memo
- Plan: `.../plan/plan-pr-fin-1a.md`
- Target-state spec: `.gobbi/projects/gobbi/tmp/gobbi-config-target-state.md` §3.2, §6
- Parent: #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)