### PR TITLE
feat(config): wire workflow.<step>.{agent,evaluate.agent} into spec spawn pipeline (PR-FIN-1e)

### DIFF
--- a/packages/cli/src/__tests__/features/gobbi-config.test.ts
+++ b/packages/cli/src/__tests__/features/gobbi-config.test.ts
@@ -49,7 +49,8 @@ import {
 } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
-import { basename, join } from 'node:path';
+import { basename, dirname, join, resolve as resolvePath } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import {
   projectDir as projectDirForName,
@@ -1648,5 +1649,179 @@ describe('CFG-24..28: gobbi config env — $CLAUDE_ENV_FILE persistence', () => 
     expect(cwdLines).toEqual(['export CLAUDE_CWD=/cwd-2']);
 
     restoreNativeEnv();
+  });
+});
+
+// ===========================================================================
+// CFG-29 (PR-FIN-1e): agent-routing block end-to-end vertical
+// ===========================================================================
+//
+// Acceptance criterion #11 from `ideation.md` §4: a `gobbi config set
+// workflow.execution.agent.model haiku` call must surface in the rendered
+// prompt as `model=haiku` with the `(override: workflow.execution.agent)`
+// provenance suffix.
+//
+// This test drives the end-to-end vertical via the public function surface
+// the CLI uses (no shelling out to a child process):
+//
+//   1. `runConfig(['set', 'workflow.execution.agent.model', 'haiku',
+//      '--level', 'workspace'])` writes the override to
+//      `<repo>/.gobbi/settings.json`.
+//   2. `resolveSettings({repoRoot})` walks the cascade and produces the
+//      merged `Settings` shape with `workflow.execution.agent.model = 'haiku'`.
+//   3. `loadSpecForRuntime(executionSpecPath, resolvedSettings, 'execution')`
+//      overlays the slot onto every entry of `spec.delegation.agents[*]` AND
+//      returns the `originals` map carrying the spec.json hardcoded
+//      `(opus, max)` defaults.
+//   4. `compile(input, { originals, slotHint: 'workflow.execution.agent' })`
+//      renders the agent-routing block via `renderAgentRoutingBlock` with
+//      the override-provenance suffix.
+//   5. The rendered prompt text contains the literal heading, the new
+//      `model=haiku` value, and the `(override: workflow.execution.agent)`
+//      suffix.
+//
+// Direct loader+compile invocation (rather than shelling out to
+// `gobbi workflow init` + `gobbi workflow next`) is the lighter integration
+// path: it exercises the same critical seams (config write → cascade
+// resolution → spec overlay → render decoration → prompt text) without
+// requiring a session scaffold, and matches the unit-vs-integration boundary
+// briefing item: "If invoking the actual CLI commands programmatically is
+// heavy, an acceptable alternative: load the execution spec.json with
+// `loadSpecForRuntime` directly with the settings, then call `compile()` …".
+
+describe('CFG-29 (PR-FIN-1e): agent-routing block surfaces config overrides end-to-end', () => {
+  test('CFG-29: gobbi config set workflow.execution.agent.model haiku → rendered prompt contains model=haiku + (override: workflow.execution.agent)', async () => {
+    const repo = makeScratchRepo();
+
+    // Step 1a: write the override via the CLI's own `set` verb for `model`.
+    // Lands at workspace level so the cascade resolves it without needing
+    // a session.
+    await captureExit(async () => {
+      await runConfig([
+        'set',
+        'workflow.execution.agent.model',
+        'haiku',
+        '--level',
+        'workspace',
+      ]);
+    });
+    expect(captured.exitCode).toBeNull();
+    resetCapture();
+
+    // Step 1b: pin `effort` to a concrete tier (`high`) via the CLI too.
+    // Without this, DEFAULTS.workflow.execution.agent.effort = 'auto' would
+    // win the cascade, making `renderAgentRoutingBlock` emit the
+    // `(auto: resolve via _gobbi-rule Model Selection)` provenance suffix
+    // instead of `(override: ...)` — `'auto'` precedence is the locked
+    // behaviour from ideation.md §2.4. Briefing for T7 explicitly calls for
+    // a settings file shape with both `model: 'haiku'` AND `effort: 'high'`
+    // for this same reason.
+    await captureExit(async () => {
+      await runConfig([
+        'set',
+        'workflow.execution.agent.effort',
+        'high',
+        '--level',
+        'workspace',
+      ]);
+    });
+    expect(captured.exitCode).toBeNull();
+
+    // Sanity: the file landed with both values we wrote.
+    const wsFile = join(repo, '.gobbi', 'settings.json');
+    expect(existsSync(wsFile)).toBe(true);
+    const wsBody = JSON.parse(readFileSync(wsFile, 'utf8')) as Settings;
+    expect(wsBody.workflow?.execution?.agent?.model).toBe('haiku');
+    expect(wsBody.workflow?.execution?.agent?.effort).toBe('high');
+
+    // Step 2: resolve the cascade. With only the workspace file present, the
+    // resolved Settings carry the overrides.
+    const resolved = resolveSettings({ repoRoot: repo });
+    expect(resolved.workflow?.execution?.agent?.model).toBe('haiku');
+    expect(resolved.workflow?.execution?.agent?.effort).toBe('high');
+
+    // Steps 3-4: load the execution spec with overlay, then compile with
+    // the originals + slotHint decoration. The execution spec lives in the
+    // CLI source tree, addressed relative to this test file.
+    const HERE = dirname(fileURLToPath(import.meta.url));
+    const executionSpecPath = resolvePath(
+      HERE,
+      '..',
+      '..',
+      'specs',
+      'execution',
+      'spec.json',
+    );
+
+    // Lazy import — avoids loading these modules when unrelated CFG-* tests
+    // run; mirrors the lazy pattern used by CFG-23 / CFG-24..28.
+    const { loadSpecForRuntime } = await import('../../specs/spec-loader.js');
+    const { compile } = await import('../../specs/assembly.js');
+    const { defaultBudgetAllocator } = await import('../../specs/budget.js');
+    const { defaultPredicates } = await import('../../workflow/predicates.js');
+    const { initialState } = await import('../../workflow/state.js');
+
+    const { spec, originals } = loadSpecForRuntime(
+      executionSpecPath,
+      resolved,
+      'execution',
+    );
+
+    // Sanity: the overlay actually applied — every agent on the post-overlay
+    // spec carries `modelTier: 'haiku'` + `effort: 'high'`, and the
+    // originals map still mirrors the spec.json hardcoded `(opus, max)`.
+    for (const agent of spec.delegation.agents) {
+      expect(agent.modelTier).toBe('haiku');
+      expect(agent.effort).toBe('high');
+    }
+    expect(originals['executor']?.modelTier).toBe('opus');
+    expect(originals['executor']?.effort).toBe('max');
+
+    const fixedTimestamp = '2026-04-16T12:00:00.000Z';
+    const state = {
+      ...initialState('cfg-29-session'),
+      currentStep: 'execution' as const,
+    };
+    const input = {
+      spec,
+      state,
+      dynamic: {
+        timestamp: fixedTimestamp,
+        activeSubagentCount: 0,
+        artifacts: [],
+      },
+      predicates: defaultPredicates,
+      activeAgent: null,
+    };
+
+    const prompt = compile(input, {
+      allocator: defaultBudgetAllocator,
+      contextWindowTokens: 200_000,
+      originals,
+      slotHint: 'workflow.execution.agent',
+    });
+
+    // Step 5: the rendered text carries every load-bearing assertion from
+    // ideation.md AC #11.
+    expect(prompt.text).toContain(
+      'Agent routing for this step (resolved from settings cascade):',
+    );
+    expect(prompt.text).toContain('model=haiku');
+    expect(prompt.text).toContain('(override: workflow.execution.agent)');
+    // The (default) suffix must NOT appear for the executor row — it was
+    // overridden. (The string `(default)` may appear in unrelated prose,
+    // but every agent row of the routing block must carry the override
+    // suffix; checked structurally below.)
+    const lines = prompt.text.split('\n');
+    const routingHeaderIdx = lines.findIndex((l) =>
+      l.startsWith('Agent routing for this step'),
+    );
+    expect(routingHeaderIdx).toBeGreaterThan(-1);
+    const executorRow = lines[routingHeaderIdx + 1];
+    expect(executorRow).toContain('role=executor');
+    expect(executorRow).toContain('model=haiku');
+    expect(executorRow).toContain(
+      '(override: workflow.execution.agent)',
+    );
   });
 });

--- a/packages/cli/src/__tests__/features/gobbi-config.test.ts
+++ b/packages/cli/src/__tests__/features/gobbi-config.test.ts
@@ -1479,10 +1479,10 @@ describe('CFG-24..28: gobbi config env — $CLAUDE_ENV_FILE persistence', () => 
 
     expect(existsSync(envFile)).toBe(true);
     const body = readFileSync(envFile, 'utf8');
-    expect(body).toContain('CLAUDE_SESSION_ID=sess-cfg-24\n');
-    expect(body).toContain('CLAUDE_TRANSCRIPT_PATH=/tmp/transcript-24.jsonl\n');
-    expect(body).toContain('CLAUDE_CWD=/tmp/cfg-24\n');
-    expect(body).toContain('CLAUDE_HOOK_EVENT_NAME=SessionStart\n');
+    expect(body).toContain('export CLAUDE_SESSION_ID=sess-cfg-24\n');
+    expect(body).toContain('export CLAUDE_TRANSCRIPT_PATH=/tmp/transcript-24.jsonl\n');
+    expect(body).toContain('export CLAUDE_CWD=/tmp/cfg-24\n');
+    expect(body).toContain('export CLAUDE_HOOK_EVENT_NAME=SessionStart\n');
     // Native passthrough vars are unset → no lines.
     expect(body).not.toContain('CLAUDE_PROJECT_DIR=');
     expect(body).not.toContain('CLAUDE_PLUGIN_ROOT=');
@@ -1516,17 +1516,17 @@ describe('CFG-24..28: gobbi config env — $CLAUDE_ENV_FILE persistence', () => 
 
     const body = readFileSync(envFile, 'utf8');
     // Stdin-derived lines (all 7).
-    expect(body).toContain('CLAUDE_SESSION_ID=sess-cfg-25\n');
-    expect(body).toContain('CLAUDE_TRANSCRIPT_PATH=/tmp/t.jsonl\n');
-    expect(body).toContain('CLAUDE_CWD=/tmp/cfg-25\n');
-    expect(body).toContain('CLAUDE_HOOK_EVENT_NAME=SessionStart\n');
-    expect(body).toContain('CLAUDE_AGENT_ID=agent-cfg-25\n');
-    expect(body).toContain('CLAUDE_AGENT_TYPE=subagent\n');
-    expect(body).toContain('CLAUDE_PERMISSION_MODE=allow\n');
+    expect(body).toContain('export CLAUDE_SESSION_ID=sess-cfg-25\n');
+    expect(body).toContain('export CLAUDE_TRANSCRIPT_PATH=/tmp/t.jsonl\n');
+    expect(body).toContain('export CLAUDE_CWD=/tmp/cfg-25\n');
+    expect(body).toContain('export CLAUDE_HOOK_EVENT_NAME=SessionStart\n');
+    expect(body).toContain('export CLAUDE_AGENT_ID=agent-cfg-25\n');
+    expect(body).toContain('export CLAUDE_AGENT_TYPE=subagent\n');
+    expect(body).toContain('export CLAUDE_PERMISSION_MODE=allow\n');
     // Native passthrough lines (all 3).
-    expect(body).toContain('CLAUDE_PROJECT_DIR=/repo/cfg-25\n');
-    expect(body).toContain('CLAUDE_PLUGIN_ROOT=/plugin/root-25\n');
-    expect(body).toContain('CLAUDE_PLUGIN_DATA=/plugin/data-25\n');
+    expect(body).toContain('export CLAUDE_PROJECT_DIR=/repo/cfg-25\n');
+    expect(body).toContain('export CLAUDE_PLUGIN_ROOT=/plugin/root-25\n');
+    expect(body).toContain('export CLAUDE_PLUGIN_DATA=/plugin/data-25\n');
 
     restoreNativeEnv();
   });
@@ -1604,7 +1604,9 @@ describe('CFG-24..28: gobbi config env — $CLAUDE_ENV_FILE persistence', () => 
 
     // Sanity: file has each managed key exactly once.
     const firstBody = readFileSync(envFile, 'utf8');
-    const countA = firstBody.split('\n').filter((l) => l.startsWith('CLAUDE_SESSION_ID=')).length;
+    const countA = firstBody
+      .split('\n')
+      .filter((l) => l.startsWith('export CLAUDE_SESSION_ID=')).length;
     expect(countA).toBe(1);
 
     resetCapture();
@@ -1630,20 +1632,20 @@ describe('CFG-24..28: gobbi config env — $CLAUDE_ENV_FILE persistence', () => 
     // New session id is present exactly once.
     const sessionLines = secondBody
       .split('\n')
-      .filter((l) => l.startsWith('CLAUDE_SESSION_ID='));
-    expect(sessionLines).toEqual(['CLAUDE_SESSION_ID=sess-B']);
+      .filter((l) => l.startsWith('export CLAUDE_SESSION_ID='));
+    expect(sessionLines).toEqual(['export CLAUDE_SESSION_ID=sess-B']);
     // New key landed.
-    expect(secondBody).toContain('CLAUDE_TRANSCRIPT_PATH=/tmp/replay.jsonl\n');
+    expect(secondBody).toContain('export CLAUDE_TRANSCRIPT_PATH=/tmp/replay.jsonl\n');
     // Old hook_event_name was overwritten.
     const eventLines = secondBody
       .split('\n')
-      .filter((l) => l.startsWith('CLAUDE_HOOK_EVENT_NAME='));
-    expect(eventLines).toEqual(['CLAUDE_HOOK_EVENT_NAME=SubagentStop']);
+      .filter((l) => l.startsWith('export CLAUDE_HOOK_EVENT_NAME='));
+    expect(eventLines).toEqual(['export CLAUDE_HOOK_EVENT_NAME=SubagentStop']);
     // Cwd was overwritten.
     const cwdLines = secondBody
       .split('\n')
-      .filter((l) => l.startsWith('CLAUDE_CWD='));
-    expect(cwdLines).toEqual(['CLAUDE_CWD=/cwd-2']);
+      .filter((l) => l.startsWith('export CLAUDE_CWD='));
+    expect(cwdLines).toEqual(['export CLAUDE_CWD=/cwd-2']);
 
     restoreNativeEnv();
   });

--- a/packages/cli/src/__tests__/features/hook.test.ts
+++ b/packages/cli/src/__tests__/features/hook.test.ts
@@ -332,11 +332,11 @@ describe('HOOK-1: gobbi hook session-start chains config env + workflow init', (
     // file-header docstring promises HOOK-1 covers.
     expect(existsSync(envFile)).toBe(true);
     const body = readFileSync(envFile, 'utf8');
-    expect(body).toContain('CLAUDE_SESSION_ID=hook-1-sess\n');
-    expect(body).toContain('CLAUDE_TRANSCRIPT_PATH=/tmp/hook-1-transcript.jsonl\n');
-    expect(body).toContain(`CLAUDE_CWD=${repo}\n`);
-    expect(body).toContain('CLAUDE_HOOK_EVENT_NAME=SessionStart\n');
-    expect(body).toContain(`CLAUDE_PROJECT_DIR=${repo}\n`);
+    expect(body).toContain('export CLAUDE_SESSION_ID=hook-1-sess\n');
+    expect(body).toContain('export CLAUDE_TRANSCRIPT_PATH=/tmp/hook-1-transcript.jsonl\n');
+    expect(body).toContain(`export CLAUDE_CWD=${repo}\n`);
+    expect(body).toContain('export CLAUDE_HOOK_EVENT_NAME=SessionStart\n');
+    expect(body).toContain(`export CLAUDE_PROJECT_DIR=${repo}\n`);
 
     // workflow init created the session directory and metadata.json.
     const projectName = basename(repo);
@@ -358,21 +358,19 @@ describe('HOOK-1: gobbi hook session-start chains config env + workflow init', (
 // HOOK-2: pre-tool-use chain — guard invocation, fail-open allow
 // ===========================================================================
 
-describe('HOOK-2: gobbi hook pre-tool-use chains workflow guard', () => {
-  test('HOOK-2: missing session yields fail-open allow JSON on stdout', async () => {
+describe('HOOK-2: gobbi hook pre-tool-use is stubbed when GUARDS is empty', () => {
+  test('HOOK-2: empty GUARDS short-circuits the stub silently (exit 0, no stdout)', async () => {
     makeScratchRepo();
 
-    // No session directory exists in the scratch repo. guard's resolveSessionDir
-    // returns null → emitAllow() is the fail-open default.
+    // The hook drains stdin then early-returns when GUARDS.length === 0.
+    // CC treats no stdout as "no opinion" → tool call is allowed by default.
     const { runHookPreToolUse } = await import('../../commands/hook/pre-tool-use.js');
     await captureExit(async () => {
       await runHookPreToolUse([]);
     });
     expect(captured.exitCode).toBeNull();
-    // Even with no payload (TTY null + guard's `!isPreToolUsePayload` fallback),
-    // guard emits allow JSON. Confirms the chain reached guard.
-    expect(captured.stdout).toContain('"hookEventName":"PreToolUse"');
-    expect(captured.stdout).toContain('"permissionDecision":"allow"');
+    expect(captured.stdout).toBe('');
+    expect(captured.stderr).toBe('');
   });
 });
 
@@ -478,7 +476,7 @@ describe('HOOK-6: end-to-end SessionStart chain', () => {
     // is set above and should appear.
     expect(existsSync(envFile)).toBe(true);
     const body = readFileSync(envFile, 'utf8');
-    expect(body).toContain(`CLAUDE_PROJECT_DIR=${repo}\n`);
+    expect(body).toContain(`export CLAUDE_PROJECT_DIR=${repo}\n`);
 
     // Session dir created by workflow init.
     const projectName = basename(repo);

--- a/packages/cli/src/commands/__tests__/config.test.ts
+++ b/packages/cli/src/commands/__tests__/config.test.ts
@@ -400,8 +400,13 @@ describe('runConfig get read paths', () => {
       await runConfig(['get', 'workflow.ideation.discuss']);
     });
     // A subtree — parse and compare rather than relying on key ordering.
+    // PR-FIN-1e reshaped DEFAULTS: `discuss` now nests `agent: {model, effort}`
+    // instead of flat `model`/`effort` siblings.
     const parsed = JSON.parse(captured.stdout.trim()) as unknown;
-    expect(parsed).toEqual({ mode: 'user', model: 'auto', effort: 'auto' });
+    expect(parsed).toEqual({
+      mode: 'user',
+      agent: { model: 'auto', effort: 'auto' },
+    });
   });
 });
 

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -692,6 +692,8 @@ export interface HookEnvPayload {
   readonly agent_id?: string;
   readonly agent_type?: string;
   readonly permission_mode?: string;
+  readonly source?: string;
+  readonly model?: string;
 }
 
 /**
@@ -709,6 +711,8 @@ const ENV_KEY_MAP: readonly { readonly stdinKey: keyof HookEnvPayload; readonly 
   { stdinKey: 'agent_id', envKey: 'CLAUDE_AGENT_ID' },
   { stdinKey: 'agent_type', envKey: 'CLAUDE_AGENT_TYPE' },
   { stdinKey: 'permission_mode', envKey: 'CLAUDE_PERMISSION_MODE' },
+  { stdinKey: 'source', envKey: 'CLAUDE_SOURCE' },
+  { stdinKey: 'model', envKey: 'CLAUDE_MODEL' },
 ];
 
 /**
@@ -720,6 +724,9 @@ const NATIVE_PASSTHROUGH_KEYS: readonly string[] = [
   'CLAUDE_PROJECT_DIR',
   'CLAUDE_PLUGIN_ROOT',
   'CLAUDE_PLUGIN_DATA',
+  'CLAUDE_CODE_REMOTE',
+  'CLAUDE_CODE_ENTRYPOINT',
+  'CLAUDE_CODE_EXECPATH',
 ];
 
 /**
@@ -926,33 +933,33 @@ function upsertEnvLines(
 
   const outLines: string[] = [];
   for (const line of inputLines) {
-    const eq = line.indexOf('=');
+    // Strip an optional `export ` prefix when matching managed keys, so
+    // legacy plain `KEY=...` lines and current `export KEY=...` lines
+    // upsert against the same key. New output is always `export KEY=...`
+    // — without the prefix, child processes spawned from CC's bash
+    // wrapper (e.g. the `gobbi` binary itself) do not inherit the var.
+    const stripped = line.startsWith('export ') ? line.slice('export '.length) : line;
+    const eq = stripped.indexOf('=');
     if (eq <= 0) {
-      // Comment, blank line, or malformed — preserve verbatim.
       outLines.push(line);
       continue;
     }
-    const key = line.slice(0, eq);
+    const key = stripped.slice(0, eq);
     if (newKeys.has(key)) {
       if (replaced.has(key)) {
-        // Collapse duplicate of an already-replaced managed key.
         continue;
       }
       const v = valueByKey.get(key);
-      // `valueByKey.get` returns `string | undefined`; the `newKeys.has`
-      // guard above proves the key is present, so `v` is a string. The
-      // explicit fallback is belt-and-braces for the type narrowing.
-      outLines.push(`${key}=${v ?? ''}`);
+      outLines.push(`export ${key}=${v ?? ''}`);
       replaced.add(key);
     } else {
       outLines.push(line);
     }
   }
 
-  // Append new keys (those not already in the file) in entry order.
   for (const [key, value] of entries) {
     if (!replaced.has(key)) {
-      outLines.push(`${key}=${value}`);
+      outLines.push(`export ${key}=${value}`);
       replaced.add(key);
     }
   }

--- a/packages/cli/src/commands/hook/pre-tool-use.ts
+++ b/packages/cli/src/commands/hook/pre-tool-use.ts
@@ -16,6 +16,7 @@
  */
 
 import { readStdinJson } from '../../lib/stdin.js';
+import { GUARDS } from '../../workflow/guards.js';
 import { runGuardWithOptions } from '../workflow/guard.js';
 
 export async function runHookPreToolUse(args: string[]): Promise<void> {
@@ -24,21 +25,17 @@ export async function runHookPreToolUse(args: string[]): Promise<void> {
     return;
   }
 
-  // Read stdin ONCE in the hook entrypoint. Pass the parsed payload
-  // through to guard so it does not re-read.
+  // Stub gate: registry is empty (workflow/guards.ts:117). Drain stdin
+  // for broken-pipe safety, then exit 0. Falls through to the real guard
+  // body the moment GUARDS gains entries — no source edit needed.
   const payload = await readStdinJson<unknown>();
+  if (GUARDS.length === 0) {
+    return;
+  }
 
   try {
-    // `runGuardWithOptions` accepts `payload` directly (skips its own
-    // stdin read when supplied). We pass `payload` even when `null` —
-    // guard's `isPreToolUsePayload` narrowing will reject and emit the
-    // fail-open default (`permissionDecision: 'allow'`) without
-    // reading stdin.
     await runGuardWithOptions(args, { payload });
-
-    // TODO(PR-FIN-1d) — dispatch notify for PreToolUse triggers.
   } catch (err) {
-    // Hook contract — never propagate.
     const message = err instanceof Error ? err.message : String(err);
     process.stderr.write(`gobbi hook pre-tool-use: ${message}\n`);
   }

--- a/packages/cli/src/commands/workflow/next.ts
+++ b/packages/cli/src/commands/workflow/next.ts
@@ -36,19 +36,24 @@ import {
 } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { compile, type CompileInput } from '../../specs/assembly.js';
+import { compile, type CompileInput, type CompileOptions } from '../../specs/assembly.js';
 import { compileErrorPrompt } from '../../specs/errors.js';
 import { getStepById, loadGraph, type WorkflowGraph } from '../../specs/graph.js';
 import { applyOverlay, validateOverlay } from '../../specs/overlay.js';
-import { validateStepSpec } from '../../specs/_schema/v1.js';
+import {
+  loadSpecForRuntime,
+  type AgentOriginal,
+} from '../../specs/spec-loader.js';
 import type { StepSpec } from '../../specs/types.js';
 import {
   compileVerificationBlock,
   hasVerificationResultsFor,
 } from '../../specs/verification-block.js';
+import { getRepoRoot } from '../../lib/repo.js';
+import { resolveSettings } from '../../lib/settings-io.js';
 import { resolveWorkflowState } from '../../workflow/engine.js';
 import { defaultPredicates } from '../../workflow/predicates.js';
-import type { WorkflowState } from '../../workflow/state.js';
+import type { WorkflowState, WorkflowStep } from '../../workflow/state.js';
 import { EventStore } from '../../workflow/store.js';
 import { resolvePartitionKeys, resolveSessionDir } from '../session.js';
 
@@ -233,8 +238,29 @@ export async function compileCurrentStep(
     );
   }
 
+  // Resolve the settings cascade once per invocation so the spec loader can
+  // overlay `workflow.<step>.{agent,evaluate.agent}.{model,effort}` onto
+  // every entry of `spec.delegation.agents[*]` per the step-driven mapping
+  // (see `spec-loader.ts::loadSpecForRuntime` JSDoc + PR-FIN-1e ideation
+  // §2.3.1). The `partitionKeys.projectId` field carries the resolved
+  // project name from `<sessionDir>/metadata.json`; absent → falls back to
+  // `basename(repoRoot)` inside `resolveSettings`.
+  const repoRoot = getRepoRoot();
+  const partitionKeys = resolvePartitionKeys(sessionDir);
+  const resolvedSettings = resolveSettings({
+    repoRoot,
+    sessionId,
+    ...(partitionKeys.projectId !== null
+      ? { projectName: partitionKeys.projectId }
+      : {}),
+  });
+
   const specPath = resolveSpecPath(graphPath, stepDef.spec);
-  const baseSpec = loadSpec(specPath);
+  const { spec: baseSpec, originals } = loadSpecForRuntime(
+    specPath,
+    resolvedSettings,
+    state.currentStep,
+  );
 
   let spec: StepSpec = baseSpec;
   if (state.currentSubstate !== null) {
@@ -259,7 +285,13 @@ export async function compileCurrentStep(
     activeAgent: null,
   };
 
-  const prompt = compile(input);
+  // Build compile options, threading the agent-routing decoration only
+  // when settings produced a non-empty `originals` map. The decoration
+  // surfaces the per-agent (model, effort) + provenance suffix in the
+  // rendered prompt — orchestrator reads it to drive `Agent()` spawn.
+  const slotHint = slotHintForStep(state.currentStep);
+  const compileOptions: CompileOptions = buildCompileOptions(originals, slotHint);
+  const prompt = compile(input, compileOptions);
 
   // Verification-block rendering (E.8). Emits one block per active subagent
   // whose `verification.result` entries landed in `state.verificationResults`
@@ -290,20 +322,58 @@ function resolveDir(dir: string): string {
   return isAbsolute(dir) ? dir : resolve(process.cwd(), dir);
 }
 
+/**
+ * Map a {@link WorkflowStep} to the dotted-path that names the active
+ * settings slot (used by the agent-routing block as the override
+ * provenance suffix). Mirrors `spec-loader.ts::pickSettingsSlot`'s
+ * step-driven mapping.
+ *
+ * Returns `null` for steps that do not consume a settings slot
+ * (`idle`, `done`, `error`, `memorization`, `handoff`) — the renderer
+ * skips the block entirely for empty `delegation.agents` anyway, so the
+ * `null` return is the symmetric safe default.
+ */
+function slotHintForStep(step: WorkflowStep): string | null {
+  switch (step) {
+    case 'ideation':
+      return 'workflow.ideation.agent';
+    case 'planning':
+      return 'workflow.planning.agent';
+    case 'execution':
+      return 'workflow.execution.agent';
+    case 'ideation_eval':
+      return 'workflow.ideation.evaluate.agent';
+    case 'planning_eval':
+      return 'workflow.planning.evaluate.agent';
+    case 'execution_eval':
+      return 'workflow.execution.evaluate.agent';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Assemble the {@link CompileOptions} bag for `compile()`. Builds
+ * `originals` and `slotHint` fields conditionally so the spread never
+ * sets a value of `undefined` explicitly (incompatible with
+ * `exactOptionalPropertyTypes: true` — both fields are declared as
+ * pure-optional, not `T | undefined`).
+ */
+function buildCompileOptions(
+  originals: Readonly<Record<string, AgentOriginal>>,
+  slotHint: string | null,
+): CompileOptions {
+  // The originals map is always populated by `loadSpecForRuntime` (one
+  // entry per spec.delegation.agents[*]); empty only when the spec has no
+  // agents (planning, memorization, handoff). Forward an empty map and
+  // let `renderAgentRoutingBlock` skip emission internally — the block
+  // gating on `delegation.agents.length === 0` is the canonical guard.
+  return { originals, slotHint };
+}
+
 function resolveSpecPath(graphPath: string, stepSpec: string): string {
   if (isAbsolute(stepSpec)) return stepSpec;
   return resolve(dirname(graphPath), stepSpec);
-}
-
-function loadSpec(path: string): StepSpec {
-  const raw: unknown = JSON.parse(readFileSync(path, 'utf8'));
-  const result = validateStepSpec(raw);
-  if (!result.ok) {
-    throw new Error(
-      `gobbi workflow next: spec ${path} failed validation: ${JSON.stringify(result.errors)}`,
-    );
-  }
-  return result.value;
 }
 
 function applySubstateOverlay(base: StepSpec, overlayPath: string): StepSpec {

--- a/packages/cli/src/lib/__tests__/ensure-settings-cascade.test.ts
+++ b/packages/cli/src/lib/__tests__/ensure-settings-cascade.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Unit tests for the PR-FIN-1e agent-shape migration composed inside
+ * `upgradeFileInPlace` (`ensure-settings-cascade.ts`).
+ *
+ * The PR-FIN-1c GitSettings reshape lives in {@link ../__tests__/settings-io.test.ts}
+ * (cross-cutting cascade behaviour) and the integration tests; this file
+ * narrowly exercises the new agent-shape primitives + their composition
+ * inside the existing pipeline.
+ *
+ * Coverage:
+ *
+ *   1. `needsAgentShapeUpgrade` returns `true` when `discuss.model` is
+ *      present at the legacy flat shape.
+ *   2. `needsAgentShapeUpgrade` returns `false` when only the nested
+ *      `discuss.agent.model` form is present.
+ *   3. `reshapeStepAgentShape` migrates legacy `discuss.{model,effort}`
+ *      keys under `discuss.agent.{model,effort}`; `mutated === true`.
+ *   4. `reshapeStepAgentShape` resolves legacy-vs-nested conflicts:
+ *      nested wins, legacy is dropped, `mutated === true` (because the
+ *      legacy keys the user wrote were removed).
+ *   5. `ensureSettingsCascade` end-to-end: a workspace fixture with
+ *      legacy-shape `discuss` / `evaluate` keys upgrades to the nested
+ *      form, the file no longer carries the legacy keys, and the
+ *      PR-FIN-1e breadcrumb fires on stderr.
+ *   6. Idempotency: a second `ensureSettingsCascade` pass on the same
+ *      file does NOT fire the migration breadcrumb and does NOT rewrite
+ *      the file (post-state is identical).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  ensureSettingsCascade,
+  needsAgentShapeUpgrade,
+  reshapeStepAgentShape,
+} from '../ensure-settings-cascade.js';
+
+// ---------------------------------------------------------------------------
+// Stderr capture — ensureSettingsCascade writes breadcrumbs via process.stderr.
+// ---------------------------------------------------------------------------
+
+let scratchDir: string;
+let captured: { stderr: string };
+let origStderrWrite: typeof process.stderr.write;
+
+beforeEach(() => {
+  scratchDir = mkdtempSync(join(tmpdir(), 'gobbi-ensure-cascade-'));
+  captured = { stderr: '' };
+  origStderrWrite = process.stderr.write;
+  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+    captured.stderr +=
+      typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    return true;
+  }) as typeof process.stderr.write;
+});
+
+afterEach(() => {
+  process.stderr.write = origStderrWrite;
+  try {
+    rmSync(scratchDir, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+});
+
+function writeJson(filePath: string, value: unknown): void {
+  mkdirSync(join(filePath, '..'), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function readJson(filePath: string): Record<string, unknown> {
+  const raw = readFileSync(filePath, 'utf8');
+  const parsed: unknown = JSON.parse(raw);
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new Error(`expected object at ${filePath}`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 — needsAgentShapeUpgrade detects legacy `discuss.model`
+// ---------------------------------------------------------------------------
+
+describe('needsAgentShapeUpgrade', () => {
+  test('returns true when workflow.ideation.discuss.model is present (legacy shape)', () => {
+    const parsed = {
+      schemaVersion: 1,
+      workflow: {
+        ideation: {
+          discuss: { mode: 'user', model: 'opus' },
+        },
+      },
+    };
+    expect(needsAgentShapeUpgrade(parsed)).toBe(true);
+  });
+
+  test('returns true when workflow.execution.evaluate.effort is present (legacy shape)', () => {
+    const parsed = {
+      schemaVersion: 1,
+      workflow: {
+        execution: {
+          evaluate: { mode: 'always', effort: 'high' },
+        },
+      },
+    };
+    expect(needsAgentShapeUpgrade(parsed)).toBe(true);
+  });
+
+  // Test 2 — nested-only form is the post-migration shape.
+  test('returns false when only the nested form is present', () => {
+    const parsed = {
+      schemaVersion: 1,
+      workflow: {
+        ideation: {
+          discuss: { mode: 'user', agent: { model: 'opus', effort: 'max' } },
+          evaluate: { mode: 'always', agent: { model: 'sonnet' } },
+        },
+        execution: {
+          agent: { model: 'haiku' },
+          evaluate: { mode: 'always', agent: { model: 'sonnet' } },
+        },
+      },
+    };
+    expect(needsAgentShapeUpgrade(parsed)).toBe(false);
+  });
+
+  test('returns false on a minimum-shape document', () => {
+    expect(needsAgentShapeUpgrade({ schemaVersion: 1 })).toBe(false);
+    expect(needsAgentShapeUpgrade({ schemaVersion: 1, workflow: {} })).toBe(false);
+  });
+
+  test('returns false on non-record input', () => {
+    expect(needsAgentShapeUpgrade(null)).toBe(false);
+    expect(needsAgentShapeUpgrade(42)).toBe(false);
+    expect(needsAgentShapeUpgrade('string')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 3 — reshapeStepAgentShape moves legacy keys under agent.*
+// ---------------------------------------------------------------------------
+
+describe('reshapeStepAgentShape', () => {
+  test('migrates legacy discuss.{model, effort} → discuss.agent.{model, effort}', () => {
+    const stepCfg = {
+      discuss: { mode: 'user', model: 'opus', effort: 'max' },
+      evaluate: { mode: 'always', model: 'sonnet', effort: 'high' },
+    };
+    const { out, mutated } = reshapeStepAgentShape(stepCfg);
+    expect(mutated).toBe(true);
+    expect(out).toEqual({
+      discuss: { mode: 'user', agent: { model: 'opus', effort: 'max' } },
+      evaluate: { mode: 'always', agent: { model: 'sonnet', effort: 'high' } },
+    });
+    // Negative — legacy keys must be gone from the post-state.
+    const discussOut = (out as { discuss?: Record<string, unknown> }).discuss;
+    expect(discussOut !== undefined && 'model' in discussOut).toBe(false);
+    expect(discussOut !== undefined && 'effort' in discussOut).toBe(false);
+  });
+
+  // Test 4 — conflict resolution: nested wins, legacy dropped, mutated=true.
+  test('legacy + nested conflict — nested wins, legacy dropped, mutated stays true', () => {
+    const stepCfg = {
+      discuss: {
+        mode: 'user',
+        model: 'opus', // legacy
+        effort: 'max', // legacy
+        agent: { model: 'haiku', effort: 'low' }, // nested wins
+      },
+    };
+    const { out, mutated } = reshapeStepAgentShape(stepCfg);
+    expect(mutated).toBe(true);
+    expect(out).toEqual({
+      discuss: { mode: 'user', agent: { model: 'haiku', effort: 'low' } },
+    });
+  });
+
+  test('returns mutated=false when no legacy keys are present (idempotent shape)', () => {
+    const stepCfg = {
+      discuss: { mode: 'user', agent: { model: 'opus', effort: 'max' } },
+      agent: { model: 'auto' },
+      evaluate: { mode: 'always', agent: { model: 'sonnet' } },
+      maxIterations: 3,
+    } as const;
+    const { out, mutated } = reshapeStepAgentShape(stepCfg);
+    expect(mutated).toBe(false);
+    expect(out).toEqual(stepCfg);
+  });
+
+  test('carries net-new step-wide agent slot and maxIterations verbatim', () => {
+    const stepCfg = {
+      discuss: { mode: 'user', model: 'opus' }, // legacy → triggers mutation
+      agent: { model: 'haiku', effort: 'high' }, // net-new, carry verbatim
+      maxIterations: 7,
+    };
+    const { out, mutated } = reshapeStepAgentShape(stepCfg);
+    expect(mutated).toBe(true);
+    expect(out).toEqual({
+      discuss: { mode: 'user', agent: { model: 'opus' } },
+      agent: { model: 'haiku', effort: 'high' },
+      maxIterations: 7,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 5 — end-to-end ensureSettingsCascade upgrades + breadcrumb fires
+// ---------------------------------------------------------------------------
+
+describe('ensureSettingsCascade — agent-shape end-to-end (PR-FIN-1e)', () => {
+  test('legacy-shape workspace settings file upgrades to nested form + breadcrumb', async () => {
+    const workspacePath = join(scratchDir, '.gobbi', 'settings.json');
+    writeJson(workspacePath, {
+      schemaVersion: 1,
+      workflow: {
+        ideation: {
+          discuss: { mode: 'user', model: 'opus', effort: 'max' },
+          evaluate: { mode: 'always', model: 'sonnet' },
+        },
+        execution: {
+          discuss: { mode: 'agent', model: 'haiku' },
+        },
+      },
+    });
+
+    await ensureSettingsCascade(scratchDir, 'gobbi');
+
+    // Post-state — file reshaped into nested form, no legacy keys.
+    const post = readJson(workspacePath);
+    expect(post).toEqual({
+      schemaVersion: 1,
+      workflow: {
+        ideation: {
+          discuss: { mode: 'user', agent: { model: 'opus', effort: 'max' } },
+          evaluate: { mode: 'always', agent: { model: 'sonnet' } },
+        },
+        execution: {
+          discuss: { mode: 'agent', agent: { model: 'haiku' } },
+        },
+      },
+    });
+
+    // Breadcrumb format: literal "agent fields → PR-FIN-1e shape" line.
+    expect(captured.stderr).toContain(
+      'migrated .gobbi/settings.json agent fields → PR-FIN-1e shape',
+    );
+    // PR-FIN-1c breadcrumb must NOT fire — there is no legacy git/projects
+    // payload in this fixture, so the GitSettings reshape gate stays clean.
+    expect(captured.stderr).not.toContain('→ PR-FIN-1c shape');
+  });
+
+  test('project-level legacy-shape file upgrades + breadcrumb names the project path', async () => {
+    const projectPath = join(
+      scratchDir,
+      '.gobbi',
+      'projects',
+      'gobbi',
+      'settings.json',
+    );
+    writeJson(projectPath, {
+      schemaVersion: 1,
+      workflow: {
+        planning: {
+          evaluate: { mode: 'ask', model: 'sonnet', effort: 'medium' },
+        },
+      },
+    });
+
+    await ensureSettingsCascade(scratchDir, 'gobbi');
+
+    const post = readJson(projectPath);
+    expect(post).toEqual({
+      schemaVersion: 1,
+      workflow: {
+        planning: {
+          evaluate: { mode: 'ask', agent: { model: 'sonnet', effort: 'medium' } },
+        },
+      },
+    });
+    expect(captured.stderr).toContain(
+      'migrated .gobbi/projects/gobbi/settings.json agent fields → PR-FIN-1e shape',
+    );
+  });
+
+  // Test 6 — idempotency on second pass.
+  test('second pass produces no breadcrumb and no rewrite (idempotent)', async () => {
+    const workspacePath = join(scratchDir, '.gobbi', 'settings.json');
+    writeJson(workspacePath, {
+      schemaVersion: 1,
+      workflow: {
+        execution: {
+          discuss: { mode: 'agent', model: 'haiku', effort: 'low' },
+        },
+      },
+    });
+
+    // First pass — runs the migration.
+    await ensureSettingsCascade(scratchDir, 'gobbi');
+    expect(captured.stderr).toContain(
+      'migrated .gobbi/settings.json agent fields → PR-FIN-1e shape',
+    );
+    const firstPassMtimeNs = statSync(workspacePath).mtimeMs;
+    const firstPassContents = readFileSync(workspacePath, 'utf8');
+
+    // Reset stderr capture for the second pass and force a measurable
+    // mtime gap so any accidental rewrite would be observable.
+    captured.stderr = '';
+    await new Promise<void>((resolve) => setTimeout(resolve, 25));
+
+    // Second pass — file is already migrated; no breadcrumb should fire.
+    await ensureSettingsCascade(scratchDir, 'gobbi');
+    expect(captured.stderr).not.toContain('PR-FIN-1e shape');
+    expect(captured.stderr).not.toContain('PR-FIN-1c shape');
+
+    // File contents identical, mtime unchanged — no rewrite happened.
+    expect(readFileSync(workspacePath, 'utf8')).toBe(firstPassContents);
+    expect(statSync(workspacePath).mtimeMs).toBe(firstPassMtimeNs);
+  });
+});

--- a/packages/cli/src/lib/__tests__/settings-io.test.ts
+++ b/packages/cli/src/lib/__tests__/settings-io.test.ts
@@ -28,6 +28,10 @@
  *      for the session path too.
  *  11. PR-FIN-1c cross-field check: `pr.open=true` + `baseBranch=null`
  *      throws `ConfigCascadeError('parse', …)`.
+ *  12. PR-FIN-1e nested `agent` cascade: `workflow.<step>.{agent,
+ *      discuss.agent, evaluate.agent}.{model,effort}` deep-merge cleanly
+ *      across workspace + project tiers; DEFAULTS-only resolution returns
+ *      the nested `mode + agent` shape per ideation §2.1.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
@@ -361,6 +365,88 @@ describe('resolveSettings — cross-project cascade precedence', () => {
     expect(loadSettingsAtLevel(scratchDir, 'project', undefined, 'foo')).toEqual(fooSettings);
     expect(loadSettingsAtLevel(scratchDir, 'project', undefined, 'bar')).toBeNull();
     expect(loadSettingsAtLevel(scratchDir, 'workspace')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Workflow.agent cascade (PR-FIN-1e) — nested `{model,effort}` merge
+// ---------------------------------------------------------------------------
+
+describe('resolveSettings — workflow.<step>.agent cascade (PR-FIN-1e)', () => {
+  test('project overrides workspace for workflow.ideation.agent.model', () => {
+    writeJson(workspaceSettingsPath(scratchDir), {
+      schemaVersion: 1,
+      workflow: { ideation: { agent: { model: 'opus' } } },
+    });
+    writeJson(projectSettingsPath(scratchDir, 'gobbi'), {
+      schemaVersion: 1,
+      workflow: { ideation: { agent: { model: 'sonnet' } } },
+    });
+
+    const resolved = resolveSettings({ repoRoot: scratchDir, projectName: 'gobbi' });
+    // Project wins per existing precedence; deepMerge of nested `agent`
+    // objects must replace the model leaf without dropping siblings.
+    expect(resolved.workflow?.ideation?.agent?.model).toBe('sonnet');
+  });
+
+  test('workspace-only workflow.execution.discuss.agent.effort flows through to resolved', () => {
+    writeJson(workspaceSettingsPath(scratchDir), {
+      schemaVersion: 1,
+      workflow: { execution: { discuss: { agent: { effort: 'high' } } } },
+    });
+
+    const resolved = resolveSettings({ repoRoot: scratchDir, projectName: 'gobbi' });
+    expect(resolved.workflow?.execution?.discuss?.agent?.effort).toBe('high');
+    // `discuss.mode` defaults to 'agent' for execution per DEFAULTS — the
+    // partial `agent.effort` overlay must not clobber the sibling `mode`.
+    expect(resolved.workflow?.execution?.discuss?.mode).toBe('agent');
+  });
+
+  test('workspace evaluate.agent.model + project evaluate.agent.effort merge into one AgentConfig', () => {
+    writeJson(workspaceSettingsPath(scratchDir), {
+      schemaVersion: 1,
+      workflow: { ideation: { evaluate: { agent: { model: 'haiku' } } } },
+    });
+    writeJson(projectSettingsPath(scratchDir, 'gobbi'), {
+      schemaVersion: 1,
+      workflow: { ideation: { evaluate: { agent: { effort: 'low' } } } },
+    });
+
+    const resolved = resolveSettings({ repoRoot: scratchDir, projectName: 'gobbi' });
+    // Cross-tier nested merge: workspace contributes `model`, project
+    // contributes `effort`; both survive the cascade.
+    expect(resolved.workflow?.ideation?.evaluate?.agent).toEqual({
+      model: 'haiku',
+      effort: 'low',
+    });
+    // `evaluate.mode` from DEFAULTS ('always') must remain intact.
+    expect(resolved.workflow?.ideation?.evaluate?.mode).toBe('always');
+  });
+
+  test('DEFAULTS-only resolution returns the nested mode+agent shape', () => {
+    // No fixture files written — every workflow value comes from DEFAULTS.
+    const resolved = resolveSettings({ repoRoot: scratchDir, projectName: 'gobbi' });
+
+    // Per ideation §2.1 DEFAULTS reshape: each step has `discuss`,
+    // `agent`, `evaluate` with nested `agent: {model, effort}` sub-objects.
+    expect(resolved.workflow?.ideation).toEqual({
+      discuss: { mode: 'user', agent: { model: 'auto', effort: 'auto' } },
+      agent: { model: 'auto', effort: 'auto' },
+      evaluate: { mode: 'always', agent: { model: 'auto', effort: 'auto' } },
+      maxIterations: 3,
+    });
+    expect(resolved.workflow?.planning).toEqual({
+      discuss: { mode: 'user', agent: { model: 'auto', effort: 'auto' } },
+      agent: { model: 'auto', effort: 'auto' },
+      evaluate: { mode: 'always', agent: { model: 'auto', effort: 'auto' } },
+      maxIterations: 3,
+    });
+    expect(resolved.workflow?.execution).toEqual({
+      discuss: { mode: 'agent', agent: { model: 'auto', effort: 'auto' } },
+      agent: { model: 'auto', effort: 'auto' },
+      evaluate: { mode: 'always', agent: { model: 'auto', effort: 'auto' } },
+      maxIterations: 3,
+    });
   });
 });
 

--- a/packages/cli/src/lib/ensure-settings-cascade.ts
+++ b/packages/cli/src/lib/ensure-settings-cascade.ts
@@ -42,6 +42,7 @@ import {
   type Settings,
   type StepEvaluate,
   type StepSettings,
+  type WorkflowSettings,
 } from './settings.js';
 import { writeSettingsAtLevel } from './settings-io.js';
 import { formatAjvErrors, validateSettings } from './settings-validator.js';
@@ -248,6 +249,176 @@ function reshapeCurrentShape(parsed: unknown): Settings {
 }
 
 // ---------------------------------------------------------------------------
+// PR-FIN-1e — agent-shape migration primitives
+// ---------------------------------------------------------------------------
+
+/** The set of step keys whose `discuss` / `evaluate` slots may carry the
+ * legacy flat `{model, effort}` form. Mirrors {@link WorkflowSettings}'s
+ * three productive-step slots — eval-mode steps (`*_eval`) reuse the
+ * productive step's `evaluate` substate, so there is no `*_eval` entry
+ * here. */
+const AGENT_SHAPE_STEP_KEYS = ['ideation', 'planning', 'execution'] as const;
+const AGENT_SHAPE_MODE_KEYS = ['discuss', 'evaluate'] as const;
+
+/**
+ * Returns `true` when the parsed settings record carries any
+ * `workflow.<step>.{discuss,evaluate}.{model,effort}` field at the legacy
+ * flat shape — i.e. PR-FIN-1e moved those keys under a nested
+ * `agent` sub-object and the on-disk file still uses the pre-migration
+ * shape.
+ *
+ * Conservative: a missing key alone never triggers an upgrade (the new
+ * shape's optional fields are legitimately absent on minimal seeds and
+ * already-migrated files). Only the *presence* of a legacy `model`/`effort`
+ * directly under `discuss` or `evaluate` flags the file as needing
+ * migration. The net-new `workflow.<step>.agent` slot has no legacy
+ * precursor and never triggers this predicate by itself.
+ */
+export function needsAgentShapeUpgrade(parsed: unknown): boolean {
+  if (!isRecord(parsed)) return false;
+  const workflow = parsed['workflow'];
+  if (!isRecord(workflow)) return false;
+
+  for (const stepKey of AGENT_SHAPE_STEP_KEYS) {
+    const step = workflow[stepKey];
+    if (!isRecord(step)) continue;
+    for (const modeKey of AGENT_SHAPE_MODE_KEYS) {
+      const slot = step[modeKey];
+      if (!isRecord(slot)) continue;
+      if ('model' in slot || 'effort' in slot) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Reshape a single step's mode slots (`discuss`, `evaluate`) so that any
+ * legacy flat `{model, effort}` keys move under the nested `agent`
+ * sub-object that PR-FIN-1e introduced.
+ *
+ * Conflict rule (when both legacy and nested form exist on the same slot):
+ * nested wins, legacy is dropped, `mutated` becomes `true` because the
+ * post-state differs from the pre-state — a legacy key the user wrote was
+ * removed. Mirrors PR-FIN-1c's mode/baseBranch precedence at
+ * {@link reshapeGit} (Pass-3 wins when both present).
+ *
+ * The step-wide `agent` slot is net-new (no legacy precursor); it is
+ * carried verbatim if present. `maxIterations` and `mode` are likewise
+ * carried verbatim. `mutated` reflects only changes the agent-shape
+ * migration introduced — moves of legacy `{model, effort}` keys, and
+ * legacy-vs-nested conflict resolution.
+ */
+export function reshapeStepAgentShape(
+  stepCfg: unknown,
+): { readonly out: StepSettings; readonly mutated: boolean } {
+  if (!isRecord(stepCfg)) {
+    // Non-record input — return an empty StepSettings; nothing to migrate.
+    return { out: {}, mutated: false };
+  }
+
+  let mutated = false;
+  const out: { -readonly [K in keyof StepSettings]?: StepSettings[K] } = {};
+
+  for (const modeKey of AGENT_SHAPE_MODE_KEYS) {
+    const slot = stepCfg[modeKey];
+    if (slot === undefined) continue;
+    if (!isRecord(slot)) {
+      // Non-record value at a known mode key (e.g. `null`) — preserve as-is
+      // so AJV surfaces it later; do not flag mutation.
+      (out as Record<string, unknown>)[modeKey] = slot;
+      continue;
+    }
+
+    const legacyModel = 'model' in slot ? slot['model'] : undefined;
+    const legacyEffort = 'effort' in slot ? slot['effort'] : undefined;
+    const hasLegacy = 'model' in slot || 'effort' in slot;
+
+    const nestedAgentRaw = slot['agent'];
+    const nestedAgent = isRecord(nestedAgentRaw) ? nestedAgentRaw : null;
+
+    // Build the migrated agent sub-object. Nested wins on conflict — start
+    // with legacy values, overlay nested values on top.
+    const mergedAgent: { -readonly [K in 'model' | 'effort']?: unknown } = {};
+    if (legacyModel !== undefined) mergedAgent.model = legacyModel;
+    if (legacyEffort !== undefined) mergedAgent.effort = legacyEffort;
+    if (nestedAgent !== null) {
+      if ('model' in nestedAgent) mergedAgent.model = nestedAgent['model'];
+      if ('effort' in nestedAgent) mergedAgent.effort = nestedAgent['effort'];
+    }
+
+    // Build the rebuilt slot, carrying every key that was NOT a legacy
+    // {model, effort} or the `agent` sub-object — those we owned. Other
+    // keys (notably `mode`) survive verbatim.
+    const rebuiltSlot: Record<string, unknown> = {};
+    for (const k of Object.keys(slot)) {
+      if (k === 'model' || k === 'effort' || k === 'agent') continue;
+      rebuiltSlot[k] = slot[k];
+    }
+    if (Object.keys(mergedAgent).length > 0) {
+      rebuiltSlot['agent'] = mergedAgent;
+    } else if (nestedAgent !== null) {
+      // Nested agent was present but empty — preserve verbatim.
+      rebuiltSlot['agent'] = nestedAgent;
+    }
+
+    // Mutation detection: any legacy key present means we removed it from
+    // the slot's top level. That alone counts as a mutation regardless of
+    // whether the nested form already had the same value.
+    if (hasLegacy) mutated = true;
+
+    (out as Record<string, unknown>)[modeKey] = rebuiltSlot;
+  }
+
+  // Carry net-new step-wide `agent` slot verbatim (no legacy precursor).
+  if ('agent' in stepCfg) {
+    (out as Record<string, unknown>)['agent'] = stepCfg['agent'];
+  }
+  // Carry maxIterations verbatim.
+  if ('maxIterations' in stepCfg) {
+    (out as Record<string, unknown>)['maxIterations'] = stepCfg['maxIterations'];
+  }
+
+  return { out, mutated };
+}
+
+/**
+ * Apply {@link reshapeStepAgentShape} across every productive-step entry
+ * under `settings.workflow`. Returns the rewritten workflow tree plus a
+ * `mutated` flag aggregated across all steps. Steps absent from the input
+ * stay absent. Non-record `workflow` payloads are returned as-is with
+ * `mutated: false` so AJV surfaces the malformed shape later.
+ */
+function reshapeWorkflowAgentShape(
+  workflow: unknown,
+): { readonly out: WorkflowSettings | undefined; readonly mutated: boolean } {
+  if (workflow === undefined) return { out: undefined, mutated: false };
+  if (!isRecord(workflow)) {
+    return { out: workflow as WorkflowSettings, mutated: false };
+  }
+
+  let mutated = false;
+  const out: { -readonly [K in keyof WorkflowSettings]?: StepSettings } = {};
+
+  for (const stepKey of AGENT_SHAPE_STEP_KEYS) {
+    if (!(stepKey in workflow)) continue;
+    const stepCfg = workflow[stepKey];
+    const { out: reshapedStep, mutated: stepMutated } =
+      reshapeStepAgentShape(stepCfg);
+    if (stepMutated) mutated = true;
+    out[stepKey] = reshapedStep;
+  }
+
+  // Preserve any unknown step keys verbatim — AJV will reject them later
+  // with the proper validator-side error message rather than silent loss.
+  for (const k of Object.keys(workflow)) {
+    if ((AGENT_SHAPE_STEP_KEYS as readonly string[]).includes(k)) continue;
+    (out as Record<string, unknown>)[k] = workflow[k];
+  }
+
+  return { out: out as WorkflowSettings, mutated };
+}
+
+// ---------------------------------------------------------------------------
 // Step 3 — T2-v1 → new-shape upgrader
 // ---------------------------------------------------------------------------
 
@@ -350,11 +521,27 @@ function ensureGitignoreLines(repoRoot: string): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Read a settings file at `filePath`, decide whether it needs the
- * PR-FIN-1c reshape, and rewrite it atomically when so. Best-effort: if
- * the file is malformed JSON we skip silently (the regular cascade load
- * surfaces the error with proper provenance); if it already conforms we
- * do nothing. Returns `true` when the file was rewritten.
+ * Read a settings file at `filePath`, decide whether it needs any of the
+ * shape reshapes (PR-FIN-1c GitSettings + ProjectsRegistry removal,
+ * PR-FIN-1e agent-shape migration), and rewrite it atomically when so.
+ *
+ * Composition (PR-FIN-1e): both reshapes run in the same pipeline so the
+ * file is read once, validated once, and written once. The two reshapes
+ * are tracked independently — each can fire its own breadcrumb depending
+ * on whether it actually moved anything:
+ *
+ *   - PR-FIN-1c GitSettings reshape — gated on
+ *     {@link needsCurrentShapeUpgrade}; breadcrumb fires whenever that
+ *     gate triggered (legacy-shape detection IS the mutation signal —
+ *     the reshape is unconditional inside the gate).
+ *   - PR-FIN-1e agent-shape reshape — gated on
+ *     {@link needsAgentShapeUpgrade}; breadcrumb fires only when the
+ *     reshape's `mutated` flag is `true` (idempotent on re-run).
+ *
+ * Best-effort: if the file is malformed JSON we skip silently (the
+ * regular cascade load surfaces the error with proper provenance); if it
+ * already conforms to both shapes we do nothing. Returns `true` when the
+ * file was rewritten.
  */
 function upgradeFileInPlace(
   repoRoot: string,
@@ -379,9 +566,34 @@ function upgradeFileInPlace(
     return false;
   }
 
-  if (!needsCurrentShapeUpgrade(parsed)) return false;
+  const gitShapeNeeded = needsCurrentShapeUpgrade(parsed);
+  const agentShapeNeeded = needsAgentShapeUpgrade(parsed);
+  if (!gitShapeNeeded && !agentShapeNeeded) return false;
 
-  const reshaped = reshapeCurrentShape(parsed);
+  // Step 1 — PR-FIN-1c: reshape git/projects when their gate triggered.
+  // When the gate is clean the original payload flows through unchanged
+  // so the agent-shape reshape can apply on top.
+  const afterGitReshape: Settings = gitShapeNeeded
+    ? reshapeCurrentShape(parsed)
+    : (() => {
+        const root = isRecord(parsed) ? parsed : {};
+        return {
+          schemaVersion: 1,
+          ...(isRecord(root['workflow']) ? { workflow: root['workflow'] as NonNullable<Settings['workflow']> } : {}),
+          ...(isRecord(root['notify']) ? { notify: root['notify'] as NonNullable<Settings['notify']> } : {}),
+          ...(isRecord(root['git']) ? { git: root['git'] as NonNullable<Settings['git']> } : {}),
+        };
+      })();
+
+  // Step 2 — PR-FIN-1e: agent-shape migration on the workflow tree.
+  const { out: reshapedWorkflow, mutated: agentShapeMutated } =
+    reshapeWorkflowAgentShape(afterGitReshape.workflow);
+
+  const reshaped: Settings = {
+    ...afterGitReshape,
+    ...(reshapedWorkflow !== undefined ? { workflow: reshapedWorkflow } : {}),
+  };
+
   if (!validateSettings(reshaped)) {
     const messages = formatAjvErrors(validateSettings.errors);
     throw new ConfigCascadeError(
@@ -391,14 +603,29 @@ function upgradeFileInPlace(
     );
   }
 
+  // If neither reshape actually moved anything, skip the write. This
+  // happens when `gitShapeNeeded` was false and the agent-shape pass
+  // produced a no-op (e.g., the file was already migrated and we entered
+  // this branch via a stale predicate — defensive guard, not expected
+  // under correct gate logic).
+  if (!gitShapeNeeded && !agentShapeMutated) return false;
+
   if (level === 'workspace') {
     writeSettingsAtLevel(repoRoot, 'workspace', reshaped);
   } else {
     writeSettingsAtLevel(repoRoot, 'project', reshaped, undefined, projectName);
   }
-  process.stderr.write(
-    `[ensure-settings-cascade] reshaped ${path.relative(repoRoot, filePath)} → PR-FIN-1c shape\n`,
-  );
+
+  if (gitShapeNeeded) {
+    process.stderr.write(
+      `[ensure-settings-cascade] reshaped ${path.relative(repoRoot, filePath)} → PR-FIN-1c shape\n`,
+    );
+  }
+  if (agentShapeMutated) {
+    process.stderr.write(
+      `[ensure-settings-cascade] migrated ${path.relative(repoRoot, filePath)} agent fields → PR-FIN-1e shape\n`,
+    );
+  }
   return true;
 }
 

--- a/packages/cli/src/lib/settings-validator.ts
+++ b/packages/cli/src/lib/settings-validator.ts
@@ -91,6 +91,28 @@ const AGENT_EFFORT_ENUM = ['low', 'medium', 'high', 'max', 'auto'] as const;
 const DISCUSS_MODE_ENUM = ['agent', 'user', 'auto', 'skip'] as const;
 const EVALUATE_MODE_ENUM = ['ask', 'always', 'skip', 'auto'] as const;
 
+// PR-FIN-1e: shared `AgentConfig` sub-schema used by `StepSettings.agent`,
+// `StepDiscuss.agent`, and `StepEvaluate.agent`. Hoisting keeps the three
+// AJV sites byte-identical so a future enum widening only edits one spot.
+//
+// Not annotated with `JSONSchemaType<AgentConfig>` — that annotation collides
+// with `exactOptionalPropertyTypes: true` when the constant is reused at
+// optional-property positions on the outer `JSONSchemaType<Settings>` schema
+// (the `T | undefined` discriminant on optional fields rejects a
+// `JSONSchemaType<T>`-typed constant). Drift safety holds because the outer
+// `settingsSchema: JSONSchemaType<Settings>` annotation type-checks every
+// inline use of `agentConfigSchema` against the matching `AgentConfig`
+// property on `Settings` — the same pattern as `_schema/v1.ts:60-73`.
+const agentConfigSchema = {
+  type: 'object',
+  nullable: true,
+  additionalProperties: false,
+  properties: {
+    model: { type: 'string', nullable: true, enum: [...AGENT_MODEL_ENUM] },
+    effort: { type: 'string', nullable: true, enum: [...AGENT_EFFORT_ENUM] },
+  },
+} as const;
+
 // ---------------------------------------------------------------------------
 // Schema — single AJV JSONSchemaType<Settings>
 // ---------------------------------------------------------------------------
@@ -117,18 +139,17 @@ const settingsSchema: JSONSchemaType<Settings> = {
               additionalProperties: false,
               properties: {
                 mode: { type: 'string', nullable: true, enum: [...DISCUSS_MODE_ENUM] },
-                model: { type: 'string', nullable: true, enum: [...AGENT_MODEL_ENUM] },
-                effort: { type: 'string', nullable: true, enum: [...AGENT_EFFORT_ENUM] },
+                agent: agentConfigSchema,
               },
             },
+            agent: agentConfigSchema,
             evaluate: {
               type: 'object',
               nullable: true,
               additionalProperties: false,
               properties: {
                 mode: { type: 'string', nullable: true, enum: [...EVALUATE_MODE_ENUM] },
-                model: { type: 'string', nullable: true, enum: [...AGENT_MODEL_ENUM] },
-                effort: { type: 'string', nullable: true, enum: [...AGENT_EFFORT_ENUM] },
+                agent: agentConfigSchema,
               },
             },
             maxIterations: { type: 'integer', nullable: true, minimum: 1 },
@@ -145,18 +166,17 @@ const settingsSchema: JSONSchemaType<Settings> = {
               additionalProperties: false,
               properties: {
                 mode: { type: 'string', nullable: true, enum: [...DISCUSS_MODE_ENUM] },
-                model: { type: 'string', nullable: true, enum: [...AGENT_MODEL_ENUM] },
-                effort: { type: 'string', nullable: true, enum: [...AGENT_EFFORT_ENUM] },
+                agent: agentConfigSchema,
               },
             },
+            agent: agentConfigSchema,
             evaluate: {
               type: 'object',
               nullable: true,
               additionalProperties: false,
               properties: {
                 mode: { type: 'string', nullable: true, enum: [...EVALUATE_MODE_ENUM] },
-                model: { type: 'string', nullable: true, enum: [...AGENT_MODEL_ENUM] },
-                effort: { type: 'string', nullable: true, enum: [...AGENT_EFFORT_ENUM] },
+                agent: agentConfigSchema,
               },
             },
             maxIterations: { type: 'integer', nullable: true, minimum: 1 },
@@ -173,18 +193,17 @@ const settingsSchema: JSONSchemaType<Settings> = {
               additionalProperties: false,
               properties: {
                 mode: { type: 'string', nullable: true, enum: [...DISCUSS_MODE_ENUM] },
-                model: { type: 'string', nullable: true, enum: [...AGENT_MODEL_ENUM] },
-                effort: { type: 'string', nullable: true, enum: [...AGENT_EFFORT_ENUM] },
+                agent: agentConfigSchema,
               },
             },
+            agent: agentConfigSchema,
             evaluate: {
               type: 'object',
               nullable: true,
               additionalProperties: false,
               properties: {
                 mode: { type: 'string', nullable: true, enum: [...EVALUATE_MODE_ENUM] },
-                model: { type: 'string', nullable: true, enum: [...AGENT_MODEL_ENUM] },
-                effort: { type: 'string', nullable: true, enum: [...AGENT_EFFORT_ENUM] },
+                agent: agentConfigSchema,
               },
             },
             maxIterations: { type: 'integer', nullable: true, minimum: 1 },

--- a/packages/cli/src/lib/settings.ts
+++ b/packages/cli/src/lib/settings.ts
@@ -99,6 +99,25 @@ export type HookTrigger =
   | 'ElicitationResult';
 
 /**
+ * Per-agent model + effort override for a workflow step.
+ *
+ * PR-FIN-1e introduced this nested shape — the prior flat
+ * `{model, effort}` fields on `StepDiscuss` / `StepEvaluate` were lifted
+ * into a sibling `agent` sub-object so the productive-step spawn surface
+ * (`StepSettings.agent`) and the per-mode surfaces (`discuss.agent`,
+ * `evaluate.agent`) share one uniform shape.
+ *
+ * `model: 'auto'` defers to `_delegation`'s model table and `effort:
+ * 'auto'` defers to core-rule's max-effort policy. Concrete tiers
+ * override unconditionally — no per-tier policy lookup at the loader
+ * boundary.
+ */
+export interface AgentConfig {
+  readonly model?: AgentModel;
+  readonly effort?: AgentEffort;
+}
+
+/**
  * Discussion configuration for a workflow step.
  *
  *   - `mode: 'agent'` → delegate to a step-specific subagent (orchestrator
@@ -107,13 +126,14 @@ export type HookTrigger =
  *   - `mode: 'user'` → interactive discussion with the user.
  *   - `mode: 'auto'` → orchestrator decides based on context.
  *   - `mode: 'skip'` → no discussion.
- *   - `model` + `effort` of `'auto'` defer to `_delegation`'s model table
- *     and core-rule's max-effort policy.
+ *   - `agent.{model,effort}` override the agent that the discussion mode
+ *     spawns. Schema slot reserved for future discussion-agent spawn —
+ *     not yet consumed by any spec.json. PR-FIN-1e shipped the schema;
+ *     consumer wiring is a follow-up.
  */
 export interface StepDiscuss {
   readonly mode?: 'agent' | 'user' | 'auto' | 'skip';
-  readonly model?: AgentModel;
-  readonly effort?: AgentEffort;
+  readonly agent?: AgentConfig;
 }
 
 /**
@@ -124,15 +144,25 @@ export interface StepDiscuss {
  *   - `mode: 'ask'` → prompt the user via AskUserQuestion at the eval
  *     checkpoint; translation helper converts the answer to boolean.
  *   - `mode: 'auto'` → orchestrator decides based on context.
+ *   - `agent.{model,effort}` override the evaluator-perspective agents
+ *     spawned for this step's eval-mode (`*_eval` substate).
  */
 export interface StepEvaluate {
   readonly mode?: 'ask' | 'always' | 'skip' | 'auto';
-  readonly model?: AgentModel;
-  readonly effort?: AgentEffort;
+  readonly agent?: AgentConfig;
 }
 
 export interface StepSettings {
   readonly discuss?: StepDiscuss;
+  /**
+   * Step-wide primary-spawn agent override (PI/executor for productive
+   * steps). Applied at the spec-loader boundary to every entry of
+   * `spec.delegation.agents[*]` for productive-step substates
+   * (`ideation`, `planning`, `execution`). Eval-mode substates
+   * (`*_eval`) read from `evaluate.agent` instead — see ideation §2.3.1
+   * step-driven role-to-mode mapping.
+   */
+  readonly agent?: AgentConfig;
   readonly evaluate?: StepEvaluate;
   /**
    * Per-step REVISE-loop iteration cap. Default `3` (matches
@@ -284,18 +314,21 @@ export const DEFAULTS: Settings = {
   schemaVersion: 1,
   workflow: {
     ideation: {
-      discuss: { mode: 'user', model: 'auto', effort: 'auto' },
-      evaluate: { mode: 'always', model: 'auto', effort: 'auto' },
+      discuss: { mode: 'user', agent: { model: 'auto', effort: 'auto' } },
+      agent: { model: 'auto', effort: 'auto' },
+      evaluate: { mode: 'always', agent: { model: 'auto', effort: 'auto' } },
       maxIterations: 3,
     },
     planning: {
-      discuss: { mode: 'user', model: 'auto', effort: 'auto' },
-      evaluate: { mode: 'always', model: 'auto', effort: 'auto' },
+      discuss: { mode: 'user', agent: { model: 'auto', effort: 'auto' } },
+      agent: { model: 'auto', effort: 'auto' },
+      evaluate: { mode: 'always', agent: { model: 'auto', effort: 'auto' } },
       maxIterations: 3,
     },
     execution: {
-      discuss: { mode: 'agent', model: 'auto', effort: 'auto' },
-      evaluate: { mode: 'always', model: 'auto', effort: 'auto' },
+      discuss: { mode: 'agent', agent: { model: 'auto', effort: 'auto' } },
+      agent: { model: 'auto', effort: 'auto' },
+      evaluate: { mode: 'always', agent: { model: 'auto', effort: 'auto' } },
       maxIterations: 3,
     },
   },

--- a/packages/cli/src/specs/__tests__/assembly-agent-routing.test.ts
+++ b/packages/cli/src/specs/__tests__/assembly-agent-routing.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Unit tests for `assembly.ts::renderAgentRoutingBlock` plus the
+ * `compile()` backward-compat path when no `originals` is supplied.
+ *
+ * Pins the four locked behaviours from PR-FIN-1e ideation §2.4 and from
+ * the renderer's `(auto > override > default)` provenance precedence:
+ *
+ *   1. all-default rendering — every agent's resolved values match
+ *      `originals[role]` and no `'auto'` is present, so every line carries
+ *      `(default)`.
+ *   2. mixed default+override rendering — one agent matches, one differs;
+ *      the differing agent gets `(override: <slotHint>)` while the
+ *      matching agent retains `(default)`.
+ *   3. `'auto'` rendering — when the resolved value is `'auto'`, the
+ *      provenance suffix is `(auto: resolve via _gobbi-rule Model Selection)`
+ *      regardless of `originals`.
+ *   4. empty `delegation.agents` returns null, AND `compile()` without
+ *      `originals` does not emit the agent-routing block (the
+ *      `originals === undefined` short-circuit preserves backward compat
+ *      for spec-authoring callers like `prompt render` / `prompt patch`).
+ *
+ * Fixtures are inline `StepSpec` objects so each case isolates one
+ * behaviour from on-disk concrete spec values.
+ */
+
+import { describe, it, expect } from 'bun:test';
+
+import {
+  compile,
+  renderAgentRoutingBlock,
+  type CompileInput,
+  type CompilePredicateRegistry,
+  type DynamicContext,
+} from '../assembly.js';
+import type { AgentOriginal } from '../spec-loader.js';
+import { initialState } from '../../workflow/state.js';
+import type { WorkflowState } from '../../workflow/state.js';
+import type { AgentConfig, StepSpec } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers — minimal but valid StepSpec; agents list driven by case
+// ---------------------------------------------------------------------------
+
+function makeSpec(agents: readonly AgentConfig[]): StepSpec {
+  return {
+    $schema: 'https://gobbi.dev/schemas/step-spec/v1',
+    version: 1,
+    meta: {
+      description: 'Agent-routing fixture step',
+      allowedAgentTypes: ['__pi'],
+      maxParallelAgents: 2,
+      requiredSkills: ['_gotcha'],
+      optionalSkills: [],
+      expectedArtifacts: ['fixture.md'],
+      completionSignal: 'SubagentStop',
+    },
+    transitions: [{ to: 'done', condition: '' }],
+    delegation: { agents },
+    tokenBudget: {
+      staticPrefix: 0.4,
+      session: 0.1,
+      instructions: 0.2,
+      artifacts: 0.2,
+      materials: 0.1,
+    },
+    blocks: {
+      static: [{ id: 'role', content: 'Fixture orchestrator role.' }],
+      conditional: [],
+      delegation: {},
+      synthesis: [{ id: 'synth', content: 'Fixture synthesis.' }],
+      completion: {
+        instruction: 'Emit completion signal.',
+        criteria: ['fixture criterion'],
+      },
+      footer: 'Step completion protocol — run gobbi workflow transition COMPLETE.',
+    },
+  };
+}
+
+function baseDynamic(): DynamicContext {
+  return {
+    timestamp: '2026-04-29T00:00:00Z',
+    activeSubagentCount: 0,
+    artifacts: [],
+  };
+}
+
+function baseState(): WorkflowState {
+  return initialState('agent-routing-test');
+}
+
+const EMPTY_REGISTRY: CompilePredicateRegistry = {};
+
+function baseInput(spec: StepSpec): CompileInput {
+  return {
+    spec,
+    state: baseState(),
+    dynamic: baseDynamic(),
+    predicates: EMPTY_REGISTRY,
+    activeAgent: null,
+  };
+}
+
+// Two-agent fixture used by cases 1 + 2 — same `originals` shape; cases
+// vary which agents diverge from their originals.
+const innovativeAgent: AgentConfig = {
+  role: 'innovative',
+  stance: 'innovative',
+  modelTier: 'opus',
+  effort: 'max',
+  skills: [],
+  artifactTarget: 'innovative.md',
+  blockRef: 'pi.innovative',
+};
+
+const bestAgent: AgentConfig = {
+  role: 'best',
+  stance: 'best-practice',
+  modelTier: 'opus',
+  effort: 'max',
+  skills: [],
+  artifactTarget: 'best.md',
+  blockRef: 'pi.best',
+};
+
+// ===========================================================================
+// renderAgentRoutingBlock — 4 cases per ideation §2.4
+// ===========================================================================
+
+describe('renderAgentRoutingBlock — provenance suffixing', () => {
+  it('renders (default) for every agent when resolved values match originals', () => {
+    const spec = makeSpec([innovativeAgent, bestAgent]);
+    const originals: Readonly<Record<string, AgentOriginal>> = {
+      innovative: { modelTier: 'opus', effort: 'max' },
+      best: { modelTier: 'opus', effort: 'max' },
+    };
+
+    const section = renderAgentRoutingBlock(spec, originals);
+    expect(section).not.toBeNull();
+    if (section === null) throw new Error('precondition failed');
+
+    expect(section.id).toBe('blocks.agent-routing');
+
+    const lines = section.content.split('\n');
+    expect(lines[0]).toBe(
+      'Agent routing for this step (resolved from settings cascade):',
+    );
+    // One body line per agent — both terminate in `(default)`.
+    expect(lines.length).toBe(3);
+    expect(lines[1]).toMatch(/^\s+- role=innovative\s+model=opus\s+effort=max\s+\(default\)$/);
+    expect(lines[2]).toMatch(/^\s+- role=best\s+model=opus\s+effort=max\s+\(default\)$/);
+  });
+
+  it('mixes (default) and (override: <slotHint>) when one agent diverges', () => {
+    // `best` was overridden from opus → haiku via settings; `innovative`
+    // still matches its original.
+    const spec = makeSpec([
+      innovativeAgent,
+      { ...bestAgent, modelTier: 'haiku' },
+    ]);
+    const originals: Readonly<Record<string, AgentOriginal>> = {
+      innovative: { modelTier: 'opus', effort: 'max' },
+      best: { modelTier: 'opus', effort: 'max' },
+    };
+
+    const section = renderAgentRoutingBlock(
+      spec,
+      originals,
+      'workflow.execution.agent',
+    );
+    expect(section).not.toBeNull();
+    if (section === null) throw new Error('precondition failed');
+
+    const lines = section.content.split('\n');
+    expect(lines.length).toBe(3);
+    // Innovative line — unchanged → (default).
+    expect(lines[1]).toMatch(/^\s+- role=innovative\s+model=opus\s+effort=max\s+\(default\)$/);
+    // Best line — diverged from original → (override: workflow.execution.agent).
+    expect(lines[2]).toMatch(
+      /^\s+- role=best\s+model=haiku\s+effort=max\s+\(override: workflow\.execution\.agent\)$/,
+    );
+  });
+
+  it("renders (auto: resolve via _gobbi-rule Model Selection) when modelTier is 'auto'", () => {
+    // `'auto'` precedence > override > default — even though the resolved
+    // value differs from `originals` the auto branch wins.
+    const spec = makeSpec([{ ...innovativeAgent, modelTier: 'auto' }]);
+    const originals: Readonly<Record<string, AgentOriginal>> = {
+      innovative: { modelTier: 'opus', effort: 'max' },
+    };
+
+    const section = renderAgentRoutingBlock(
+      spec,
+      originals,
+      'workflow.ideation.agent',
+    );
+    expect(section).not.toBeNull();
+    if (section === null) throw new Error('precondition failed');
+
+    const lines = section.content.split('\n');
+    expect(lines.length).toBe(2);
+    expect(lines[1]).toMatch(
+      /^\s+- role=innovative\s+model=auto\s+effort=max\s+\(auto: resolve via _gobbi-rule Model Selection\)$/,
+    );
+  });
+
+  it('returns null for empty delegation.agents AND compile() without originals emits no agent-routing section', () => {
+    const spec = makeSpec([]);
+    const originals: Readonly<Record<string, AgentOriginal>> = {};
+
+    // Direct call: empty agents → null, regardless of originals.
+    expect(renderAgentRoutingBlock(spec, originals)).toBeNull();
+    // Even with non-empty originals, empty agents short-circuits to null
+    // (the renderer guards on `agents.length === 0` before consulting
+    // originals).
+    expect(
+      renderAgentRoutingBlock(makeSpec([]), {
+        ghost: { modelTier: 'opus', effort: 'max' },
+      }),
+    ).toBeNull();
+
+    // Backward-compat path: `compile()` called WITHOUT `originals` (the
+    // pre-PR-FIN-1e behaviour preserved for spec-authoring tools and
+    // existing test fixtures) must emit no `blocks.agent-routing` section
+    // even when delegation.agents is non-empty.
+    const specWithAgent = makeSpec([innovativeAgent]);
+    const compiled = compile(baseInput(specWithAgent), {});
+    const ids = compiled.sections.map((s) => s.id);
+    expect(ids).not.toContain('blocks.agent-routing');
+  });
+});

--- a/packages/cli/src/specs/__tests__/schema.test.ts
+++ b/packages/cli/src/specs/__tests__/schema.test.ts
@@ -249,15 +249,17 @@ describe('validate (negative — const / enum)', () => {
     expect(enumError?.instancePath).toBe('/delegation/agents/0/modelTier');
   });
 
-  test('`effort: "low"` is rejected by the enum constraint', () => {
+  test('`effort: "low"` is accepted by the enum constraint', () => {
+    // PR-FIN-1e widens EffortLevel to include `'low'` and `'auto'` so that
+    // settings cascade may inject either as a step-wide override. The
+    // previous negative assertion (`'low'` rejected) is flipped here to
+    // affirm the widened union: `'low'` validates clean, no enum error.
     const spec = clone(validSpec);
     const first = spec.delegation.agents[0];
     if (!first) throw new Error('fixture invariant: delegation.agents[0] exists');
     (first as { effort: string }).effort = 'low';
-    expect(validate(spec)).toBe(false);
-    const enumError = (validate.errors ?? []).find((e) => e.keyword === 'enum');
-    expect(enumError).toBeDefined();
-    expect(enumError?.instancePath).toBe('/delegation/agents/0/effort');
+    expect(validate(spec)).toBe(true);
+    expect(validate.errors).toBeNull();
   });
 });
 

--- a/packages/cli/src/specs/__tests__/spec-loader.test.ts
+++ b/packages/cli/src/specs/__tests__/spec-loader.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Unit tests for `specs/spec-loader.ts` — `loadSpecForRuntime` step-driven
+ * settings overlay.
+ *
+ * Mirrors the 6-case discipline from `workflow/__tests__/state.test.ts:139-198`
+ * (settings-driven `maxFeedbackRounds` wiring): each case asserts a single
+ * locked behaviour from PR-FIN-1e ideation §§2.3, 2.3.1, 2.3.2.
+ *
+ * The fixtures reuse the on-disk committed spec.json files at
+ * `packages/cli/src/specs/<step>/spec.json` rather than building synthetic
+ * specs — the loader is exercised against the same bytes the production
+ * pipeline reads via `next.ts:237`. Hardcoded delegation values per spec
+ * (verified at test authoring time):
+ *
+ *   - `ideation/spec.json` — innovative + best, both `modelTier: 'opus'`,
+ *     `effort: 'max'`
+ *   - `execution/spec.json` — executor, `modelTier: 'opus'`, `effort: 'max'`
+ *   - `evaluation/spec.json` — project + overall, both `modelTier: 'sonnet'`,
+ *     `effort: 'max'`
+ *   - `planning/spec.json` — `delegation.agents: []` (no agents)
+ *
+ * Memorization is intentionally NOT bound to a settings slot in
+ * `pickSettingsSlot` (ideation §2.3.1 mapping table omits it); the case 6
+ * test confirms that an unknown step short-circuits the overlay.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { loadSpecForRuntime } from '../spec-loader.js';
+import { DEFAULTS, type ResolvedSettings } from '../../lib/settings.js';
+
+// ---------------------------------------------------------------------------
+// Spec paths — resolved once relative to this test file's location
+// ---------------------------------------------------------------------------
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const IDEATION_SPEC = resolve(HERE, '..', 'ideation', 'spec.json');
+const EXECUTION_SPEC = resolve(HERE, '..', 'execution', 'spec.json');
+const EVALUATION_SPEC = resolve(HERE, '..', 'evaluation', 'spec.json');
+const PLANNING_SPEC = resolve(HERE, '..', 'planning', 'spec.json');
+
+// ---------------------------------------------------------------------------
+// Settings fixture builders — one per case, mirroring state.test.ts pattern
+// ---------------------------------------------------------------------------
+
+function settingsWithExecutionAgent(
+  agent: { model?: 'opus' | 'sonnet' | 'haiku' | 'auto'; effort?: 'low' | 'medium' | 'high' | 'max' | 'auto' },
+): ResolvedSettings {
+  return {
+    ...DEFAULTS,
+    workflow: {
+      ...DEFAULTS.workflow,
+      execution: {
+        ...DEFAULTS.workflow?.execution,
+        agent,
+      },
+    },
+  };
+}
+
+function settingsWithIdeationEvaluateAgent(
+  agent: { model?: 'opus' | 'sonnet' | 'haiku' | 'auto'; effort?: 'low' | 'medium' | 'high' | 'max' | 'auto' },
+): ResolvedSettings {
+  return {
+    ...DEFAULTS,
+    workflow: {
+      ...DEFAULTS.workflow,
+      ideation: {
+        ...DEFAULTS.workflow?.ideation,
+        evaluate: {
+          ...DEFAULTS.workflow?.ideation?.evaluate,
+          agent,
+        },
+      },
+    },
+  };
+}
+
+// ===========================================================================
+// loadSpecForRuntime — 6 cases per ideation §§2.3.1 / 2.3.2
+// ===========================================================================
+
+describe('loadSpecForRuntime — step-driven settings overlay', () => {
+  it('returns spec.json hardcoded values verbatim when settings is undefined', () => {
+    const { spec, originals } = loadSpecForRuntime(
+      IDEATION_SPEC,
+      undefined,
+      'ideation',
+    );
+
+    // Spec carries the on-disk values unchanged.
+    expect(spec.delegation.agents).toHaveLength(2);
+    const innovative = spec.delegation.agents[0];
+    const best = spec.delegation.agents[1];
+    expect(innovative?.role).toBe('innovative');
+    expect(innovative?.modelTier).toBe('opus');
+    expect(innovative?.effort).toBe('max');
+    expect(best?.role).toBe('best');
+    expect(best?.modelTier).toBe('opus');
+    expect(best?.effort).toBe('max');
+
+    // `originals` mirrors the spec.json values keyed by role — even with
+    // settings === undefined the loader produces the originals map so
+    // callers can rely on a stable shape (per JSDoc on RuntimeSpec).
+    expect(originals['innovative']).toEqual({ modelTier: 'opus', effort: 'max' });
+    expect(originals['best']).toEqual({ modelTier: 'opus', effort: 'max' });
+  });
+
+  it('overlays workflow.execution.agent onto execution-step delegation.agents', () => {
+    const settings = settingsWithExecutionAgent({ model: 'haiku', effort: 'high' });
+    const { spec, originals } = loadSpecForRuntime(
+      EXECUTION_SPEC,
+      settings,
+      'execution',
+    );
+
+    // Post-overlay: executor carries the override values.
+    expect(spec.delegation.agents).toHaveLength(1);
+    const executor = spec.delegation.agents[0];
+    expect(executor?.role).toBe('executor');
+    expect(executor?.modelTier).toBe('haiku');
+    expect(executor?.effort).toBe('high');
+
+    // `originals` carries the pre-overlay (spec.json hardcoded) values so
+    // the renderer can compute `(default)` vs `(override)` provenance
+    // without re-reading the spec from disk.
+    expect(originals['executor']).toEqual({ modelTier: 'opus', effort: 'max' });
+  });
+
+  it('overlays workflow.ideation.evaluate.agent onto ideation_eval delegation.agents', () => {
+    const settings = settingsWithIdeationEvaluateAgent({ model: 'opus', effort: 'high' });
+    const { spec, originals } = loadSpecForRuntime(
+      EVALUATION_SPEC,
+      settings,
+      'ideation_eval',
+    );
+
+    // Both evaluator perspectives receive the eval-mode overlay.
+    expect(spec.delegation.agents).toHaveLength(2);
+    const project = spec.delegation.agents[0];
+    const overall = spec.delegation.agents[1];
+    expect(project?.role).toBe('project');
+    expect(project?.modelTier).toBe('opus');
+    expect(project?.effort).toBe('high');
+    expect(overall?.role).toBe('overall');
+    expect(overall?.modelTier).toBe('opus');
+    expect(overall?.effort).toBe('high');
+
+    // `originals` reflects the spec.json hardcoded sonnet/max values.
+    expect(originals['project']).toEqual({ modelTier: 'sonnet', effort: 'max' });
+    expect(originals['overall']).toEqual({ modelTier: 'sonnet', effort: 'max' });
+  });
+
+  it("flows 'auto' verbatim into the resolved spec — no pre-resolution", () => {
+    const settings = settingsWithExecutionAgent({ model: 'auto', effort: 'auto' });
+    const { spec, originals } = loadSpecForRuntime(
+      EXECUTION_SPEC,
+      settings,
+      'execution',
+    );
+
+    // The literal string `'auto'` flows through every layer; the
+    // orchestrator (not the CLI) resolves it via `_gobbi-rule` Model
+    // Selection at spawn time.
+    const executor = spec.delegation.agents[0];
+    expect(executor?.modelTier).toBe('auto');
+    expect(executor?.effort).toBe('auto');
+
+    // Originals still hold the pre-overlay literals.
+    expect(originals['executor']).toEqual({ modelTier: 'opus', effort: 'max' });
+  });
+
+  it('returns empty originals map when delegation.agents is empty (planning)', () => {
+    const settings = settingsWithExecutionAgent({ model: 'haiku' });
+    const { spec, originals } = loadSpecForRuntime(
+      PLANNING_SPEC,
+      settings,
+      'planning',
+    );
+
+    // Planning has no agents to overlay onto — the empty array passes
+    // through and the originals map is correspondingly empty.
+    expect(spec.delegation.agents).toHaveLength(0);
+    expect(Object.keys(originals)).toHaveLength(0);
+  });
+
+  it('skips overlay when step is outside the productive/eval mapping (memorization)', () => {
+    // Memorization is not in the ideation §2.3.1 step-driven mapping table;
+    // pickSettingsSlot returns null, so even a populated settings tree
+    // produces no overlay. The spec returns as-authored.
+    const settings = settingsWithExecutionAgent({ model: 'haiku', effort: 'low' });
+    const { spec, originals } = loadSpecForRuntime(
+      EXECUTION_SPEC,
+      settings,
+      'memorization',
+    );
+
+    // Spec values remain spec-hardcoded — proves no overlay was applied
+    // even though execution.agent was populated in settings.
+    const executor = spec.delegation.agents[0];
+    expect(executor?.modelTier).toBe('opus');
+    expect(executor?.effort).toBe('max');
+    expect(originals['executor']).toEqual({ modelTier: 'opus', effort: 'max' });
+  });
+});

--- a/packages/cli/src/specs/__tests__/types.test.ts
+++ b/packages/cli/src/specs/__tests__/types.test.ts
@@ -120,13 +120,15 @@ describe('StepSpec shape', () => {
   });
 
   test('EffortLevel is a closed literal union', () => {
-    // @ts-expect-error — 'low' is not a permitted EffortLevel value
-    const bad: EffortLevel = 'low';
+    // PR-FIN-1e widened EffortLevel to 'low'|'medium'|'high'|'max'|'auto'.
+    // `'extreme'` remains outside the union and serves as the rejection probe.
+    // @ts-expect-error — 'extreme' is not a permitted EffortLevel value
+    const bad: EffortLevel = 'extreme';
     expect(typeof bad).toBe('string');
   });
 
   test('AgentConfig rejects unknown model tiers', () => {
-    // @ts-expect-error — modelTier must be one of opus|sonnet|haiku
+    // @ts-expect-error — modelTier must be one of opus|sonnet|haiku|auto
     const bad: AgentConfig = { ...agent, modelTier: 'o1' };
     expect(bad.role).toBe('innovative');
   });

--- a/packages/cli/src/specs/_schema/v1.json
+++ b/packages/cli/src/specs/_schema/v1.json
@@ -153,15 +153,18 @@
                 "enum": [
                   "opus",
                   "sonnet",
-                  "haiku"
+                  "haiku",
+                  "auto"
                 ]
               },
               "effort": {
                 "type": "string",
                 "enum": [
-                  "max",
+                  "low",
+                  "medium",
                   "high",
-                  "medium"
+                  "max",
+                  "auto"
                 ]
               },
               "skills": {
@@ -501,15 +504,18 @@
           "enum": [
             "opus",
             "sonnet",
-            "haiku"
+            "haiku",
+            "auto"
           ]
         },
         "effort": {
           "type": "string",
           "enum": [
-            "max",
+            "low",
+            "medium",
             "high",
-            "medium"
+            "max",
+            "auto"
           ]
         },
         "skills": {
@@ -564,15 +570,18 @@
                 "enum": [
                   "opus",
                   "sonnet",
-                  "haiku"
+                  "haiku",
+                  "auto"
                 ]
               },
               "effort": {
                 "type": "string",
                 "enum": [
-                  "max",
+                  "low",
+                  "medium",
                   "high",
-                  "medium"
+                  "max",
+                  "auto"
                 ]
               },
               "skills": {

--- a/packages/cli/src/specs/_schema/v1.ts
+++ b/packages/cli/src/specs/_schema/v1.ts
@@ -124,8 +124,8 @@ const AgentConfigSchema = {
   properties: {
     role: { type: 'string', minLength: 1 },
     stance: { type: 'string', minLength: 1, nullable: true },
-    modelTier: { type: 'string', enum: ['opus', 'sonnet', 'haiku'] },
-    effort: { type: 'string', enum: ['max', 'high', 'medium'] },
+    modelTier: { type: 'string', enum: ['opus', 'sonnet', 'haiku', 'auto'] },
+    effort: { type: 'string', enum: ['low', 'medium', 'high', 'max', 'auto'] },
     skills: { type: 'array', items: { type: 'string', minLength: 1 } },
     artifactTarget: { type: 'string', minLength: 1 },
     blockRef: { type: 'string', minLength: 1 },

--- a/packages/cli/src/specs/assembly.ts
+++ b/packages/cli/src/specs/assembly.ts
@@ -45,8 +45,11 @@ import type {
   AllocationResult,
   BudgetAllocator,
   TokenBudget,
+  ModelTier,
+  EffortLevel,
 } from './types.js';
 import { defaultBudgetAllocator } from './budget.js';
+import type { AgentOriginal } from './spec-loader.js';
 import type { WorkflowState } from '../workflow/state.js';
 import type { WorkflowGraph } from './graph.js';
 
@@ -514,14 +517,192 @@ function renderDynamicContext(dynamic: DynamicContext): string {
   return parts.join('\n');
 }
 
+// ---------------------------------------------------------------------------
+// Agent-routing block — settings-cascade provenance surfaced in the prompt
+//
+// Emitted as a static section between the active delegation block and the
+// synthesis block (per PR-FIN-1e ideation §2.4). Surfaces the resolved
+// `(model, effort)` plus a provenance suffix for every entry of
+// `spec.delegation.agents`. The orchestrator reads concrete tiers directly;
+// only `'auto'` carries a policy reference, and the policy itself stays in
+// `_gobbi-rule.md` Model Selection (where it already lives).
+//
+// The block is NOT emitted when:
+//   - `spec.delegation.agents` is empty (planning, memorization, handoff);
+//   - `originals` is undefined (caller used {@link loadSpec} directly,
+//     bypassing the runtime settings overlay — preserves backward compat
+//     for spec-authoring tools and test fixtures).
+//
+// Cache-prefix engineering (ideation §2.4):
+//   - Default-only sessions produce a fixed-byte block per step.
+//   - Toggling an override → one-time cache miss; subsequent same-state
+//     sessions are cache-stable again.
+//   - Block content is byte-stable for any given (spec, originals,
+//     resolved settings) triple — the renderer is deterministic.
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-agent entry that drives one rendered line of the agent-routing block.
+ * Values mirror the resolved spec post-overlay, so the renderer can compare
+ * them against `originals[role]` to compute `(default)` vs `(override)`.
+ */
+interface AgentRoutingRow {
+  readonly role: string;
+  readonly modelTier: ModelTier;
+  readonly effort: EffortLevel;
+}
+
+/**
+ * Render the `agent-routing` static section.
+ *
+ * Returns `null` when no block should be emitted:
+ *
+ * - `originals === undefined` — the caller did not opt into the runtime
+ *   overlay path. Preserves backward compatibility for spec-authoring
+ *   tools (`prompt render` / `prompt patch`) and test fixtures.
+ * - `spec.delegation.agents.length === 0` — empty-delegation steps
+ *   (planning, memorization, handoff) emit no block.
+ *
+ * Format (per PR-FIN-1e ideation §2.4):
+ *
+ * ```
+ * Agent routing for this step (resolved from settings cascade):
+ *   - role=<R>   model=<M>   effort=<E>   (<provenance>)
+ * ```
+ *
+ * Provenance suffix rules:
+ *
+ * - `(auto: resolve via _gobbi-rule Model Selection)` — resolved
+ *   `modelTier === 'auto'` OR `effort === 'auto'`. Takes precedence over
+ *   the default/override branches because `'auto'` defers to a policy
+ *   reference regardless of how the value was selected.
+ * - `(override: <slot>)` — resolved value differs from `originals[role]`.
+ *   `<slot>` is the `slotHint` argument when supplied (e.g.
+ *   `'workflow.execution.agent'`); otherwise a bare `(override)` marker.
+ *   The loader (`spec-loader.ts::loadSpecForRuntime`) is the only producer
+ *   that knows the active slot; passing `slotHint` from the caller keeps
+ *   this renderer stateless.
+ * - `(default)` — resolved value matches the spec.json hardcoded literal
+ *   exactly AND no `'auto'` is present.
+ *
+ * Column widths are fixed (role=10, model=8, effort=6) to keep lines
+ * visually scannable across the typical role names. Roles longer than 10
+ * characters extend the line; the suffix sits at the end of each line.
+ *
+ * @param spec  - The post-overlay {@link StepSpec} (`spec.delegation.agents`
+ *   carries the resolved values).
+ * @param originals - Pre-overlay `{modelTier, effort}` keyed by `role`. May
+ *   be `undefined` (returns `null`) or an empty/partial map (roles missing
+ *   from the map are treated as "no original known" — falls back to the
+ *   `'auto'` or bare `(override)` branch as appropriate).
+ * @param slotHint - Optional dotted-path naming the active settings slot
+ *   that produced an override (e.g. `'workflow.ideation.agent'` for
+ *   productive steps, `'workflow.execution.evaluate.agent'` for eval
+ *   steps). When `null` or omitted, override lines render `(override)`
+ *   without the slot tail.
+ */
+export function renderAgentRoutingBlock(
+  spec: StepSpec,
+  originals: Readonly<Record<string, AgentOriginal>> | undefined,
+  slotHint: string | null = null,
+): StaticSection | null {
+  if (originals === undefined) return null;
+  if (spec.delegation.agents.length === 0) return null;
+
+  const rows: readonly AgentRoutingRow[] = spec.delegation.agents.map(
+    (agent) => ({
+      role: agent.role,
+      modelTier: agent.modelTier,
+      effort: agent.effort,
+    }),
+  );
+
+  const lines: string[] = ['Agent routing for this step (resolved from settings cascade):'];
+  for (const row of rows) {
+    const provenance = computeProvenance(row, originals, slotHint);
+    const rolePart = padRight(`role=${row.role}`, 16);
+    const modelPart = padRight(`model=${row.modelTier}`, 14);
+    const effortPart = padRight(`effort=${row.effort}`, 13);
+    lines.push(`  - ${rolePart}${modelPart}${effortPart}${provenance}`);
+  }
+
+  return makeStatic({
+    id: 'blocks.agent-routing',
+    content: lines.join('\n'),
+  });
+}
+
+/**
+ * Compute the provenance suffix for one agent-routing row.
+ *
+ * Precedence: auto > override > default. The `'auto'` branch fires when
+ * either the resolved model or effort carries the literal `'auto'` — both
+ * paths defer to `_gobbi-rule` Model Selection at orchestrator-spawn time,
+ * so a single suffix covers both legs.
+ */
+function computeProvenance(
+  row: AgentRoutingRow,
+  originals: Readonly<Record<string, AgentOriginal>>,
+  slotHint: string | null,
+): string {
+  if (row.modelTier === 'auto' || row.effort === 'auto') {
+    return '(auto: resolve via _gobbi-rule Model Selection)';
+  }
+  const original = originals[row.role];
+  const overridden =
+    original === undefined ||
+    original.modelTier !== row.modelTier ||
+    original.effort !== row.effort;
+  if (overridden) {
+    return slotHint === null ? '(override)' : `(override: ${slotHint})`;
+  }
+  return '(default)';
+}
+
+/**
+ * Right-pad a string with spaces to `width`. Strings already at or beyond
+ * `width` are returned unchanged plus a single trailing space — keeps the
+ * column separators visible even for over-long roles.
+ */
+function padRight(s: string, width: number): string {
+  if (s.length >= width) return `${s} `;
+  return s + ' '.repeat(width - s.length);
+}
+
+/**
+ * Optional decorations consumed only by {@link renderSpec} and forwarded by
+ * {@link compile}/{@link compileWithIssues} from {@link CompileOptions}.
+ *
+ * Kept separate from {@link CompileInput} because these fields are
+ * settings-cascade provenance — a rendering decoration, not part of the
+ * deterministic-input identity (spec/state/dynamic). The sibling-parameter
+ * placement is the locked design choice from PR-FIN-1e plan §"Locked design
+ * choices".
+ */
+export interface RenderDecorations {
+  readonly originals?: Readonly<Record<string, AgentOriginal>>;
+  readonly slotHint?: string | null;
+}
+
 /**
  * Render a `StepSpec` plus the active session and dynamic context into an
  * ordered `KindedSection[]`. The output satisfies Static* → Session* →
  * Dynamic* by construction.
  *
  * Exported for tests; `compile()` is the normal entry point.
+ *
+ * @param input - The deterministic compile inputs.
+ * @param decorations - Optional rendering decorations forwarded by
+ *   {@link compile}/{@link compileWithIssues}. When `decorations.originals`
+ *   is present AND `spec.delegation.agents` is non-empty, an additional
+ *   `agent-routing` static section is inserted between the active
+ *   delegation block (step 3) and the synthesis block (step 4) — see
+ *   {@link renderAgentRoutingBlock} for format and provenance rules.
  */
-export function renderSpec(input: CompileInput): readonly KindedSection[] {
+export function renderSpec(
+  input: CompileInput,
+  decorations: RenderDecorations = {},
+): readonly KindedSection[] {
   const { spec, state, dynamic, predicates, activeAgent } = input;
   const kinded: KindedSection[] = [];
 
@@ -566,6 +747,22 @@ export function renderSpec(input: CompileInput): readonly KindedSection[] {
       });
       kinded.push(staticKinded(s));
     }
+  }
+
+  // 3b) Agent-routing block — settings-cascade provenance surfaced in the
+  //     prompt. Emitted only when `decorations.originals` was supplied (the
+  //     runtime overlay path via {@link loadSpecForRuntime}); spec-authoring
+  //     callers (`prompt render`, `prompt patch`) and unsettings-aware test
+  //     fixtures pass no `originals` and skip this section to preserve their
+  //     deterministic snapshots. See {@link renderAgentRoutingBlock} for
+  //     format, provenance suffix rules, and cache-prefix engineering.
+  {
+    const routing = renderAgentRoutingBlock(
+      spec,
+      decorations.originals,
+      decorations.slotHint ?? null,
+    );
+    if (routing !== null) kinded.push(staticKinded(routing));
   }
 
   // 4) Synthesis blocks — concatenated into one StaticSection.
@@ -709,6 +906,40 @@ export interface CompileOptions {
   readonly contextWindowTokens?: number;
   readonly lintRules?: readonly ContentLintRule[];
   readonly lintMode?: 'throw' | 'collect';
+  /**
+   * Pre-overlay `{modelTier, effort}` for each agent in the spec, keyed by
+   * the agent's `role`. When supplied AND `spec.delegation.agents` is
+   * non-empty, `renderSpec` emits an additional `agent-routing` static
+   * section (between the delegation block and the synthesis block) that
+   * surfaces the resolved model/effort + provenance for each agent. When
+   * omitted (or empty map), no `agent-routing` block is emitted — preserving
+   * backward compatibility for callers that load the spec directly via
+   * {@link loadSpec} without going through the runtime overlay path.
+   *
+   * Sibling-parameter design (locked per PR-FIN-1e plan): `originals` is
+   * NOT a field on {@link CompileInput}. Keeping it on the options bag
+   * preserves the "compile() is deterministic given (spec, state, dynamic)"
+   * contract — settings provenance is a rendering decoration, not part of
+   * the spec/state/dynamic identity.
+   *
+   * The map is small (≤2 entries per step today). It is consumed only by
+   * {@link renderAgentRoutingBlock}; downstream pipeline stages (linter,
+   * allocator, hashes) do not see it.
+   *
+   * @see `loadSpecForRuntime` in `./spec-loader.ts` for the producer.
+   */
+  readonly originals?: Readonly<Record<string, AgentOriginal>>;
+  /**
+   * Optional dotted-path naming the active settings slot that produced an
+   * override (e.g. `'workflow.ideation.agent'` for productive steps,
+   * `'workflow.execution.evaluate.agent'` for eval steps). Surfaces in the
+   * `agent-routing` block as `(override: <slotHint>)`. When absent or
+   * `null`, override lines render as a bare `(override)` marker.
+   *
+   * Only the caller that resolved the cascade knows which slot fired —
+   * `renderAgentRoutingBlock` stays stateless by accepting this as a hint.
+   */
+  readonly slotHint?: string | null;
 }
 
 /**
@@ -756,10 +987,24 @@ export function compileWithIssues(
     contextWindowTokens = DEFAULT_CONTEXT_WINDOW_TOKENS,
     lintRules = STATIC_LINT_RULES,
     lintMode = 'collect',
+    originals,
+    slotHint = null,
   } = options;
 
-  // 1) Render spec + inputs into an ordered kinded list.
-  const kinded = renderSpec(input);
+  // 1) Render spec + inputs into an ordered kinded list. The agent-routing
+  //    decoration is forwarded only to the renderer — downstream stages
+  //    (linter, allocator, hashes) work on the already-decorated section
+  //    list and do not see `originals` directly.
+  //
+  //    Build the decorations record with conditional spread so we never set
+  //    `originals: undefined` explicitly (incompatible with the
+  //    `exactOptionalPropertyTypes: true` compile flag — see `_typescript`
+  //    skill on optional-property semantics).
+  const decorations: RenderDecorations = {
+    ...(originals !== undefined ? { originals } : {}),
+    slotHint,
+  };
+  const kinded = renderSpec(input, decorations);
 
   // 2) Runtime cache-order assertion (belt-and-braces with the compile-time
   //    `CacheOrderedSections<T>` guard in sections.ts).

--- a/packages/cli/src/specs/evaluation/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/cli/src/specs/evaluation/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -229,3 +229,79 @@ dynamic.artifacts=[plan.md]
 --- plan.md ---
 Direction: revised four-task decomposition with verification criteria tightened per prior-round evaluator feedback."
 `;
+
+exports[`evaluation — agent-routing block snapshot (PR-FIN-1e) ideation-eval-first-entry with originals threads agent-routing block with (default) provenance for project + overall evaluators 1`] = `
+"You are the orchestrator of an Evaluation step. Your job is to spawn independent evaluator agents across at least two perspectives (Project and Overall are mandatory; more perspectives are selected based on the step under evaluation), collect their findings, and produce a single consolidated verdict the user decides what to act on.
+
+You are not an evaluator yourself. The evaluators assess; you frame the evaluation scope, delegate, discuss the findings with the user, and record the verdict. The creating agent of the preceding step must not participate in its own evaluation — that isolation is the reason evaluation is a separate step.
+
+Evaluation principles:
+
+- Evaluators find problems, not confirmations. An evaluator that reports only successes has not done the job. Instruct each evaluator to surface concrete defects with severity and location.
+- Minimum two perspectives. Project and Overall are always included; additional perspectives (Architecture, Security, Performance, UX) are selected based on what the step under evaluation produced. A single-perspective evaluation is structurally blind.
+- Discuss before deciding. Evaluator findings are input, not instruction. Use AskUserQuestion to walk the user through each finding — they decide what to address, defer, or disagree with. Never auto-apply findings.
+- The verdict belongs to the user. You synthesize the findings into a proposed verdict (pass or revise), but the user commits. Revise verdicts include a \`loopTarget\` when issued from execution_eval — the user picks which prior step to return to.
+- Evaluators run on fresh context. Do not pass the preceding step's orchestrator transcript to evaluators. Each evaluator receives the artifacts under assessment and their perspective skill; their independence is the point.
+
+Scope boundary:
+
+- This spec is reused for ideation_eval, planning_eval, and execution_eval via \`index.json\`'s \`evalFor\` indirection. The preceding step under evaluation is identified by the session state, not by the spec — read \`state.currentStep\` and its \`evalFor\` target when assembling the delegation prompts.
+- The \`transitions\` array in this spec declares ideation_eval defaults. For planning_eval and execution_eval, the graph (\`index.json\`) is authoritative: planning_eval verdictPass routes to execution, execution_eval verdictPass routes to memorization. Do not rely on the spec-level transitions for non-ideation eval routing.
+- Do not modify the artifacts under evaluation. Evaluation is read-only. If a finding requires a fix, that fix belongs in the loop-back step (ideation, planning, or execution), not here.
+- Do not spawn more than \`maxParallelAgents\` evaluators in a single wave. Cap set conservatively at five to keep the parallel response channel observable and to keep per-call rate-limit exposure bounded.
+- Stay in evaluation. Do not ask the user to make planning or implementation decisions here — the verdict is what exits the step; the next step handles the response.
+
+Agent routing for this step (resolved from settings cascade):
+  - role=project    model=sonnet  effort=max   (default)
+  - role=overall    model=sonnet  effort=max   (default)
+
+Synthesis instructions:
+
+After all evaluators complete, produce \`evaluation.md\` — the consolidated verdict the workflow acts on. Your synthesis process:
+
+1. Read every evaluator artifact in full. Do not summarize them without reading; the severity labels and locations are load-bearing.
+2. Deduplicate findings that multiple evaluators raised. A finding flagged by two perspectives is stronger evidence than two findings of equal severity from one perspective; note the cross-perspective agreement explicitly.
+3. Propose a verdict: \`pass\` if no critical or major findings remain, \`revise\` otherwise. For execution_eval revise verdicts, propose a \`loopTarget\` (ideation, plan, or execution) — the target is determined by where the findings point.
+4. Discuss every finding with the user via AskUserQuestion. The user decides what to address, defer, or disagree with. Record the decisions.
+5. Commit \`evaluation.md\` with: the verdict, the loop target (for execution_eval revise), the deduplicated findings with their user-agreed disposition, and the per-evaluator artifact list.
+6. The CLI emits the \`decision.eval.verdict\` event on your completion signal; the verdict payload is read from \`evaluation.md\`.
+
+Emit the SubagentStop completion signal once every evaluator artifact is written, \`evaluation.md\` is written with the verdict and agreed dispositions, and the user has confirmed the verdict.
+
+Criteria:
+  1. at least two evaluator artifacts are written — Project and Overall — to the session's evaluation directory
+  2. evaluation.md is written with a verdict (pass or revise) and, for execution_eval revise verdicts, a loopTarget
+  3. every finding from every evaluator has a user-agreed disposition recorded in evaluation.md
+  4. no evaluator assessed the artifacts it helped create — creator-evaluator isolation is preserved
+  5. the user has confirmed the verdict via AskUserQuestion before the completion signal is emitted
+
+---
+## Step completion protocol
+
+You have finished this evaluation when the criteria above are satisfied and the user has confirmed the verdict. Once they are met, run EXACTLY ONE of the following commands as your last action:
+
+  gobbi workflow transition PASS
+    — Use this when no critical or major findings remain after user discussion.
+
+  gobbi workflow transition REVISE [--loop-target <step>]
+    — Use this when findings require re-entering a prior step. For execution_eval, include --loop-target with the user-agreed target (ideation, planning, or execution). For ideation_eval and planning_eval, the loop target is the preceding productive step by default.
+
+  gobbi workflow transition ESCALATE
+    — Use this when a critical structural defect requires user intervention outside the workflow. Routes to the error step.
+
+You MUST run exactly one of these as your last action. COMPLETE is not valid for evaluation steps. The CLI's output is the authoritative record; no other phrasing advances the workflow.
+
+session.schemaVersion=4
+session.currentStep=ideation_eval
+session.currentSubstate=null
+session.completedSteps=[ideation]
+session.evalConfig=ideation=true,planning=false
+session.feedbackRound=0/3
+session.artifactCounts={ideation=3}
+
+dynamic.timestamp=2026-04-16T12:00:00.000Z
+dynamic.activeSubagentCount=0
+dynamic.artifacts=[ideation.md]
+--- ideation.md ---
+Direction: adopt the proven-pattern decomposition with one novel exit: cache-aware prompt assembly."
+`;

--- a/packages/cli/src/specs/evaluation/__tests__/snapshot.test.ts
+++ b/packages/cli/src/specs/evaluation/__tests__/snapshot.test.ts
@@ -46,6 +46,7 @@ import { validateStepSpec } from '../../_schema/v1.js';
 import { initialState } from '../../../workflow/state.js';
 import type { WorkflowState } from '../../../workflow/state.js';
 import { defaultPredicates } from '../../../workflow/predicates.js';
+import { loadSpecForRuntime } from '../../spec-loader.js';
 import type { StepSpec } from '../../types.js';
 
 // ---------------------------------------------------------------------------
@@ -284,6 +285,57 @@ describe('evaluation — compile snapshots', () => {
     // compare-against-prior-findings guidance.
     expect(text).toContain('Feedback round context');
     expect(text).toContain('did the revision actually address');
+  });
+});
+
+// ===========================================================================
+// PR-FIN-1e — agent-routing block snapshot (default-provenance fixture)
+// ===========================================================================
+//
+// Captures the new `Agent routing for this step (resolved from settings
+// cascade):` static section emitted by `renderSpec` when the caller threads
+// `originals` through `CompileOptions`. This fixture pins the
+// `(default)`-provenance rendering: settings are `undefined`, so
+// `loadSpecForRuntime` produces an `originals` map mirroring the spec.json
+// hardcoded values, and `renderAgentRoutingBlock` walks both evaluator
+// agents and emits `(default)` for each.
+//
+// The fixture is deliberately distinct from the three existing fixtures
+// (which call `compile` without `originals` and therefore stay byte-stable
+// across this PR). Only this new test captures the agent-routing block.
+// `step` is `ideation_eval` — the eval-side mapping that surfaces the
+// `workflow.<step>.evaluate.agent` slot in the override provenance suffix
+// when settings are non-empty (here: settings are undefined → all
+// `(default)`).
+
+describe('evaluation — agent-routing block snapshot (PR-FIN-1e)', () => {
+  test('ideation-eval-first-entry with originals threads agent-routing block with (default) provenance for project + overall evaluators', () => {
+    const { spec, originals } = loadSpecForRuntime(
+      SPEC_PATH,
+      undefined,
+      'ideation_eval',
+    );
+    const input = ideationEvalFirstEntryFixture(spec);
+    const prompt = compile(input, {
+      allocator: defaultBudgetAllocator,
+      contextWindowTokens: GENEROUS_WINDOW,
+      originals,
+      slotHint: 'workflow.ideation.evaluate.agent',
+    });
+    expect(prompt.text).toMatchSnapshot();
+
+    // Cross-check intent: the agent-routing block appears with both
+    // evaluator perspectives at their hardcoded (sonnet, max) defaults.
+    expect(prompt.text).toContain(
+      'Agent routing for this step (resolved from settings cascade):',
+    );
+    expect(prompt.text).toContain('role=project');
+    expect(prompt.text).toContain('role=overall');
+    expect(prompt.text).toContain('model=sonnet');
+    expect(prompt.text).toContain('effort=max');
+    expect(prompt.text).toContain('(default)');
+    // No (override: ...) suffix should appear because settings are undefined.
+    expect(prompt.text).not.toContain('(override:');
   });
 });
 

--- a/packages/cli/src/specs/execution/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/cli/src/specs/execution/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -227,3 +227,78 @@ session.artifactCounts={ideation=3,planning=1}
 dynamic.timestamp=2026-04-16T12:00:00.000Z
 dynamic.activeSubagentCount=0"
 `;
+
+exports[`execution — agent-routing block snapshot (PR-FIN-1e) first-entry with originals threads agent-routing block with (default) provenance for executor 1`] = `
+"You are the orchestrator of the Execution step. Your job is to run the approved plan one task at a time, verifying each task before the next begins, until the plan is complete or a failure surfaces that requires feedback.
+
+You delegate each task to an executor subagent; you do not implement tasks yourself. You do not evaluate the execution output — that is \`execution_eval\`'s job. You do not re-decompose tasks on the fly; if a task is structurally wrong, surface it to the user rather than silently reshaping the plan.
+
+Execution principles:
+
+- One task at a time. Complete a task, verify it, then move to the next. Broad parallel execution produces broad shallow mistakes.
+- Verify against the plan's criteria, not against whether the code "looks right." The plan's verification column is the contract; satisfying it is the definition of done for that task.
+- Delegate with specificity. Every executor subagent prompt must include the task's scope, inputs, outputs, verification criteria, the relevant prior-step artifacts, and the skills to load. A subagent that has to guess is a subagent that guesses wrong.
+- Respect scope boundaries. If an executor notices adjacent improvements, they note them in their response — they do not implement them. Scope creep in Execution is scope creep everywhere downstream.
+- Record gotchas immediately after any correction. A correction not recorded is a correction repeated across sessions.
+
+Scope boundary:
+
+- Execute the plan as written. Do not re-plan mid-step. If a task is blocked or malformed, stop and ask the user — skipping back to \`plan\` is a legitimate option.
+- Do not evaluate execution quality yourself. \`execution_eval\` runs after Execution exits; it is mandatory and non-skippable.
+- Stay inside the per-task scope when briefing executors. A subagent that executes task 3 must receive exactly the context task 3 requires — not the full history of tasks 1 and 2.
+- Write artifacts to the session's execution directory, not to the plan directory or the ideation directory. Each step owns its own artifact namespace.
+
+Verification contract:
+
+After each executor subagent completes, run the task's verification before dispatching the next task. Verification can be:
+
+- A shell command the plan specified (lint, test, typecheck)
+- A structural check on produced artifacts (file exists, required sections present)
+- A focused reading of a diff against the task's declared outputs
+
+A failing verification is not a silent regression — record the failure in the execution artifact, decide with the user whether to retry the task, skip to a focused fix, or escape the step and return to \`plan\`. Never mark a task complete on a failing verification just to keep the list moving.
+
+Agent routing for this step (resolved from settings cascade):
+  - role=executor   model=opus    effort=max   (default)
+
+Synthesis instructions:
+
+After every task in the plan has a verified completion (or has been deliberately deferred with the user), produce \`execution.md\` — the step-level summary that downstream evaluation and memorization read. Your synthesis process:
+
+1. Read each executor subagent's final response in order. The per-task record is authoritative; do not rely on memory.
+2. For each task, record: the task title, the verification that ran, the verification result, the artifacts produced, and any scope-boundary notes the executor flagged.
+3. Aggregate any gotchas the executors surfaced. Gotchas belong in the gotcha system; record them there before synthesizing.
+4. Note any tasks that were skipped, re-ordered, or returned to \`plan\` mid-step — the evaluator needs the history, not just the endpoint.
+5. Commit \`execution.md\` with the above. Do not assess the work's quality — execution_eval does that. Your job is to produce a faithful ledger of what happened.
+
+Emit the SubagentStop completion signal once every plan task has a verified completion (or a recorded deferral), \`execution.md\` is written, and any executor-surfaced gotchas have been recorded.
+
+Criteria:
+  1. every task in the approved plan has a verified completion recorded in execution.md, or a deliberate deferral recorded with the user's agreement
+  2. execution.md is written to the session's execution directory with a per-task ledger of scope, verification, result, and artifacts
+  3. gotchas surfaced during execution have been written to the appropriate gotcha location before the step exits
+  4. no task was marked complete on a failing verification without explicit user agreement recorded in execution.md
+
+---
+## Step completion protocol
+
+You have finished this step's work when the criteria above are satisfied. Once they are met, run EXACTLY this command as your last action:
+
+  gobbi workflow transition COMPLETE
+
+The CLI's output is the authoritative record of step completion. No other phrasing — prose, markdown headers, comments — advances the workflow. Run the command, observe the printed next step, and stop.
+
+session.schemaVersion=4
+session.currentStep=execution
+session.currentSubstate=null
+session.completedSteps=[ideation,planning]
+session.evalConfig=ideation=false,planning=false
+session.feedbackRound=0/3
+session.artifactCounts={ideation=3,planning=1}
+
+dynamic.timestamp=2026-04-16T12:00:00.000Z
+dynamic.activeSubagentCount=0
+dynamic.artifacts=[plan.md]
+--- plan.md ---
+Direction: author four step specs. Tasks: [1] plan spec, [2] execution spec, [3] evaluation spec, [4] memorization spec. Verification: ajv passes + snapshots locked."
+`;

--- a/packages/cli/src/specs/execution/__tests__/snapshot.test.ts
+++ b/packages/cli/src/specs/execution/__tests__/snapshot.test.ts
@@ -54,6 +54,7 @@ import { validateStepSpec } from '../../_schema/v1.js';
 import { initialState } from '../../../workflow/state.js';
 import type { WorkflowState } from '../../../workflow/state.js';
 import { defaultPredicates } from '../../../workflow/predicates.js';
+import { loadSpecForRuntime } from '../../spec-loader.js';
 import type { StepSpec } from '../../types.js';
 
 // ---------------------------------------------------------------------------
@@ -295,6 +296,52 @@ describe('execution — compile snapshots', () => {
     expect(gotchaIdx).toBeGreaterThanOrEqual(0);
     expect(executionIdx).toBeGreaterThan(gotchaIdx);
     expect(roleIdx).toBeGreaterThan(executionIdx);
+  });
+});
+
+// ===========================================================================
+// PR-FIN-1e — agent-routing block snapshot (default-provenance fixture)
+// ===========================================================================
+//
+// Captures the new `Agent routing for this step (resolved from settings
+// cascade):` static section emitted by `renderSpec` when the caller threads
+// `originals` through `CompileOptions`. This fixture pins the
+// `(default)`-provenance rendering: settings are `undefined`, so
+// `loadSpecForRuntime` produces an `originals` map mirroring the spec.json
+// hardcoded values, and `renderAgentRoutingBlock` walks the executor agent
+// and emits `(default)`.
+//
+// The fixture is deliberately distinct from the three existing fixtures
+// (which call `compile` without `originals` and therefore stay byte-stable
+// across this PR). Only this new test captures the agent-routing block.
+
+describe('execution — agent-routing block snapshot (PR-FIN-1e)', () => {
+  test('first-entry with originals threads agent-routing block with (default) provenance for executor', () => {
+    const { spec, originals } = loadSpecForRuntime(
+      SPEC_PATH,
+      undefined,
+      'execution',
+    );
+    const input = firstEntryFixture(spec);
+    const prompt = compile(input, {
+      allocator: defaultBudgetAllocator,
+      contextWindowTokens: GENEROUS_WINDOW,
+      originals,
+      slotHint: 'workflow.execution.agent',
+    });
+    expect(prompt.text).toMatchSnapshot();
+
+    // Cross-check intent: the agent-routing block appears with the executor
+    // agent at its hardcoded (opus, max) defaults — single-line block.
+    expect(prompt.text).toContain(
+      'Agent routing for this step (resolved from settings cascade):',
+    );
+    expect(prompt.text).toContain('role=executor');
+    expect(prompt.text).toContain('model=opus');
+    expect(prompt.text).toContain('effort=max');
+    expect(prompt.text).toContain('(default)');
+    // No (override: ...) suffix should appear because settings are undefined.
+    expect(prompt.text).not.toContain('(override:');
   });
 });
 

--- a/packages/cli/src/specs/ideation/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/cli/src/specs/ideation/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -203,3 +203,65 @@ session.artifactCounts={}
 dynamic.timestamp=2026-04-16T12:00:00.000Z
 dynamic.activeSubagentCount=2"
 `;
+
+exports[`ideation — agent-routing block snapshot (PR-FIN-1e) first-entry with originals threads agent-routing block with (default) provenance for both PI agents 1`] = `
+"You are the orchestrator of the Ideation step. Your job is to coordinate two parallel PI (perspective-informed) agents — one innovative, one best-practice — and synthesize their findings into a single shared direction the user approves before the workflow moves to planning.
+
+You are not the ideator yourself. The PI agents ideate; you frame the problem, delegate, discuss the options with the user, and synthesize.
+
+Ideation principles:
+
+- Two stances, not one. Innovative explores novel approaches; best-practice grounds the work in proven patterns. Neither is correct alone — the synthesis is where the direction emerges.
+- Discuss before delegating. Talk to the user about the problem shape, constraints, and priorities. Use AskUserQuestion for every decision point. A detailed prompt to the PI agents produces detailed ideation; a vague prompt produces vague options.
+- Synthesize, do not concatenate. The output \`ideation.md\` is one chosen direction, not both stances pasted together. When the stances conflict, surface the tradeoff to the user and decide together.
+- Never evaluate your own synthesis. If evaluation is enabled for this step, the CLI will transition to \`ideation_eval\` and spawn independent evaluator agents after your synthesis lands.
+
+Scope boundary:
+
+- Stay within the Ideation step. Do not begin decomposition or implementation — that is the Plan and Execution steps' job.
+- Do not load orchestration, discussion, or ideation skills as content — their behavior is already encoded in this prompt. Load only domain skills the PI agents need for the specific problem.
+- Note adjacent improvements in the ideation artifact, but do not implement them now. The Plan step decides what belongs in scope.
+
+Agent routing for this step (resolved from settings cascade):
+  - role=innovative model=opus    effort=max   (default)
+  - role=best       model=opus    effort=max   (default)
+
+Synthesis instructions:
+
+After both PI agents complete, produce \`ideation.md\` — one chosen direction, not a concatenation of both stances. Your synthesis process:
+
+1. Read both \`innovative.md\` and \`best.md\` in full. Do not skim. Overlaps and conflicts are what the synthesis is actually about.
+2. Extract the options table. List every distinct approach across both artifacts with a one-line summary, a stance tag, and an honest tradeoff. Deduplicate near-identical approaches; keep the clearer articulation.
+3. Discuss the options with the user via AskUserQuestion. Recommend one option first with a clear rationale. The user decides which direction to take — never auto-select.
+4. Write \`ideation.md\` with the chosen direction, the reasoning that led there, and the options that were considered but not selected with their tradeoffs. Future steps read this file; it is the record of why this direction was taken over the alternatives.
+5. If the evaluation gate is enabled for this step, the CLI will spawn evaluator agents after your synthesis lands. Do not evaluate your own synthesis.
+
+Emit the SubagentStop completion signal once \`ideation.md\` is written, the user has approved the chosen direction, and (if evaluation is enabled) the user has decided whether to run ideation_eval.
+
+Criteria:
+  1. innovative.md is written to the session's ideation directory by the innovative PI agent
+  2. best.md is written to the session's ideation directory by the best-practice PI agent
+  3. ideation.md is written by the orchestrator with a single chosen direction and a record of the options considered
+  4. the user has approved the chosen direction via AskUserQuestion
+  5. the user has decided whether to run ideation_eval (if the eval gate is enabled for this session)
+
+---
+## Step completion protocol
+
+You have finished this step's work when the criteria above are satisfied. Once they are met, run EXACTLY this command as your last action:
+
+  gobbi workflow transition COMPLETE
+
+The CLI's output is the authoritative record of step completion. No other phrasing — prose, markdown headers, comments — advances the workflow. Run the command, observe the printed next step, and stop.
+
+session.schemaVersion=4
+session.currentStep=ideation
+session.currentSubstate=null
+session.completedSteps=[]
+session.evalConfig=null
+session.feedbackRound=0/3
+session.artifactCounts={}
+
+dynamic.timestamp=2026-04-16T12:00:00.000Z
+dynamic.activeSubagentCount=0"
+`;

--- a/packages/cli/src/specs/ideation/__tests__/snapshot.test.ts
+++ b/packages/cli/src/specs/ideation/__tests__/snapshot.test.ts
@@ -46,6 +46,7 @@ import { validateStepSpec } from '../../_schema/v1.js';
 import { initialState } from '../../../workflow/state.js';
 import type { WorkflowState } from '../../../workflow/state.js';
 import { defaultPredicates } from '../../../workflow/predicates.js';
+import { loadSpecForRuntime } from '../../spec-loader.js';
 import type { StepSpec } from '../../types.js';
 
 // ---------------------------------------------------------------------------
@@ -305,6 +306,53 @@ describe('ideation — compile snapshots', () => {
     // The best-practice delegation block is NOT included in the same compile
     // — it runs in a separate delegation invocation.
     expect(text).not.toContain('You are a PI agent working the best-practice stance');
+  });
+});
+
+// ===========================================================================
+// PR-FIN-1e — agent-routing block snapshot (default-provenance fixture)
+// ===========================================================================
+//
+// Captures the new `Agent routing for this step (resolved from settings
+// cascade):` static section emitted by `renderSpec` when the caller threads
+// `originals` through `CompileOptions`. This fixture pins the
+// `(default)`-provenance rendering: settings are `undefined`, so
+// `loadSpecForRuntime` produces an `originals` map mirroring the spec.json
+// hardcoded values, and `renderAgentRoutingBlock` walks every agent and
+// emits `(default)` for each.
+//
+// The fixture is deliberately distinct from the three existing fixtures
+// (which call `compile` without `originals` and therefore stay byte-stable
+// across this PR). Only this new test captures the agent-routing block.
+
+describe('ideation — agent-routing block snapshot (PR-FIN-1e)', () => {
+  test('first-entry with originals threads agent-routing block with (default) provenance for both PI agents', () => {
+    const { spec, originals } = loadSpecForRuntime(
+      SPEC_PATH,
+      undefined,
+      'ideation',
+    );
+    const input = firstEntryFixture(spec);
+    const prompt = compile(input, {
+      allocator: defaultBudgetAllocator,
+      contextWindowTokens: GENEROUS_WINDOW,
+      originals,
+      slotHint: 'workflow.ideation.agent',
+    });
+    expect(prompt.text).toMatchSnapshot();
+
+    // Cross-check intent: the agent-routing block appears with both PI
+    // agents at their hardcoded (opus, max) defaults — one line per agent.
+    expect(prompt.text).toContain(
+      'Agent routing for this step (resolved from settings cascade):',
+    );
+    expect(prompt.text).toContain('role=innovative');
+    expect(prompt.text).toContain('role=best');
+    expect(prompt.text).toContain('model=opus');
+    expect(prompt.text).toContain('effort=max');
+    expect(prompt.text).toContain('(default)');
+    // No (override: ...) suffix should appear because settings are undefined.
+    expect(prompt.text).not.toContain('(override:');
   });
 });
 

--- a/packages/cli/src/specs/spec-loader.ts
+++ b/packages/cli/src/specs/spec-loader.ts
@@ -1,0 +1,296 @@
+/**
+ * Spec loader — read a `spec.json`, validate via {@link validateStepSpec},
+ * and (optionally) overlay user-config-driven model/effort onto every entry
+ * of `spec.delegation.agents[*]` according to the step-driven role-to-mode
+ * mapping documented in PR-FIN-1e ideation §2.3.1.
+ *
+ * Two exported entry points:
+ *
+ * - {@link loadSpec} — pure factor-out of the prior inline definition in
+ *   `commands/workflow/next.ts`. Reads + validates + returns the typed spec.
+ *   No settings awareness; preserved for callers (`render.ts`, `patch.ts`,
+ *   tests) that compile against the spec-as-authored without runtime overlay.
+ *
+ * - {@link loadSpecForRuntime} — reads + validates + overlays the resolved
+ *   settings cascade for the active workflow step. Returns both the
+ *   post-overlay `StepSpec` AND a sibling `originals` map carrying the
+ *   pre-overlay `{modelTier, effort}` keyed by each agent's `role` field.
+ *   The sibling-map shape sidesteps the readonly-`StepSpec` contract: we
+ *   never mutate the input; the overlay produces a fresh `StepSpec` and the
+ *   pre-overlay values flow alongside (rather than embedded in) the spec so
+ *   the renderer can compute `(default)` vs `(override: ...)` provenance
+ *   without re-reading the spec from disk.
+ *
+ * ## Step-driven role-to-mode mapping (ideation §2.3.1)
+ *
+ * | `step`             | Active settings slot                              |
+ * |--------------------|---------------------------------------------------|
+ * | `ideation`         | `workflow.ideation.agent`                         |
+ * | `planning`         | `workflow.planning.agent`                         |
+ * | `execution`        | `workflow.execution.agent`                        |
+ * | `ideation_eval`    | `workflow.ideation.evaluate.agent`                |
+ * | `planning_eval`    | `workflow.planning.evaluate.agent`                |
+ * | `execution_eval`   | `workflow.execution.evaluate.agent`               |
+ * | (any other)        | none — no overlay                                 |
+ *
+ * The overlay applies to **every** entry of `spec.delegation.agents[*]` —
+ * the array is uniform within the step's purpose (PI/executor for
+ * productive steps, evaluator perspectives for `*_eval`). No role-name
+ * filter; if the user picks `model: 'haiku'` for ideation, both
+ * `innovative` and `best` agents get `'haiku'`.
+ *
+ * `'auto'` flows verbatim through the overlay — the orchestrator resolves
+ * it via `_gobbi-rule` Model Selection at spawn time. The CLI does not
+ * pre-resolve `'auto'` at any layer.
+ *
+ * ## Module boundary
+ *
+ * - `commands/workflow/next.ts` is the only caller that passes resolved
+ *   settings (T4b will swap `next.ts:237` to `loadSpecForRuntime`).
+ * - `commands/workflow/render.ts` and `commands/workflow/patch.ts` are
+ *   spec-authoring/inspection commands: they take a `PromptId` (not a
+ *   `WorkflowStep`) and pin `FIXED_TIMESTAMP` for deterministic snapshots.
+ *   They continue to call {@link loadSpec} (no settings overlay).
+ */
+
+import { readFileSync } from 'node:fs';
+
+import type { ResolvedSettings, StepSettings } from '../lib/settings.js';
+import { validateStepSpec } from './_schema/v1.js';
+import type {
+  AgentConfig,
+  EffortLevel,
+  ModelTier,
+  StepDelegation,
+  StepSpec,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Pre-overlay (model, effort) snapshot for one agent — keyed in the
+ * {@link RuntimeSpec.originals} map by the agent's `role` field. The
+ * renderer uses this to compute `(default)` vs `(override: ...)` provenance
+ * for each agent in the `agent-routing` rendered-prompt block.
+ */
+export interface AgentOriginal {
+  readonly modelTier: ModelTier;
+  readonly effort: EffortLevel;
+}
+
+/** Result of {@link loadSpecForRuntime}. */
+export interface RuntimeSpec {
+  /**
+   * Spec with the active settings overlay applied to every entry of
+   * `delegation.agents[*]`. When no overlay applies (no settings, no slot
+   * for the step, slot present but empty), this is the spec as-authored.
+   */
+  readonly spec: StepSpec;
+  /**
+   * Pre-overlay `{modelTier, effort}` for each agent in the spec, keyed by
+   * the agent's `role`. Always reflects the spec.json hardcoded values
+   * regardless of whether an overlay was applied.
+   */
+  readonly originals: Readonly<Record<string, AgentOriginal>>;
+}
+
+// ---------------------------------------------------------------------------
+// loadSpec — factor-out of next.ts:298-307 (pure read + validate)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a `spec.json` from disk, validate it against the v1 schema, and
+ * return the typed {@link StepSpec}. Throws when validation fails — the
+ * thrown `Error` includes the file path and the AJV error list serialized
+ * as JSON for log surfaces.
+ *
+ * Pure factor-out of the prior inline definition in `commands/workflow/next.ts`.
+ * Behaviour-preserving — no overlay, no settings awareness.
+ */
+export function loadSpec(path: string): StepSpec {
+  const raw: unknown = JSON.parse(readFileSync(path, 'utf8'));
+  const result = validateStepSpec(raw);
+  if (!result.ok) {
+    throw new Error(
+      `gobbi workflow next: spec ${path} failed validation: ${JSON.stringify(result.errors)}`,
+    );
+  }
+  return result.value;
+}
+
+// ---------------------------------------------------------------------------
+// loadSpecForRuntime — load + step-driven settings overlay
+// ---------------------------------------------------------------------------
+
+/**
+ * Load a spec and overlay the active settings slot's `{model, effort}`
+ * onto every entry of `spec.delegation.agents[*]` according to the
+ * step-driven role-to-mode mapping (ideation §2.3.1).
+ *
+ * `settings === undefined` short-circuits the overlay — the spec returns
+ * as-authored, and `originals` still mirrors the spec's hardcoded values
+ * so callers can rely on a stable shape regardless of cascade presence.
+ *
+ * For steps outside the productive/eval set (idle, done, error,
+ * memorization, handoff), no overlay applies — those steps either have
+ * empty `delegation.agents` or don't expose a settings slot.
+ *
+ * @param specPath Absolute (or caller-resolved) path to the `spec.json`.
+ * @param settings Resolved settings cascade; `undefined` skips overlay.
+ * @param step Current workflow step identifier from `state.currentStep`.
+ *   Drives the slot lookup per the ideation §2.3.1 table.
+ * @returns The spec (post-overlay when applicable) plus the `originals`
+ *   map of pre-overlay values keyed by agent role.
+ */
+export function loadSpecForRuntime(
+  specPath: string,
+  settings: ResolvedSettings | undefined,
+  step: string,
+): RuntimeSpec {
+  const baseSpec = loadSpec(specPath);
+  const originals = buildOriginals(baseSpec);
+
+  if (settings === undefined) {
+    return { spec: baseSpec, originals };
+  }
+
+  const slot = pickSettingsSlot(settings, step);
+  if (slot === null) {
+    return { spec: baseSpec, originals };
+  }
+
+  const overlaid = overlayAgents(baseSpec, slot);
+  return { spec: overlaid, originals };
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+/**
+ * Snapshot the spec's hardcoded `{modelTier, effort}` for each agent into
+ * a frozen-shape map keyed by `role`. The map is small (≤2 entries per
+ * step today) and lives only inside the loader's caller chain — it is not
+ * persisted, not snapshotted, not compared across compiles.
+ */
+function buildOriginals(
+  spec: StepSpec,
+): Readonly<Record<string, AgentOriginal>> {
+  const out: Record<string, AgentOriginal> = {};
+  for (const agent of spec.delegation.agents) {
+    out[agent.role] = {
+      modelTier: agent.modelTier,
+      effort: agent.effort,
+    };
+  }
+  return out;
+}
+
+/**
+ * Resolve `step` to the active {@link StepSettings.agent}-shaped slot
+ * (productive: `workflow.<step>.agent`; eval: `workflow.<step>.evaluate.agent`).
+ *
+ * Returns `null` when the step has no slot (any step outside the
+ * productive/eval set) or when the resolved settings cascade did not
+ * supply the slot.
+ */
+function pickSettingsSlot(
+  settings: ResolvedSettings,
+  step: string,
+): { readonly model?: ModelTier; readonly effort?: EffortLevel } | null {
+  const workflow = settings.workflow;
+  if (workflow === undefined) return null;
+
+  switch (step) {
+    case 'ideation':
+      return slotFromStep(workflow.ideation, 'agent');
+    case 'planning':
+      return slotFromStep(workflow.planning, 'agent');
+    case 'execution':
+      return slotFromStep(workflow.execution, 'agent');
+    case 'ideation_eval':
+      return slotFromStep(workflow.ideation, 'evaluate');
+    case 'planning_eval':
+      return slotFromStep(workflow.planning, 'evaluate');
+    case 'execution_eval':
+      return slotFromStep(workflow.execution, 'evaluate');
+    default:
+      // idle, done, error, memorization, handoff, or any unknown step —
+      // no overlay slot is defined.
+      return null;
+  }
+}
+
+/**
+ * Pull the `{model, effort}` pair from a {@link StepSettings} entry,
+ * dispatching by `kind`:
+ *
+ * - `'agent'` → `step.agent`
+ * - `'evaluate'` → `step.evaluate.agent`
+ *
+ * Returns `null` when the step entry, the inner branch, or the agent
+ * sub-object is absent. The caller treats `null` as "no overlay applies"
+ * — the {@link AgentModel}/{@link AgentEffort} types from `lib/settings.ts`
+ * are structurally identical to {@link ModelTier}/{@link EffortLevel}
+ * (both unions widened to include `'auto'` in T2), so the returned shape
+ * carries directly into {@link overlayAgents}.
+ */
+function slotFromStep(
+  stepCfg: StepSettings | undefined,
+  kind: 'agent' | 'evaluate',
+): { readonly model?: ModelTier; readonly effort?: EffortLevel } | null {
+  if (stepCfg === undefined) return null;
+  const agent =
+    kind === 'agent' ? stepCfg.agent : stepCfg.evaluate?.agent;
+  if (agent === undefined) return null;
+  // `AgentModel` ⊆ `ModelTier` and `AgentEffort` ⊆ `EffortLevel` after
+  // T2's enum widening — both unions are now `'opus' | 'sonnet' | 'haiku'
+  // | 'auto'` and `'low' | 'medium' | 'high' | 'max' | 'auto'`. The
+  // settings-side and spec-side aliases are nominally distinct but
+  // structurally identical, so a direct read is type-safe.
+  const out: { model?: ModelTier; effort?: EffortLevel } = {};
+  if (agent.model !== undefined) out.model = agent.model;
+  if (agent.effort !== undefined) out.effort = agent.effort;
+  // Empty-slot guard: a parsed `agent: {}` carries no override; treat as
+  // null so the caller skips the (no-op) overlay path entirely.
+  if (out.model === undefined && out.effort === undefined) return null;
+  return out;
+}
+
+/**
+ * Apply the `{model, effort}` overlay onto every entry of
+ * `spec.delegation.agents[*]`, returning a fresh {@link StepSpec}.
+ *
+ * `StepSpec` and its sub-shapes are deeply readonly (`types.ts`) — this
+ * function never mutates the input. New objects are constructed via
+ * spread; the agents array is rebuilt as a fresh array; each agent that
+ * receives an override becomes a new object with the resolved fields
+ * substituted. Agents whose values match the overlay no-op-ly identical
+ * still get a fresh object — the overhead is negligible (≤2 objects per
+ * compile) and keeping the code branch-free reads cleaner than testing
+ * for equality before rebuilding.
+ *
+ * `'auto'` flows verbatim — no resolution at this layer.
+ */
+function overlayAgents(
+  spec: StepSpec,
+  slot: { readonly model?: ModelTier; readonly effort?: EffortLevel },
+): StepSpec {
+  const newAgents: AgentConfig[] = spec.delegation.agents.map((agent) => ({
+    ...agent,
+    modelTier: slot.model ?? agent.modelTier,
+    effort: slot.effort ?? agent.effort,
+  }));
+
+  const newDelegation: StepDelegation = {
+    ...spec.delegation,
+    agents: newAgents,
+  };
+
+  return {
+    ...spec,
+    delegation: newDelegation,
+  };
+}

--- a/packages/cli/src/specs/types.ts
+++ b/packages/cli/src/specs/types.ts
@@ -55,16 +55,29 @@
 /**
  * Anthropic model tier assigned to a delegated agent. Matches the `model:`
  * front-matter values used in `.claude/agents/*.md`.
+ *
+ * `'auto'` defers tier selection to the orchestrator at spawn time —
+ * consult `_gobbi-rule` Model Selection (innovative/implementation → opus;
+ * evaluators/reviewers/docs → sonnet). Settings cascade may inject
+ * `'auto'` as a step-wide override; spec.json files may also use `'auto'`
+ * if the spec author wants to defer to the rule rather than hardcode a
+ * tier. The CLI does not pre-resolve `'auto'`; it flows verbatim into
+ * `spec.delegation.agents[*].modelTier` and the rendered prompt's
+ * `agent-routing` block annotates it for the orchestrator to resolve.
  */
-export type ModelTier = 'opus' | 'sonnet' | 'haiku';
+export type ModelTier = 'opus' | 'sonnet' | 'haiku' | 'auto';
 
 /**
- * Effort level for the delegated agent. `max` is the only value used by
- * the workflow today — the field exists so downstream specs can opt into
- * lower effort if that becomes useful. `_gobbi-rule.md` currently mandates
- * max effort for all workflow agents.
+ * Effort level for the delegated agent. `max` is the workflow default per
+ * `_gobbi-rule` Model Selection ("All agents run at max effort"); the
+ * field permits lower effort for downstream specs that opt in.
+ *
+ * `'auto'` defers effort selection to the orchestrator at spawn time —
+ * consult `_gobbi-rule` Model Selection. Same flow-verbatim semantics as
+ * `ModelTier`'s `'auto'`: the CLI does not pre-resolve, the rendered
+ * prompt's `agent-routing` block annotates, the orchestrator picks.
  */
-export type EffortLevel = 'max' | 'high' | 'medium';
+export type EffortLevel = 'low' | 'medium' | 'high' | 'max' | 'auto';
 
 // ---------------------------------------------------------------------------
 // Meta — step-level configuration that does not vary per prompt compile


### PR DESCRIPTION
Closes #223. Fifth of 7 PRs in the gobbi-config finalization cluster (#162).

## Summary

Settings cascade now reaches the orchestrator's `Agent()` spawn — closing the cluster's locked decision #8 ("model/effort/maxIterations are NOT legacy — wire them, not delete"). `maxIterations` shipped earlier via #143; this PR completes the model/effort half.

The user's `gobbi config set workflow.execution.agent.model haiku` now produces a rendered prompt with an `Agent routing for this step` block tagged `(override: workflow.execution.agent)`, which the orchestrator reads at spawn time.

## What ships

**Schema (additive, no `schemaVersion` bump):**
- Uniform `mode + agent: AgentConfig` shape across `discuss`/`evaluate` per step
- New step-level `agent?: AgentConfig` slot (controls primary spawn)
- `discuss.agent` schema slot kept as forward-compat (no spec consumer today)
- Spec schema enums widened: `ModelTier += 'auto'`; `EffortLevel += 'low' + 'auto'`

**Wiring:**
- New `packages/cli/src/specs/spec-loader.ts` exporting `loadSpecForRuntime(specPath, settings, step) → {spec, originals}`. Step-driven role-to-mode mapping: productive steps read `agent.*`; eval steps read `evaluate.agent.*`
- `assembly.ts::renderAgentRoutingBlock` — emits for steps with non-empty `delegation.agents`; suffix-tagged `(default)` / `(override: <slot>)` / `(auto: resolve via _gobbi-rule Model Selection)`
- `compile()` accepts `originals` + `slotHint` via `CompileOptions` (sibling parameter; `CompileInput` unchanged for backward compat)
- Caller swap: `next.ts` only. `render.ts`/`patch.ts` continue to call `loadSpec` directly — they take `PromptId` and pin `FIXED_TIMESTAMP` for deterministic snapshots

**Migration (T2-v1 upgrader):**
- `discuss.{model,effort}` → `discuss.agent.{model,effort}`, same for `evaluate`
- Composed inside existing `upgradeFileInPlace` (one read, one validate, one write per file)
- Mutated-flag breadcrumb gate — fires only when a value actually moves
- Workspace + project levels (skip session — gitignored ephemeral)
- Conflict rule: nested wins, drop legacy
- Idempotent

**Tests (5 layers, +14 new tests + CFG-29 integration):**
- spec-loader unit (6 cases) — undefined fallback, productive override, eval override, `'auto'` verbatim, planning empty, memorization untouched
- assembly-agent-routing unit (4 cases) — default/override/auto/null branches
- settings cascade fixture (+4 cases) — workspace+project+session merge
- ensure-settings-cascade tests (12 cases, NEW FILE) — predicate, primitive, end-to-end, idempotency, breadcrumb gating
- Integration CFG-29 — programmatic vertical: `settings.set` → `resolveSettings` → `loadSpecForRuntime` → `compile` → rendered block contains override

Snapshot regeneration: ideation/execution/evaluation only. `planning`, `memorization`, `handoff` snapshots byte-identical (empty `delegation.agents` → renderer returns null).

## Acceptance criteria (ideation §4)

- [x] 1. Settings schema reshaped to uniform `mode + agent` shape; new `agent?: AgentConfig` per step
- [x] 2. AJV validates new shape; existing fixtures clean
- [x] 3. Spec schema accepts `'auto'` and `'low'`
- [x] 4. `loadSpecForRuntime` exported; only `next.ts` swaps
- [x] 5. Step-driven mapping wires productive + eval overlays
- [x] 6. `'auto'` flows verbatim — no pre-resolution
- [x] 7. T2-v1 upgrader migrates legacy → nested; nested wins; breadcrumb-on-move; idempotent
- [x] 8. DEFAULTS reshape to nested form
- [x] 9. `renderAgentRoutingBlock` per format spec
- [x] 10. 5-layer test coverage
- [x] 11. Default-case snapshots capture agent-routing block
- [x] 12. `bun test` + `bun run build` clean (`gobbi workflow validate` pre-existing PR-FIN-5 ENOENT bug, out of scope)
- [x] 13. No `schemaVersion` bump
- [x] 14. `state.maxFeedbackRounds` untouched
- [x] 15. `discuss.agent` JSDoc reserves the slot

## Out of scope

- `workflow.<step>.discuss.agent.*` consumer wiring — schema slot present; no spec-spawn consumer until a discussion-agent role lands. Forward compat.
- Determinism-aware spec rendering for `prompt render` / `prompt patch` — separate concern
- `maxFeedbackRounds` per-step extension — #134 closed via PR #143

## Test plan

- [x] `bun test` — 2107 pass / 0 fail / 9 skip / 8 todo across 99 files
- [x] `bun run typecheck` — only pre-existing `gobbi-memory.test.ts:1499` (PR-FIN-5 backlog, unrelated)
- [x] `bun run build:safe` — clean (dist/cli.js 0.81 MB; `dist/` mkdir guard needed for fresh worktrees, separate concern)
- [x] CFG-29 integration test asserts override + provenance suffix end-to-end
- [x] Manual smoke: settings override reaches `(override: workflow.execution.agent)` in rendered prompt
- [x] Snapshot diff scope: only `ideation/execution/evaluation` regenerated; `planning/memorization/handoff` byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)