### PR TITLE
PR-FIN-2a-ii — JSON memory pivot (session.json + project.json)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
       },
       "dependencies": {
         "ajv": "^8.18.0",
+        "ajv-formats": "^3.0.1",
         "fast-json-patch": "^3.1.1",
       },
       "devDependencies": {
@@ -39,6 +40,8 @@
     "@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "ajv": "^8.18.0",
+    "ajv-formats": "^3.0.1",
     "fast-json-patch": "^3.1.1"
   },
   "peerDependencies": {

--- a/packages/cli/src/__tests__/cross-pass-invariant.test.ts
+++ b/packages/cli/src/__tests__/cross-pass-invariant.test.ts
@@ -1,5 +1,5 @@
 /**
- * Cross-pass invariant — Wave 3.D.
+ * Cross-pass invariant — Wave 3.D (rewritten under PR-FIN-2a-ii T-2a.9.tests).
  *
  * Pass-1 (Pass 1 / Pass 2 / Pass 3) each landed schema-version handshakes
  * at independent layers:
@@ -7,19 +7,19 @@
  *   - workspace/project/session `settings.json` — `schemaVersion: 1` plus
  *     the pre-Pass-3 `.gobbi/project-config.json` (T2-v1) → unified-shape
  *     upgrade in `ensureSettingsCascade`.
- *   - per-session `metadata.json` — `schemaVersion: 3` (gobbi-memory Pass-2
- *     redesign — multi-project layout).
- *   - per-session `state.json` — `schemaVersion: 4` (Pass-2 reducer state v4
- *     adds `verificationResults` + `stepStartedAt`).
- *   - per-session `gobbi.db` — `CURRENT_SCHEMA_VERSION = 5` (gobbi-memory
- *     Pass 2 adds `session_id` + `project_id` columns; ALTER + backfill
- *     happens on `EventStore` open).
+ *   - per-session `session.json` — `schemaVersion: 1` (PR-FIN-2a-ii — JSON
+ *     memory pivot retired the legacy `metadata.json` v3 + `state.json` v4
+ *     in favour of a single 6-required-field `session.json` stub at init
+ *     and a fully-populated shape at memorization-step exit).
+ *   - per-session `gobbi.db` — `CURRENT_SCHEMA_VERSION = 7` (Wave C.1.2
+ *     adds `prompt_patches`; gobbi-memory Pass 2 v5 adds `session_id` +
+ *     `project_id` columns; ALTER + backfill happens on `EventStore` open).
  *
  * Bugs at the SEAMS between these layers cannot show up in any single
  * pass's tests — each pass's owner only validates their own layer in
  * isolation. This file locks the cross-layer invariant: a session
  * directory built from legacy on-disk shapes must converge to current
- * schemas across ALL four layers in a single `runInitWithOptions` call,
+ * schemas across ALL three layers in a single `runInitWithOptions` call,
  * and the result must be semantically equivalent to a fresh-install
  * session for the same logical inputs.
  *
@@ -43,9 +43,9 @@
  *
  * The fresh-install comparison runs the same `runInitWithOptions` call
  * against a fresh tmpdir with no legacy fixtures, then asserts the
- * resulting `metadata.json` + `state.json` + `gobbi.db` schema versions
- * match the legacy-seed run modulo per-session-unique fields
- * (sessionId, createdAt, projectRoot path).
+ * resulting `session.json` + `gobbi.db` schema versions match the
+ * legacy-seed run modulo per-session-unique fields (sessionId,
+ * createdAt, projectId).
  *
  * Pattern: mirrors `__tests__/features/gobbi-config.test.ts` env-hygiene
  * and stdout-capture conventions; uses `runInitWithOptions({ repoRoot })`
@@ -67,8 +67,8 @@ import { Database } from 'bun:sqlite';
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 
-import { runInitWithOptions, readMetadata } from '../commands/workflow/init.js';
-import { readState } from '../workflow/state.js';
+import { runInitWithOptions } from '../commands/workflow/init.js';
+import { readSessionJson, sessionJsonPath } from '../lib/json-memory.js';
 import { CURRENT_SCHEMA_VERSION } from '../workflow/migrations.js';
 import {
   projectDir as projectDirForName,
@@ -266,8 +266,8 @@ function seedLegacyClaudeGobbi(repo: string): void {
 // ---------------------------------------------------------------------------
 
 interface LayerSnapshot {
-  readonly metadataSchemaVersion: number;
-  readonly stateSchemaVersion: number;
+  readonly sessionSchemaVersion: number;
+  readonly sessionProjectId: string;
   readonly dbColumnsHaveSessionAndProjectId: boolean;
   readonly workspaceSchemaVersion: number | null;
   readonly workspaceProjectsActive: string | null;
@@ -279,27 +279,21 @@ interface LayerSnapshot {
    * branch explicitly rather than asserting parity.
    */
   readonly projectSettingsExists: boolean;
-  readonly currentStep: string;
-  readonly evalConfigKeys: readonly string[];
 }
 
 function snapshotLayers(repo: string, sessionId: string): LayerSnapshot {
   const projectName = basename(repo);
   const sDir = sessionDirForProject(repo, projectName, sessionId);
 
-  // Layer 1 — metadata.json
-  const meta = readMetadata(join(sDir, 'metadata.json'));
-  if (meta === null) {
-    throw new Error(`metadata.json missing or malformed at ${sDir}`);
+  // Layer 1 — session.json (PR-FIN-2a-ii pivot replaced metadata.json +
+  // state.json with a single 6-field stub at init / fully-populated shape
+  // at memorization exit).
+  const session = readSessionJson(sessionJsonPath(repo, projectName, sessionId));
+  if (session === null) {
+    throw new Error(`session.json missing or malformed at ${sDir}`);
   }
 
-  // Layer 2 — state.json
-  const state = readState(sDir);
-  if (state === null) {
-    throw new Error(`state.json missing or malformed at ${sDir}`);
-  }
-
-  // Layer 3 — gobbi.db: open and confirm `session_id` + `project_id`
+  // Layer 2 — gobbi.db: open and confirm `session_id` + `project_id`
   // columns exist (v5 schema). PRAGMA table_info returns one row per
   // column; we narrow on `name` rather than column index.
   const dbPath = join(sDir, 'gobbi.db');
@@ -315,7 +309,7 @@ function snapshotLayers(repo: string, sessionId: string): LayerSnapshot {
     db.close();
   }
 
-  // Layer 4 — workspace settings.json. The unified resolver gives us the
+  // Layer 3 — workspace settings.json. The unified resolver gives us the
   // bootstrap-populated `projects.active` + `projects.known`; we read the
   // raw file directly so the snapshot reflects what landed on disk
   // (the resolver returns a merged Settings, which doesn't expose
@@ -352,16 +346,13 @@ function snapshotLayers(repo: string, sessionId: string): LayerSnapshot {
   );
 
   return {
-    metadataSchemaVersion: meta.schemaVersion,
-    stateSchemaVersion: state.schemaVersion,
+    sessionSchemaVersion: session.schemaVersion,
+    sessionProjectId: session.projectId,
     dbColumnsHaveSessionAndProjectId: dbHasV5Columns,
     workspaceSchemaVersion,
     workspaceProjectsActive,
     workspaceProjectsKnown,
     projectSettingsExists: existsSync(projectSettingsPath),
-    currentStep: state.currentStep,
-    evalConfigKeys:
-      state.evalConfig === null ? [] : Object.keys(state.evalConfig).sort(),
   };
 }
 
@@ -475,15 +466,17 @@ describe('cross-pass invariant: init normalises legacy-shape session', () => {
       // by construction; everything else MUST agree.
       // ---------------------------------------------------------------------
 
-      // Layer 1 — metadata.json schema (gobbi-memory Pass 2: v3).
-      expect(legacySnap.metadataSchemaVersion).toBe(3);
-      expect(freshSnap.metadataSchemaVersion).toBe(3);
+      // Layer 1 — session.json schema (PR-FIN-2a-ii JSON-memory pivot:
+      // v1). The 6-field stub at init carries `schemaVersion: 1` plus
+      // `sessionId`, `projectId`, `createdAt`, `gobbiVersion`, `task`.
+      // `projectId` is bound to the resolved project name at birth
+      // (basename(repoRoot) when no `--project` flag).
+      expect(legacySnap.sessionSchemaVersion).toBe(1);
+      expect(freshSnap.sessionSchemaVersion).toBe(1);
+      expect(legacySnap.sessionProjectId).toBe(basename(legacyRepo));
+      expect(freshSnap.sessionProjectId).toBe(basename(freshRepo));
 
-      // Layer 2 — state.json schema (Pass-2 reducer state: v4).
-      expect(legacySnap.stateSchemaVersion).toBe(4);
-      expect(freshSnap.stateSchemaVersion).toBe(4);
-
-      // Layer 3 — gobbi.db schema (Wave C.1.2: v7 — `prompt_patches`
+      // Layer 2 — gobbi.db schema (Wave C.1.2: v7 — `prompt_patches`
       // workspace-partitioned audit table on top of v6's
       // workspace-partitioned audit + meta tables, on top of the
       // gobbi-memory Pass 2 v5 events columns). `CURRENT_SCHEMA_VERSION`
@@ -494,7 +487,7 @@ describe('cross-pass invariant: init normalises legacy-shape session', () => {
       expect(legacySnap.dbColumnsHaveSessionAndProjectId).toBe(true);
       expect(freshSnap.dbColumnsHaveSessionAndProjectId).toBe(true);
 
-      // Layer 4 — workspace settings.json schema (Pass-3 unified: v1).
+      // Layer 3 — workspace settings.json schema (Pass-3 unified: v1).
       expect(legacySnap.workspaceSchemaVersion).toBe(1);
       expect(freshSnap.workspaceSchemaVersion).toBe(1);
 
@@ -511,13 +504,6 @@ describe('cross-pass invariant: init normalises legacy-shape session', () => {
       // upgrader output); fresh install did not.
       expect(legacySnap.projectSettingsExists).toBe(true);
       expect(freshSnap.projectSettingsExists).toBe(false);
-
-      // Initial workflow step + evalConfig shape match across arms — the
-      // event-store seed (workflow.start + workflow.eval.decide) lands the
-      // session in `ideation` with both eval gates wired identically.
-      expect(legacySnap.currentStep).toBe('ideation');
-      expect(freshSnap.currentStep).toBe('ideation');
-      expect(legacySnap.evalConfigKeys).toEqual(freshSnap.evalConfigKeys);
 
       // ---------------------------------------------------------------------
       // Cascade-resolution invariant — the legacy arm's upgrader wrote the
@@ -587,7 +573,7 @@ describe('cross-pass invariant: upgrader resolves project name via init ladder',
         existsSync(
           join(
             sessionDirForProject(repo, 'my-app', sessionId),
-            'metadata.json',
+            'session.json',
           ),
         ),
       ).toBe(true);

--- a/packages/cli/src/__tests__/e2e/migration-chain.test.ts
+++ b/packages/cli/src/__tests__/e2e/migration-chain.test.ts
@@ -4,26 +4,25 @@
  * L-F11 / ARCH-P2).
  *
  * Flow:
- *   1. `gobbi workflow init` seeds a session (metadata.json, gobbi.db at
- *      v4, state.json).
- *   2. Inject schema_version=1 rows directly via `bun:sqlite`.
- *   3. Delete state.json (ARCH-P2) so resolveWorkflowState can no longer
- *      short-circuit through readState — next CLI call falls through to
- *      store.replayAll → deriveState → rowToEvent → migrateEvent.
- *   4. `gobbi workflow status --json` triggers the chain. Assert the
- *      resulting schemaVersion equals CURRENT_SCHEMA_VERSION (imported,
- *      NOT literal 4 — L-F11 + R2 canary).
- *   5. Triangulation (innovative I11): stored rows still carry
+ *   1. `gobbi workflow init` seeds a session (`session.json`, `gobbi.db`).
+ *   2. Inject schema_version=1 rows directly via `bun:sqlite`. The seeded
+ *      rows are stamped with the same `(session_id, project_id)`
+ *      partition keys init wrote so they survive the partition-aware
+ *      read filter (Option α — see `workflow/store.ts` module header).
+ *   3. `gobbi workflow status --json` triggers the chain.
+ *      `resolveWorkflowState` walks `replayAll → rowToEvent →
+ *      migrateEvent` on every replayed row (PR-FIN-2a-ii / T-2a.9.unified
+ *      retired the `state.json` projection — every call is a pure
+ *      derive). Assert the resulting schemaVersion equals
+ *      `CURRENT_SCHEMA_VERSION` (imported, NOT literal 4 — L-F11 + R2
+ *      canary).
+ *   4. Triangulation (innovative I11): stored rows still carry
  *      schema_version=1 — migration must stay lazy/in-memory.
  *
  * Complements `workflow/__tests__/migrations.test.ts` (function-level) by
  * locking the full CLI binary path — if a future refactor caches
- * schemaVersion on metadata.json and bypasses deriveState, the in-process
+ * schemaVersion at the row level and bypasses deriveState, the in-process
  * test still passes but this one fails.
- *
- * Option A (state.json delete + `workflow status`) chosen over Option B
- * (`workflow resume`) because resume requires currentStep==='error',
- * forcing extra fixture complexity; Option A is strictly simpler.
  */
 
 import { test, describe, expect } from 'bun:test';
@@ -55,27 +54,41 @@ function parseStatus(buf: Buffer): Record<string, unknown> {
 }
 
 /**
- * v1 fixture events, shapes from `workflow/__tests__/migrations.test.ts:103-183`.
- * Inlined rather than shared-extracted — duplication locks the v1 wire
- * format in each test. `seq` starts at 100 to dodge init's v4 events
- * (PRIMARY KEY at seq 1 + 2). `parent_seq` is null so we don't create
- * dangling FKs to init's rows — migration is orthogonal to parent-seq.
+ * v1 fixture event factory — shapes from
+ * `workflow/__tests__/migrations.test.ts:103-183`. Inlined rather than
+ * shared-extracted: duplication locks the v1 wire format in each test.
+ * `seq` starts at 100 to dodge init's v4 events (PRIMARY KEY at seq 1 +
+ * 2). `parent_seq` is null so we don't create dangling FKs to init's
+ * rows — migration is orthogonal to parent-seq.
+ *
+ * Partition keys: PR-FIN-2a-ii (T-2a.9.unified) `EventStore` reads bake
+ * a `WHERE session_id IS $session_id AND project_id IS $project_id`
+ * filter (Option α). The seeded rows must match the same `(sessionId,
+ * projectId)` pair init stamped on `workflow.start` /
+ * `workflow.eval.decide` or the lazy migration walk skips them. The
+ * factory accepts both keys verbatim and writes them on every fixture
+ * row.
  */
-const v1Events: readonly EventRow[] = [
-  { seq: 100, ts: '2026-01-01T00:00:00.000Z', schema_version: 1, type: 'workflow.step.exit', step: 'ideation',
-    data: JSON.stringify({ step: 'ideation' }),
-    actor: 'orchestrator', parent_seq: null, idempotency_key: 'tool-call:tc-mig-001:workflow.step.exit',
-    session_id: null, project_id: null },
-  { seq: 101, ts: '2026-01-01T00:00:01.000Z', schema_version: 1, type: 'guard.violation', step: 'plan',
-    data: JSON.stringify({ guardId: 'g-scope', toolName: 'Write', reason: 'outside scope', step: 'plan',
-      timestamp: '2026-01-01T00:00:01.000Z' }),
-    actor: 'hook', parent_seq: null, idempotency_key: 'tool-call:tc-mig-002:guard.violation',
-    session_id: null, project_id: null },
-  { seq: 102, ts: '2026-01-01T00:00:02.000Z', schema_version: 1, type: 'artifact.write', step: 'execution',
-    data: JSON.stringify({ step: 'execution', filename: 'research.md', artifactType: 'note' }),
-    actor: 'executor', parent_seq: null, idempotency_key: 'tool-call:tc-mig-003:artifact.write',
-    session_id: null, project_id: null },
-];
+function buildV1Events(
+  sessionId: string,
+  projectId: string,
+): readonly EventRow[] {
+  return [
+    { seq: 100, ts: '2026-01-01T00:00:00.000Z', schema_version: 1, type: 'workflow.step.exit', step: 'ideation',
+      data: JSON.stringify({ step: 'ideation' }),
+      actor: 'orchestrator', parent_seq: null, idempotency_key: 'tool-call:tc-mig-001:workflow.step.exit',
+      session_id: sessionId, project_id: projectId },
+    { seq: 101, ts: '2026-01-01T00:00:01.000Z', schema_version: 1, type: 'guard.violation', step: 'plan',
+      data: JSON.stringify({ guardId: 'g-scope', toolName: 'Write', reason: 'outside scope', step: 'plan',
+        timestamp: '2026-01-01T00:00:01.000Z' }),
+      actor: 'hook', parent_seq: null, idempotency_key: 'tool-call:tc-mig-002:guard.violation',
+      session_id: sessionId, project_id: projectId },
+    { seq: 102, ts: '2026-01-01T00:00:02.000Z', schema_version: 1, type: 'artifact.write', step: 'execution',
+      data: JSON.stringify({ step: 'execution', filename: 'research.md', artifactType: 'note' }),
+      actor: 'executor', parent_seq: null, idempotency_key: 'tool-call:tc-mig-003:artifact.write',
+      session_id: sessionId, project_id: projectId },
+  ];
+}
 
 describe('migration chain e2e', () => {
   test(
@@ -92,30 +105,36 @@ describe('migration chain e2e', () => {
       };
 
       try {
-        // Step A — init a session shell (state.json at v4).
+        // Step A — init a session shell (writes session.json + opens
+        // gobbi.db with the v5+ partition columns).
         const initResult = await $`bun run ${CLI_PATH} workflow init --session-id ${sessionId} --task migration-e2e`
           .cwd(tmpRoot)
           .env(childEnv)
           .quiet();
         expect(initResult.exitCode).toBe(0);
 
+        const projectName = basename(tmpRoot);
         const sessionDir = sessionDirForProject(
           tmpRoot,
-          basename(tmpRoot),
+          projectName,
           sessionId,
         );
         const dbPath = join(sessionDir, 'gobbi.db');
-        const statePath = join(sessionDir, 'state.json');
-        const stateBackupPath = join(sessionDir, 'state.json.backup');
-        expect(existsSync(join(sessionDir, 'metadata.json'))).toBe(true);
+        // PR-FIN-2a-ii: `metadata.json` retired in favour of
+        // `session.json`; the engine no longer writes `state.json`.
+        expect(existsSync(join(sessionDir, 'session.json'))).toBe(true);
         expect(existsSync(dbPath)).toBe(true);
 
-        // Step B — inject schema_version=1 rows directly.
+        // Step B — inject schema_version=1 rows directly. Stamp the
+        // partition keys init wrote so the partition-aware read filter
+        // (`WHERE session_id IS $session_id AND project_id IS
+        // $project_id`) admits the rows on the `replayAll` walk.
+        const v1Events = buildV1Events(sessionId, projectName);
         const db = new Database(dbPath);
         try {
           const insert = db.prepare(
-            'INSERT INTO events (seq, ts, schema_version, type, step, data, actor, parent_seq, idempotency_key) ' +
-              'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            'INSERT INTO events (seq, ts, schema_version, type, step, data, actor, parent_seq, idempotency_key, session_id, project_id) ' +
+              'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
           );
           for (const row of v1Events) {
             insert.run(
@@ -128,23 +147,19 @@ describe('migration chain e2e', () => {
               row.actor,
               row.parent_seq,
               row.idempotency_key,
+              row.session_id,
+              row.project_id,
             );
           }
         } finally {
           db.close();
         }
 
-        // ARCH-P2 fix + innovative I11 pre-triangulation: delete state.json
-        // so the next CLI call falls through to deriveState. The pre-assert
-        // locks the intent (we deliberately removed a file we know existed).
-        expect(existsSync(statePath)).toBe(true);
-        rmSync(statePath);
-        rmSync(stateBackupPath, { force: true }); // defensive — init may add one later
-        expect(existsSync(statePath)).toBe(false);
-
-        // Step C — trigger migration via `workflow status --json`. With
-        // state.json gone, resolveWorkflowState walks replayAll → rowToEvent
-        // → migrateEvent on every seeded v1 row.
+        // Step C — trigger migration via `workflow status --json`.
+        // PR-FIN-2a-ii (T-2a.9.unified) retired `state.json`;
+        // `resolveWorkflowState` is now a pure derive over the partition-
+        // filtered event stream every call. The seeded v1 rows flow
+        // through `replayAll → rowToEvent → migrateEvent`.
         const statusResult = await $`bun run ${CLI_PATH} workflow status --session-id ${sessionId} --json`
           .cwd(tmpRoot)
           .env(childEnv)

--- a/packages/cli/src/__tests__/e2e/workflow-cycle.test.ts
+++ b/packages/cli/src/__tests__/e2e/workflow-cycle.test.ts
@@ -93,7 +93,9 @@ test(
         basename(tmpRoot),
         sessionId,
       );
-      expect(existsSync(join(sessionDir, 'metadata.json'))).toBe(true);
+      // PR-FIN-2a-ii: `metadata.json` retired; `session.json` stub is
+      // written at init by `lib/json-memory.ts::writeSessionStub`.
+      expect(existsSync(join(sessionDir, 'session.json'))).toBe(true);
       expect(existsSync(join(sessionDir, 'gobbi.db'))).toBe(true);
       // Pass 3 finalize: `ensureSettingsCascade` seeds a sparse workspace
       // `.gobbi/settings.json` on first init. The project-level file

--- a/packages/cli/src/__tests__/features/gobbi-config.test.ts
+++ b/packages/cli/src/__tests__/features/gobbi-config.test.ts
@@ -1392,17 +1392,18 @@ describe('CFG-23: fresh-setup config set + workflow init resolve to the same pro
     });
     expect(captured.exitCode).toBeNull();
 
-    // The metadata.projectName must match the project the pre-init `set`
-    // landed under.
-    const metaPath = join(
+    // The session.projectId must match the project the pre-init `set`
+    // landed under. PR-FIN-2a-ii: `metadata.projectName` was retired in
+    // favour of `session.json.projectId`.
+    const sessionPath = join(
       sessionDirForProject(repo, expectedProject, 'sess1'),
-      'metadata.json',
+      'session.json',
     );
-    expect(existsSync(metaPath)).toBe(true);
-    const meta = JSON.parse(readFileSync(metaPath, 'utf8')) as {
-      readonly projectName: string;
+    expect(existsSync(sessionPath)).toBe(true);
+    const session = JSON.parse(readFileSync(sessionPath, 'utf8')) as {
+      readonly projectId: string;
     };
-    expect(meta.projectName).toBe(expectedProject);
+    expect(session.projectId).toBe(expectedProject);
 
     // Step 3: read the value back via `config get --level session` — it
     // must still be the value we set in step 1.

--- a/packages/cli/src/__tests__/features/gobbi-memory.test.ts
+++ b/packages/cli/src/__tests__/features/gobbi-memory.test.ts
@@ -960,24 +960,32 @@ describe('gobbi-memory — G-MEM2 scenarios', () => {
   });
 
   // =========================================================================
-  // Legacy-session wipe (PR-FIN-2a-i T-2a.1.5: active-session guard removed)
+  // Legacy-session wipe
+  //   - PR-FIN-2a-i T-2a.1.5: active-session guard for the FLAT layer removed
+  //   - PR-FIN-2a-ii T-2a.10: per-project sweep extension — pre-pivot
+  //     artifacts (state.json, gobbi.db, …) are reaped from per-project
+  //     sessions while the session DIR (and any session.json + step
+  //     subdirs) is preserved.
   // =========================================================================
   describe('legacy-session wipe', () => {
-    test('G-MEM2-37: wipe-legacy-sessions deletes every legacy session', async () => {
+    test('G-MEM2-37: wipe-legacy-sessions deletes every flat-layout session AND reaps per-project legacy artifacts', async () => {
       const repo = makeRepo();
       seedLegacySession(repo, 'done-1', 'done');
       seedLegacySession(repo, 'err-1', 'error');
       seedLegacySession(repo, 'live', 'execution');
-      // Per-project sessions are NEVER touched by wipe-legacy-sessions.
-      seedProjectSession(repo, 'gobbi', 'proj-done', 'done');
-      seedProjectSession(repo, 'gobbi', 'proj-live', 'planning');
+      // `seedProjectSession` writes a pre-pivot `state.json` but no
+      // `session.json` — under T-2a.10 these are now per-project legacy
+      // sessions. Their state.json artifacts are wiped; the directories
+      // themselves remain.
+      const projDoneDir = seedProjectSession(repo, 'gobbi', 'proj-done', 'done');
+      const projLiveDir = seedProjectSession(repo, 'gobbi', 'proj-live', 'planning');
 
       await captureExit(() =>
         runWipeLegacySessionsWithOptions([], { repoRoot: repo }),
       );
       expect(captured.exitCode).toBeNull();
 
-      // Every legacy session — terminal or not — is wiped.
+      // Every flat-layout legacy session — terminal or not — is wiped.
       expect(existsSync(join(repo, '.gobbi', 'sessions', 'done-1'))).toBe(
         false,
       );
@@ -985,14 +993,38 @@ describe('gobbi-memory — G-MEM2 scenarios', () => {
         false,
       );
       expect(existsSync(join(repo, '.gobbi', 'sessions', 'live'))).toBe(false);
-      // Per-project sessions untouched.
-      expect(
-        existsSync(sessionDirForProject(repo, 'gobbi', 'proj-done')),
-      ).toBe(true);
-      expect(
-        existsSync(sessionDirForProject(repo, 'gobbi', 'proj-live')),
-      ).toBe(true);
-      expect(captured.stdout).toContain('3 session');
+      // Per-project session DIRECTORIES remain (T-2a.10 only reaps the
+      // five legacy artifacts, never the dir itself).
+      expect(existsSync(projDoneDir)).toBe(true);
+      expect(existsSync(projLiveDir)).toBe(true);
+      // The legacy `state.json` inside each per-project session was wiped.
+      expect(existsSync(join(projDoneDir, 'state.json'))).toBe(false);
+      expect(existsSync(join(projLiveDir, 'state.json'))).toBe(false);
+      // Combined-form summary: 3 flat + 2 per-project artifacts.
+      expect(captured.stdout).toContain('3 flat-layout sessions');
+      expect(captured.stdout).toContain('2 legacy artifacts wiped');
+    });
+
+    test('G-MEM2-37b: per-project session with a session.json marker is preserved untouched', async () => {
+      const repo = makeRepo();
+      const dir = sessionDirForProject(repo, 'gobbi', 'native');
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, 'session.json'),
+        JSON.stringify({ schemaVersion: 1, sessionId: 'native' }),
+        'utf8',
+      );
+      // A stray legacy artifact alongside session.json must NOT trigger
+      // a reap — session.json's presence marks the session as post-pivot.
+      writeFileSync(join(dir, 'state.json'), '{}', 'utf8');
+
+      await captureExit(() =>
+        runWipeLegacySessionsWithOptions([], { repoRoot: repo }),
+      );
+      expect(captured.exitCode).toBeNull();
+      // Both files preserved — the post-pivot marker wins over stray legacy.
+      expect(existsSync(join(dir, 'session.json'))).toBe(true);
+      expect(existsSync(join(dir, 'state.json'))).toBe(true);
     });
   });
 

--- a/packages/cli/src/__tests__/features/gobbi-memory.test.ts
+++ b/packages/cli/src/__tests__/features/gobbi-memory.test.ts
@@ -1030,7 +1030,6 @@ describe('gobbi-memory — G-MEM2 scenarios', () => {
         runPromoteWithOptions(['--project', 'gobbi'], {
           repoRoot: repo,
           claudeDir,
-          now: () => new Date('2026-04-24T00:00:00Z'),
         }),
       );
       expect(captured.exitCode).toBeNull();
@@ -1073,7 +1072,6 @@ describe('gobbi-memory — G-MEM2 scenarios', () => {
         runPromoteWithOptions(['--project', 'gobbi', '--destination-project', 'demo'], {
           repoRoot: repo,
           claudeDir,
-          now: () => new Date('2026-04-24T00:00:00Z'),
         }),
       );
       expect(captured.exitCode).toBeNull();
@@ -1272,9 +1270,13 @@ describe('gobbi-memory — G-MEM2 scenarios', () => {
       // registry removal. Preserved in git history.
     });
 
-    test('G-MEM2-MP-04: workflow init stamps metadata.projectName at birth', async () => {
+    test('G-MEM2-MP-04: workflow init stamps session.json.projectId at birth', async () => {
       // PR-FIN-1c: project name resolves to basename(repoRoot) when no
       // --project flag is supplied. No more bootstrap registry write.
+      // PR-FIN-2a-ii: `metadata.json` retired; the per-session payload is
+      // `session.json`. `session.json.projectId` carries the project the
+      // session is bound to at birth — read it here for the same lock the
+      // legacy `metadata.projectName` assertion provided.
       const repo = makeRepo();
       await captureExit(() =>
         runInitWithOptions(
@@ -1285,11 +1287,11 @@ describe('gobbi-memory — G-MEM2 scenarios', () => {
       const expectedName = basename(repo);
 
       const sessionPath = sessionDirForProject(repo, expectedName, 'sess-mp04');
-      expect(existsSync(join(sessionPath, 'metadata.json'))).toBe(true);
-      const meta = JSON.parse(
-        readFileSync(join(sessionPath, 'metadata.json'), 'utf8'),
-      ) as { readonly projectName: string };
-      expect(meta.projectName).toBe(expectedName);
+      expect(existsSync(join(sessionPath, 'session.json'))).toBe(true);
+      const session = JSON.parse(
+        readFileSync(join(sessionPath, 'session.json'), 'utf8'),
+      ) as { readonly projectId: string };
+      expect(session.projectId).toBe(expectedName);
 
       // Re-init with a DIFFERENT project flag must refuse — mismatch
       // gate locks the session to the project it was born under.

--- a/packages/cli/src/__tests__/features/hook.test.ts
+++ b/packages/cli/src/__tests__/features/hook.test.ts
@@ -338,19 +338,22 @@ describe('HOOK-1: gobbi hook session-start chains config env + workflow init', (
     expect(body).toContain('export CLAUDE_HOOK_EVENT_NAME=SessionStart\n');
     expect(body).toContain(`export CLAUDE_PROJECT_DIR=${repo}\n`);
 
-    // workflow init created the session directory and metadata.json.
+    // workflow init created the session directory and session.json.
+    // PR-FIN-2a-ii: `metadata.json` retired in favour of `session.json`
+    // (a 6-field stub at init carrying schemaVersion / sessionId /
+    // projectId / createdAt / gobbiVersion / task).
     const projectName = basename(repo);
-    const metaPath = join(
+    const sessionPath = join(
       sessionDirForProject(repo, projectName, 'hook-1-sess'),
-      'metadata.json',
+      'session.json',
     );
-    expect(existsSync(metaPath)).toBe(true);
-    const meta = JSON.parse(readFileSync(metaPath, 'utf8')) as {
+    expect(existsSync(sessionPath)).toBe(true);
+    const session = JSON.parse(readFileSync(sessionPath, 'utf8')) as {
       readonly sessionId: string;
-      readonly projectName: string;
+      readonly projectId: string;
     };
-    expect(meta.sessionId).toBe('hook-1-sess');
-    expect(meta.projectName).toBe(projectName);
+    expect(session.sessionId).toBe('hook-1-sess');
+    expect(session.projectId).toBe(projectName);
   });
 });
 
@@ -479,15 +482,16 @@ describe('HOOK-6: end-to-end SessionStart chain', () => {
     expect(body).toContain(`export CLAUDE_PROJECT_DIR=${repo}\n`);
 
     // Session dir created by workflow init.
+    // PR-FIN-2a-ii: `metadata.json` retired; check `session.json`.
     const projectName = basename(repo);
-    const metaPath = join(
+    const sessionPath = join(
       sessionDirForProject(repo, projectName, 'hook-6-sess'),
-      'metadata.json',
+      'session.json',
     );
-    expect(existsSync(metaPath)).toBe(true);
-    const meta = JSON.parse(readFileSync(metaPath, 'utf8')) as {
+    expect(existsSync(sessionPath)).toBe(true);
+    const session = JSON.parse(readFileSync(sessionPath, 'utf8')) as {
       readonly sessionId: string;
     };
-    expect(meta.sessionId).toBe('hook-6-sess');
+    expect(session.sessionId).toBe('hook-6-sess');
   });
 });

--- a/packages/cli/src/__tests__/integration/guard-emits-spawn.test.ts
+++ b/packages/cli/src/__tests__/integration/guard-emits-spawn.test.ts
@@ -138,17 +138,33 @@ function makeScratchRepo(): string {
 
 async function initScratchSession(
   sessionId: string,
-): Promise<{ sessionDir: string; repo: string }> {
+): Promise<{ sessionDir: string; repo: string; projectId: string }> {
   const repo = makeScratchRepo();
+  const projectId = basename(repo);
   await captureExit(() =>
     runInitWithOptions(
       ['--session-id', sessionId, '--task', 'spawn-emit-test'],
       { repoRoot: repo },
     ),
   );
-  const sessionDir = sessionDirForProject(repo, basename(repo), sessionId);
+  const sessionDir = sessionDirForProject(repo, projectId, sessionId);
   captured = { stdout: '', stderr: '', exitCode: null };
-  return { sessionDir, repo };
+  return { sessionDir, repo, projectId };
+}
+
+/**
+ * Open the per-session event store with explicit partition keys (PR-FIN-
+ * 2a-ii / T-2a.9.unified Option α).
+ */
+function openStore(
+  sessionDir: string,
+  sessionId: string,
+  projectId: string,
+): EventStore {
+  return new EventStore(join(sessionDir, 'gobbi.db'), {
+    sessionId,
+    projectId,
+  });
 }
 
 function emptyMatcher(): GuardMatcher {
@@ -162,7 +178,7 @@ function emptyMatcher(): GuardMatcher {
 describe('PreToolUse guard — single-agent spawn emission', () => {
   test('Agent tool with subagent_type + tool_call_id → one delegation.spawn', async () => {
     const sessionId = 'spawn-single';
-    const { sessionDir } = await initScratchSession(sessionId);
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
 
     await captureExit(() =>
       runGuardWithOptions([], {
@@ -182,7 +198,7 @@ describe('PreToolUse guard — single-agent spawn emission', () => {
 
     expect(captured.exitCode).toBeNull();
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, sessionId, projectId);
     try {
       const spawns = store.byType('delegation.spawn');
       expect(spawns).toHaveLength(1);
@@ -205,7 +221,7 @@ describe('PreToolUse guard — single-agent spawn emission', () => {
 
   test('Agent tool via tool_use_id (canonical Claude Code field) emits spawn', async () => {
     const sessionId = 'spawn-use-id';
-    const { sessionDir } = await initScratchSession(sessionId);
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
 
     await captureExit(() =>
       runGuardWithOptions([], {
@@ -220,7 +236,7 @@ describe('PreToolUse guard — single-agent spawn emission', () => {
       }),
     );
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, sessionId, projectId);
     try {
       const spawns = store.byType('delegation.spawn');
       expect(spawns).toHaveLength(1);
@@ -237,7 +253,7 @@ describe('PreToolUse guard — single-agent spawn emission', () => {
 
   test('non-Agent tool → no delegation.spawn event', async () => {
     const sessionId = 'spawn-no-agent';
-    const { sessionDir } = await initScratchSession(sessionId);
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
 
     await captureExit(() =>
       runGuardWithOptions([], {
@@ -252,7 +268,7 @@ describe('PreToolUse guard — single-agent spawn emission', () => {
       }),
     );
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, sessionId, projectId);
     try {
       expect(store.byType('delegation.spawn')).toHaveLength(0);
     } finally {
@@ -262,7 +278,7 @@ describe('PreToolUse guard — single-agent spawn emission', () => {
 
   test('Agent tool without tool_call_id / tool_use_id → no spawn (linkage impossible)', async () => {
     const sessionId = 'spawn-no-tcid';
-    const { sessionDir } = await initScratchSession(sessionId);
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
 
     await captureExit(() =>
       runGuardWithOptions([], {
@@ -277,7 +293,7 @@ describe('PreToolUse guard — single-agent spawn emission', () => {
       }),
     );
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, sessionId, projectId);
     try {
       expect(store.byType('delegation.spawn')).toHaveLength(0);
     } finally {
@@ -287,7 +303,7 @@ describe('PreToolUse guard — single-agent spawn emission', () => {
 
   test('Agent tool without subagent_type → no spawn (agentType missing)', async () => {
     const sessionId = 'spawn-no-type';
-    const { sessionDir } = await initScratchSession(sessionId);
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
 
     await captureExit(() =>
       runGuardWithOptions([], {
@@ -302,7 +318,7 @@ describe('PreToolUse guard — single-agent spawn emission', () => {
       }),
     );
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, sessionId, projectId);
     try {
       expect(store.byType('delegation.spawn')).toHaveLength(0);
     } finally {
@@ -318,7 +334,7 @@ describe('PreToolUse guard — single-agent spawn emission', () => {
 describe('PreToolUse guard — parallel-agent spawn emission', () => {
   test('two distinct tool_call_ids → two distinct spawn events; SubagentStop links each correctly', async () => {
     const sessionId = 'spawn-parallel';
-    const { sessionDir } = await initScratchSession(sessionId);
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
 
     // Two PreToolUse invocations land back-to-back from the same orchestrator
     // turn — Claude Code dispatches Agent tool calls in parallel batches.
@@ -351,7 +367,7 @@ describe('PreToolUse guard — parallel-agent spawn emission', () => {
     let spawnA: number | null = null;
     let spawnB: number | null = null;
     {
-      const store = new EventStore(join(sessionDir, 'gobbi.db'));
+      const store = openStore(sessionDir, sessionId, projectId);
       try {
         const spawns = store.byType('delegation.spawn');
         expect(spawns).toHaveLength(2);
@@ -420,7 +436,7 @@ describe('PreToolUse guard — parallel-agent spawn emission', () => {
       }),
     );
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, sessionId, projectId);
     try {
       const completes = store.byType('delegation.complete');
       expect(completes).toHaveLength(2);
@@ -446,7 +462,7 @@ describe('PreToolUse guard — parallel-agent spawn emission', () => {
 describe('Ripple — reducer.delegation.spawn populates state.activeSubagents', () => {
   test('after guard emits spawn, derived state lists the subagent', async () => {
     const sessionId = 'ripple-reducer';
-    const { sessionDir } = await initScratchSession(sessionId);
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
 
     await captureExit(() =>
       runGuardWithOptions([], {
@@ -461,7 +477,7 @@ describe('Ripple — reducer.delegation.spawn populates state.activeSubagents', 
       }),
     );
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, sessionId, projectId);
     try {
       const state = resolveWorkflowState(sessionDir, store, sessionId);
       expect(state.activeSubagents).toHaveLength(1);
@@ -484,7 +500,7 @@ describe('Ripple — reducer.delegation.spawn populates state.activeSubagents', 
 describe('Ripple — predicates.piAgentsToSpawn fires once a __pi spawn lands', () => {
   test('false before spawn, true after spawn', async () => {
     const sessionId = 'ripple-pi';
-    const { sessionDir } = await initScratchSession(sessionId);
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
 
     const pred = defaultPredicates['piAgentsToSpawn'];
     if (pred === undefined) {
@@ -492,7 +508,7 @@ describe('Ripple — predicates.piAgentsToSpawn fires once a __pi spawn lands', 
     }
 
     {
-      const store = new EventStore(join(sessionDir, 'gobbi.db'));
+      const store = openStore(sessionDir, sessionId, projectId);
       try {
         const state = resolveWorkflowState(sessionDir, store, sessionId);
         expect(pred(state)).toBe(false);
@@ -515,7 +531,7 @@ describe('Ripple — predicates.piAgentsToSpawn fires once a __pi spawn lands', 
     );
 
     {
-      const store = new EventStore(join(sessionDir, 'gobbi.db'));
+      const store = openStore(sessionDir, sessionId, projectId);
       try {
         const state = resolveWorkflowState(sessionDir, store, sessionId);
         expect(pred(state)).toBe(true);
@@ -539,7 +555,7 @@ describe('Ripple — predicates.piAgentsToSpawn fires once a __pi spawn lands', 
 describe('Ripple — reducer accepts verification.result when matching spawn exists', () => {
   test('spawn → reducer admits verification.result for the same subagent (no rejection)', async () => {
     const sessionId = 'ripple-verify';
-    const { sessionDir } = await initScratchSession(sessionId);
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
 
     await captureExit(() =>
       runGuardWithOptions([], {
@@ -554,7 +570,7 @@ describe('Ripple — reducer accepts verification.result when matching spawn exi
       }),
     );
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, sessionId, projectId);
     try {
       const state = resolveWorkflowState(sessionDir, store, sessionId);
       // The subagent is in activeSubagents — the reducer's "must be active"
@@ -585,7 +601,7 @@ describe('Ripple — reducer accepts verification.result when matching spawn exi
 describe('Ripple — step-readme writes correct subagentsActiveAtExit', () => {
   test('one __pi spawn at ideation → frontmatter shows subagentsActiveAtExit: 1', async () => {
     const sessionId = 'ripple-readme';
-    const { sessionDir } = await initScratchSession(sessionId);
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
 
     await captureExit(() =>
       runGuardWithOptions([], {
@@ -600,7 +616,7 @@ describe('Ripple — step-readme writes correct subagentsActiveAtExit', () => {
       }),
     );
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, sessionId, projectId);
     try {
       const state = resolveWorkflowState(sessionDir, store, sessionId);
       // Exercise the writer's pure rendering path. The count is filtered by
@@ -643,7 +659,7 @@ describe('Ripple — step-readme writes correct subagentsActiveAtExit', () => {
 describe('Ripple — verification-block renders for spawned subagent', () => {
   test('compiles a per-subagent block once a spawn has landed', async () => {
     const sessionId = 'ripple-vblock';
-    const { sessionDir } = await initScratchSession(sessionId);
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
 
     await captureExit(() =>
       runGuardWithOptions([], {
@@ -658,7 +674,7 @@ describe('Ripple — verification-block renders for spawned subagent', () => {
       }),
     );
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, sessionId, projectId);
     try {
       const state = resolveWorkflowState(sessionDir, store, sessionId);
       const sub = state.activeSubagents[0];

--- a/packages/cli/src/__tests__/integration/guard-emits-spawn.test.ts
+++ b/packages/cli/src/__tests__/integration/guard-emits-spawn.test.ts
@@ -1,0 +1,677 @@
+/**
+ * Integration tests — PR-FIN-2a-ii T-2a.8.0.
+ *
+ * Pins end-to-end behavior of the PreToolUse-guard spawn emitter and the
+ * ripple effects this turn-on triggers across the codebase. The spawn
+ * emitter is the canonical site for `delegation.spawn` (per
+ * `v050-hooks.md:59`); turning it on for the first time activates several
+ * dormant code paths:
+ *
+ *   1. `workflow/reducer.ts:314` — the `delegation.spawn` reducer handler
+ *      mutates `state.activeSubagents`. Asserts the mutation lands.
+ *   2. `predicates.piAgentsToSpawn` — fires `true` when at least one
+ *      `__pi`-typed agent is in `state.activeSubagents`. Verifies the
+ *      end-to-end activation through the guard.
+ *   3. `workflow/reducer.ts:681-687` — `verification.result` rejects when
+ *      no spawn has been recorded for the subagent. Verifies the rejection
+ *      does NOT fire when the spawn IS present.
+ *   4. `workflow/step-readme-writer.subagentsActiveAtExit` — frontmatter
+ *      field that has been writing 0 in production because no spawns were
+ *      recorded. Verifies the count populates correctly post-emit.
+ *   5. `next.ts::verification-block` — the per-subagent block render
+ *      iterates `state.activeSubagents`. Verifies it composes correctly
+ *      when the active set is non-empty.
+ *
+ * Plus the primary contract:
+ *   - Single-agent spawn → one `delegation.spawn` event with the
+ *     `tool_call_id` from the PreToolUse payload.
+ *   - Two parallel agents spawned in distinct guard invocations →
+ *     two distinct `delegation.spawn` events; SubagentStop linkage uses
+ *     `tool_call_id` to find the right parent.
+ *   - Non-Agent tools → no spawn event is emitted (additive scope).
+ *   - Allowed Agent calls without `tool_call_id` / `tool_use_id` → spawn
+ *     skipped (the linkage cannot be reconstructed without the id).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+
+import { runInitWithOptions } from '../../commands/workflow/init.js';
+import { runGuardWithOptions } from '../../commands/workflow/guard.js';
+import { runCaptureSubagentWithOptions } from '../../commands/workflow/capture-subagent.js';
+import { sessionDir as sessionDirForProject } from '../../lib/workspace-paths.js';
+import { EventStore } from '../../workflow/store.js';
+import { resolveWorkflowState } from '../../workflow/engine.js';
+import {
+  buildGuardMatcher,
+  type GuardMatcher,
+} from '../../workflow/guards.js';
+import { defaultPredicates } from '../../workflow/predicates.js';
+import { generateStepReadme } from '../../workflow/step-readme-writer.js';
+import { compileVerificationBlock } from '../../specs/verification-block.js';
+import type { WorkflowState } from '../../workflow/state.js';
+
+// ---------------------------------------------------------------------------
+// stdout / stderr capture + process.exit trap
+// ---------------------------------------------------------------------------
+
+interface Captured {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+}
+
+class ExitCalled extends Error {
+  constructor(readonly code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+let captured: Captured;
+let origStdoutWrite: typeof process.stdout.write;
+let origStderrWrite: typeof process.stderr.write;
+let origExit: typeof process.exit;
+
+beforeEach(() => {
+  captured = { stdout: '', stderr: '', exitCode: null };
+  origStdoutWrite = process.stdout.write;
+  origStderrWrite = process.stderr.write;
+  origExit = process.exit;
+
+  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+    captured.stdout +=
+      typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+    captured.stderr +=
+      typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    return true;
+  }) as typeof process.stderr.write;
+  process.exit = ((code?: number | string | null): never => {
+    captured.exitCode = typeof code === 'number' ? code : 0;
+    throw new ExitCalled(captured.exitCode);
+  }) as typeof process.exit;
+});
+
+afterEach(() => {
+  process.stdout.write = origStdoutWrite;
+  process.stderr.write = origStderrWrite;
+  process.exit = origExit;
+});
+
+async function captureExit(fn: () => Promise<void>): Promise<void> {
+  try {
+    await fn();
+  } catch (err) {
+    if (err instanceof ExitCalled) return;
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scratch dirs
+// ---------------------------------------------------------------------------
+
+const scratchDirs: string[] = [];
+
+afterEach(() => {
+  while (scratchDirs.length > 0) {
+    const d = scratchDirs.pop();
+    if (d !== undefined) {
+      try {
+        rmSync(d, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    }
+  }
+});
+
+function makeScratchRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gobbi-spawn-emit-'));
+  scratchDirs.push(dir);
+  return dir;
+}
+
+async function initScratchSession(
+  sessionId: string,
+): Promise<{ sessionDir: string; repo: string }> {
+  const repo = makeScratchRepo();
+  await captureExit(() =>
+    runInitWithOptions(
+      ['--session-id', sessionId, '--task', 'spawn-emit-test'],
+      { repoRoot: repo },
+    ),
+  );
+  const sessionDir = sessionDirForProject(repo, basename(repo), sessionId);
+  captured = { stdout: '', stderr: '', exitCode: null };
+  return { sessionDir, repo };
+}
+
+function emptyMatcher(): GuardMatcher {
+  return buildGuardMatcher([]);
+}
+
+// ===========================================================================
+// Primary contract — single-agent spawn
+// ===========================================================================
+
+describe('PreToolUse guard — single-agent spawn emission', () => {
+  test('Agent tool with subagent_type + tool_call_id → one delegation.spawn', async () => {
+    const sessionId = 'spawn-single';
+    const { sessionDir } = await initScratchSession(sessionId);
+
+    await captureExit(() =>
+      runGuardWithOptions([], {
+        sessionDir,
+        matcher: emptyMatcher(),
+        payload: {
+          tool_name: 'Task',
+          session_id: sessionId,
+          tool_call_id: 'toolu_single',
+          tool_input: {
+            subagent_type: '__executor',
+            prompt: 'do the thing',
+          },
+        },
+      }),
+    );
+
+    expect(captured.exitCode).toBeNull();
+
+    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    try {
+      const spawns = store.byType('delegation.spawn');
+      expect(spawns).toHaveLength(1);
+      const data = JSON.parse(spawns[0]!.data) as {
+        readonly agentType: string;
+        readonly tool_call_id?: string;
+        readonly subagentId: string;
+        readonly step: string;
+      };
+      expect(data.agentType).toBe('__executor');
+      expect(data.tool_call_id).toBe('toolu_single');
+      // No agent_id in the payload, so subagentId falls back to tool_call_id.
+      expect(data.subagentId).toBe('toolu_single');
+      // ideation is the step init lands on after eval.decide.
+      expect(data.step).toBe('ideation');
+    } finally {
+      store.close();
+    }
+  });
+
+  test('Agent tool via tool_use_id (canonical Claude Code field) emits spawn', async () => {
+    const sessionId = 'spawn-use-id';
+    const { sessionDir } = await initScratchSession(sessionId);
+
+    await captureExit(() =>
+      runGuardWithOptions([], {
+        sessionDir,
+        matcher: emptyMatcher(),
+        payload: {
+          tool_name: 'Task',
+          session_id: sessionId,
+          tool_use_id: 'toolu_canonical',
+          tool_input: { subagent_type: '__pi' },
+        },
+      }),
+    );
+
+    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    try {
+      const spawns = store.byType('delegation.spawn');
+      expect(spawns).toHaveLength(1);
+      const data = JSON.parse(spawns[0]!.data) as {
+        readonly tool_call_id?: string;
+        readonly agentType: string;
+      };
+      expect(data.tool_call_id).toBe('toolu_canonical');
+      expect(data.agentType).toBe('__pi');
+    } finally {
+      store.close();
+    }
+  });
+
+  test('non-Agent tool → no delegation.spawn event', async () => {
+    const sessionId = 'spawn-no-agent';
+    const { sessionDir } = await initScratchSession(sessionId);
+
+    await captureExit(() =>
+      runGuardWithOptions([], {
+        sessionDir,
+        matcher: emptyMatcher(),
+        payload: {
+          tool_name: 'Write',
+          session_id: sessionId,
+          tool_call_id: 'toolu_write',
+          tool_input: { file_path: '/tmp/x', content: '' },
+        },
+      }),
+    );
+
+    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    try {
+      expect(store.byType('delegation.spawn')).toHaveLength(0);
+    } finally {
+      store.close();
+    }
+  });
+
+  test('Agent tool without tool_call_id / tool_use_id → no spawn (linkage impossible)', async () => {
+    const sessionId = 'spawn-no-tcid';
+    const { sessionDir } = await initScratchSession(sessionId);
+
+    await captureExit(() =>
+      runGuardWithOptions([], {
+        sessionDir,
+        matcher: emptyMatcher(),
+        payload: {
+          tool_name: 'Task',
+          session_id: sessionId,
+          tool_input: { subagent_type: '__executor' },
+          // no tool_call_id, no tool_use_id
+        },
+      }),
+    );
+
+    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    try {
+      expect(store.byType('delegation.spawn')).toHaveLength(0);
+    } finally {
+      store.close();
+    }
+  });
+
+  test('Agent tool without subagent_type → no spawn (agentType missing)', async () => {
+    const sessionId = 'spawn-no-type';
+    const { sessionDir } = await initScratchSession(sessionId);
+
+    await captureExit(() =>
+      runGuardWithOptions([], {
+        sessionDir,
+        matcher: emptyMatcher(),
+        payload: {
+          tool_name: 'Task',
+          session_id: sessionId,
+          tool_call_id: 'toolu_no_type',
+          tool_input: { prompt: 'no type carried' },
+        },
+      }),
+    );
+
+    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    try {
+      expect(store.byType('delegation.spawn')).toHaveLength(0);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+// ===========================================================================
+// Primary contract — two parallel agents
+// ===========================================================================
+
+describe('PreToolUse guard — parallel-agent spawn emission', () => {
+  test('two distinct tool_call_ids → two distinct spawn events; SubagentStop links each correctly', async () => {
+    const sessionId = 'spawn-parallel';
+    const { sessionDir } = await initScratchSession(sessionId);
+
+    // Two PreToolUse invocations land back-to-back from the same orchestrator
+    // turn — Claude Code dispatches Agent tool calls in parallel batches.
+    await captureExit(() =>
+      runGuardWithOptions([], {
+        sessionDir,
+        matcher: emptyMatcher(),
+        payload: {
+          tool_name: 'Task',
+          session_id: sessionId,
+          tool_call_id: 'toolu_par_A',
+          tool_input: { subagent_type: '__pi', stance: 'innovative' },
+        },
+      }),
+    );
+    captured = { stdout: '', stderr: '', exitCode: null };
+    await captureExit(() =>
+      runGuardWithOptions([], {
+        sessionDir,
+        matcher: emptyMatcher(),
+        payload: {
+          tool_name: 'Task',
+          session_id: sessionId,
+          tool_call_id: 'toolu_par_B',
+          tool_input: { subagent_type: '__pi', stance: 'best' },
+        },
+      }),
+    );
+
+    let spawnA: number | null = null;
+    let spawnB: number | null = null;
+    {
+      const store = new EventStore(join(sessionDir, 'gobbi.db'));
+      try {
+        const spawns = store.byType('delegation.spawn');
+        expect(spawns).toHaveLength(2);
+        for (const row of spawns) {
+          const data = JSON.parse(row.data) as { readonly tool_call_id: string };
+          if (data.tool_call_id === 'toolu_par_A') spawnA = row.seq;
+          if (data.tool_call_id === 'toolu_par_B') spawnB = row.seq;
+        }
+      } finally {
+        store.close();
+      }
+    }
+    expect(spawnA).not.toBeNull();
+    expect(spawnB).not.toBeNull();
+    expect(spawnA).not.toBe(spawnB);
+
+    // Now SubagentStop arrives in REVERSE order (B first, then A). The
+    // previous heuristic (last('delegation.spawn') filtered by subagentId)
+    // would link both completions to the same most-recent spawn unless the
+    // subagentIds happened to match. The new tool_call_id-scoped lookup
+    // links each completion to its own spawn regardless of arrival order.
+    const transcriptDir = mkdtempSync(join(tmpdir(), 'spawn-emit-tr-'));
+    scratchDirs.push(transcriptDir);
+    const trA = join(transcriptDir, 'A.jsonl');
+    const trB = join(transcriptDir, 'B.jsonl');
+    {
+      const { writeFileSync } = await import('node:fs');
+      const lineA = JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'A' }] },
+      });
+      const lineB = JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'B' }] },
+      });
+      writeFileSync(trA, `${lineA}\n`, 'utf8');
+      writeFileSync(trB, `${lineB}\n`, 'utf8');
+    }
+
+    captured = { stdout: '', stderr: '', exitCode: null };
+    await captureExit(() =>
+      runCaptureSubagentWithOptions([], {
+        sessionDir,
+        payload: {
+          // agent_id is not present in the spawn payload; capture-subagent
+          // uses tool_call_id to find the right parent regardless.
+          agent_id: 'toolu_par_B',
+          agent_type: '__pi',
+          agent_transcript_path: trB,
+          session_id: sessionId,
+          tool_call_id: 'toolu_par_B',
+        },
+      }),
+    );
+    captured = { stdout: '', stderr: '', exitCode: null };
+    await captureExit(() =>
+      runCaptureSubagentWithOptions([], {
+        sessionDir,
+        payload: {
+          agent_id: 'toolu_par_A',
+          agent_type: '__pi',
+          agent_transcript_path: trA,
+          session_id: sessionId,
+          tool_call_id: 'toolu_par_A',
+        },
+      }),
+    );
+
+    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    try {
+      const completes = store.byType('delegation.complete');
+      expect(completes).toHaveLength(2);
+      const linkage = new Map<string, number | null>();
+      for (const row of completes) {
+        const data = JSON.parse(row.data) as { readonly subagentId: string };
+        linkage.set(data.subagentId, row.parent_seq);
+      }
+      // Each completion must link to its own spawn — the parallel-subagent
+      // misattribution that the previous heuristic produced is gone.
+      expect(linkage.get('toolu_par_A')).toBe(spawnA);
+      expect(linkage.get('toolu_par_B')).toBe(spawnB);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+// ===========================================================================
+// Ripple — `workflow/reducer.ts:314` (delegation.spawn handler)
+// ===========================================================================
+
+describe('Ripple — reducer.delegation.spawn populates state.activeSubagents', () => {
+  test('after guard emits spawn, derived state lists the subagent', async () => {
+    const sessionId = 'ripple-reducer';
+    const { sessionDir } = await initScratchSession(sessionId);
+
+    await captureExit(() =>
+      runGuardWithOptions([], {
+        sessionDir,
+        matcher: emptyMatcher(),
+        payload: {
+          tool_name: 'Task',
+          session_id: sessionId,
+          tool_call_id: 'toolu_R1',
+          tool_input: { subagent_type: '__pi' },
+        },
+      }),
+    );
+
+    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    try {
+      const state = resolveWorkflowState(sessionDir, store, sessionId);
+      expect(state.activeSubagents).toHaveLength(1);
+      const sub = state.activeSubagents[0]!;
+      expect(sub.agentType).toBe('__pi');
+      expect(sub.subagentId).toBe('toolu_R1');
+      expect(sub.step).toBe('ideation');
+      // spawnedAt is the spawn event's `data.timestamp` — a non-empty ISO.
+      expect(sub.spawnedAt.length).toBeGreaterThan(0);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+// ===========================================================================
+// Ripple — `predicates.piAgentsToSpawn`
+// ===========================================================================
+
+describe('Ripple — predicates.piAgentsToSpawn fires once a __pi spawn lands', () => {
+  test('false before spawn, true after spawn', async () => {
+    const sessionId = 'ripple-pi';
+    const { sessionDir } = await initScratchSession(sessionId);
+
+    const pred = defaultPredicates['piAgentsToSpawn'];
+    if (pred === undefined) {
+      throw new Error('piAgentsToSpawn predicate not registered');
+    }
+
+    {
+      const store = new EventStore(join(sessionDir, 'gobbi.db'));
+      try {
+        const state = resolveWorkflowState(sessionDir, store, sessionId);
+        expect(pred(state)).toBe(false);
+      } finally {
+        store.close();
+      }
+    }
+
+    await captureExit(() =>
+      runGuardWithOptions([], {
+        sessionDir,
+        matcher: emptyMatcher(),
+        payload: {
+          tool_name: 'Task',
+          session_id: sessionId,
+          tool_call_id: 'toolu_pi',
+          tool_input: { subagent_type: '__pi' },
+        },
+      }),
+    );
+
+    {
+      const store = new EventStore(join(sessionDir, 'gobbi.db'));
+      try {
+        const state = resolveWorkflowState(sessionDir, store, sessionId);
+        expect(pred(state)).toBe(true);
+      } finally {
+        store.close();
+      }
+    }
+  });
+});
+
+// ===========================================================================
+// Ripple — `workflow/reducer.ts:681-687` (verification.result presence guard)
+//
+// The reducer rejects `verification.result` when its `subagentId` is NOT in
+// `state.activeSubagents`. With the spawn emitter live, this rejection
+// SHOULD NOT fire when the spawn has been recorded. Verifies the
+// reducer handler accepts a verification.result whose subagent has been
+// spawned through the new guard path.
+// ===========================================================================
+
+describe('Ripple — reducer accepts verification.result when matching spawn exists', () => {
+  test('spawn → reducer admits verification.result for the same subagent (no rejection)', async () => {
+    const sessionId = 'ripple-verify';
+    const { sessionDir } = await initScratchSession(sessionId);
+
+    await captureExit(() =>
+      runGuardWithOptions([], {
+        sessionDir,
+        matcher: emptyMatcher(),
+        payload: {
+          tool_name: 'Task',
+          session_id: sessionId,
+          tool_call_id: 'toolu_V',
+          tool_input: { subagent_type: '__executor' },
+        },
+      }),
+    );
+
+    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    try {
+      const state = resolveWorkflowState(sessionDir, store, sessionId);
+      // The subagent is in activeSubagents — the reducer's "must be active"
+      // gate at lines 681-687 will admit a verification.result keyed on
+      // this subagentId. We don't append the verification.result here (it
+      // requires a complete event factory + state), but the precondition
+      // check the reducer relies on is now satisfied.
+      const subagentId = state.activeSubagents[0]?.subagentId;
+      expect(subagentId).toBe('toolu_V');
+      const isActive = state.activeSubagents.some(
+        (a) => a.subagentId === subagentId,
+      );
+      expect(isActive).toBe(true);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+// ===========================================================================
+// Ripple — `workflow/step-readme-writer.subagentsActiveAtExit`
+//
+// The frontmatter field has been writing 0 in production because no spawn
+// events were recorded. With the spawn emitter live, the field reflects
+// the actual count of subagents whose `step === <exiting step>`.
+// ===========================================================================
+
+describe('Ripple — step-readme writes correct subagentsActiveAtExit', () => {
+  test('one __pi spawn at ideation → frontmatter shows subagentsActiveAtExit: 1', async () => {
+    const sessionId = 'ripple-readme';
+    const { sessionDir } = await initScratchSession(sessionId);
+
+    await captureExit(() =>
+      runGuardWithOptions([], {
+        sessionDir,
+        matcher: emptyMatcher(),
+        payload: {
+          tool_name: 'Task',
+          session_id: sessionId,
+          tool_call_id: 'toolu_RM',
+          tool_input: { subagent_type: '__pi' },
+        },
+      }),
+    );
+
+    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    try {
+      const state = resolveWorkflowState(sessionDir, store, sessionId);
+      // Exercise the writer's pure rendering path. The count is filtered by
+      // step === exitedStep — the spawn we just emitted is at `ideation`, so
+      // exiting `ideation` should show 1.
+      const subagentsActiveAtExit = state.activeSubagents.filter(
+        (a) => a.step === 'ideation',
+      ).length;
+      expect(subagentsActiveAtExit).toBe(1);
+
+      const md = generateStepReadme({
+        sessionId: state.sessionId,
+        projectName: 'gobbi',
+        step: 'ideation',
+        enteredAt: state.stepStartedAt,
+        exitedAt: '2026-04-29T00:00:00.000Z',
+        verdictOutcome: state.lastVerdictOutcome,
+        artifacts: state.artifacts['ideation'] ?? [],
+        subagentsActiveAtExit,
+        feedbackRound: state.feedbackRound,
+        nextStep: 'planning',
+      });
+      expect(md).toContain('subagentsActiveAtExit: 1');
+    } finally {
+      store.close();
+    }
+  });
+});
+
+// ===========================================================================
+// Ripple — `next.ts::verification-block` rendering with active subagents
+//
+// `compileVerificationBlock` reads `state.activeSubagents` and
+// `state.verificationResults` to render per-subagent verification rows.
+// With at least one spawn now landed in production, the block can be
+// invoked against a non-empty active set without trampling its existing
+// header/empty-results contract.
+// ===========================================================================
+
+describe('Ripple — verification-block renders for spawned subagent', () => {
+  test('compiles a per-subagent block once a spawn has landed', async () => {
+    const sessionId = 'ripple-vblock';
+    const { sessionDir } = await initScratchSession(sessionId);
+
+    await captureExit(() =>
+      runGuardWithOptions([], {
+        sessionDir,
+        matcher: emptyMatcher(),
+        payload: {
+          tool_name: 'Task',
+          session_id: sessionId,
+          tool_call_id: 'toolu_VB',
+          tool_input: { subagent_type: '__executor' },
+        },
+      }),
+    );
+
+    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    try {
+      const state = resolveWorkflowState(sessionDir, store, sessionId);
+      const sub = state.activeSubagents[0];
+      expect(sub).toBeDefined();
+      const block = compileVerificationBlock(state as WorkflowState, sub!.subagentId);
+      // The block always carries the static header; presence of any non-
+      // empty render output proves the function did not throw on the new
+      // active set. The exact text is the responsibility of the
+      // verification-block tests; here we just pin "compiles + emits".
+      expect(typeof block.text).toBe('string');
+      expect(block.text.length).toBeGreaterThan(0);
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/packages/cli/src/commands/gotcha/__tests__/promote.test.ts
+++ b/packages/cli/src/commands/gotcha/__tests__/promote.test.ts
@@ -1,0 +1,459 @@
+/**
+ * project.json index assertions for `gobbi gotcha promote`.
+ *
+ * The dispatcher, registry, file-routing, dry-run, and edge-case behaviours
+ * for `runPromoteWithOptions` live next door at
+ * `packages/cli/src/commands/__tests__/gotcha.test.ts`. THIS file scopes
+ * narrowly to PR-FIN-2a-ii T-2a.8.3 — the rewire from a stand-alone
+ * gotcha-index seam to `lib/json-memory.ts::upsertProjectGotcha`.
+ *
+ * What we verify here:
+ *
+ *   - A project-scoped promote populates `project.json.gotchas[]` with one
+ *     `ProjectJsonGotcha` entry whose `path` is the destination's
+ *     repo-relative path and whose `sha256` matches the bytes actually on
+ *     disk after the append (NOT the bytes of the source draft, which can
+ *     differ when the destination already had prior accumulated entries).
+ *   - Multiple project-scoped promotes land sorted alphabetically by
+ *     `path` (the `lib/json-memory.ts` invariant from lock 32 — sort
+ *     discipline applied at the writer call site).
+ *   - Re-running promote is idempotent at the index level: `upsertById`
+ *     in `json-memory.ts` keys gotchas by `path` and replaces in place,
+ *     so the index never grows duplicates even when the same destination
+ *     is touched twice.
+ *   - Skill-scoped promotes do NOT add anything to
+ *     `project.json.gotchas[]` — skill gotchas live colocated with their
+ *     skill via the `.claude/skills/` symlink farm and are not part of
+ *     cross-session project memory.
+ *   - The same-path no-op case (default project — source and destination
+ *     are the same absolute path) still records the entry: the file is in
+ *     its permanent location and should be indexed even though no
+ *     filesystem move happened.
+ *   - `promotedFromSession` reads `$CLAUDE_SESSION_ID`; falls back to the
+ *     literal `'unknown'` when the env var is absent so the AJV
+ *     `minLength: 1` constraint holds.
+ *
+ * The scratch-repo helper mirrors the post-W3.1 layout used by
+ * `commands/__tests__/gotcha.test.ts` so the two files are visually
+ * compatible.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { readProjectJson, projectJsonPath } from '../../../lib/json-memory.js';
+import { runPromoteWithOptions } from '../promote.js';
+
+// ---------------------------------------------------------------------------
+// stdout/stderr capture + process.exit trap (mirrors gotcha.test.ts)
+// ---------------------------------------------------------------------------
+
+interface Captured {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+}
+
+class ExitCalled extends Error {
+  constructor(readonly code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+let captured: Captured;
+let origStdoutWrite: typeof process.stdout.write;
+let origStderrWrite: typeof process.stderr.write;
+let origExit: typeof process.exit;
+let origSessionId: string | undefined;
+
+beforeEach(() => {
+  captured = { stdout: '', stderr: '', exitCode: null };
+  origStdoutWrite = process.stdout.write;
+  origStderrWrite = process.stderr.write;
+  origExit = process.exit;
+  origSessionId = process.env['CLAUDE_SESSION_ID'];
+
+  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+    captured.stdout +=
+      typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+    captured.stderr +=
+      typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    return true;
+  }) as typeof process.stderr.write;
+  process.exit = ((code?: number | string | null): never => {
+    captured.exitCode = typeof code === 'number' ? code : 0;
+    throw new ExitCalled(captured.exitCode);
+  }) as typeof process.exit;
+});
+
+afterEach(() => {
+  process.stdout.write = origStdoutWrite;
+  process.stderr.write = origStderrWrite;
+  process.exit = origExit;
+  if (origSessionId === undefined) {
+    delete process.env['CLAUDE_SESSION_ID'];
+  } else {
+    process.env['CLAUDE_SESSION_ID'] = origSessionId;
+  }
+});
+
+async function captureExit(fn: () => Promise<void>): Promise<void> {
+  try {
+    await fn();
+  } catch (err) {
+    if (err instanceof ExitCalled) return;
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scratch dir helpers
+// ---------------------------------------------------------------------------
+
+const scratchDirs: string[] = [];
+
+afterEach(() => {
+  while (scratchDirs.length > 0) {
+    const d = scratchDirs.pop();
+    if (d !== undefined) {
+      try {
+        rmSync(d, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    }
+  }
+});
+
+function makeScratchRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gobbi-promote-index-'));
+  scratchDirs.push(dir);
+  return dir;
+}
+
+function makeRepoLayout(destinationProjectName: string | null): {
+  repo: string;
+  sourceDir: string;
+  claudeDir: string;
+} {
+  const repo = makeScratchRepo();
+  const sourceDir = join(repo, '.gobbi', 'projects', 'gobbi', 'gotchas');
+  mkdirSync(sourceDir, { recursive: true });
+  const claudeDir = join(repo, '.claude');
+  mkdirSync(claudeDir, { recursive: true });
+  if (destinationProjectName !== null) {
+    mkdirSync(join(repo, '.gobbi', 'projects', destinationProjectName), {
+      recursive: true,
+    });
+  }
+  return { repo, sourceDir, claudeDir };
+}
+
+function sha256Hex(bytes: Buffer | string): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+// ===========================================================================
+// project.json index — single project-scoped promote
+// ===========================================================================
+
+describe('runPromote — project.json index (project-scoped)', () => {
+  test('writes one ProjectJsonGotcha entry with the correct path + sha256', async () => {
+    process.env['CLAUDE_SESSION_ID'] = 'test-session-abc';
+    const { repo, sourceDir, claudeDir } = makeRepoLayout('testproj');
+    const body = '## foo\n\nPriority: high\n\nbody.\n';
+    writeFileSync(join(sourceDir, 'foo.md'), body, 'utf8');
+
+    await captureExit(() =>
+      runPromoteWithOptions(
+        ['--project', 'gobbi', '--destination-project', 'testproj'],
+        { repoRoot: repo, claudeDir },
+      ),
+    );
+    expect(captured.exitCode).toBeNull();
+
+    const indexFile = projectJsonPath(repo, 'testproj');
+    const project = readProjectJson(indexFile);
+    expect(project).not.toBeNull();
+    expect(project?.gotchas).toHaveLength(1);
+
+    const entry = project?.gotchas[0];
+    expect(entry?.path).toBe(
+      join('.gobbi', 'projects', 'testproj', 'gotchas', 'foo.md'),
+    );
+    // sha256 reflects the bytes actually on disk after the append. For a
+    // first-time promote with no prior accumulated entries the destination
+    // body equals the source body (the body already ends in '\n', so the
+    // applyPromotion newline-fixer is a no-op).
+    const destBytes = readFileSync(
+      join(repo, '.gobbi', 'projects', 'testproj', 'gotchas', 'foo.md'),
+    );
+    expect(entry?.sha256).toBe(sha256Hex(destBytes));
+    expect(entry?.sha256).toMatch(/^[0-9a-f]{64}$/);
+
+    expect(entry?.class).toBe('unknown');
+    expect(entry?.promotedFromSession).toBe('test-session-abc');
+    expect(typeof entry?.promotedAt).toBe('string');
+    expect(entry?.promotedAt).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/,
+    );
+  });
+
+  test('sha256 reflects post-append bytes when the destination already exists', async () => {
+    process.env['CLAUDE_SESSION_ID'] = 'sess-2';
+    const { repo, sourceDir, claudeDir } = makeRepoLayout('testproj');
+    const destDir = join(repo, '.gobbi', 'projects', 'testproj', 'gotchas');
+    mkdirSync(destDir, { recursive: true });
+    const existing = '## prior entry\n\nold.\n';
+    writeFileSync(join(destDir, 'bar.md'), existing, 'utf8');
+
+    const newBody = '## fresh entry\n\nnew.\n';
+    writeFileSync(join(sourceDir, 'bar.md'), newBody, 'utf8');
+
+    await captureExit(() =>
+      runPromoteWithOptions(
+        ['--project', 'gobbi', '--destination-project', 'testproj'],
+        { repoRoot: repo, claudeDir },
+      ),
+    );
+
+    const destBytes = readFileSync(join(destDir, 'bar.md'));
+    const project = readProjectJson(projectJsonPath(repo, 'testproj'));
+    expect(project?.gotchas).toHaveLength(1);
+    expect(project?.gotchas[0]?.sha256).toBe(sha256Hex(destBytes));
+    // Sanity: the post-append digest is NOT the digest of the source body
+    // alone, because the destination already held the prior entry.
+    expect(project?.gotchas[0]?.sha256).not.toBe(sha256Hex(newBody));
+  });
+});
+
+// ===========================================================================
+// project.json index — sort order
+// ===========================================================================
+
+describe('runPromote — project.json index sort order', () => {
+  test('multiple project-scoped promotes land alphabetically by path', async () => {
+    process.env['CLAUDE_SESSION_ID'] = 'sess-sort';
+    const { repo, sourceDir, claudeDir } = makeRepoLayout('testproj');
+    // Seed in non-alphabetical order so any accidental insertion-order
+    // bug surfaces clearly.
+    writeFileSync(join(sourceDir, 'zeta.md'), 'z\n', 'utf8');
+    writeFileSync(join(sourceDir, 'alpha.md'), 'a\n', 'utf8');
+    writeFileSync(join(sourceDir, 'mango.md'), 'm\n', 'utf8');
+
+    await captureExit(() =>
+      runPromoteWithOptions(
+        ['--project', 'gobbi', '--destination-project', 'testproj'],
+        { repoRoot: repo, claudeDir },
+      ),
+    );
+
+    const project = readProjectJson(projectJsonPath(repo, 'testproj'));
+    const paths = project?.gotchas.map((g) => g.path);
+    expect(paths).toEqual([
+      join('.gobbi', 'projects', 'testproj', 'gotchas', 'alpha.md'),
+      join('.gobbi', 'projects', 'testproj', 'gotchas', 'mango.md'),
+      join('.gobbi', 'projects', 'testproj', 'gotchas', 'zeta.md'),
+    ]);
+  });
+});
+
+// ===========================================================================
+// project.json index — idempotency
+// ===========================================================================
+
+describe('runPromote — project.json index idempotency', () => {
+  test('re-promoting the same destination does not duplicate the entry', async () => {
+    // The default-project same-path-no-op case is the natural fixture: the
+    // source `solo.md` lives at `gotchas/solo.md` and the destination
+    // resolves to the SAME path, so re-running keeps the file in place
+    // (no source delete) and keeps `upsertProjectGotcha` working against
+    // the same `path` key. `upsertById` filters by key and replaces, so
+    // the gotchas[] array stays length 1.
+    process.env['CLAUDE_SESSION_ID'] = 'sess-idem';
+    const repo = makeScratchRepo();
+    const sourceDir = join(repo, '.gobbi', 'projects', 'gobbi', 'gotchas');
+    mkdirSync(sourceDir, { recursive: true });
+    const claudeDir = join(repo, '.claude');
+    writeFileSync(join(sourceDir, 'solo.md'), '## solo\n', 'utf8');
+
+    await captureExit(() =>
+      runPromoteWithOptions(['--project', 'gobbi'], {
+        repoRoot: repo,
+        claudeDir,
+      }),
+    );
+    expect(captured.exitCode).toBeNull();
+
+    const indexFile = projectJsonPath(repo, 'gobbi');
+    const first = readProjectJson(indexFile);
+    expect(first?.gotchas).toHaveLength(1);
+    const firstSha = first?.gotchas[0]?.sha256;
+
+    // Re-run — same source still in place (same-path no-op preserves it),
+    // index upsert key is unchanged.
+    await captureExit(() =>
+      runPromoteWithOptions(['--project', 'gobbi'], {
+        repoRoot: repo,
+        claudeDir,
+      }),
+    );
+    const second = readProjectJson(indexFile);
+    expect(second?.gotchas).toHaveLength(1);
+    // Bytes on disk did not change between runs (same-path no-op skips the
+    // append), so the sha256 round-trips unchanged too.
+    expect(second?.gotchas[0]?.sha256).toBe(firstSha);
+  });
+});
+
+// ===========================================================================
+// project.json index — skill-scoped exclusion
+// ===========================================================================
+
+describe('runPromote — project.json index excludes skill-scoped', () => {
+  test('skill-scoped promotes do not populate project.json.gotchas[]', async () => {
+    process.env['CLAUDE_SESSION_ID'] = 'sess-skill';
+    const { repo, sourceDir, claudeDir } = makeRepoLayout('testproj');
+    writeFileSync(
+      join(sourceDir, '_skill-_git.md'),
+      '## skill-scoped\n',
+      'utf8',
+    );
+
+    await captureExit(() =>
+      runPromoteWithOptions(['--project', 'gobbi'], {
+        repoRoot: repo,
+        claudeDir,
+      }),
+    );
+    expect(captured.exitCode).toBeNull();
+
+    // Skill-scoped destination written.
+    expect(
+      existsSync(join(claudeDir, 'skills', '_git', 'gotchas.md')),
+    ).toBe(true);
+
+    // testproj's project.json was never created — there were no
+    // project-scoped entries to record.
+    expect(existsSync(projectJsonPath(repo, 'testproj'))).toBe(false);
+  });
+
+  test('mixed batch only indexes the project-scoped entries', async () => {
+    process.env['CLAUDE_SESSION_ID'] = 'sess-mixed';
+    const { repo, sourceDir, claudeDir } = makeRepoLayout('testproj');
+    writeFileSync(join(sourceDir, 'realdeal.md'), '## real\n', 'utf8');
+    writeFileSync(
+      join(sourceDir, '_skill-_plan.md'),
+      '## plan-skill\n',
+      'utf8',
+    );
+
+    await captureExit(() =>
+      runPromoteWithOptions(
+        ['--project', 'gobbi', '--destination-project', 'testproj'],
+        { repoRoot: repo, claudeDir },
+      ),
+    );
+    expect(captured.exitCode).toBeNull();
+
+    const project = readProjectJson(projectJsonPath(repo, 'testproj'));
+    expect(project?.gotchas).toHaveLength(1);
+    expect(project?.gotchas[0]?.path).toBe(
+      join('.gobbi', 'projects', 'testproj', 'gotchas', 'realdeal.md'),
+    );
+    // Skill-scoped destination still written, but it is NOT in the index.
+    expect(
+      existsSync(join(claudeDir, 'skills', '_plan', 'gotchas.md')),
+    ).toBe(true);
+  });
+});
+
+// ===========================================================================
+// project.json index — same-path no-op (default project)
+// ===========================================================================
+
+describe('runPromote — project.json index for same-path no-op', () => {
+  test('default-project same-path collision still indexes the file', async () => {
+    process.env['CLAUDE_SESSION_ID'] = 'sess-samepath';
+    const repo = makeScratchRepo();
+    const sourceDir = join(repo, '.gobbi', 'projects', 'gobbi', 'gotchas');
+    mkdirSync(sourceDir, { recursive: true });
+    const claudeDir = join(repo, '.claude');
+    const body = '## the only gotcha\n';
+    writeFileSync(join(sourceDir, 'foo.md'), body, 'utf8');
+
+    await captureExit(() =>
+      runPromoteWithOptions(['--project', 'gobbi'], {
+        repoRoot: repo,
+        claudeDir,
+      }),
+    );
+    expect(captured.exitCode).toBeNull();
+
+    // Source file untouched (same-path no-op preserves it).
+    expect(existsSync(join(sourceDir, 'foo.md'))).toBe(true);
+    expect(readFileSync(join(sourceDir, 'foo.md'), 'utf8')).toBe(body);
+
+    // Index entry IS recorded — the file is in its permanent location and
+    // should appear in the project's cross-session memory.
+    const project = readProjectJson(projectJsonPath(repo, 'gobbi'));
+    expect(project?.gotchas).toHaveLength(1);
+    expect(project?.gotchas[0]?.path).toBe(
+      join('.gobbi', 'projects', 'gobbi', 'gotchas', 'foo.md'),
+    );
+    expect(project?.gotchas[0]?.sha256).toBe(sha256Hex(body));
+  });
+});
+
+// ===========================================================================
+// project.json index — session-id fallback
+// ===========================================================================
+
+describe('runPromote — promotedFromSession resolution', () => {
+  test('falls back to "unknown" when CLAUDE_SESSION_ID is unset', async () => {
+    delete process.env['CLAUDE_SESSION_ID'];
+    const { repo, sourceDir, claudeDir } = makeRepoLayout('testproj');
+    writeFileSync(join(sourceDir, 'foo.md'), 'body\n', 'utf8');
+
+    await captureExit(() =>
+      runPromoteWithOptions(
+        ['--project', 'gobbi', '--destination-project', 'testproj'],
+        { repoRoot: repo, claudeDir },
+      ),
+    );
+    expect(captured.exitCode).toBeNull();
+
+    const project = readProjectJson(projectJsonPath(repo, 'testproj'));
+    expect(project?.gotchas[0]?.promotedFromSession).toBe('unknown');
+  });
+
+  test('falls back to "unknown" when CLAUDE_SESSION_ID is the empty string', async () => {
+    process.env['CLAUDE_SESSION_ID'] = '';
+    const { repo, sourceDir, claudeDir } = makeRepoLayout('testproj');
+    writeFileSync(join(sourceDir, 'foo.md'), 'body\n', 'utf8');
+
+    await captureExit(() =>
+      runPromoteWithOptions(
+        ['--project', 'gobbi', '--destination-project', 'testproj'],
+        { repoRoot: repo, claudeDir },
+      ),
+    );
+    expect(captured.exitCode).toBeNull();
+
+    const project = readProjectJson(projectJsonPath(repo, 'testproj'));
+    expect(project?.gotchas[0]?.promotedFromSession).toBe('unknown');
+  });
+});

--- a/packages/cli/src/commands/gotcha/promote.ts
+++ b/packages/cli/src/commands/gotcha/promote.ts
@@ -17,6 +17,11 @@
  *      re-running does not duplicate.
  *   2. `--dry-run` — prints the planned moves; writes nothing, deletes
  *      nothing, exits 0.
+ *   3. Project-scoped promotions also upsert a `ProjectJsonGotcha` entry
+ *      into the destination project's `project.json.gotchas[]` (PR-FIN-2a-ii
+ *      T-2a.8.3 — the JSON-memory pivot retired the legacy SQLite gotcha
+ *      index). Skill-scoped promotions are NOT indexed: skill gotchas live
+ *      colocated with their skill, not in cross-session project memory.
  *
  * ## Active-session guard (removed, PR-FIN-2a-i T-2a.1.5)
  *
@@ -41,18 +46,43 @@
  *                                   (symlink target:
  *                                   `.gobbi/projects/<project>/skills/{skillName}/gotchas.md`)
  *
+ * ## project.json index (PR-FIN-2a-ii T-2a.8.3)
+ *
+ * For each project-scoped promotion, the command upserts a
+ * `ProjectJsonGotcha` entry into
+ * `.gobbi/projects/<project>/project.json.gotchas[]` keyed by `path`. The
+ * stored `path` is the destination relative to `repoRoot`; `sha256` is a
+ * 64-char hex digest of the destination file's bytes after append (so the
+ * digest reflects the indexed file's actual on-disk state, including any
+ * accumulated prior entries). `class` defaults to `'unknown'` — promotion
+ * does not parse the markdown body to extract a Priority line, and the
+ * legacy SQLite index never carried a typed class either. A future
+ * frontmatter-aware promote can populate `class` without a schema change.
+ * `promotedFromSession` reads `$CLAUDE_SESSION_ID` (the canonical session
+ * ID env var per `_gotcha/session-id-discovery.md`); when absent the
+ * literal string `'unknown'` is used so the AJV `minLength: 1` constraint
+ * holds.
+ *
+ * Re-running the command on the same destination file is idempotent: the
+ * `upsertById` keying in `lib/json-memory.ts` replaces an existing entry
+ * keyed by `path`, never duplicates.
+ *
  * ## Future work (out of scope — PR D+)
  *
- * Duplicate-entry detection, structured frontmatter merge, and per-category
- * validation stay out of this file. Research explicitly keeps them deferred
- * so the first shipped version has a small, reviewable surface. The current
- * append-and-delete flow is safe because git diff is the merge review.
+ * Duplicate-entry detection (within a single `gotchas.md` file),
+ * structured frontmatter merge, per-category validation, and class
+ * extraction stay out of this file. Research explicitly keeps them
+ * deferred so the first shipped version has a small, reviewable surface.
+ * The current append-and-delete flow is safe because git diff is the
+ * merge review.
  *
  * @see `.gobbi/projects/gobbi/design/v050-cli.md` §`gobbi gotcha` commands
  * @see `.claude/skills/_gotcha/SKILL.md`
  * @see `.claude/skills/_gotcha/project-gotcha.md`
+ * @see ../../lib/json-memory.ts §`upsertProjectGotcha`
  */
 
+import { createHash } from 'node:crypto';
 import {
   existsSync,
   readdirSync,
@@ -62,10 +92,15 @@ import {
   appendFileSync,
   unlinkSync,
 } from 'node:fs';
-import { basename, join } from 'node:path';
+import { basename, join, relative } from 'node:path';
 
 import { parseArgs } from 'node:util';
 
+import {
+  projectJsonPath,
+  upsertProjectGotcha,
+  type ProjectJsonGotcha,
+} from '../../lib/json-memory.js';
 import { getRepoRoot } from '../../lib/repo.js';
 import {
   projectSubdir,
@@ -222,8 +257,12 @@ export async function runPromoteWithOptions(
     return;
   }
 
+  // The project.json index lives at the destination project's root; only
+  // project-scoped (non-skill) promotions are recorded there. The plan's
+  // discriminant carries the destination project explicitly so this loop
+  // does not re-thread `projectName`.
   for (const item of plan) {
-    applyPromotion(item);
+    applyPromotion(item, repoRoot);
   }
 }
 
@@ -231,12 +270,29 @@ export async function runPromoteWithOptions(
 // Promotion planning
 // ---------------------------------------------------------------------------
 
-interface PromotionPlan {
-  readonly source: string;
-  readonly destination: string;
-  readonly body: string;
-  readonly bytes: number;
-}
+/**
+ * One planned promotion. `scope` discriminates project-scoped (which
+ * upserts a `ProjectJsonGotcha` index entry post-write) vs skill-scoped
+ * (which routes via the `.claude/skills/` symlink farm and is NOT
+ * indexed). `destinationProject` is the project name whose `project.json`
+ * receives the index entry — only meaningful when `scope === 'project'`.
+ */
+type PromotionPlan =
+  | {
+      readonly scope: 'project';
+      readonly source: string;
+      readonly destination: string;
+      readonly body: string;
+      readonly bytes: number;
+      readonly destinationProject: string;
+    }
+  | {
+      readonly scope: 'skill';
+      readonly source: string;
+      readonly destination: string;
+      readonly body: string;
+      readonly bytes: number;
+    };
 
 function isSkillScopedName(filename: string): boolean {
   return filename.startsWith(SKILL_PREFIX);
@@ -304,8 +360,8 @@ function planPromotion(
 ): PromotionPlan {
   const sourcePath = join(sourceDir, filename);
   const body = readFileSync(sourcePath, 'utf8');
+  const bytes = Buffer.byteLength(body, 'utf8');
 
-  let destination: string;
   if (isSkillScopedName(filename)) {
     // `_skill-<name>.md` → `.claude/skills/<name>/gotchas.md`
     //
@@ -316,62 +372,141 @@ function planPromotion(
     // through the farm keeps the source of truth in the project dir
     // while preserving the loader-visible path.
     const skillPart = filename.slice(SKILL_PREFIX.length, -'.md'.length);
-    destination = join(claudeDir, 'skills', skillPart, 'gotchas.md');
-  } else {
-    // `<category>.md` → `.gobbi/projects/<project>/gotchas/<category>.md`
-    //
-    // Routes through the `workspace-paths` facade so a future rename of
-    // the taxonomy lands in one place. `projectName === null` is screened
-    // out by the caller when any non-skill entry is present, so a fallback
-    // name here is unreachable; we still pick a sentinel rather than
-    // `!`-asserting so a future miswiring fails loudly at the filesystem
-    // layer instead of a runtime TypeError.
-    //
-    // PR-FIN-2a-i: gotcha drafts live at top-level `gotchas/`, no longer
-    // nested under `learnings/`.
-    const projectDir =
-      projectName ?? '__unset__project__' /* unreachable — caller checks */;
-    destination = join(
-      projectSubdir(repoRoot, projectDir, 'gotchas'),
-      filename,
-    );
+    const destination = join(claudeDir, 'skills', skillPart, 'gotchas.md');
+    return { scope: 'skill', source: sourcePath, destination, body, bytes };
   }
 
+  // `<category>.md` → `.gobbi/projects/<project>/gotchas/<category>.md`
+  //
+  // Routes through the `workspace-paths` facade so a future rename of
+  // the taxonomy lands in one place. `projectName === null` is screened
+  // out by the caller when any non-skill entry is present, so a fallback
+  // name here is unreachable; we still pick a sentinel rather than
+  // `!`-asserting so a future miswiring fails loudly at the filesystem
+  // layer instead of a runtime TypeError.
+  //
+  // PR-FIN-2a-i: gotcha drafts live at top-level `gotchas/`, no longer
+  // nested under `learnings/`.
+  const destinationProject =
+    projectName ?? '__unset__project__' /* unreachable — caller checks */;
+  const destination = join(
+    projectSubdir(repoRoot, destinationProject, 'gotchas'),
+    filename,
+  );
   return {
+    scope: 'project',
     source: sourcePath,
     destination,
     body,
-    bytes: Buffer.byteLength(body, 'utf8'),
+    bytes,
+    destinationProject,
   };
 }
 
 /**
- * Append-and-delete. The destination file is created if absent, and the
- * source file is removed post-append so re-runs do not duplicate. If the
- * source body does not already end in a newline we add one so successive
- * promotions do not fuse the last line of one entry into the first of the
- * next.
+ * Append-and-delete plus project.json index upsert.
  *
- * Post-W3.1 / PR-FIN-2a-i subtlety: for a non-skill promotion in the
- * default project (project name == `basename(repoRoot)`), the category
- * source file and its destination resolve to the same absolute path —
- * both live under `.gobbi/projects/<basename>/gotchas/<category>.md`.
- * Appending to itself and then unlinking would double the body and then
- * delete the file (data loss). When source and destination collide we
- * treat the promotion as already complete (the draft is already in its
- * permanent location by virtue of the taxonomy) and skip the file with
- * no writes.
+ * Filesystem half (unchanged from pre-PR-FIN-2a-ii):
+ *
+ *   - The destination file is created if absent; otherwise the source body
+ *     is appended (if the body does not already end in a newline we add one
+ *     so successive promotions do not fuse the last line of one entry into
+ *     the first of the next).
+ *   - The source file is removed post-append so re-runs do not duplicate.
+ *   - Post-W3.1 / PR-FIN-2a-i subtlety: for a non-skill promotion in the
+ *     default project (project name == `basename(repoRoot)`), the category
+ *     source file and its destination resolve to the same absolute path —
+ *     both live under `.gobbi/projects/<basename>/gotchas/<category>.md`.
+ *     Appending to itself and then unlinking would double the body and
+ *     then delete the file (data loss). When source and destination
+ *     collide we skip the filesystem write — the draft is already in its
+ *     permanent location.
+ *
+ * Index half (new in PR-FIN-2a-ii T-2a.8.3):
+ *
+ *   - For project-scoped promotions only, after the filesystem write
+ *     resolves (or is skipped on a same-path collision) we upsert a
+ *     `ProjectJsonGotcha` entry into the destination project's
+ *     `project.json.gotchas[]` keyed by destination path. `sha256` is
+ *     computed from the destination file's bytes after the write so the
+ *     digest reflects what's actually on disk (including any prior
+ *     accumulated entries from earlier promotes).
+ *   - Skill-scoped promotions are NOT indexed in `project.json` — skill
+ *     gotchas live colocated with their skill via the `.claude/skills/`
+ *     symlink farm and have no role in cross-session project memory.
  */
-function applyPromotion(plan: PromotionPlan): void {
-  if (plan.source === plan.destination) {
-    // Same-path no-op — the draft already lives at the destination.
+function applyPromotion(plan: PromotionPlan, repoRoot: string): void {
+  const samePath = plan.source === plan.destination;
+  if (!samePath) {
+    const destDir = destinationParent(plan.destination);
+    mkdirSync(destDir, { recursive: true });
+    const payload = plan.body.endsWith('\n') ? plan.body : `${plan.body}\n`;
+    appendFileSync(plan.destination, payload, 'utf8');
+    unlinkSync(plan.source);
+  }
+
+  if (plan.scope === 'skill') {
+    // Skill-scoped gotchas live with their skill, not in project memory.
     return;
   }
-  const destDir = destinationParent(plan.destination);
-  mkdirSync(destDir, { recursive: true });
-  const payload = plan.body.endsWith('\n') ? plan.body : `${plan.body}\n`;
-  appendFileSync(plan.destination, payload, 'utf8');
-  unlinkSync(plan.source);
+
+  // Project-scoped: upsert the index entry. The plan's `destinationProject`
+  // is carved out by `planPromotion`, which itself is reached only after
+  // the caller's needs-project guard has resolved a non-null project name.
+  const destinationProject = plan.destinationProject;
+  const indexPath = projectJsonPath(repoRoot, destinationProject);
+  const sha256 = sha256OfFile(plan.destination);
+  const entry: ProjectJsonGotcha = {
+    path: relative(repoRoot, plan.destination),
+    sha256,
+    class: classifyGotcha(),
+    promotedAt: new Date().toISOString(),
+    promotedFromSession: resolvePromotedFromSession(),
+  };
+  upsertProjectGotcha({
+    path: indexPath,
+    entry,
+    projectName: destinationProject,
+    projectId: destinationProject,
+  });
+}
+
+/** sha256(file_bytes) as 64-char lowercase hex. */
+function sha256OfFile(filePath: string): string {
+  const bytes = readFileSync(filePath);
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+/**
+ * Default class for promoted gotchas.
+ *
+ * The legacy SQLite gotcha index never carried a typed class; the markdown
+ * body holds a free-text `Priority:` line that this command does not parse.
+ * `'unknown'` keeps the AJV `minLength: 1` constraint satisfied without
+ * inventing a taxonomy. A frontmatter-aware promote in a future PR can
+ * populate this field without a `project.json` schema change.
+ */
+function classifyGotcha(): string {
+  return 'unknown';
+}
+
+/**
+ * Resolve the session ID under which this promote runs.
+ *
+ * `gobbi gotcha promote` is a between-sessions admin command — by design
+ * `$CLAUDE_SESSION_ID` is typically populated only when the operator
+ * invokes it from inside an active Claude Code session (e.g., as part of
+ * an agent's wrap-up). When the env var is absent or empty we fall back
+ * to the literal string `'unknown'` rather than the empty string so the
+ * `project.json` AJV `minLength: 1` constraint holds.
+ *
+ * @see `_gotcha/session-id-discovery.md` for the canonical env-var name.
+ */
+function resolvePromotedFromSession(): string {
+  const envSessionId = process.env['CLAUDE_SESSION_ID'];
+  return envSessionId !== undefined && envSessionId !== ''
+    ? envSessionId
+    : 'unknown';
 }
 
 function destinationParent(destPath: string): string {

--- a/packages/cli/src/commands/hook/subagent-start.ts
+++ b/packages/cli/src/commands/hook/subagent-start.ts
@@ -2,6 +2,16 @@
  * gobbi hook subagent-start — SubagentStart hook entrypoint (stub for PR-FIN-1b).
  *
  * Body lives in `_stub.ts`. PR-FIN-1d adds notify dispatch.
+ *
+ * NOTE (PR-FIN-2a-ii T-2a.8.0): SubagentStart is NO LONGER the
+ * `delegation.spawn` emission site. Per `v050-hooks.md:59` and ideation
+ * lock 26, the canonical emitter lives in the PreToolUse guard at
+ * `commands/workflow/guard.ts::maybeEmitDelegationSpawn`. PreToolUse
+ * carries the `tool_use_id` / `tool_call_id` and the orchestrator-level
+ * `tool_input.subagent_type`, both of which SubagentStart lacks. The file
+ * stays in place because SubagentStart remains a registered hook event
+ * (notify dispatch is wired through the generic stub), but it does not
+ * write workflow events.
  */
 
 import { runGenericHookStub } from './_stub.js';

--- a/packages/cli/src/commands/maintenance.ts
+++ b/packages/cli/src/commands/maintenance.ts
@@ -49,7 +49,7 @@ export const MAINTENANCE_COMMANDS: readonly MaintenanceCommand[] = [
   {
     name: 'wipe-legacy-sessions',
     summary:
-      'Delete terminal sessions from .gobbi/sessions/ (refuses if any legacy session is active)',
+      'Delete pre-pivot session residue from .gobbi/sessions/ (whole-tree) and per-project sessions (5 legacy artifacts only; preserves session.json + step subdirs)',
     run: async (args: string[]): Promise<void> => {
       const { runWipeLegacySessions } = await import(
         './maintenance/wipe-legacy-sessions.js'

--- a/packages/cli/src/commands/maintenance/__tests__/wipe-legacy-sessions.test.ts
+++ b/packages/cli/src/commands/maintenance/__tests__/wipe-legacy-sessions.test.ts
@@ -22,10 +22,12 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { Database } from 'bun:sqlite';
 import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
@@ -39,6 +41,7 @@ import {
   type MaintenanceCommand,
 } from '../../maintenance.js';
 import {
+  isLegacyPerProjectSession,
   renderSummary,
   runWipeLegacySessionsWithOptions,
 } from '../wipe-legacy-sessions.js';
@@ -372,5 +375,519 @@ describe('renderSummary', () => {
   test('dry-run prefix', () => {
     const out = renderSummary({ wiped: 3, dryRun: true });
     expect(out.startsWith('[dry-run] ')).toBe(true);
+  });
+
+  test('combined form when artifactsWiped > 0 (singular)', () => {
+    const out = renderSummary({
+      wiped: 1,
+      artifactsWiped: 1,
+      dryRun: false,
+    });
+    expect(out).toBe('1 flat-layout session + 1 legacy artifact wiped\n');
+  });
+
+  test('combined form when artifactsWiped > 0 (plural)', () => {
+    const out = renderSummary({
+      wiped: 2,
+      artifactsWiped: 5,
+      dryRun: true,
+    });
+    expect(out).toBe(
+      '[dry-run] 2 flat-layout sessions + 5 legacy artifacts wiped\n',
+    );
+  });
+});
+
+// ===========================================================================
+// Per-project legacy sweep — predicate + active-session probe + deletion
+// ===========================================================================
+
+/**
+ * Seed a per-project session directory with a hand-picked subset of the
+ * five legacy artifacts. Every created file's content is the artifact
+ * name (small but non-empty so `existsSync` and `statSync.size > 0` both
+ * report truthy).
+ *
+ * @param artifacts subset of `'gobbi.db' | 'state.json' | 'state.json.backup' | 'metadata.json' | 'artifacts'`
+ */
+function seedPerProjectLegacy(
+  repo: string,
+  projectName: string,
+  sessionId: string,
+  artifacts: ReadonlyArray<
+    'gobbi.db' | 'state.json' | 'state.json.backup' | 'metadata.json' | 'artifacts'
+  >,
+): string {
+  const dir = join(
+    repo,
+    '.gobbi',
+    'projects',
+    projectName,
+    'sessions',
+    sessionId,
+  );
+  mkdirSync(dir, { recursive: true });
+  for (const artifact of artifacts) {
+    if (artifact === 'artifacts') {
+      const artifactsDir = join(dir, 'artifacts');
+      mkdirSync(artifactsDir, { recursive: true });
+      writeFileSync(join(artifactsDir, 'a.txt'), 'a', 'utf8');
+      writeFileSync(join(artifactsDir, 'b.txt'), 'b', 'utf8');
+      // A nested subdir to verify recursive removal.
+      mkdirSync(join(artifactsDir, 'nested'), { recursive: true });
+      writeFileSync(join(artifactsDir, 'nested', 'c.txt'), 'c', 'utf8');
+    } else {
+      writeFileSync(join(dir, artifact), artifact, 'utf8');
+    }
+  }
+  return dir;
+}
+
+/**
+ * Seed a per-project session that already has the post-pivot
+ * `session.json` marker. Optionally add a per-step subdir to verify it
+ * is preserved.
+ */
+function seedPostPivot(
+  repo: string,
+  projectName: string,
+  sessionId: string,
+  opts: {
+    readonly withStepSubdir?: boolean;
+    readonly withLegacyAlongside?: ReadonlyArray<
+      | 'gobbi.db'
+      | 'state.json'
+      | 'state.json.backup'
+      | 'metadata.json'
+      | 'artifacts'
+    >;
+  } = {},
+): string {
+  const dir = join(
+    repo,
+    '.gobbi',
+    'projects',
+    projectName,
+    'sessions',
+    sessionId,
+  );
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, 'session.json'),
+    JSON.stringify({ schemaVersion: 1, sessionId }),
+    'utf8',
+  );
+  if (opts.withStepSubdir === true) {
+    mkdirSync(join(dir, 'ideation'), { recursive: true });
+    writeFileSync(join(dir, 'ideation', 'README.md'), '# ideation', 'utf8');
+  }
+  if (opts.withLegacyAlongside !== undefined) {
+    for (const artifact of opts.withLegacyAlongside) {
+      if (artifact === 'artifacts') {
+        mkdirSync(join(dir, 'artifacts'), { recursive: true });
+      } else {
+        writeFileSync(join(dir, artifact), artifact, 'utf8');
+      }
+    }
+  }
+  return dir;
+}
+
+/**
+ * Create a workspace `state.db` at `<repo>/.gobbi/state.db` with a
+ * minimum-viable `events` table. The shape mirrors the v5+ event-store
+ * schema's relevant columns; we only need (session_id, project_id, type)
+ * for the active-session probe to function. `idempotency_key` is
+ * required by the column constraint, so we generate a unique value per
+ * row.
+ */
+function makeStateDb(
+  repo: string,
+  rows: ReadonlyArray<{
+    readonly sessionId: string;
+    readonly projectId: string;
+    readonly type: string;
+  }>,
+): void {
+  const gobbiDir = join(repo, '.gobbi');
+  mkdirSync(gobbiDir, { recursive: true });
+  const dbPath = join(gobbiDir, 'state.db');
+  const db = new Database(dbPath, { strict: true });
+  try {
+    db.run(
+      `CREATE TABLE events (
+         seq INTEGER PRIMARY KEY,
+         ts TEXT NOT NULL,
+         schema_version INTEGER NOT NULL,
+         type TEXT NOT NULL,
+         step TEXT,
+         data TEXT NOT NULL DEFAULT '{}',
+         actor TEXT NOT NULL,
+         parent_seq INTEGER,
+         idempotency_key TEXT NOT NULL UNIQUE,
+         session_id TEXT,
+         project_id TEXT
+       )`,
+    );
+    const stmt = db.query(
+      `INSERT INTO events (ts, schema_version, type, actor, idempotency_key, session_id, project_id)
+       VALUES ($ts, 5, $type, 'test', $key, $sessionId, $projectId)`,
+    );
+    let seq = 0;
+    for (const row of rows) {
+      seq += 1;
+      stmt.run({
+        ts: '2026-04-29T00:00:00.000Z',
+        type: row.type,
+        key: `${row.sessionId}:${seq}:${row.type}`,
+        sessionId: row.sessionId,
+        projectId: row.projectId,
+      });
+    }
+  } finally {
+    db.close();
+  }
+}
+
+describe('isLegacyPerProjectSession (predicate)', () => {
+  test('returns true when any of the 5 legacy artifacts exists and session.json is absent', () => {
+    const repo = makeRepo();
+    const dir = seedPerProjectLegacy(repo, 'p', 's', ['gobbi.db']);
+    expect(isLegacyPerProjectSession(dir)).toBe(true);
+  });
+
+  test('returns true for each of the 5 legacy artifacts individually', () => {
+    const repo = makeRepo();
+    for (const artifact of [
+      'gobbi.db',
+      'state.json',
+      'state.json.backup',
+      'metadata.json',
+      'artifacts',
+    ] as const) {
+      const dir = seedPerProjectLegacy(repo, 'p', `s-${artifact}`, [artifact]);
+      expect(isLegacyPerProjectSession(dir)).toBe(true);
+    }
+  });
+
+  test('returns false when session.json is present (post-pivot, even with stray legacy)', () => {
+    const repo = makeRepo();
+    const dir = seedPostPivot(repo, 'p', 's', {
+      withLegacyAlongside: ['gobbi.db'],
+    });
+    expect(isLegacyPerProjectSession(dir)).toBe(false);
+  });
+
+  test('returns false when none of the 5 legacy artifacts exist', () => {
+    const repo = makeRepo();
+    const dir = join(
+      repo,
+      '.gobbi',
+      'projects',
+      'p',
+      'sessions',
+      'native',
+    );
+    mkdirSync(dir, { recursive: true });
+    // Only a per-step subdir, no legacy artifacts and no session.json.
+    mkdirSync(join(dir, 'ideation'), { recursive: true });
+    expect(isLegacyPerProjectSession(dir)).toBe(false);
+  });
+});
+
+describe('runWipeLegacySessions — per-project legacy sweep', () => {
+  test('1. wipes all 5 legacy artifacts; preserves per-step subdirs', async () => {
+    const repo = makeRepo();
+    const sessionDir = seedPerProjectLegacy(repo, 'gobbi', 'legacy-1', [
+      'gobbi.db',
+      'state.json',
+      'state.json.backup',
+      'metadata.json',
+      'artifacts',
+    ]);
+    // Per-step subdir that must be preserved.
+    mkdirSync(join(sessionDir, 'ideation'), { recursive: true });
+    writeFileSync(
+      join(sessionDir, 'ideation', 'README.md'),
+      '# ideation',
+      'utf8',
+    );
+
+    await captureExit(() =>
+      runWipeLegacySessionsWithOptions([], { repoRoot: repo }),
+    );
+
+    expect(captured.exitCode).toBeNull();
+    expect(existsSync(join(sessionDir, 'gobbi.db'))).toBe(false);
+    expect(existsSync(join(sessionDir, 'state.json'))).toBe(false);
+    expect(existsSync(join(sessionDir, 'state.json.backup'))).toBe(false);
+    expect(existsSync(join(sessionDir, 'metadata.json'))).toBe(false);
+    expect(existsSync(join(sessionDir, 'artifacts'))).toBe(false);
+    // Per-step subdir untouched.
+    expect(existsSync(join(sessionDir, 'ideation', 'README.md'))).toBe(true);
+    // Session dir itself preserved.
+    expect(existsSync(sessionDir)).toBe(true);
+    expect(captured.stdout).toContain('5 legacy artifacts wiped');
+  });
+
+  test('2. per-project session with no legacy artifacts is a no-op (idempotent first run)', async () => {
+    const repo = makeRepo();
+    const sessionDir = join(
+      repo,
+      '.gobbi',
+      'projects',
+      'gobbi',
+      'sessions',
+      'native',
+    );
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(
+      join(sessionDir, 'session.json'),
+      JSON.stringify({ schemaVersion: 1, sessionId: 'native' }),
+      'utf8',
+    );
+    mkdirSync(join(sessionDir, 'ideation'), { recursive: true });
+
+    const before = readdirSync(sessionDir).sort();
+
+    await captureExit(() =>
+      runWipeLegacySessionsWithOptions([], { repoRoot: repo }),
+    );
+
+    expect(captured.exitCode).toBeNull();
+    const after = readdirSync(sessionDir).sort();
+    expect(after).toEqual(before);
+    // No artifacts wiped — falls back to the legacy single-counter
+    // form (`0 sessions wiped`).
+    expect(captured.stdout).toContain('0 sessions wiped');
+  });
+
+  test('3. artifacts/ directory with files and nested dirs is wiped recursively', async () => {
+    const repo = makeRepo();
+    const sessionDir = seedPerProjectLegacy(repo, 'gobbi', 's3', [
+      'artifacts',
+    ]);
+    // Sanity-check seed shape.
+    expect(existsSync(join(sessionDir, 'artifacts', 'a.txt'))).toBe(true);
+    expect(
+      existsSync(join(sessionDir, 'artifacts', 'nested', 'c.txt')),
+    ).toBe(true);
+
+    await captureExit(() =>
+      runWipeLegacySessionsWithOptions([], { repoRoot: repo }),
+    );
+
+    expect(captured.exitCode).toBeNull();
+    expect(existsSync(join(sessionDir, 'artifacts'))).toBe(false);
+    expect(existsSync(sessionDir)).toBe(true);
+  });
+
+  test('4. mixed workspace — flat + per-project legacy + per-project clean', async () => {
+    const repo = makeRepo();
+    const flatDir = seedLegacy(repo, 'flat-1');
+    const perProjectLegacy = seedPerProjectLegacy(
+      repo,
+      'gobbi',
+      'pp-legacy',
+      ['gobbi.db', 'state.json', 'metadata.json'],
+    );
+    // Preserve a step subdir on the per-project legacy session.
+    mkdirSync(join(perProjectLegacy, 'planning'), { recursive: true });
+    const perProjectClean = seedPostPivot(repo, 'gobbi', 'pp-clean', {
+      withStepSubdir: true,
+    });
+
+    await captureExit(() =>
+      runWipeLegacySessionsWithOptions([], { repoRoot: repo }),
+    );
+
+    expect(captured.exitCode).toBeNull();
+    // Flat layout: whole-tree wiped.
+    expect(existsSync(flatDir)).toBe(false);
+    // Per-project legacy: artifacts wiped, dir + step subdir preserved.
+    expect(existsSync(perProjectLegacy)).toBe(true);
+    expect(existsSync(join(perProjectLegacy, 'gobbi.db'))).toBe(false);
+    expect(existsSync(join(perProjectLegacy, 'state.json'))).toBe(false);
+    expect(existsSync(join(perProjectLegacy, 'metadata.json'))).toBe(false);
+    expect(existsSync(join(perProjectLegacy, 'planning'))).toBe(true);
+    // Per-project clean: untouched (session.json + step subdir intact).
+    expect(existsSync(join(perProjectClean, 'session.json'))).toBe(true);
+    expect(existsSync(join(perProjectClean, 'ideation', 'README.md'))).toBe(
+      true,
+    );
+    // Combined summary form fires when artifactsWiped > 0.
+    expect(captured.stdout).toContain('1 flat-layout session');
+    expect(captured.stdout).toContain('legacy artifacts wiped');
+  });
+
+  test('5. idempotent — running a second time produces the same on-disk state', async () => {
+    const repo = makeRepo();
+    seedLegacy(repo, 'flat');
+    const perProject = seedPerProjectLegacy(repo, 'gobbi', 'pp', [
+      'gobbi.db',
+      'state.json',
+      'state.json.backup',
+      'metadata.json',
+      'artifacts',
+    ]);
+    mkdirSync(join(perProject, 'execution'), { recursive: true });
+
+    await captureExit(() =>
+      runWipeLegacySessionsWithOptions([], { repoRoot: repo }),
+    );
+    const firstRunExit = captured.exitCode;
+
+    // Reset capture so the second run is observed in isolation.
+    captured = { stdout: '', stderr: '', exitCode: null };
+
+    await captureExit(() =>
+      runWipeLegacySessionsWithOptions([], { repoRoot: repo }),
+    );
+
+    expect(firstRunExit).toBeNull();
+    expect(captured.exitCode).toBeNull();
+    // Second run: nothing to wipe, falls back to `0 sessions wiped`.
+    expect(captured.stdout).toContain('0 sessions wiped');
+    // Final state matches the first-run end state.
+    expect(existsSync(join(repo, '.gobbi', 'sessions', 'flat'))).toBe(false);
+    expect(existsSync(perProject)).toBe(true);
+    expect(existsSync(join(perProject, 'gobbi.db'))).toBe(false);
+    expect(existsSync(join(perProject, 'execution'))).toBe(true);
+  });
+
+  test('dry-run prints the deletion list and deletes nothing', async () => {
+    const repo = makeRepo();
+    seedLegacy(repo, 'flat-dry');
+    const perProject = seedPerProjectLegacy(repo, 'gobbi', 'pp-dry', [
+      'gobbi.db',
+      'metadata.json',
+    ]);
+
+    await captureExit(() =>
+      runWipeLegacySessionsWithOptions(['--dry-run'], { repoRoot: repo }),
+    );
+
+    expect(captured.exitCode).toBeNull();
+    // Flat layout shows the legacy "Would wipe:" line.
+    expect(captured.stdout).toContain('Would wipe:');
+    expect(captured.stdout).toContain('flat-dry');
+    // Per-project shows the per-artifact line with the new wording.
+    expect(captured.stdout).toContain('Would remove legacy artifact:');
+    expect(captured.stdout).toContain(join(perProject, 'gobbi.db'));
+    expect(captured.stdout).toContain(join(perProject, 'metadata.json'));
+    // Combined dry-run summary.
+    expect(captured.stdout).toContain('[dry-run]');
+    expect(captured.stdout).toContain('1 flat-layout session');
+    expect(captured.stdout).toContain('2 legacy artifacts wiped');
+    // Nothing actually deleted.
+    expect(existsSync(join(repo, '.gobbi', 'sessions', 'flat-dry'))).toBe(
+      true,
+    );
+    expect(existsSync(join(perProject, 'gobbi.db'))).toBe(true);
+    expect(existsSync(join(perProject, 'metadata.json'))).toBe(true);
+  });
+});
+
+describe('runWipeLegacySessions — active-session probe', () => {
+  test('skips a per-project session whose state.db has events but no terminal event', async () => {
+    const repo = makeRepo();
+    const active = seedPerProjectLegacy(repo, 'gobbi', 'active', [
+      'gobbi.db',
+      'state.json',
+    ]);
+    // state.db has a workflow.start but no workflow.finish/abort —
+    // the partition is "active."
+    makeStateDb(repo, [
+      {
+        sessionId: 'active',
+        projectId: 'gobbi',
+        type: 'workflow.start',
+      },
+    ]);
+
+    await captureExit(() =>
+      runWipeLegacySessionsWithOptions([], { repoRoot: repo }),
+    );
+
+    expect(captured.exitCode).toBeNull();
+    // Active session left untouched.
+    expect(existsSync(join(active, 'gobbi.db'))).toBe(true);
+    expect(existsSync(join(active, 'state.json'))).toBe(true);
+    // Skip notice on stderr.
+    expect(captured.stderr).toContain('Skipping active session');
+    expect(captured.stderr).toContain(active);
+    // No artifacts counted.
+    expect(captured.stdout).toContain('0 sessions wiped');
+  });
+
+  test('wipes a per-project session whose state.db has a workflow.finish event', async () => {
+    const repo = makeRepo();
+    const finished = seedPerProjectLegacy(repo, 'gobbi', 'finished', [
+      'gobbi.db',
+      'state.json',
+    ]);
+    makeStateDb(repo, [
+      {
+        sessionId: 'finished',
+        projectId: 'gobbi',
+        type: 'workflow.start',
+      },
+      {
+        sessionId: 'finished',
+        projectId: 'gobbi',
+        type: 'workflow.finish',
+      },
+    ]);
+
+    await captureExit(() =>
+      runWipeLegacySessionsWithOptions([], { repoRoot: repo }),
+    );
+
+    expect(captured.exitCode).toBeNull();
+    expect(existsSync(join(finished, 'gobbi.db'))).toBe(false);
+    expect(existsSync(join(finished, 'state.json'))).toBe(false);
+    expect(existsSync(finished)).toBe(true);
+    expect(captured.stdout).toContain('legacy artifacts wiped');
+  });
+
+  test('wipes a per-project session when state.db has zero events for the partition', async () => {
+    const repo = makeRepo();
+    const noEvents = seedPerProjectLegacy(repo, 'gobbi', 'no-events', [
+      'gobbi.db',
+    ]);
+    // state.db exists but has events for an UNRELATED partition.
+    makeStateDb(repo, [
+      {
+        sessionId: 'someone-else',
+        projectId: 'other-project',
+        type: 'workflow.start',
+      },
+    ]);
+
+    await captureExit(() =>
+      runWipeLegacySessionsWithOptions([], { repoRoot: repo }),
+    );
+
+    expect(captured.exitCode).toBeNull();
+    expect(existsSync(join(noEvents, 'gobbi.db'))).toBe(false);
+    expect(existsSync(noEvents)).toBe(true);
+  });
+
+  test('wipes when state.db is missing entirely (fresh workspace)', async () => {
+    const repo = makeRepo();
+    const fresh = seedPerProjectLegacy(repo, 'gobbi', 'fresh', [
+      'gobbi.db',
+      'metadata.json',
+    ]);
+    // No state.db at all.
+    expect(existsSync(join(repo, '.gobbi', 'state.db'))).toBe(false);
+
+    await captureExit(() =>
+      runWipeLegacySessionsWithOptions([], { repoRoot: repo }),
+    );
+
+    expect(captured.exitCode).toBeNull();
+    expect(existsSync(join(fresh, 'gobbi.db'))).toBe(false);
+    expect(existsSync(join(fresh, 'metadata.json'))).toBe(false);
   });
 });

--- a/packages/cli/src/commands/maintenance/wipe-legacy-sessions.ts
+++ b/packages/cli/src/commands/maintenance/wipe-legacy-sessions.ts
@@ -1,32 +1,47 @@
 /**
- * gobbi maintenance wipe-legacy-sessions — remove every session directory
- * under the legacy flat layout (`.gobbi/sessions/<id>`). The new
- * multi-project layout (`.gobbi/projects/<name>/sessions/...`) is NEVER
- * touched.
+ * gobbi maintenance wipe-legacy-sessions — remove legacy on-disk session
+ * residue from BOTH layouts:
  *
- * ## Context (v0.5.0 Pass-2 W3.3 + PR-FIN-2a-i T-2a.1.5)
+ *   1. The pre-Pass-2 flat layout `.gobbi/sessions/<sessionId>/` — the
+ *      ENTIRE directory is wiped (whole-tree `rm -rf`). The flat layout
+ *      preserves nothing post-pivot.
+ *
+ *   2. The per-project layout
+ *      `.gobbi/projects/<projectName>/sessions/<sessionId>/` — only the
+ *      five PRE-PIVOT artifacts (gobbi.db, state.json, state.json.backup,
+ *      metadata.json, artifacts/) are wiped. session.json and per-step
+ *      subdirectories are preserved.
+ *
+ * The new multi-project layout's CURRENT-shape sessions (those with a
+ * `session.json` file) are never touched: presence of `session.json`
+ * marks a session as post-pivot and out of scope for this command.
+ *
+ * ## Context (v0.5.0 Pass-2 W3.3 + PR-FIN-2a-i T-2a.1.5 + PR-FIN-2a-ii T-2a.10)
  *
  * The v0.5.0 Pass-2 redesign moved sessions into per-project subdirectories
- * and left the legacy flat layer behind as a compatibility hold-over. Once
- * the migration session finished, the operator runs this command ONCE to
- * reclaim the legacy directories.
+ * and left the legacy flat layer behind as a compatibility hold-over.
  *
- * Until PR-FIN-2a-i this command guarded the wipe with a state-based
- * active-session check (`findStateActiveSessions` in
- * `lib/active-sessions.ts`). The JSON-pivot memory model landing in
- * PR-FIN-2a-ii drops per-session `gobbi.db` and `state.json` entirely, so
- * the "session is active" check has nothing left to read. We therefore
- * removed the guard outright in T-2a.1.5: the wipe is now an unconditional
- * `rm -rf .gobbi/sessions/<id>/` for every legacy directory.
+ * PR-FIN-2a-i T-2a.1.5 dropped the active-session guard for the flat
+ * layer because the JSON-pivot drops `state.json` entirely — there is
+ * nothing left for the guard to read.
+ *
+ * PR-FIN-2a-ii T-2a.10 extends the command to ALSO sweep the per-project
+ * layout: pre-pivot per-project sessions still hold the same five legacy
+ * artifacts that the flat layer did, plus a session.json (or per-step
+ * subdir) we must preserve. To prevent reaping a session whose workflow
+ * is still in flight, the per-project sweep gates each candidate behind
+ * a workspace `state.db` probe — a session with appended events but no
+ * terminal `workflow.finish` / `workflow.abort` event is treated as
+ * active and skipped.
  *
  * ## Scope boundary
  *
  *   - No hook integration. The command is run manually by the operator.
- *   - No recursive delete across the per-project layer — ever. That is
- *     owned by `gobbi project delete` (not yet implemented).
+ *   - No directory deletion under `.gobbi/projects/<name>/sessions/<id>/`
+ *     — only the per-artifact removal listed above. `session.json` and
+ *     per-step subdirs (`ideation/`, `planning/`, `execution/`,
+ *     `memorization/`) are preserved.
  *   - No migration logic. Sessions are not MOVED to the new layout here.
- *   - No active-session guard. Operators run this knowingly; the JSON
- *     pivot retires the per-session state files the guard depended on.
  *
  * ## Exit codes
  *
@@ -37,12 +52,23 @@
  *      active-session guard in T-2a.1.5)
  */
 
-import { existsSync, readdirSync, rmSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { Database } from 'bun:sqlite';
+import {
+  existsSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+} from 'node:fs';
+import { basename, join } from 'node:path';
 import { parseArgs } from 'node:util';
 
 import { getRepoRoot } from '../../lib/repo.js';
-import { workspaceRoot } from '../../lib/workspace-paths.js';
+import {
+  projectsRoot,
+  sessionsRoot,
+  workspaceRoot,
+} from '../../lib/workspace-paths.js';
 
 // ---------------------------------------------------------------------------
 // Usage
@@ -50,13 +76,51 @@ import { workspaceRoot } from '../../lib/workspace-paths.js';
 
 const USAGE = `Usage: gobbi maintenance wipe-legacy-sessions [options]
 
-Delete every session directory under the legacy flat layout
-(.gobbi/sessions/<id>). The new multi-project layout
-(.gobbi/projects/<name>/sessions/...) is NEVER touched by this command.
+Delete legacy session residue from both layouts:
+
+  - Flat layout (.gobbi/sessions/<sessionId>/) — the whole directory is
+    wiped.
+
+  - Per-project layout (.gobbi/projects/<projectName>/sessions/<sessionId>/)
+    — only the five pre-pivot artifacts (gobbi.db, state.json,
+    state.json.backup, metadata.json, artifacts/) are wiped. session.json
+    and per-step subdirs are preserved. Sessions with appended events but
+    no workflow.finish / workflow.abort terminal event are skipped.
+
+The new layout's current-shape sessions (those with session.json) are
+never wiped.
 
 Options:
   --dry-run     Print the planned deletions; write nothing, delete nothing
   --help, -h    Show this help message`;
+
+// ---------------------------------------------------------------------------
+// Legacy artifact constants
+// ---------------------------------------------------------------------------
+
+/**
+ * The five pre-pivot artifacts that the per-project sweep removes. Order
+ * is the deletion order: file artifacts first, the `artifacts/` directory
+ * last so a partially-completed wipe leaves the most-bytes-recovered state.
+ *
+ * Sourced from PR-FIN-2a-ii ideation lock 40: `gobbi.db, state.json,
+ * state.json.backup, metadata.json, artifacts/`.
+ */
+const LEGACY_ARTIFACTS = [
+  'gobbi.db',
+  'state.json',
+  'state.json.backup',
+  'metadata.json',
+  'artifacts',
+] as const;
+
+/**
+ * The "current-shape" marker file. A per-project session directory that
+ * contains `session.json` is post-pivot and out of scope for this
+ * command — neither the legacy artifacts (if somehow present alongside)
+ * nor the directory itself is touched.
+ */
+const SESSION_JSON = 'session.json';
 
 // ---------------------------------------------------------------------------
 // Overrides (for tests)
@@ -112,29 +176,51 @@ export async function runWipeLegacySessionsWithOptions(
   // --- 2. Resolve repo root ---------------------------------------------
   const repoRoot = overrides.repoRoot ?? getRepoRoot();
 
-  // --- 3. Enumerate every legacy session directory ----------------------
-  const legacy = listLegacySessions(repoRoot);
+  // --- 3. Enumerate legacy targets --------------------------------------
+  const flatSessions = listFlatLegacySessions(repoRoot);
+  const stateDbPath = join(workspaceRoot(repoRoot), 'state.db');
+  const perProjectArtifacts = listPerProjectLegacyArtifacts(
+    repoRoot,
+    stateDbPath,
+  );
 
   // --- 4. Execute (or print) --------------------------------------------
-  const wiped = legacy.length;
-
   if (dryRun) {
-    for (const dir of legacy) {
+    for (const dir of flatSessions) {
       process.stdout.write(`Would wipe: ${dir}\n`);
     }
-    process.stdout.write(renderSummary({ wiped, dryRun: true }));
+    for (const artifact of perProjectArtifacts) {
+      process.stdout.write(`Would remove legacy artifact: ${artifact}\n`);
+    }
+    process.stdout.write(
+      renderSummary({
+        wiped: flatSessions.length,
+        artifactsWiped: perProjectArtifacts.length,
+        dryRun: true,
+      }),
+    );
     return;
   }
 
-  for (const dir of legacy) {
+  for (const dir of flatSessions) {
     process.stdout.write(`Wiping: ${dir}\n`);
     rmSync(dir, { recursive: true, force: true });
   }
-  process.stdout.write(renderSummary({ wiped, dryRun: false }));
+  for (const artifact of perProjectArtifacts) {
+    process.stdout.write(`Removing legacy artifact: ${artifact}\n`);
+    removeArtifact(artifact);
+  }
+  process.stdout.write(
+    renderSummary({
+      wiped: flatSessions.length,
+      artifactsWiped: perProjectArtifacts.length,
+      dryRun: false,
+    }),
+  );
 }
 
 // ---------------------------------------------------------------------------
-// Legacy-session enumeration
+// Legacy-session enumeration — flat layout
 // ---------------------------------------------------------------------------
 
 /**
@@ -142,7 +228,7 @@ export async function runWipeLegacySessionsWithOptions(
  * missing legacy root degrades silently to `[]` so a fresh workspace runs
  * through to the zero-wiped summary.
  */
-function listLegacySessions(repoRoot: string): readonly string[] {
+function listFlatLegacySessions(repoRoot: string): readonly string[] {
   const legacyRoot = join(workspaceRoot(repoRoot), 'sessions');
   if (!existsSync(legacyRoot)) return [];
 
@@ -167,22 +253,248 @@ function listLegacySessions(repoRoot: string): readonly string[] {
 }
 
 // ---------------------------------------------------------------------------
+// Legacy-artifact enumeration — per-project layout
+// ---------------------------------------------------------------------------
+
+/**
+ * Predicate — `sessionDir` is a per-project legacy session iff:
+ *
+ *   1. At least one of the five pre-pivot artifacts (gobbi.db, state.json,
+ *      state.json.backup, metadata.json, artifacts/) exists inside it.
+ *   2. `session.json` does NOT exist inside it. The new shape uses
+ *      session.json as the sole on-disk session marker; any directory
+ *      that already has session.json is post-pivot and out of scope —
+ *      even if a stray legacy artifact happens to coexist (e.g. an
+ *      incomplete prior wipe). This is intentional: post-pivot sessions
+ *      are owned by the JSON memory model, not by this reaper.
+ *
+ * Returns `false` (no eligible artifacts) for any other shape. Stat
+ * failures on individual artifacts are treated as "not present" — a
+ * permission-denied probe must not promote a directory to legacy status.
+ */
+export function isLegacyPerProjectSession(sessionDir: string): boolean {
+  if (existsSync(join(sessionDir, SESSION_JSON))) return false;
+  return LEGACY_ARTIFACTS.some((artifact) =>
+    existsSync(join(sessionDir, artifact)),
+  );
+}
+
+/**
+ * Walk every project under `.gobbi/projects/` and return the absolute
+ * paths of all per-project legacy artifacts that should be reaped. The
+ * resulting list contains one entry per artifact (not per session) so
+ * the dry-run preview shows the operator exactly what the deletion plan
+ * touches.
+ *
+ * For each per-project session that {@link isLegacyPerProjectSession}
+ * accepts, the active-session probe runs against `state.db` — sessions
+ * with appended events but no terminal `workflow.finish` /
+ * `workflow.abort` event are skipped (a stderr line records the skip).
+ *
+ * Order: files first (`gobbi.db, state.json, state.json.backup,
+ * metadata.json`) then `artifacts/` last. Operators reading the dry-run
+ * see the safest-first ordering.
+ */
+function listPerProjectLegacyArtifacts(
+  repoRoot: string,
+  stateDbPath: string,
+): readonly string[] {
+  const root = projectsRoot(repoRoot);
+  if (!existsSync(root)) return [];
+
+  let projectNames: string[];
+  try {
+    projectNames = readdirSync(root);
+  } catch {
+    return [];
+  }
+
+  const out: string[] = [];
+  for (const projectName of projectNames) {
+    const sessionsDir = sessionsRoot(repoRoot, projectName);
+    if (!existsSync(sessionsDir)) continue;
+
+    let sessionIds: string[];
+    try {
+      sessionIds = readdirSync(sessionsDir);
+    } catch {
+      continue;
+    }
+
+    for (const sessionId of sessionIds) {
+      const sessionDir = join(sessionsDir, sessionId);
+      try {
+        if (!statSync(sessionDir).isDirectory()) continue;
+      } catch {
+        continue;
+      }
+
+      if (!isLegacyPerProjectSession(sessionDir)) continue;
+
+      // Active-session probe: skip sessions that have appended events
+      // but no terminal event. The probe only runs once per candidate,
+      // and only if state.db exists — fresh workspaces with no event
+      // history can never have an active session, so a missing state.db
+      // is treated as "no events, safe to wipe."
+      if (isSessionActive(stateDbPath, projectName, sessionId)) {
+        process.stderr.write(
+          `Skipping active session: ${sessionDir}\n`,
+        );
+        continue;
+      }
+
+      for (const artifact of LEGACY_ARTIFACTS) {
+        const artifactPath = join(sessionDir, artifact);
+        if (existsSync(artifactPath)) {
+          out.push(artifactPath);
+        }
+      }
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Active-session probe
+// ---------------------------------------------------------------------------
+
+/**
+ * Probe the workspace `state.db` for the partition `(projectId,
+ * sessionId)`. Returns `true` iff at least one event row exists for the
+ * partition AND none of those rows is a terminal `workflow.finish` /
+ * `workflow.abort` event.
+ *
+ * The probe is read-only — it opens `state.db` with `{ readonly: true }`
+ * and closes the handle in `finally`. A missing state.db, missing events
+ * table, or any SQLite-level error is treated as "no events" and the
+ * caller proceeds with the wipe — fresh workspaces with no event history
+ * cannot have an active session.
+ *
+ * The semantics match T-2a.10's brief:
+ *
+ *   - 0 rows for the partition  → not active (fresh / never appended).
+ *   - n>0 rows AND ≥1 terminal  → not active (workflow finished cleanly).
+ *   - n>0 rows AND 0 terminal   → ACTIVE, skip.
+ */
+function isSessionActive(
+  stateDbPath: string,
+  projectId: string,
+  sessionId: string,
+): boolean {
+  if (!existsSync(stateDbPath)) return false;
+
+  let db: Database;
+  try {
+    db = new Database(stateDbPath, { readonly: true });
+  } catch {
+    return false;
+  }
+  try {
+    interface CountRow {
+      readonly cnt: number;
+    }
+    type Bindings = [string, string];
+    let totalRow: CountRow | null;
+    let terminalRow: CountRow | null;
+    try {
+      totalRow = db
+        .query<CountRow, Bindings>(
+          `SELECT count(*) AS cnt FROM events
+           WHERE session_id = ?1 AND project_id = ?2`,
+        )
+        .get(sessionId, projectId);
+      terminalRow = db
+        .query<CountRow, Bindings>(
+          `SELECT count(*) AS cnt FROM events
+           WHERE session_id = ?1 AND project_id = ?2
+             AND type IN ('workflow.finish', 'workflow.abort')`,
+        )
+        .get(sessionId, projectId);
+    } catch {
+      // Missing events table on a fresh / partially-migrated state.db —
+      // treat as no events, safe to wipe.
+      return false;
+    }
+    const total = totalRow?.cnt ?? 0;
+    const terminal = terminalRow?.cnt ?? 0;
+    return total > 0 && terminal === 0;
+  } finally {
+    db.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-artifact removal
+// ---------------------------------------------------------------------------
+
+/**
+ * Remove a single legacy artifact at `path`. Files use `unlinkSync`;
+ * directories (only `artifacts/` should reach this branch) use
+ * `rmSync({recursive,force})`. Stat failures are tolerated — a vanished
+ * artifact is treated as already-removed.
+ */
+function removeArtifact(path: string): void {
+  let isDir: boolean;
+  try {
+    isDir = statSync(path).isDirectory();
+  } catch {
+    return;
+  }
+  if (isDir) {
+    rmSync(path, { recursive: true, force: true });
+  } else {
+    try {
+      unlinkSync(path);
+    } catch {
+      // Treat already-removed as success.
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Rendering
 // ---------------------------------------------------------------------------
 
 /**
- * Render the one-line summary of the wipe result. Kept as a helper so the
- * string is testable without executing `rmSync`.
+ * Render the summary line.
+ *
+ *   - When both counts are zero, the summary is `"0 sessions wiped"` for
+ *     backwards-compat with the pre-T-2a.10 single-counter shape.
+ *   - When `artifactsWiped > 0` (per-project sweep ran), the summary
+ *     becomes `"N flat-layout sessions + M legacy artifacts wiped"`.
+ *   - Otherwise the legacy single-counter form is used so existing
+ *     workflows (and operator muscle memory) keep working.
  */
 export function renderSummary(opts: {
   readonly wiped: number;
+  readonly artifactsWiped?: number;
   readonly dryRun: boolean;
 }): string {
   const prefix = opts.dryRun ? '[dry-run] ' : '';
+  const artifacts = opts.artifactsWiped ?? 0;
+  if (artifacts > 0) {
+    const sessionsWord = opts.wiped === 1 ? 'session' : 'sessions';
+    const artifactsWord = artifacts === 1 ? 'artifact' : 'artifacts';
+    return `${prefix}${opts.wiped} flat-layout ${sessionsWord} + ${artifacts} legacy ${artifactsWord} wiped\n`;
+  }
   return `${prefix}${opts.wiped} session${
     opts.wiped === 1 ? '' : 's'
   } wiped\n`;
 }
+
+// ---------------------------------------------------------------------------
+// Test-only re-exports
+// ---------------------------------------------------------------------------
+
+// Surface `basename` so tests can demonstrate the projectId/sessionId
+// derivation matches `path.basename` semantics. (The decision in T-2a.10
+// derives projectId from the per-project directory name and sessionId
+// from `basename(sessionDir)`.)
+export const _internal = {
+  basename,
+  LEGACY_ARTIFACTS,
+  SESSION_JSON,
+} as const;
 
 // ---------------------------------------------------------------------------
 // Exports for tests

--- a/packages/cli/src/commands/session.ts
+++ b/packages/cli/src/commands/session.ts
@@ -17,9 +17,9 @@
  */
 
 import { appendFile, readFile, chmod } from 'node:fs/promises';
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, statSync } from 'node:fs';
 import { parseArgs } from 'node:util';
-import { basename, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 
 import { readStdinJson } from '../lib/stdin.js';
 import { getRepoRoot } from '../lib/repo.js';
@@ -509,22 +509,17 @@ export interface ResolvedPartitionKeys {
 /**
  * Resolve `(sessionId, projectId)` from a session directory so callers of
  * `new EventStore(dbPath, opts)` can supply the partition keys explicitly.
- * Mirrors the on-disk derivation that {@link EventStore} performs internally
- * today — extracted into a single source of truth so the 11 callsites stay
- * in sync once Wave A.1's workspace re-scope (`.gobbi/state.db`) lands and
- * the path-derivation fallback no longer yields the right values.
  *
  *   - `sessionId` = `basename(sessionDir)` (matches the per-session layout
  *     `.gobbi/projects/<name>/sessions/<sessionId>/`). `null` only when the
  *     basename resolves to the empty string (filesystem root).
- *   - `projectId` = `metadata.projectName` read verbatim from the session's
- *     `metadata.json` (schema v3+). The previous derivation read
- *     `basename(metadata.projectRoot)`, but `projectRoot` is the repo root
- *     directory — in a multi-project workspace (`.gobbi/projects/{a,b,c}/`)
- *     every event would be stamped with the same project_id (issue #178).
- *     Silent on every failure mode (missing file, parse error, missing or
- *     non-string `projectName`) — `null` defers to the constructor fallback,
- *     which performs the same read.
+ *   - `projectId` = the `<projectName>` segment from the standard layout
+ *     `<repoRoot>/.gobbi/projects/<projectName>/sessions/<sessionId>/`,
+ *     extracted as `basename(dirname(dirname(sessionDir)))`. The path
+ *     itself is the source of truth after PR-FIN-2a-ii (T-2a.9.unified)
+ *     retired the legacy `metadata.json` reader. `null` for legacy-flat
+ *     sessions under `.gobbi/sessions/<sessionId>/` where the parent
+ *     segment is `'sessions'` rather than a project name.
  *
  * Empty-string and `null` are treated identically as "explicitly unset" by
  * the {@link EventStore} constructor, so empty-string columns can never reach
@@ -533,42 +528,36 @@ export interface ResolvedPartitionKeys {
 export function resolvePartitionKeys(sessionDir: string): ResolvedPartitionKeys {
   const sessionName = basename(sessionDir);
   const sessionId = sessionName === '' ? null : sessionName;
-  const projectId = readProjectIdFromMetadata(sessionDir);
+  const projectId = projectIdFromSessionDir(sessionDir);
   return { sessionId, projectId };
 }
 
 /**
- * Read `metadata.projectName` from `<sessionDir>/metadata.json`. Silent on
- * every failure mode — the `EventStore` constructor's
- * `resolveProjectIdFromMetadata` performs the same read with the same
- * fallback semantics, so a `null` here defers cleanly to the constructor's
- * fallback.
+ * Extract `<projectName>` from a per-project session directory of the
+ * shape `<repoRoot>/.gobbi/projects/<projectName>/sessions/<sessionId>/`.
  *
- * Schema v3+ `metadata.json` carries the `projectName` field directly (see
- * `commands/workflow/init.ts::SessionMetadata`). The legacy
- * `basename(metadata.projectRoot)` derivation is dropped: `projectRoot` is
- * always the repo root, so it conflated every project under a multi-project
- * workspace into the same `project_id` (issue #178).
+ * Returns `null` when:
+ *   - the path does not have at least two ancestor segments (e.g. fs
+ *     root, malformed path),
+ *   - the immediate parent is not literally `'sessions'` — this is the
+ *     signal that the path is NOT inside the per-project layout
+ *     (legacy-flat sessions live at `.gobbi/sessions/<sessionId>/` and
+ *     their parent is `'sessions'` but the grandparent is `'.gobbi'`,
+ *     not `'projects'`),
+ *   - the great-grandparent is not literally `'projects'`.
+ *
+ * Path-only resolution is the post–PR-FIN-2a-ii canonical source — the
+ * legacy `metadata.json` reader was retired alongside metadata.json
+ * itself.
  */
-function readProjectIdFromMetadata(sessionDir: string): string | null {
-  let raw: string;
-  try {
-    raw = readFileSync(join(sessionDir, 'metadata.json'), 'utf8');
-  } catch {
-    return null;
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return null;
-  }
-  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    return null;
-  }
-  const projectName = (parsed as Record<string, unknown>)['projectName'];
-  if (typeof projectName !== 'string' || projectName === '') return null;
-  return projectName;
+function projectIdFromSessionDir(sessionDir: string): string | null {
+  const sessionsDir = dirname(sessionDir); // …/sessions
+  if (basename(sessionsDir) !== 'sessions') return null;
+  const projectDirCandidate = dirname(sessionsDir); // …/<projectName>
+  const projectsDirCandidate = dirname(projectDirCandidate); // …/projects
+  if (basename(projectsDirCandidate) !== 'projects') return null;
+  const projectName = basename(projectDirCandidate);
+  return projectName === '' ? null : projectName;
 }
 
 /**

--- a/packages/cli/src/commands/workflow/__tests__/capture-planning.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/capture-planning.test.ts
@@ -113,8 +113,9 @@ function makeScratchRepo(): string {
 
 async function initScratchSession(
   sessionId: string,
-): Promise<{ sessionDir: string; repo: string }> {
+): Promise<{ sessionDir: string; repo: string; projectId: string }> {
   const repo = makeScratchRepo();
+  const projectId = basename(repo);
   await captureExit(() =>
     runInitWithOptions(
       ['--session-id', sessionId, '--task', 'capture-planning-test'],
@@ -127,12 +128,27 @@ async function initScratchSession(
     repo,
     '.gobbi',
     'projects',
-    basename(repo),
+    projectId,
     'sessions',
     sessionId,
   );
   captured = { stdout: '', stderr: '', exitCode: null };
-  return { sessionDir, repo };
+  return { sessionDir, repo, projectId };
+}
+
+/**
+ * Open the per-session event store with explicit partition keys (PR-FIN-
+ * 2a-ii / T-2a.9.unified Option α).
+ */
+function openStore(
+  sessionDir: string,
+  sessionId: string,
+  projectId: string,
+): EventStore {
+  return new EventStore(join(sessionDir, 'gobbi.db'), {
+    sessionId,
+    projectId,
+  });
 }
 
 function planPayload(
@@ -175,7 +191,7 @@ describe('WORKFLOW_COMMANDS registration', () => {
 
 describe('runCapturePlanning — happy path', () => {
   test('writes plan.md and emits artifact.write', async () => {
-    const { sessionDir } = await initScratchSession('cap-plan-ok');
+    const { sessionDir, projectId } = await initScratchSession('cap-plan-ok');
 
     await captureExit(() =>
       runCapturePlanningWithOptions([], {
@@ -198,7 +214,7 @@ describe('runCapturePlanning — happy path', () => {
       '# Plan\n\n1. step one\n2. step two\n',
     );
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, 'cap-plan-ok', projectId);
     try {
       const writes = store.byType('artifact.write');
       expect(writes).toHaveLength(1);
@@ -220,7 +236,7 @@ describe('runCapturePlanning — happy path', () => {
 
 describe('runCapturePlanning — revision overwrite', () => {
   test('re-run with new plan overwrites plan.md and emits a second artifact.write', async () => {
-    const { sessionDir } = await initScratchSession('cap-plan-rev');
+    const { sessionDir, projectId } = await initScratchSession('cap-plan-rev');
 
     // First invocation — uses tool-call idempotency with one id.
     await captureExit(() =>
@@ -253,7 +269,7 @@ describe('runCapturePlanning — revision overwrite', () => {
       '# Plan v2\n\nrevised content\n',
     );
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, 'cap-plan-rev', projectId);
     try {
       const writes = store.byType('artifact.write');
       expect(writes).toHaveLength(2);
@@ -292,7 +308,7 @@ describe('runCapturePlanning — missing session', () => {
 
 describe('runCapturePlanning — missing plan content', () => {
   test('payload without tool_input.plan → silent no-op (no file, no events)', async () => {
-    const { sessionDir } = await initScratchSession('cap-plan-empty');
+    const { sessionDir, projectId } = await initScratchSession('cap-plan-empty');
 
     await captureExit(() =>
       runCapturePlanningWithOptions([], {
@@ -308,7 +324,7 @@ describe('runCapturePlanning — missing plan content', () => {
     expect(captured.exitCode).toBeNull();
     expect(existsSync(join(sessionDir, 'planning', 'plan.md'))).toBe(false);
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, 'cap-plan-empty', projectId);
     try {
       expect(store.byType('artifact.write')).toHaveLength(0);
     } finally {

--- a/packages/cli/src/commands/workflow/__tests__/capture-subagent.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/capture-subagent.test.ts
@@ -129,17 +129,35 @@ function makeScratchRepo(): string {
 
 async function initScratchSession(
   sessionId: string,
-): Promise<{ sessionDir: string; repo: string }> {
+): Promise<{ sessionDir: string; repo: string; projectId: string }> {
   const repo = makeScratchRepo();
+  const projectId = basename(repo);
   await captureExit(() =>
     runInitWithOptions(
       ['--session-id', sessionId, '--task', 'capture-subagent-test'],
       { repoRoot: repo },
     ),
   );
-  const sessionDir = sessionDirForProject(repo, basename(repo), sessionId);
+  const sessionDir = sessionDirForProject(repo, projectId, sessionId);
   captured = { stdout: '', stderr: '', exitCode: null };
-  return { sessionDir, repo };
+  return { sessionDir, repo, projectId };
+}
+
+/**
+ * Open the per-session event store with explicit partition keys (PR-FIN-
+ * 2a-ii / T-2a.9.unified Option α). Tests that previously relied on the
+ * `metadata.json` fallback for `project_id` now stamp NULL and read no
+ * rows; this helper threads the keys init wrote at write time.
+ */
+function openStore(
+  sessionDir: string,
+  sessionId: string,
+  projectId: string,
+): EventStore {
+  return new EventStore(join(sessionDir, 'gobbi.db'), {
+    sessionId,
+    projectId,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -241,7 +259,7 @@ describe('WORKFLOW_COMMANDS registration', () => {
 
 describe('runCaptureSubagent — case 1 (parseable)', () => {
   test('writes artifact + emits delegation.complete + artifact.write', async () => {
-    const { sessionDir } = await initScratchSession('cap-sub-case1');
+    const { sessionDir, projectId } = await initScratchSession('cap-sub-case1');
     const transcriptDir = mkdtempSync(join(tmpdir(), 'transcripts-'));
     scratchDirs.push(transcriptDir);
     const transcript = writeParseableTranscript(
@@ -273,7 +291,7 @@ describe('runCaptureSubagent — case 1 (parseable)', () => {
       'final assistant text for subtask',
     );
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, 'cap-sub-case1', projectId);
     try {
       const completes = store.byType('delegation.complete');
       expect(completes).toHaveLength(1);
@@ -305,7 +323,7 @@ describe('runCaptureSubagent — case 1 (parseable)', () => {
   });
 
   test('passes tokensUsed / cacheHitRatio through when present on stdin', async () => {
-    const { sessionDir } = await initScratchSession('cap-sub-cost');
+    const { sessionDir, projectId } = await initScratchSession('cap-sub-cost');
     const transcriptDir = mkdtempSync(join(tmpdir(), 'transcripts-'));
     scratchDirs.push(transcriptDir);
     const transcript = writeParseableTranscript(
@@ -328,7 +346,7 @@ describe('runCaptureSubagent — case 1 (parseable)', () => {
       }),
     );
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, 'cap-sub-cost', projectId);
     try {
       const completes = store.byType('delegation.complete');
       expect(completes).toHaveLength(1);
@@ -350,7 +368,7 @@ describe('runCaptureSubagent — case 1 (parseable)', () => {
 
 describe('runCaptureSubagent — case 2 (unparseable)', () => {
   test('tool_use-terminated transcript → marker artifact + delegation.fail with transcriptPath', async () => {
-    const { sessionDir } = await initScratchSession('cap-sub-case2a');
+    const { sessionDir, projectId } = await initScratchSession('cap-sub-case2a');
     const transcriptDir = mkdtempSync(join(tmpdir(), 'transcripts-'));
     scratchDirs.push(transcriptDir);
     const transcript = writeToolUseTerminatedTranscript(
@@ -375,7 +393,7 @@ describe('runCaptureSubagent — case 2 (unparseable)', () => {
     expect(existsSync(marker)).toBe(true);
     expect(readFileSync(marker, 'utf8')).toContain(transcript);
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, 'cap-sub-case2a', projectId);
     try {
       const fails = store.byType('delegation.fail');
       expect(fails).toHaveLength(1);
@@ -394,7 +412,7 @@ describe('runCaptureSubagent — case 2 (unparseable)', () => {
   });
 
   test('malformed JSONL transcript → marker artifact + delegation.fail', async () => {
-    const { sessionDir } = await initScratchSession('cap-sub-case2b');
+    const { sessionDir, projectId } = await initScratchSession('cap-sub-case2b');
     const transcriptDir = mkdtempSync(join(tmpdir(), 'transcripts-'));
     scratchDirs.push(transcriptDir);
     const transcript = writeMalformedTailTranscript(
@@ -417,7 +435,7 @@ describe('runCaptureSubagent — case 2 (unparseable)', () => {
     const marker = join(sessionDir, 'artifacts', 'delegation-fail-r1.md');
     expect(existsSync(marker)).toBe(true);
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, 'cap-sub-case2b', projectId);
     try {
       expect(store.byType('delegation.fail')).toHaveLength(1);
       expect(store.byType('delegation.complete')).toHaveLength(0);
@@ -433,7 +451,7 @@ describe('runCaptureSubagent — case 2 (unparseable)', () => {
 
 describe('runCaptureSubagent — case 3 (absent)', () => {
   test('nonexistent transcript path → marker artifact + delegation.fail with reason', async () => {
-    const { sessionDir } = await initScratchSession('cap-sub-case3');
+    const { sessionDir, projectId } = await initScratchSession('cap-sub-case3');
     const missingPath = join(sessionDir, 'does-not-exist.jsonl');
     expect(existsSync(missingPath)).toBe(false);
 
@@ -455,7 +473,7 @@ describe('runCaptureSubagent — case 3 (absent)', () => {
     const content = readFileSync(marker, 'utf8');
     expect(content).toContain('transcript not found');
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, 'cap-sub-case3', projectId);
     try {
       const fails = store.byType('delegation.fail');
       expect(fails).toHaveLength(1);
@@ -477,7 +495,7 @@ describe('runCaptureSubagent — case 3 (absent)', () => {
 
 describe('runCaptureSubagent — stop_hook_active', () => {
   test('stop_hook_active: true → no events, no artifact', async () => {
-    const { sessionDir } = await initScratchSession('cap-sub-sha');
+    const { sessionDir, projectId } = await initScratchSession('cap-sub-sha');
     const transcriptDir = mkdtempSync(join(tmpdir(), 'transcripts-'));
     scratchDirs.push(transcriptDir);
     const transcript = writeParseableTranscript(
@@ -503,7 +521,7 @@ describe('runCaptureSubagent — stop_hook_active', () => {
     expect(captured.stdout).toBe('');
     expect(existsSync(join(sessionDir, 'artifacts'))).toBe(false);
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, 'cap-sub-sha', projectId);
     try {
       expect(store.byType('delegation.complete')).toHaveLength(0);
       expect(store.byType('delegation.fail')).toHaveLength(0);
@@ -551,7 +569,7 @@ describe('runCaptureSubagent — parent_seq linkage', () => {
   // PreToolUse-emitted spawn does) and the SubagentStop must too —
   // otherwise the lookup refuses to guess.
   test('links delegation.complete.parent_seq to matching delegation.spawn.seq via tool_call_id', async () => {
-    const { sessionDir } = await initScratchSession('cap-sub-parent');
+    const { sessionDir, projectId } = await initScratchSession('cap-sub-parent');
     const sessionId = 'cap-sub-parent';
     const transcriptDir = mkdtempSync(join(tmpdir(), 'transcripts-'));
     scratchDirs.push(transcriptDir);
@@ -565,7 +583,7 @@ describe('runCaptureSubagent — parent_seq linkage', () => {
     // SubagentStop will land with.
     let spawnSeq: number | null = null;
     {
-      const store = new EventStore(join(sessionDir, 'gobbi.db'));
+      const store = openStore(sessionDir, 'cap-sub-parent', projectId);
       try {
         const state = resolveWorkflowState(sessionDir, store, sessionId);
         await appendEventAndUpdateState(
@@ -605,7 +623,7 @@ describe('runCaptureSubagent — parent_seq linkage', () => {
       }),
     );
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, 'cap-sub-parent', projectId);
     try {
       const completes = store.byType('delegation.complete');
       expect(completes).toHaveLength(1);
@@ -616,7 +634,7 @@ describe('runCaptureSubagent — parent_seq linkage', () => {
   });
 
   test('omits parent_seq when no matching delegation.spawn exists', async () => {
-    const { sessionDir } = await initScratchSession('cap-sub-noparent');
+    const { sessionDir, projectId } = await initScratchSession('cap-sub-noparent');
     const transcriptDir = mkdtempSync(join(tmpdir(), 'transcripts-'));
     scratchDirs.push(transcriptDir);
     const transcript = writeParseableTranscript(
@@ -638,7 +656,7 @@ describe('runCaptureSubagent — parent_seq linkage', () => {
       }),
     );
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, 'cap-sub-noparent', projectId);
     try {
       const completes = store.byType('delegation.complete');
       expect(completes).toHaveLength(1);
@@ -655,7 +673,7 @@ describe('runCaptureSubagent — parent_seq linkage', () => {
 
 describe('runCaptureSubagent — tool-call idempotency', () => {
   test('retried SubagentStop with same tool_call_id produces one delegation.complete', async () => {
-    const { sessionDir } = await initScratchSession('cap-sub-idem');
+    const { sessionDir, projectId } = await initScratchSession('cap-sub-idem');
     const transcriptDir = mkdtempSync(join(tmpdir(), 'transcripts-'));
     scratchDirs.push(transcriptDir);
     const transcript = writeParseableTranscript(
@@ -680,7 +698,7 @@ describe('runCaptureSubagent — tool-call idempotency', () => {
       runCaptureSubagentWithOptions([], { sessionDir, payload }),
     );
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, 'cap-sub-idem', projectId);
     try {
       expect(store.byType('delegation.complete')).toHaveLength(1);
       // The artifact.write event uses the same idempotency formula
@@ -707,7 +725,7 @@ describe('runCaptureSubagent — tool-call idempotency', () => {
 describe('delegation.spawn — CLAUDE_CODE_VERSION env capture (issue #92)', () => {
   test('env present → spawn event data carries claudeCodeVersion', async () => {
     const sessionId = 'cap-sub-ccv-present';
-    const { sessionDir } = await initScratchSession(sessionId);
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
 
     await withEnv({ CLAUDE_CODE_VERSION: '2.1.110' }, async () => {
       const envVersion = process.env['CLAUDE_CODE_VERSION'];
@@ -717,7 +735,7 @@ describe('delegation.spawn — CLAUDE_CODE_VERSION env capture (issue #92)', () 
       const claudeCodeVersion =
         envVersion !== undefined && envVersion !== '' ? envVersion : undefined;
 
-      const store = new EventStore(join(sessionDir, 'gobbi.db'));
+      const store = openStore(sessionDir, sessionId, projectId);
       try {
         const state = resolveWorkflowState(sessionDir, store, sessionId);
         await appendEventAndUpdateState(
@@ -769,14 +787,14 @@ describe('delegation.spawn — CLAUDE_CODE_VERSION env capture (issue #92)', () 
   // mutation through `withEnv` (scoped capture-set-restore in `finally`).
   test('env unset → spawn event data omits claudeCodeVersion', async () => {
     const sessionId = 'cap-sub-ccv-unset';
-    const { sessionDir } = await initScratchSession(sessionId);
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
 
     await withEnv({ CLAUDE_CODE_VERSION: undefined }, async () => {
       const envVersion = process.env['CLAUDE_CODE_VERSION'];
       const claudeCodeVersion =
         envVersion !== undefined && envVersion !== '' ? envVersion : undefined;
 
-      const store = new EventStore(join(sessionDir, 'gobbi.db'));
+      const store = openStore(sessionDir, sessionId, projectId);
       try {
         const state = resolveWorkflowState(sessionDir, store, sessionId);
         await appendEventAndUpdateState(
@@ -809,14 +827,14 @@ describe('delegation.spawn — CLAUDE_CODE_VERSION env capture (issue #92)', () 
 
   test('env empty string → spawn event data omits claudeCodeVersion', async () => {
     const sessionId = 'cap-sub-ccv-empty';
-    const { sessionDir } = await initScratchSession(sessionId);
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
 
     await withEnv({ CLAUDE_CODE_VERSION: '' }, async () => {
       const envVersion = process.env['CLAUDE_CODE_VERSION'];
       const claudeCodeVersion =
         envVersion !== undefined && envVersion !== '' ? envVersion : undefined;
 
-      const store = new EventStore(join(sessionDir, 'gobbi.db'));
+      const store = openStore(sessionDir, sessionId, projectId);
       try {
         const state = resolveWorkflowState(sessionDir, store, sessionId);
         await appendEventAndUpdateState(
@@ -863,7 +881,7 @@ describe('delegation.spawn — CLAUDE_CODE_VERSION env capture (issue #92)', () 
 describe('runCaptureSubagent — tool_call_id parent linkage (parallel)', () => {
   test('two parallel spawns + two SubagentStops link by tool_call_id, not by recency', async () => {
     const sessionId = 'cap-sub-parallel';
-    const { sessionDir } = await initScratchSession(sessionId);
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
     const transcriptDir = mkdtempSync(join(tmpdir(), 'transcripts-'));
     scratchDirs.push(transcriptDir);
     const transcriptA = writeParseableTranscript(
@@ -886,7 +904,7 @@ describe('runCaptureSubagent — tool_call_id parent linkage (parallel)', () => 
     let spawnSeqA: number | null = null;
     let spawnSeqB: number | null = null;
     {
-      const store = new EventStore(join(sessionDir, 'gobbi.db'));
+      const store = openStore(sessionDir, sessionId, projectId);
       try {
         const stateA = resolveWorkflowState(sessionDir, store, sessionId);
         await appendEventAndUpdateState(
@@ -963,7 +981,7 @@ describe('runCaptureSubagent — tool_call_id parent linkage (parallel)', () => 
       }),
     );
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, sessionId, projectId);
     try {
       const completes = store.byType('delegation.complete');
       expect(completes).toHaveLength(2);
@@ -985,7 +1003,7 @@ describe('runCaptureSubagent — tool_call_id parent linkage (parallel)', () => 
     // refuses to guess. Asserts the fallback contract: missing tool_call_id
     // on SubagentStop → parent_seq is null even when a spawn exists.
     const sessionId = 'cap-sub-no-tcid';
-    const { sessionDir } = await initScratchSession(sessionId);
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
     const transcriptDir = mkdtempSync(join(tmpdir(), 'transcripts-'));
     scratchDirs.push(transcriptDir);
     const transcript = writeParseableTranscript(
@@ -995,7 +1013,7 @@ describe('runCaptureSubagent — tool_call_id parent linkage (parallel)', () => 
     );
 
     {
-      const store = new EventStore(join(sessionDir, 'gobbi.db'));
+      const store = openStore(sessionDir, sessionId, projectId);
       try {
         const state = resolveWorkflowState(sessionDir, store, sessionId);
         await appendEventAndUpdateState(
@@ -1032,7 +1050,7 @@ describe('runCaptureSubagent — tool_call_id parent linkage (parallel)', () => 
       }),
     );
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, sessionId, projectId);
     try {
       const completes = store.byType('delegation.complete');
       expect(completes).toHaveLength(1);
@@ -1050,7 +1068,7 @@ describe('runCaptureSubagent — tool_call_id parent linkage (parallel)', () => 
     // path so production hooks (which carry `tool_use_id`) work alongside
     // existing test fixtures (which carry `tool_call_id`).
     const sessionId = 'cap-sub-use-id';
-    const { sessionDir } = await initScratchSession(sessionId);
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
     const transcriptDir = mkdtempSync(join(tmpdir(), 'transcripts-'));
     scratchDirs.push(transcriptDir);
     const transcript = writeParseableTranscript(
@@ -1061,7 +1079,7 @@ describe('runCaptureSubagent — tool_call_id parent linkage (parallel)', () => 
 
     let spawnSeq: number | null = null;
     {
-      const store = new EventStore(join(sessionDir, 'gobbi.db'));
+      const store = openStore(sessionDir, sessionId, projectId);
       try {
         const state = resolveWorkflowState(sessionDir, store, sessionId);
         await appendEventAndUpdateState(
@@ -1100,7 +1118,7 @@ describe('runCaptureSubagent — tool_call_id parent linkage (parallel)', () => 
       }),
     );
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, sessionId, projectId);
     try {
       const completes = store.byType('delegation.complete');
       expect(completes).toHaveLength(1);
@@ -1118,7 +1136,7 @@ describe('runCaptureSubagent — tool_call_id parent linkage (parallel)', () => 
 describe('runCaptureSubagent — transcriptSha256 capture', () => {
   test('parseable transcript → delegation.complete carries SHA-256 of file bytes', async () => {
     const sessionId = 'cap-sub-sha';
-    const { sessionDir } = await initScratchSession(sessionId);
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
     const transcriptDir = mkdtempSync(join(tmpdir(), 'transcripts-'));
     scratchDirs.push(transcriptDir);
     const transcript = writeParseableTranscript(
@@ -1147,7 +1165,7 @@ describe('runCaptureSubagent — transcriptSha256 capture', () => {
       }),
     );
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, sessionId, projectId);
     try {
       const completes = store.byType('delegation.complete');
       expect(completes).toHaveLength(1);
@@ -1165,7 +1183,7 @@ describe('runCaptureSubagent — transcriptSha256 capture', () => {
     // carries the field. Asserts the additive scope: fail events keep their
     // existing shape unchanged.
     const sessionId = 'cap-sub-fail-sha';
-    const { sessionDir } = await initScratchSession(sessionId);
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
     const transcriptDir = mkdtempSync(join(tmpdir(), 'transcripts-'));
     scratchDirs.push(transcriptDir);
     const transcript = writeMalformedTailTranscript(
@@ -1185,7 +1203,7 @@ describe('runCaptureSubagent — transcriptSha256 capture', () => {
       }),
     );
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, sessionId, projectId);
     try {
       const fails = store.byType('delegation.fail');
       expect(fails).toHaveLength(1);

--- a/packages/cli/src/commands/workflow/__tests__/capture-subagent.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/capture-subagent.test.ts
@@ -28,6 +28,7 @@ import {
   rmSync,
   writeFileSync,
 } from 'node:fs';
+// readFileSync is already imported above; the SHA test uses it for fixture hashing.
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 
@@ -545,7 +546,11 @@ describe('runCaptureSubagent — missing session', () => {
 // ---------------------------------------------------------------------------
 
 describe('runCaptureSubagent — parent_seq linkage', () => {
-  test('links delegation.complete.parent_seq to matching delegation.spawn.seq', async () => {
+  // PR-FIN-2a-ii T-2a.8.0: linkage now keys on tool_call_id, not on
+  // subagentId === agent_id. The spawn must carry tool_call_id (the new
+  // PreToolUse-emitted spawn does) and the SubagentStop must too —
+  // otherwise the lookup refuses to guess.
+  test('links delegation.complete.parent_seq to matching delegation.spawn.seq via tool_call_id', async () => {
     const { sessionDir } = await initScratchSession('cap-sub-parent');
     const sessionId = 'cap-sub-parent';
     const transcriptDir = mkdtempSync(join(tmpdir(), 'transcripts-'));
@@ -556,7 +561,8 @@ describe('runCaptureSubagent — parent_seq linkage', () => {
       'child result',
     );
 
-    // Seed a delegation.spawn event for agent-p1 so the lookup finds it.
+    // Seed a delegation.spawn carrying the same tool_call_id the
+    // SubagentStop will land with.
     let spawnSeq: number | null = null;
     {
       const store = new EventStore(join(sessionDir, 'gobbi.db'));
@@ -571,10 +577,12 @@ describe('runCaptureSubagent — parent_seq linkage', () => {
             step: state.currentStep,
             subagentId: 'agent-p1',
             timestamp: new Date().toISOString(),
+            tool_call_id: 'toolu_link',
           }),
           'cli',
           sessionId,
-          'system',
+          'tool-call',
+          'toolu_link',
         );
         const spawnRow = store.last('delegation.spawn');
         spawnSeq = spawnRow?.seq ?? null;
@@ -592,6 +600,7 @@ describe('runCaptureSubagent — parent_seq linkage', () => {
           agent_type: 'executor',
           agent_transcript_path: transcript,
           session_id: sessionId,
+          tool_call_id: 'toolu_link',
         },
       }),
     );
@@ -624,6 +633,7 @@ describe('runCaptureSubagent — parent_seq linkage', () => {
           agent_type: 'executor',
           agent_transcript_path: transcript,
           session_id: 'cap-sub-noparent',
+          tool_call_id: 'toolu_orphan',
         },
       }),
     );
@@ -835,5 +845,354 @@ describe('delegation.spawn — CLAUDE_CODE_VERSION env capture (issue #92)', () 
         store.close();
       }
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR-FIN-2a-ii T-2a.8.0 — tool_call_id-scoped parent linkage
+//
+// The previous heuristic — `last('delegation.spawn')` filtered by
+// `subagentId === agent_id` — silently misattributed parent linkage when
+// multiple subagents were spawned in parallel from one orchestrator turn.
+// These tests pin the new behavior: with `tool_call_id` carried on every
+// spawn (PR-FIN-2a-ii adds the field) the SubagentStop's `tool_call_id`
+// picks out the matching spawn even when the most recent spawn belongs to
+// a different sibling.
+// ---------------------------------------------------------------------------
+
+describe('runCaptureSubagent — tool_call_id parent linkage (parallel)', () => {
+  test('two parallel spawns + two SubagentStops link by tool_call_id, not by recency', async () => {
+    const sessionId = 'cap-sub-parallel';
+    const { sessionDir } = await initScratchSession(sessionId);
+    const transcriptDir = mkdtempSync(join(tmpdir(), 'transcripts-'));
+    scratchDirs.push(transcriptDir);
+    const transcriptA = writeParseableTranscript(
+      transcriptDir,
+      'agent-A.jsonl',
+      'A done',
+    );
+    const transcriptB = writeParseableTranscript(
+      transcriptDir,
+      'agent-B.jsonl',
+      'B done',
+    );
+
+    // Seed two delegation.spawn events in order — A first, then B. Both
+    // carry tool_call_ids so capture-subagent can match precisely. If the
+    // implementation falls back to last('delegation.spawn'), agent A's
+    // SubagentStop would link to spawn B (the most recent). The test
+    // breaks that path by sequencing the SubagentStops so A arrives BEFORE
+    // B — but A is older, so the heuristic linkage would be wrong.
+    let spawnSeqA: number | null = null;
+    let spawnSeqB: number | null = null;
+    {
+      const store = new EventStore(join(sessionDir, 'gobbi.db'));
+      try {
+        const stateA = resolveWorkflowState(sessionDir, store, sessionId);
+        appendEventAndUpdateState(
+          store,
+          sessionDir,
+          stateA,
+          createDelegationSpawn({
+            agentType: '__pi',
+            step: stateA.currentStep,
+            subagentId: 'sub-A',
+            timestamp: '2026-04-29T00:00:00.001Z',
+            tool_call_id: 'toolu_A',
+          }),
+          'hook',
+          sessionId,
+          'tool-call',
+          'toolu_A',
+        );
+        spawnSeqA = store.last('delegation.spawn')?.seq ?? null;
+
+        const stateB = resolveWorkflowState(sessionDir, store, sessionId);
+        appendEventAndUpdateState(
+          store,
+          sessionDir,
+          stateB,
+          createDelegationSpawn({
+            agentType: '__pi',
+            step: stateB.currentStep,
+            subagentId: 'sub-B',
+            timestamp: '2026-04-29T00:00:00.002Z',
+            tool_call_id: 'toolu_B',
+          }),
+          'hook',
+          sessionId,
+          'tool-call',
+          'toolu_B',
+        );
+        spawnSeqB = store.last('delegation.spawn')?.seq ?? null;
+      } finally {
+        store.close();
+      }
+    }
+    expect(spawnSeqA).not.toBeNull();
+    expect(spawnSeqB).not.toBeNull();
+    expect(spawnSeqA).not.toBe(spawnSeqB);
+
+    // SubagentStop for A — must link to spawn A even though spawn B is
+    // the most recent in the store.
+    await captureExit(() =>
+      runCaptureSubagentWithOptions([], {
+        sessionDir,
+        payload: {
+          agent_id: 'sub-A',
+          agent_type: '__pi',
+          agent_transcript_path: transcriptA,
+          session_id: sessionId,
+          tool_call_id: 'toolu_A',
+        },
+      }),
+    );
+
+    // SubagentStop for B — must link to spawn B.
+    captured = { stdout: '', stderr: '', exitCode: null };
+    await captureExit(() =>
+      runCaptureSubagentWithOptions([], {
+        sessionDir,
+        payload: {
+          agent_id: 'sub-B',
+          agent_type: '__pi',
+          agent_transcript_path: transcriptB,
+          session_id: sessionId,
+          tool_call_id: 'toolu_B',
+        },
+      }),
+    );
+
+    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    try {
+      const completes = store.byType('delegation.complete');
+      expect(completes).toHaveLength(2);
+      const byAgent = new Map<string, number | null>();
+      for (const row of completes) {
+        const data = JSON.parse(row.data) as { readonly subagentId: string };
+        byAgent.set(data.subagentId, row.parent_seq);
+      }
+      // Each completion must point at its OWN spawn — not the recent one.
+      expect(byAgent.get('sub-A')).toBe(spawnSeqA);
+      expect(byAgent.get('sub-B')).toBe(spawnSeqB);
+    } finally {
+      store.close();
+    }
+  });
+
+  test('SubagentStop without tool_call_id falls back to parent_seq null', async () => {
+    // The previous heuristic had a chance to guess; the new precise lookup
+    // refuses to guess. Asserts the fallback contract: missing tool_call_id
+    // on SubagentStop → parent_seq is null even when a spawn exists.
+    const sessionId = 'cap-sub-no-tcid';
+    const { sessionDir } = await initScratchSession(sessionId);
+    const transcriptDir = mkdtempSync(join(tmpdir(), 'transcripts-'));
+    scratchDirs.push(transcriptDir);
+    const transcript = writeParseableTranscript(
+      transcriptDir,
+      'agent-N.jsonl',
+      'no-tcid result',
+    );
+
+    {
+      const store = new EventStore(join(sessionDir, 'gobbi.db'));
+      try {
+        const state = resolveWorkflowState(sessionDir, store, sessionId);
+        appendEventAndUpdateState(
+          store,
+          sessionDir,
+          state,
+          createDelegationSpawn({
+            agentType: 'executor',
+            step: state.currentStep,
+            subagentId: 'sub-N',
+            timestamp: '2026-04-29T00:00:00.000Z',
+            tool_call_id: 'toolu_N',
+          }),
+          'hook',
+          sessionId,
+          'tool-call',
+          'toolu_N',
+        );
+      } finally {
+        store.close();
+      }
+    }
+
+    await captureExit(() =>
+      runCaptureSubagentWithOptions([], {
+        sessionDir,
+        payload: {
+          agent_id: 'sub-N',
+          agent_type: 'executor',
+          agent_transcript_path: transcript,
+          session_id: sessionId,
+          // no tool_call_id, no tool_use_id
+        },
+      }),
+    );
+
+    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    try {
+      const completes = store.byType('delegation.complete');
+      expect(completes).toHaveLength(1);
+      // Without a tool_call_id on the stop payload, the new lookup
+      // refuses to guess — parent_seq is null.
+      expect(completes[0]!.parent_seq).toBeNull();
+    } finally {
+      store.close();
+    }
+  });
+
+  test('tool_use_id on SubagentStop links the same way as tool_call_id', async () => {
+    // Claude Code's canonical hook reference uses `tool_use_id`; the
+    // resolver accepts either name. This test pins the canonical-name
+    // path so production hooks (which carry `tool_use_id`) work alongside
+    // existing test fixtures (which carry `tool_call_id`).
+    const sessionId = 'cap-sub-use-id';
+    const { sessionDir } = await initScratchSession(sessionId);
+    const transcriptDir = mkdtempSync(join(tmpdir(), 'transcripts-'));
+    scratchDirs.push(transcriptDir);
+    const transcript = writeParseableTranscript(
+      transcriptDir,
+      'agent-U.jsonl',
+      'tool_use_id linked',
+    );
+
+    let spawnSeq: number | null = null;
+    {
+      const store = new EventStore(join(sessionDir, 'gobbi.db'));
+      try {
+        const state = resolveWorkflowState(sessionDir, store, sessionId);
+        appendEventAndUpdateState(
+          store,
+          sessionDir,
+          state,
+          createDelegationSpawn({
+            agentType: 'executor',
+            step: state.currentStep,
+            subagentId: 'sub-U',
+            timestamp: '2026-04-29T00:00:00.000Z',
+            tool_call_id: 'toolu_USE',
+          }),
+          'hook',
+          sessionId,
+          'tool-call',
+          'toolu_USE',
+        );
+        spawnSeq = store.last('delegation.spawn')?.seq ?? null;
+      } finally {
+        store.close();
+      }
+    }
+    expect(spawnSeq).not.toBeNull();
+
+    await captureExit(() =>
+      runCaptureSubagentWithOptions([], {
+        sessionDir,
+        payload: {
+          agent_id: 'sub-U',
+          agent_type: 'executor',
+          agent_transcript_path: transcript,
+          session_id: sessionId,
+          tool_use_id: 'toolu_USE',
+        },
+      }),
+    );
+
+    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    try {
+      const completes = store.byType('delegation.complete');
+      expect(completes).toHaveLength(1);
+      expect(completes[0]!.parent_seq).toBe(spawnSeq);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR-FIN-2a-ii T-2a.8.0 — transcriptSha256 capture-time hash
+// ---------------------------------------------------------------------------
+
+describe('runCaptureSubagent — transcriptSha256 capture', () => {
+  test('parseable transcript → delegation.complete carries SHA-256 of file bytes', async () => {
+    const sessionId = 'cap-sub-sha';
+    const { sessionDir } = await initScratchSession(sessionId);
+    const transcriptDir = mkdtempSync(join(tmpdir(), 'transcripts-'));
+    scratchDirs.push(transcriptDir);
+    const transcript = writeParseableTranscript(
+      transcriptDir,
+      'agent-sha.jsonl',
+      'hashed result',
+    );
+
+    // Compute the expected hash with the same primitive the production
+    // path uses (node:crypto). Reading the file with the same default
+    // encoding ensures byte-equivalence regardless of the OS line ending.
+    const { createHash } = await import('node:crypto');
+    const expected = createHash('sha256')
+      .update(readFileSync(transcript))
+      .digest('hex');
+
+    await captureExit(() =>
+      runCaptureSubagentWithOptions([], {
+        sessionDir,
+        payload: {
+          agent_id: 'agent-sha',
+          agent_type: 'executor',
+          agent_transcript_path: transcript,
+          session_id: sessionId,
+        },
+      }),
+    );
+
+    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    try {
+      const completes = store.byType('delegation.complete');
+      expect(completes).toHaveLength(1);
+      const data = JSON.parse(completes[0]!.data) as {
+        readonly transcriptSha256?: string;
+      };
+      expect(data.transcriptSha256).toBe(expected);
+    } finally {
+      store.close();
+    }
+  });
+
+  test('unparseable transcript → delegation.fail; transcriptSha256 NOT on fail data', async () => {
+    // The fail path has no SHA capture by design — only delegation.complete
+    // carries the field. Asserts the additive scope: fail events keep their
+    // existing shape unchanged.
+    const sessionId = 'cap-sub-fail-sha';
+    const { sessionDir } = await initScratchSession(sessionId);
+    const transcriptDir = mkdtempSync(join(tmpdir(), 'transcripts-'));
+    scratchDirs.push(transcriptDir);
+    const transcript = writeMalformedTailTranscript(
+      transcriptDir,
+      'agent-fail.jsonl',
+    );
+
+    await captureExit(() =>
+      runCaptureSubagentWithOptions([], {
+        sessionDir,
+        payload: {
+          agent_id: 'agent-fail',
+          agent_type: 'executor',
+          agent_transcript_path: transcript,
+          session_id: sessionId,
+        },
+      }),
+    );
+
+    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    try {
+      const fails = store.byType('delegation.fail');
+      expect(fails).toHaveLength(1);
+      const data = JSON.parse(fails[0]!.data) as Record<string, unknown>;
+      expect('transcriptSha256' in data).toBe(false);
+    } finally {
+      store.close();
+    }
   });
 });

--- a/packages/cli/src/commands/workflow/__tests__/capture-subagent.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/capture-subagent.test.ts
@@ -568,7 +568,7 @@ describe('runCaptureSubagent — parent_seq linkage', () => {
       const store = new EventStore(join(sessionDir, 'gobbi.db'));
       try {
         const state = resolveWorkflowState(sessionDir, store, sessionId);
-        appendEventAndUpdateState(
+        await appendEventAndUpdateState(
           store,
           sessionDir,
           state,
@@ -709,7 +709,7 @@ describe('delegation.spawn — CLAUDE_CODE_VERSION env capture (issue #92)', () 
     const sessionId = 'cap-sub-ccv-present';
     const { sessionDir } = await initScratchSession(sessionId);
 
-    await withEnv({ CLAUDE_CODE_VERSION: '2.1.110' }, () => {
+    await withEnv({ CLAUDE_CODE_VERSION: '2.1.110' }, async () => {
       const envVersion = process.env['CLAUDE_CODE_VERSION'];
       // Emitters populate the field only when the env var is a non-empty
       // string — this is the documented pattern (see delegation.ts
@@ -720,7 +720,7 @@ describe('delegation.spawn — CLAUDE_CODE_VERSION env capture (issue #92)', () 
       const store = new EventStore(join(sessionDir, 'gobbi.db'));
       try {
         const state = resolveWorkflowState(sessionDir, store, sessionId);
-        appendEventAndUpdateState(
+        await appendEventAndUpdateState(
           store,
           sessionDir,
           state,
@@ -771,7 +771,7 @@ describe('delegation.spawn — CLAUDE_CODE_VERSION env capture (issue #92)', () 
     const sessionId = 'cap-sub-ccv-unset';
     const { sessionDir } = await initScratchSession(sessionId);
 
-    await withEnv({ CLAUDE_CODE_VERSION: undefined }, () => {
+    await withEnv({ CLAUDE_CODE_VERSION: undefined }, async () => {
       const envVersion = process.env['CLAUDE_CODE_VERSION'];
       const claudeCodeVersion =
         envVersion !== undefined && envVersion !== '' ? envVersion : undefined;
@@ -779,7 +779,7 @@ describe('delegation.spawn — CLAUDE_CODE_VERSION env capture (issue #92)', () 
       const store = new EventStore(join(sessionDir, 'gobbi.db'));
       try {
         const state = resolveWorkflowState(sessionDir, store, sessionId);
-        appendEventAndUpdateState(
+        await appendEventAndUpdateState(
           store,
           sessionDir,
           state,
@@ -811,7 +811,7 @@ describe('delegation.spawn — CLAUDE_CODE_VERSION env capture (issue #92)', () 
     const sessionId = 'cap-sub-ccv-empty';
     const { sessionDir } = await initScratchSession(sessionId);
 
-    await withEnv({ CLAUDE_CODE_VERSION: '' }, () => {
+    await withEnv({ CLAUDE_CODE_VERSION: '' }, async () => {
       const envVersion = process.env['CLAUDE_CODE_VERSION'];
       const claudeCodeVersion =
         envVersion !== undefined && envVersion !== '' ? envVersion : undefined;
@@ -819,7 +819,7 @@ describe('delegation.spawn — CLAUDE_CODE_VERSION env capture (issue #92)', () 
       const store = new EventStore(join(sessionDir, 'gobbi.db'));
       try {
         const state = resolveWorkflowState(sessionDir, store, sessionId);
-        appendEventAndUpdateState(
+        await appendEventAndUpdateState(
           store,
           sessionDir,
           state,
@@ -889,7 +889,7 @@ describe('runCaptureSubagent — tool_call_id parent linkage (parallel)', () => 
       const store = new EventStore(join(sessionDir, 'gobbi.db'));
       try {
         const stateA = resolveWorkflowState(sessionDir, store, sessionId);
-        appendEventAndUpdateState(
+        await appendEventAndUpdateState(
           store,
           sessionDir,
           stateA,
@@ -908,7 +908,7 @@ describe('runCaptureSubagent — tool_call_id parent linkage (parallel)', () => 
         spawnSeqA = store.last('delegation.spawn')?.seq ?? null;
 
         const stateB = resolveWorkflowState(sessionDir, store, sessionId);
-        appendEventAndUpdateState(
+        await appendEventAndUpdateState(
           store,
           sessionDir,
           stateB,
@@ -998,7 +998,7 @@ describe('runCaptureSubagent — tool_call_id parent linkage (parallel)', () => 
       const store = new EventStore(join(sessionDir, 'gobbi.db'));
       try {
         const state = resolveWorkflowState(sessionDir, store, sessionId);
-        appendEventAndUpdateState(
+        await appendEventAndUpdateState(
           store,
           sessionDir,
           state,
@@ -1064,7 +1064,7 @@ describe('runCaptureSubagent — tool_call_id parent linkage (parallel)', () => 
       const store = new EventStore(join(sessionDir, 'gobbi.db'));
       try {
         const state = resolveWorkflowState(sessionDir, store, sessionId);
-        appendEventAndUpdateState(
+        await appendEventAndUpdateState(
           store,
           sessionDir,
           state,

--- a/packages/cli/src/commands/workflow/__tests__/guard.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/guard.test.ts
@@ -128,17 +128,36 @@ function makeScratchRepo(): string {
 
 async function initScratchSession(
   sessionId: string,
-): Promise<{ sessionDir: string; repo: string }> {
+): Promise<{ sessionDir: string; repo: string; projectId: string }> {
   const repo = makeScratchRepo();
+  const projectId = basename(repo);
   await captureExit(() =>
     runInitWithOptions(
       ['--session-id', sessionId, '--task', 'guard-test'],
       { repoRoot: repo },
     ),
   );
-  const sessionDir = sessionDirForProject(repo, basename(repo), sessionId);
+  const sessionDir = sessionDirForProject(repo, projectId, sessionId);
   captured = { stdout: '', stderr: '', exitCode: null };
-  return { sessionDir, repo };
+  return { sessionDir, repo, projectId };
+}
+
+/**
+ * Open the per-session event store with explicit partition keys (lock 8 —
+ * PR-FIN-2a-ii / T-2a.9.unified). Production callers always supply both
+ * keys; the path-derivation fallback covers tests that don't go through
+ * the helpers but `initScratchSession` callers should use this helper to
+ * keep partition-aware reads aligned with init's stamping.
+ */
+function openStore(
+  sessionDir: string,
+  sessionId: string,
+  projectId: string,
+): EventStore {
+  return new EventStore(join(sessionDir, 'gobbi.db'), {
+    sessionId,
+    projectId,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -236,7 +255,7 @@ describe('WORKFLOW_COMMANDS registration', () => {
 
 describe('runGuard — empty registry', () => {
   test('responds allow + emits no events', async () => {
-    const { sessionDir } = await initScratchSession('guard-empty');
+    const { sessionDir, projectId } = await initScratchSession('guard-empty');
     const payload = makePayload('guard-empty', 'Write');
 
     await captureExit(() =>
@@ -251,7 +270,7 @@ describe('runGuard — empty registry', () => {
     const decision = parseResponse(captured.stdout);
     expect(decision.permissionDecision).toBe('allow');
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, 'guard-empty', projectId);
     try {
       const guardEvents = [
         ...store.byType('guard.violation'),
@@ -270,7 +289,7 @@ describe('runGuard — empty registry', () => {
 
 describe('runGuard — deny fixture', () => {
   test('emits deny + reason + guard.violation event', async () => {
-    const { sessionDir } = await initScratchSession('guard-deny');
+    const { sessionDir, projectId } = await initScratchSession('guard-deny');
     const payload = makePayload('guard-deny', 'Write', {
       tool_call_id: 'call-deny-1',
     });
@@ -291,7 +310,7 @@ describe('runGuard — deny fixture', () => {
     // `ideation` is the step init lands on once workflow.eval.decide fires.
     expect(decision.permissionDecisionReason).toContain('step: ideation');
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, 'guard-deny', projectId);
     try {
       const violations = store.byType('guard.violation');
       expect(violations).toHaveLength(1);
@@ -314,7 +333,7 @@ describe('runGuard — deny fixture', () => {
 
 describe('runGuard — warn fixture', () => {
   test('emits allow + additionalContext + guard.warn event carrying code', async () => {
-    const { sessionDir } = await initScratchSession('guard-warn');
+    const { sessionDir, projectId } = await initScratchSession('guard-warn');
     const payload = makePayload('guard-warn', 'Write', {
       tool_call_id: 'call-warn-1',
     });
@@ -333,7 +352,7 @@ describe('runGuard — warn fixture', () => {
     expect(decision.additionalContext).toBeDefined();
     expect(decision.additionalContext!).toContain('warn fixture warn-1');
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, 'guard-warn', projectId);
     try {
       const warns = store.byType('guard.warn');
       expect(warns).toHaveLength(1);
@@ -358,7 +377,7 @@ describe('runGuard — warn fixture', () => {
 
 describe('runGuard — warn + deny combo', () => {
   test('warn fires first, deny short-circuits — only deny appears in response', async () => {
-    const { sessionDir } = await initScratchSession('guard-combo');
+    const { sessionDir, projectId } = await initScratchSession('guard-combo');
     const payload = makePayload('guard-combo', 'Write', {
       tool_call_id: 'call-combo-1',
     });
@@ -384,7 +403,7 @@ describe('runGuard — warn + deny combo', () => {
     // is the sole surfaced context.
     expect(decision.additionalContext).toBeUndefined();
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, 'guard-combo', projectId);
     try {
       expect(store.byType('guard.warn')).toHaveLength(1);
       expect(store.byType('guard.violation')).toHaveLength(1);
@@ -444,7 +463,7 @@ describe('runGuard — missing session', () => {
 
 describe('runGuard — invalid stdin', () => {
   test('malformed payload → allow (fail-open), exit 0', async () => {
-    const { sessionDir } = await initScratchSession('guard-bad-stdin');
+    const { sessionDir, projectId } = await initScratchSession('guard-bad-stdin');
 
     // Pass a string where an object is expected — passes the `readStdin`
     // equivalent but fails the type guard.
@@ -460,7 +479,7 @@ describe('runGuard — invalid stdin', () => {
     const decision = parseResponse(captured.stdout);
     expect(decision.permissionDecision).toBe('allow');
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, 'guard-bad-stdin', projectId);
     try {
       expect(store.byType('guard.violation')).toHaveLength(0);
     } finally {
@@ -507,7 +526,7 @@ describe('runGuard — invalid stdin', () => {
 
 describe('runGuard — tool-call idempotency', () => {
   test('same tool_call_id retried produces a single guard.violation', async () => {
-    const { sessionDir } = await initScratchSession('guard-idem');
+    const { sessionDir, projectId } = await initScratchSession('guard-idem');
     const payload = makePayload('guard-idem', 'Write', {
       tool_call_id: 'call-retry',
     });
@@ -529,7 +548,7 @@ describe('runGuard — tool-call idempotency', () => {
     const decision = parseResponse(captured.stdout);
     expect(decision.permissionDecision).toBe('deny');
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, 'guard-idem', projectId);
     try {
       // Idempotency key is `${sessionId}:${toolCallId}:${eventType}` — the
       // second append collides on UNIQUE and is dropped by DO NOTHING.

--- a/packages/cli/src/commands/workflow/__tests__/init.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/init.test.ts
@@ -1,28 +1,36 @@
 /**
  * Unit tests for `gobbi workflow init` — idempotent session initialisation.
  *
- * Coverage:
- *   - Fresh init writes metadata.json with schemaVersion 3, projectRoot, and
- *     an empty techStack (C.2c fills techStack in a follow-up commit).
- *   - Fresh init opens gobbi.db and emits workflow.start + workflow.eval.decide
- *     atomically; the session reaches `ideation`.
- *   - Re-running against an existing directory is a silent no-op (no new
- *     events, no rewrite of metadata.json).
- *   - Malformed existing metadata.json exits 1.
- *   - CLI flags --task / --eval-ideation / --eval-planning / --context land on
- *     metadata.configSnapshot.
+ * Coverage (PR-FIN-2a-ii T-2a.8.5 — JSON memory pivot):
+ *   - Fresh init writes `session.json` (NOT `metadata.json`) carrying exactly
+ *     the 6 required-at-all-stages fields per the ideation lock
+ *     (`schemaVersion`, `sessionId`, `projectId`, `createdAt`,
+ *     `gobbiVersion`, `task`) plus `finishedAt: null`. No legacy
+ *     `metadata.json` is written.
+ *   - Fresh init opens `gobbi.db` and emits `workflow.start` +
+ *     `workflow.eval.decide` atomically.
+ *   - Re-running against an existing directory is a silent no-op.
+ *   - Malformed existing `session.json` exits 1.
+ *   - Mismatched `--project` flag still exits 2 (compared against the
+ *     stamped `session.json.projectId`).
+ *   - The CLI flags `--task / --eval-ideation / --eval-planning / --context`
+ *     reach the expected destinations: `task` lands on `session.json.task`;
+ *     the eval booleans drive the `workflow.eval.decide` event payload but
+ *     are NOT carried into session.json (ideation lock 5 — minimal
+ *     carry-forward).
  *
  * Tests use the `runInitWithOptions({ repoRoot })` test hook so we never
  * touch the actual checkout's `.gobbi/` tree.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 
 import { EventStore } from '../../../workflow/store.js';
-import { runInitWithOptions, readMetadata, resolveSessionId } from '../init.js';
+import { runInitWithOptions, resolveSessionId } from '../init.js';
+import { readSessionJson, sessionJsonPath } from '../../../lib/json-memory.js';
 import { sessionDir as sessionDirForProject } from '../../../lib/workspace-paths.js';
 
 // ---------------------------------------------------------------------------
@@ -157,11 +165,11 @@ describe('resolveSessionId', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Fresh init happy path
+// Fresh init happy path — session.json shape (T-2a.8.5)
 // ---------------------------------------------------------------------------
 
-describe('runInit — fresh session', () => {
-  test('writes metadata.json with schema v3, empty techStack, and the given flags', async () => {
+describe('runInit — fresh session (session.json)', () => {
+  test('writes session.json with schema v1 and exactly the 6 required fields + finishedAt', async () => {
     const repo = makeScratchRepo();
     await captureExit(() =>
       runInitWithOptions(
@@ -179,21 +187,52 @@ describe('runInit — fresh session', () => {
     );
     expect(captured.exitCode).toBeNull();
 
-    const metaPath = join(
-      sessionDirForProject(repo, basename(repo), 'fresh-happy'),
-      'metadata.json',
+    const sessionPath = sessionJsonPath(repo, basename(repo), 'fresh-happy');
+    const session = readSessionJson(sessionPath);
+    expect(session).not.toBeNull();
+    if (session === null) return;
+
+    // The 6 required-at-all-stages fields per ideation lock + finishedAt:null.
+    expect(session.schemaVersion).toBe(1);
+    expect(session.sessionId).toBe('fresh-happy');
+    expect(session.projectId).toBe(basename(repo));
+    expect(session.task).toBe('demo task');
+    expect(session.finishedAt).toBeNull();
+    expect(typeof session.createdAt).toBe('string');
+    expect(session.createdAt.length).toBeGreaterThan(0);
+    expect(typeof session.gobbiVersion).toBe('string');
+    expect(session.gobbiVersion.length).toBeGreaterThan(0);
+
+    // `steps` is absent in the stub (lock 43 — readers infer "stub" from the
+    // missing `steps` field; no separate `status` discriminant).
+    expect(session.steps).toBeUndefined();
+
+    // The init-only fields from previous metadata.json — `evalIdeation`,
+    // `evalPlanning`, `context`, `projectRoot`, `techStack`,
+    // `configSnapshot` — are intentionally not on session.json (ideation
+    // lock 5 — minimal carry-forward, only `task`).
+    const raw = JSON.parse(readFileSync(sessionPath, 'utf8')) as Record<
+      string,
+      unknown
+    >;
+    expect(raw['configSnapshot']).toBeUndefined();
+    expect(raw['projectRoot']).toBeUndefined();
+    expect(raw['techStack']).toBeUndefined();
+  });
+
+  test('NO legacy metadata.json is written', async () => {
+    const repo = makeScratchRepo();
+    await captureExit(() =>
+      runInitWithOptions(
+        ['--session-id', 'no-legacy', '--task', 'demo'],
+        { repoRoot: repo },
+      ),
     );
-    const meta = readMetadata(metaPath);
-    expect(meta).not.toBeNull();
-    expect(meta!.schemaVersion).toBe(3);
-    expect(meta!.sessionId).toBe('fresh-happy');
-    expect(meta!.projectRoot).toBe(repo);
-    // C.2c populates techStack; for now it's empty.
-    expect(meta!.techStack).toEqual([]);
-    expect(meta!.configSnapshot.task).toBe('demo task');
-    expect(meta!.configSnapshot.evalIdeation).toBe(true);
-    expect(meta!.configSnapshot.evalPlanning).toBe(false);
-    expect(meta!.configSnapshot.context).toBe('ctx line');
+    expect(captured.exitCode).toBeNull();
+
+    const sDir = sessionDirForProject(repo, basename(repo), 'no-legacy');
+    expect(existsSync(join(sDir, 'metadata.json'))).toBe(false);
+    expect(existsSync(join(sDir, 'session.json'))).toBe(true);
   });
 
   test('opens gobbi.db and appends workflow.start + workflow.eval.decide', async () => {
@@ -219,6 +258,43 @@ describe('runInit — fresh session', () => {
       store.close();
     }
   });
+
+  test('--eval-ideation flag drives the eval.decide payload (not session.json)', async () => {
+    const repo = makeScratchRepo();
+    await captureExit(() =>
+      runInitWithOptions(
+        ['--session-id', 'eval-flags', '--eval-ideation'],
+        { repoRoot: repo },
+      ),
+    );
+
+    const dbPath = join(
+      sessionDirForProject(repo, basename(repo), 'eval-flags'),
+      'gobbi.db',
+    );
+    const store = new EventStore(dbPath);
+    try {
+      const rows = store.replayAll();
+      const decideRow = rows.find((row) => row.type === 'workflow.eval.decide');
+      expect(decideRow).toBeDefined();
+      if (decideRow !== undefined) {
+        const data = JSON.parse(decideRow.data) as Record<string, unknown>;
+        expect(data['ideation']).toBe(true);
+        expect(data['plan']).toBe(false);
+      }
+    } finally {
+      store.close();
+    }
+
+    // session.json is the 6-field stub — no eval flags carry through.
+    const sessionPath = sessionJsonPath(repo, basename(repo), 'eval-flags');
+    const raw = JSON.parse(readFileSync(sessionPath, 'utf8')) as Record<
+      string,
+      unknown
+    >;
+    expect(raw['evalIdeation']).toBeUndefined();
+    expect(raw['evalPlanning']).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -237,8 +313,8 @@ describe('runInit — idempotency', () => {
 
     const idemSessionDir = sessionDirForProject(repo, basename(repo), 'idem');
     const dbPath = join(idemSessionDir, 'gobbi.db');
-    const metaPath = join(idemSessionDir, 'metadata.json');
-    const firstMeta = readFileSync(metaPath, 'utf8');
+    const sessionPath = sessionJsonPath(repo, basename(repo), 'idem');
+    const firstSessionJson = readFileSync(sessionPath, 'utf8');
 
     captured = { stdout: '', stderr: '', exitCode: null };
     await captureExit(() =>
@@ -251,8 +327,8 @@ describe('runInit — idempotency', () => {
     expect(captured.stdout).toBe('');
     expect(captured.stderr).toBe('');
 
-    // Metadata file unchanged.
-    expect(readFileSync(metaPath, 'utf8')).toBe(firstMeta);
+    // session.json bytes unchanged — re-init does not rewrite the stub.
+    expect(readFileSync(sessionPath, 'utf8')).toBe(firstSessionJson);
 
     // No duplicate events.
     const store = new EventStore(dbPath);
@@ -264,11 +340,11 @@ describe('runInit — idempotency', () => {
     }
   });
 
-  test('malformed existing metadata.json exits 1', async () => {
+  test('malformed existing session.json exits 1', async () => {
     const repo = makeScratchRepo();
-    const sessionDir = sessionDirForProject(repo, basename(repo), 'broken');
-    mkdirSync(sessionDir, { recursive: true });
-    writeFileSync(join(sessionDir, 'metadata.json'), 'not json', 'utf8');
+    const sDir = sessionDirForProject(repo, basename(repo), 'broken');
+    mkdirSync(sDir, { recursive: true });
+    writeFileSync(join(sDir, 'session.json'), 'not json', 'utf8');
 
     await captureExit(() =>
       runInitWithOptions(['--session-id', 'broken'], { repoRoot: repo }),
@@ -292,19 +368,14 @@ describe('runInit — PR-FIN-1c project name resolution', () => {
     );
     expect(captured.exitCode).toBeNull();
 
-    // metadata.projectName = basename(repoRoot)
-    const metaPath = join(
-      repo,
-      '.gobbi',
-      'projects',
-      expectedName,
-      'sessions',
-      'boot-1',
-      'metadata.json',
+    // session.json.projectId = basename(repoRoot)
+    const session = readSessionJson(
+      sessionJsonPath(repo, expectedName, 'boot-1'),
     );
-    const meta = readMetadata(metaPath);
-    expect(meta).not.toBeNull();
-    expect(meta!.projectName).toBe(expectedName);
+    expect(session).not.toBeNull();
+    if (session !== null) {
+      expect(session.projectId).toBe(expectedName);
+    }
 
     // PR-FIN-1c: no projects registry in settings.json — minimum shape
     // is just `{schemaVersion: 1}`.
@@ -331,18 +402,11 @@ describe('runInit — PR-FIN-1c project name resolution', () => {
     );
     expect(captured.exitCode).toBeNull();
 
-    const metaPath = join(
-      repo,
-      '.gobbi',
-      'projects',
-      'bar',
-      'sessions',
-      'flag-bar',
-      'metadata.json',
-    );
-    const meta = readMetadata(metaPath);
-    expect(meta).not.toBeNull();
-    expect(meta!.projectName).toBe('bar');
+    const session = readSessionJson(sessionJsonPath(repo, 'bar', 'flag-bar'));
+    expect(session).not.toBeNull();
+    if (session !== null) {
+      expect(session.projectId).toBe('bar');
+    }
   });
 
   test('[4] existing session re-init with no --project is a silent no-op', async () => {
@@ -354,16 +418,8 @@ describe('runInit — PR-FIN-1c project name resolution', () => {
     );
     expect(captured.exitCode).toBeNull();
 
-    const metaPath = join(
-      repo,
-      '.gobbi',
-      'projects',
-      expectedName,
-      'sessions',
-      'noop',
-      'metadata.json',
-    );
-    const firstMeta = readFileSync(metaPath, 'utf8');
+    const sessionPath = sessionJsonPath(repo, expectedName, 'noop');
+    const firstSessionJson = readFileSync(sessionPath, 'utf8');
 
     // Re-init with no flag — silent no-op.
     captured = { stdout: '', stderr: '', exitCode: null };
@@ -372,7 +428,7 @@ describe('runInit — PR-FIN-1c project name resolution', () => {
     );
     expect(captured.exitCode).toBeNull();
     expect(captured.stdout).toBe('');
-    expect(readFileSync(metaPath, 'utf8')).toBe(firstMeta);
+    expect(readFileSync(sessionPath, 'utf8')).toBe(firstSessionJson);
   });
 
   test('[5] existing session re-init with mismatching --project exits 2', async () => {
@@ -409,16 +465,8 @@ describe('runInit — PR-FIN-1c project name resolution', () => {
     );
     expect(captured.exitCode).toBeNull();
 
-    const metaPath = join(
-      repo,
-      '.gobbi',
-      'projects',
-      'foo',
-      'sessions',
-      'match-foo',
-      'metadata.json',
-    );
-    const firstMeta = readFileSync(metaPath, 'utf8');
+    const sessionPath = sessionJsonPath(repo, 'foo', 'match-foo');
+    const firstSessionJson = readFileSync(sessionPath, 'utf8');
 
     // Re-init with same --project foo — silent no-op.
     captured = { stdout: '', stderr: '', exitCode: null };
@@ -430,12 +478,12 @@ describe('runInit — PR-FIN-1c project name resolution', () => {
     );
     expect(captured.exitCode).toBeNull();
     expect(captured.stderr).toBe('');
-    expect(readFileSync(metaPath, 'utf8')).toBe(firstMeta);
+    expect(readFileSync(sessionPath, 'utf8')).toBe(firstSessionJson);
   });
 });
 
 // ---------------------------------------------------------------------------
-// #178 — project_id partition key sourced from metadata.projectName, not
+// #178 — project_id partition key sourced from session.projectId, not
 // basename(repoRoot). A multi-project workspace stamps every event with
 // the actual project the session belongs to, so cross-project queries
 // against state.db can partition by `project_id`.
@@ -500,7 +548,7 @@ describe('runInit — project_id stamping (#178)', () => {
     }
   });
 
-  test('project_id matches metadata.projectName, not basename(repoRoot)', async () => {
+  test('project_id matches session.projectId, not basename(repoRoot)', async () => {
     // The hard regression case from issue #178: a repo named gobbi-repo
     // initialised under --project=foo must stamp project_id='foo', NOT
     // 'gobbi-repo' (basename(repoRoot)).
@@ -525,7 +573,7 @@ describe('runInit — project_id stamping (#178)', () => {
       const rows = store.replayAll();
       expect(rows.length).toBeGreaterThan(0);
       for (const row of rows) {
-        // Issue #178: this MUST be 'foo' (metadata.projectName) — never
+        // Issue #178: this MUST be 'foo' (session.projectId) — never
         // basename(repo) which would be `gobbi-repo-<random>`.
         expect(row.project_id).toBe('foo');
         expect(row.project_id).not.toMatch(/^gobbi-repo-/);

--- a/packages/cli/src/commands/workflow/__tests__/init.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/init.test.ts
@@ -237,6 +237,7 @@ describe('runInit — fresh session (session.json)', () => {
 
   test('opens gobbi.db and appends workflow.start + workflow.eval.decide', async () => {
     const repo = makeScratchRepo();
+    const projectId = basename(repo);
     await captureExit(() =>
       runInitWithOptions(
         ['--session-id', 'fresh-events', '--task', 'demo'],
@@ -245,10 +246,16 @@ describe('runInit — fresh session (session.json)', () => {
     );
 
     const dbPath = join(
-      sessionDirForProject(repo, basename(repo), 'fresh-events'),
+      sessionDirForProject(repo, projectId, 'fresh-events'),
       'gobbi.db',
     );
-    const store = new EventStore(dbPath);
+    // PR-FIN-2a-ii: every read on the v5+ store filters by partition keys
+    // (`session_id`, `project_id`). Pass the same keys init stamped at
+    // write time or the read returns zero rows.
+    const store = new EventStore(dbPath, {
+      sessionId: 'fresh-events',
+      projectId,
+    });
     try {
       const rows = store.replayAll();
       expect(rows).toHaveLength(2);
@@ -261,6 +268,7 @@ describe('runInit — fresh session (session.json)', () => {
 
   test('--eval-ideation flag drives the eval.decide payload (not session.json)', async () => {
     const repo = makeScratchRepo();
+    const projectId = basename(repo);
     await captureExit(() =>
       runInitWithOptions(
         ['--session-id', 'eval-flags', '--eval-ideation'],
@@ -269,10 +277,13 @@ describe('runInit — fresh session (session.json)', () => {
     );
 
     const dbPath = join(
-      sessionDirForProject(repo, basename(repo), 'eval-flags'),
+      sessionDirForProject(repo, projectId, 'eval-flags'),
       'gobbi.db',
     );
-    const store = new EventStore(dbPath);
+    const store = new EventStore(dbPath, {
+      sessionId: 'eval-flags',
+      projectId,
+    });
     try {
       const rows = store.replayAll();
       const decideRow = rows.find((row) => row.type === 'workflow.eval.decide');
@@ -331,7 +342,10 @@ describe('runInit — idempotency', () => {
     expect(readFileSync(sessionPath, 'utf8')).toBe(firstSessionJson);
 
     // No duplicate events.
-    const store = new EventStore(dbPath);
+    const store = new EventStore(dbPath, {
+      sessionId: 'idem',
+      projectId: basename(repo),
+    });
     try {
       const rows = store.replayAll();
       expect(rows).toHaveLength(2);
@@ -504,7 +518,10 @@ describe('runInit — project_id stamping (#178)', () => {
       sessionDirForProject(repo, 'foo', 'sess-foo'),
       'gobbi.db',
     );
-    const store = new EventStore(dbPath);
+    const store = new EventStore(dbPath, {
+      sessionId: 'sess-foo',
+      projectId: 'foo',
+    });
     try {
       const rows = store.replayAll();
       // workflow init emits workflow.start + workflow.eval.decide.
@@ -535,7 +552,10 @@ describe('runInit — project_id stamping (#178)', () => {
       sessionDirForProject(repo, 'bar', 'sess-bar'),
       'gobbi.db',
     );
-    const store = new EventStore(dbPath);
+    const store = new EventStore(dbPath, {
+      sessionId: 'sess-bar',
+      projectId: 'bar',
+    });
     try {
       const rows = store.replayAll();
       expect(rows.length).toBeGreaterThan(0);
@@ -568,7 +588,10 @@ describe('runInit — project_id stamping (#178)', () => {
       sessionDirForProject(repo, 'foo', 'sess-178'),
       'gobbi.db',
     );
-    const store = new EventStore(dbPath);
+    const store = new EventStore(dbPath, {
+      sessionId: 'sess-178',
+      projectId: 'foo',
+    });
     try {
       const rows = store.replayAll();
       expect(rows.length).toBeGreaterThan(0);

--- a/packages/cli/src/commands/workflow/__tests__/next.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/next.test.ts
@@ -129,22 +129,36 @@ function makeScratchRepo(): string {
 
 async function initScratchSession(
   sessionId: string,
-): Promise<{ sessionDir: string; repo: string }> {
+): Promise<{ sessionDir: string; repo: string; projectId: string }> {
   const repo = makeScratchRepo();
+  const projectId = basename(repo);
   await captureExit(() =>
     runInitWithOptions(
       ['--session-id', sessionId, '--task', 'next-test'],
       { repoRoot: repo },
     ),
   );
-  const sessionDir = sessionDirForProject(repo, basename(repo), sessionId);
+  const sessionDir = sessionDirForProject(repo, projectId, sessionId);
   // Reset capture between init and the test's real assertions.
   captured = { stdout: '', stderr: '', exitCode: null };
-  return { sessionDir, repo };
+  return { sessionDir, repo, projectId };
 }
 
-function openStore(sessionDir: string): EventStore {
-  return new EventStore(join(sessionDir, 'gobbi.db'));
+/**
+ * Open the per-session event store for the given session. PR-FIN-2a-ii:
+ * every read is partition-filtered by `(session_id, project_id)`, so the
+ * helper mandates both keys — passing them at construction matches the
+ * values init stamps at write time.
+ */
+function openStore(
+  sessionDir: string,
+  sessionId: string,
+  projectId: string,
+): EventStore {
+  return new EventStore(join(sessionDir, 'gobbi.db'), {
+    sessionId,
+    projectId,
+  });
 }
 
 // ===========================================================================
@@ -153,8 +167,8 @@ function openStore(sessionDir: string): EventStore {
 
 describe('compileCurrentStep — productive step', () => {
   test('compiles ideation spec when state.currentStep is ideation', async () => {
-    const { sessionDir } = await initScratchSession('next-ideation');
-    const store = openStore(sessionDir);
+    const { sessionDir, projectId } = await initScratchSession('next-ideation');
+    const store = openStore(sessionDir, 'next-ideation', projectId);
     try {
       // Fresh init lands at ideation/discussing. Strip the substate for the
       // no-overlay fixture to exercise the base-spec branch directly.
@@ -188,8 +202,8 @@ describe('compileCurrentStep — productive step', () => {
 
 describe('compileCurrentStep — substate overlay', () => {
   test('applies the discussing.overlay.json when currentSubstate is "discussing"', async () => {
-    const { sessionDir } = await initScratchSession('next-overlay');
-    const store = openStore(sessionDir);
+    const { sessionDir, projectId } = await initScratchSession('next-overlay');
+    const store = openStore(sessionDir, 'next-overlay', projectId);
     try {
       const resolved = resolveWorkflowState(sessionDir, store, 'next-overlay');
       // Fresh init already lands on discussing per the reducer. Assert it
@@ -222,8 +236,8 @@ describe('compileCurrentStep — substate overlay', () => {
 describe('compileCurrentStep — error branch', () => {
   test('dispatches to compileErrorPrompt and returns the timeout-pathway prompt text', async () => {
     const sessionId = 'next-error';
-    const { sessionDir } = await initScratchSession(sessionId);
-    const store = openStore(sessionDir);
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
+    const store = openStore(sessionDir, sessionId, projectId);
     try {
       // Drive the session into `error` via STEP_TIMEOUT on the current
       // (active) step — the reducer transitions active → error on timeout.
@@ -267,8 +281,8 @@ describe('compileCurrentStep — error branch', () => {
     // events (timeout / invalid_transition / trailing-revise verdict).
     // This test asserts the fallback emits a coherent prompt rather than
     // throwing.
-    const { sessionDir } = await initScratchSession('next-error-fallback');
-    const store = openStore(sessionDir);
+    const { sessionDir, projectId } = await initScratchSession('next-error-fallback');
+    const store = openStore(sessionDir, 'next-error-fallback', projectId);
     try {
       const errorState: WorkflowState = {
         ...initialState('next-error-fallback'),
@@ -309,12 +323,12 @@ describe('runNextWithOptions', () => {
 
   test('emits the timeout-pathway error-state prompt when the session is in error', async () => {
     const sessionId = 'next-cli-error';
-    const { sessionDir } = await initScratchSession(sessionId);
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
 
     // Drive the session into `error` via STEP_TIMEOUT so the detector
     // classifies the pathway as Timeout.
     {
-      const store = new EventStore(join(sessionDir, 'gobbi.db'));
+      const store = openStore(sessionDir, sessionId, projectId);
       try {
         const state = resolveWorkflowState(sessionDir, store, sessionId);
         await appendEventAndUpdateState(

--- a/packages/cli/src/commands/workflow/__tests__/next.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/next.test.ts
@@ -228,7 +228,7 @@ describe('compileCurrentStep — error branch', () => {
       // Drive the session into `error` via STEP_TIMEOUT on the current
       // (active) step — the reducer transitions active → error on timeout.
       const state = resolveWorkflowState(sessionDir, store, sessionId);
-      const result = appendEventAndUpdateState(
+      const result = await appendEventAndUpdateState(
         store,
         sessionDir,
         state,
@@ -317,7 +317,7 @@ describe('runNextWithOptions', () => {
       const store = new EventStore(join(sessionDir, 'gobbi.db'));
       try {
         const state = resolveWorkflowState(sessionDir, store, sessionId);
-        appendEventAndUpdateState(
+        await appendEventAndUpdateState(
           store,
           sessionDir,
           state,

--- a/packages/cli/src/commands/workflow/__tests__/resume.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/resume.test.ts
@@ -20,7 +20,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 
@@ -125,17 +125,33 @@ function makeScratchRepo(): string {
 
 async function initScratchSession(
   sessionId: string,
-): Promise<{ sessionDir: string; repo: string }> {
+): Promise<{ sessionDir: string; repo: string; projectId: string }> {
   const repo = makeScratchRepo();
+  const projectId = basename(repo);
   await captureExit(() =>
     runInitWithOptions(
       ['--session-id', sessionId, '--task', 'resume-test'],
       { repoRoot: repo },
     ),
   );
-  const sessionDir = sessionDirForProject(repo, basename(repo), sessionId);
+  const sessionDir = sessionDirForProject(repo, projectId, sessionId);
   captured = { stdout: '', stderr: '', exitCode: null };
-  return { sessionDir, repo };
+  return { sessionDir, repo, projectId };
+}
+
+/**
+ * Open the per-session event store with explicit partition keys (PR-FIN-
+ * 2a-ii / T-2a.9.unified Option α).
+ */
+function openStore(
+  sessionDir: string,
+  sessionId: string,
+  projectId: string,
+): EventStore {
+  return new EventStore(join(sessionDir, 'gobbi.db'), {
+    sessionId,
+    projectId,
+  });
 }
 
 /**
@@ -146,8 +162,9 @@ async function initScratchSession(
 async function driveToErrorState(
   sessionDir: string,
   sessionId: string,
+  projectId: string,
 ): Promise<void> {
-  const store = new EventStore(join(sessionDir, 'gobbi.db'));
+  const store = openStore(sessionDir, sessionId, projectId);
   try {
     const state = resolveWorkflowState(sessionDir, store, sessionId);
     await appendEventAndUpdateState(
@@ -175,7 +192,7 @@ async function driveToErrorState(
 
 describe('runResumeWithOptions — argv parsing', () => {
   test('missing --target exits 2 with a helpful stderr message', async () => {
-    const { sessionDir } = await initScratchSession('resume-miss-target');
+    const { sessionDir, projectId } = await initScratchSession('resume-miss-target');
 
     await captureExit(() =>
       runResumeWithOptions([], { sessionDir }),
@@ -186,7 +203,7 @@ describe('runResumeWithOptions — argv parsing', () => {
   });
 
   test('unknown flag exits 2 with usage on stderr', async () => {
-    const { sessionDir } = await initScratchSession('resume-unknown-flag');
+    const { sessionDir, projectId } = await initScratchSession('resume-unknown-flag');
 
     await captureExit(() =>
       runResumeWithOptions(
@@ -206,8 +223,8 @@ describe('runResumeWithOptions — argv parsing', () => {
 
 describe('runResumeWithOptions — target validation', () => {
   test('--target error is explicitly rejected (exit 1)', async () => {
-    const { sessionDir } = await initScratchSession('resume-target-error');
-    await driveToErrorState(sessionDir, 'resume-target-error');
+    const { sessionDir, projectId } = await initScratchSession('resume-target-error');
+    await driveToErrorState(sessionDir, 'resume-target-error', projectId);
 
     await captureExit(() =>
       runResumeWithOptions(['--target', 'error'], { sessionDir }),
@@ -218,8 +235,8 @@ describe('runResumeWithOptions — target validation', () => {
   });
 
   test('non-active-step target (e.g. done) exits 1', async () => {
-    const { sessionDir } = await initScratchSession('resume-target-done');
-    await driveToErrorState(sessionDir, 'resume-target-done');
+    const { sessionDir, projectId } = await initScratchSession('resume-target-done');
+    await driveToErrorState(sessionDir, 'resume-target-done', projectId);
 
     await captureExit(() =>
       runResumeWithOptions(['--target', 'done'], { sessionDir }),
@@ -230,7 +247,7 @@ describe('runResumeWithOptions — target validation', () => {
   });
 
   test('resume from non-error state exits 1', async () => {
-    const { sessionDir } = await initScratchSession('resume-nonerror');
+    const { sessionDir, projectId } = await initScratchSession('resume-nonerror');
     // No driveToErrorState — fresh init sits at ideation/discussing.
 
     await captureExit(() =>
@@ -249,8 +266,8 @@ describe('runResumeWithOptions — target validation', () => {
 describe('runResumeWithOptions — default resume', () => {
   test('--target planning from error state appends workflow.resume and emits the resume prompt', async () => {
     const sessionId = 'resume-plan';
-    const { sessionDir } = await initScratchSession(sessionId);
-    await driveToErrorState(sessionDir, sessionId);
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
+    await driveToErrorState(sessionDir, sessionId, projectId);
 
     await captureExit(() =>
       runResumeWithOptions(['--target', 'planning'], { sessionDir }),
@@ -267,7 +284,7 @@ describe('runResumeWithOptions — default resume', () => {
     expect(captured.stdout).toContain('planning');
 
     // One workflow.resume event is persisted.
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, sessionId, projectId);
     try {
       const resumeRows = store.byType('workflow.resume');
       expect(resumeRows.length).toBe(1);
@@ -294,8 +311,8 @@ describe('runResumeWithOptions — default resume', () => {
 describe('runResumeWithOptions — --force-memorization', () => {
   test('atomically appends decision.eval.skip (with priorError) AND workflow.resume', async () => {
     const sessionId = 'resume-force';
-    const { sessionDir } = await initScratchSession(sessionId);
-    await driveToErrorState(sessionDir, sessionId);
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
+    await driveToErrorState(sessionDir, sessionId, projectId);
 
     await captureExit(() =>
       runResumeWithOptions(
@@ -307,7 +324,7 @@ describe('runResumeWithOptions — --force-memorization', () => {
     expect(captured.exitCode).toBeNull();
     expect(captured.stdout).toContain('Timeout recap:');
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, sessionId, projectId);
     try {
       const skipRows = store.byType('decision.eval.skip');
       const resumeRows = store.byType('workflow.resume');
@@ -347,14 +364,14 @@ describe('runResumeWithOptions — --force-memorization', () => {
 
   test('CP11 reversibility — priorError snapshot round-trips through the event store', async () => {
     const sessionId = 'resume-cp11';
-    const { sessionDir } = await initScratchSession(sessionId);
-    await driveToErrorState(sessionDir, sessionId);
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
+    await driveToErrorState(sessionDir, sessionId, projectId);
 
     // Snapshot the pathway detected BEFORE the resume — this is the
     // baseline the CP11 reversibility gate asserts against.
     let baselinePathway: ErrorPathway;
     {
-      const store = new EventStore(join(sessionDir, 'gobbi.db'));
+      const store = openStore(sessionDir, sessionId, projectId);
       try {
         const state = resolveWorkflowState(sessionDir, store, sessionId);
         baselinePathway = detectPathway(state, store);
@@ -372,7 +389,7 @@ describe('runResumeWithOptions — --force-memorization', () => {
     expect(captured.exitCode).toBeNull();
 
     // Read the skip event back and reconstruct the pathway snapshot.
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, sessionId, projectId);
     try {
       const skipRows = store.byType('decision.eval.skip');
       expect(skipRows.length).toBe(1);
@@ -397,25 +414,27 @@ describe('runResumeWithOptions — --force-memorization', () => {
   });
 
   // CV-9 regression — issue #163. The pre-fix `--force-memorization`
-  // branch appended events via raw `store.transaction(...)` and never
-  // wrote `state.json`. `resolveWorkflowState`'s fast path read the
-  // stale state.json and returned the pre-resume `error` step on every
-  // subsequent invocation — events said `memorization`, state.json
-  // disagreed. The fix derives state via `deriveWorkflowState` and
-  // explicitly calls `writeState` after the transaction commits.
-  //
-  // This test asserts the on-disk state.json content directly, NOT the
-  // event-store rows (the pre-existing tests above already cover those).
-  test('writes state.json with currentStep=memorization after --force-memorization (issue #163)', async () => {
+  // branch appended events via raw `store.transaction(...)` without
+  // re-deriving state — `resolveWorkflowState` returned the pre-resume
+  // `error` step on every subsequent invocation. PR-FIN-2a-ii
+  // (T-2a.9.unified) retired `state.json` entirely; `resolveWorkflowState`
+  // is now a pure derive over the partition-filtered event stream, so
+  // the regression class collapses to "did the resume events land
+  // atomically and does the next derive return memorization?".
+  test('post-force-memorization state derives currentStep=memorization (issue #163)', async () => {
     const sessionId = 'resume-force-statefile';
-    const { sessionDir } = await initScratchSession(sessionId);
-    await driveToErrorState(sessionDir, sessionId);
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
+    await driveToErrorState(sessionDir, sessionId, projectId);
 
-    // Sanity baseline: state.json reflects the error state pre-resume.
+    // Sanity baseline: derived state reflects the error step pre-resume.
     {
-      const raw = readFileSync(join(sessionDir, 'state.json'), 'utf8');
-      const before = JSON.parse(raw) as { readonly currentStep: string };
-      expect(before.currentStep).toBe('error');
+      const store = openStore(sessionDir, sessionId, projectId);
+      try {
+        const before = resolveWorkflowState(sessionDir, store, sessionId);
+        expect(before.currentStep).toBe('error');
+      } finally {
+        store.close();
+      }
     }
 
     await captureExit(() =>
@@ -426,42 +445,19 @@ describe('runResumeWithOptions — --force-memorization', () => {
     );
     expect(captured.exitCode).toBeNull();
 
-    // The actual regression assertion — state.json materialised the
-    // post-resume state, not just the event-store rows.
-    const raw = readFileSync(join(sessionDir, 'state.json'), 'utf8');
-    const after = JSON.parse(raw) as {
-      readonly currentStep: string;
-      readonly schemaVersion: number;
-    };
-    expect(after.currentStep).toBe('memorization');
-    // The fast-path readers (`resolveWorkflowState`) accept the file by
-    // schemaVersion gate — confirm the persisted shape passes that gate
-    // so downstream guard / status / next reads see the fresh state.
-    expect(after.schemaVersion).toBeGreaterThanOrEqual(4);
-
-    // Cross-check via the same code path the runtime uses — fast-path
-    // readState → resolveWorkflowState. Pre-fix, this returned 'error'
-    // because state.json was stale.
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    // Post-resume derive returns memorization — the regression case
+    // pre-#163 returned `error` here because the event stream was
+    // appended via raw transaction without state re-derivation. After
+    // T-2a.9.unified the engine's pure-derive path always replays the
+    // current event stream, so the same assertion holds without any
+    // on-disk state.json projection.
+    const store = openStore(sessionDir, sessionId, projectId);
     try {
       const resolved = resolveWorkflowState(sessionDir, store, sessionId);
       expect(resolved.currentStep).toBe('memorization');
     } finally {
       store.close();
     }
-
-    // Backup invariant — `state.json.backup` must trail `state.json` by
-    // at most one state write. The `--force-memorization` branch calls
-    // `backupState` immediately before `writeState`, so the backup
-    // captures the pre-resume `error` state that lived in `state.json`
-    // before the explicit post-transaction projection. This mirrors the
-    // discipline in `appendEventAndUpdateState` (engine.ts).
-    const backupRaw = readFileSync(
-      join(sessionDir, 'state.json.backup'),
-      'utf8',
-    );
-    const backup = JSON.parse(backupRaw) as { readonly currentStep: string };
-    expect(backup.currentStep).toBe('error');
   });
 });
 

--- a/packages/cli/src/commands/workflow/__tests__/resume.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/resume.test.ts
@@ -150,7 +150,7 @@ async function driveToErrorState(
   const store = new EventStore(join(sessionDir, 'gobbi.db'));
   try {
     const state = resolveWorkflowState(sessionDir, store, sessionId);
-    appendEventAndUpdateState(
+    await appendEventAndUpdateState(
       store,
       sessionDir,
       state,

--- a/packages/cli/src/commands/workflow/__tests__/stop.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/stop.test.ts
@@ -31,10 +31,14 @@ import { WORKFLOW_COMMANDS } from '../../workflow.js';
 import { sessionDir as sessionDirForProject } from '../../../lib/workspace-paths.js';
 import { EventStore } from '../../../workflow/store.js';
 import {
-  readState,
-  writeState,
-  type WorkflowState,
-} from '../../../workflow/state.js';
+  appendEventAndUpdateState,
+  resolveWorkflowState,
+} from '../../../workflow/engine.js';
+import {
+  createStepExit,
+  createStepTimeout,
+  createResume,
+} from '../../../workflow/events/workflow.js';
 
 // ---------------------------------------------------------------------------
 // stdout/stderr capture + process.exit trap
@@ -121,17 +125,38 @@ function makeScratchRepo(): string {
 
 async function initScratchSession(
   sessionId: string,
-): Promise<{ sessionDir: string; repo: string }> {
+): Promise<{ sessionDir: string; repo: string; projectId: string }> {
   const repo = makeScratchRepo();
+  const projectId = basename(repo);
   await captureExit(() =>
     runInitWithOptions(
       ['--session-id', sessionId, '--task', 'stop-test'],
       { repoRoot: repo },
     ),
   );
-  const sessionDir = sessionDirForProject(repo, basename(repo), sessionId);
+  const sessionDir = sessionDirForProject(repo, projectId, sessionId);
   captured = { stdout: '', stderr: '', exitCode: null };
-  return { sessionDir, repo };
+  return { sessionDir, repo, projectId };
+}
+
+/**
+ * Open the per-session event store with explicit partition keys
+ * (PR-FIN-2a-ii / T-2a.9.unified Option α). Tests that previously
+ * called `new EventStore(<sessionDir>/gobbi.db)` relied on the now-
+ * retired `metadata.json` reader to fill in `project_id`; with that
+ * fallback gone, every read filters `WHERE project_id IS NULL` and
+ * returns zero rows. Pass the same `(sessionId, projectId)` init
+ * stamped at write time.
+ */
+function openStore(
+  sessionDir: string,
+  sessionId: string,
+  projectId: string,
+): EventStore {
+  return new EventStore(join(sessionDir, 'gobbi.db'), {
+    sessionId,
+    projectId,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -151,9 +176,9 @@ describe('WORKFLOW_COMMANDS registration', () => {
 
 describe('runStop — stop_hook_active', () => {
   test('stop_hook_active: true → no heartbeat, empty stdout, exit 0', async () => {
-    const { sessionDir } = await initScratchSession('stop-reentrant');
+    const { sessionDir, projectId } = await initScratchSession('stop-reentrant');
 
-    const beforeCount = countHeartbeats(sessionDir);
+    const beforeCount = countHeartbeats(sessionDir, 'stop-reentrant', projectId);
 
     await captureExit(() =>
       runStopWithOptions([], {
@@ -169,7 +194,9 @@ describe('runStop — stop_hook_active', () => {
     expect(captured.stdout).toBe('');
 
     // No heartbeat written — reentrance branch runs before any store open.
-    expect(countHeartbeats(sessionDir)).toBe(beforeCount);
+    expect(countHeartbeats(sessionDir, 'stop-reentrant', projectId)).toBe(
+      beforeCount,
+    );
   });
 });
 
@@ -179,10 +206,10 @@ describe('runStop — stop_hook_active', () => {
 
 describe('runStop — heartbeat emission', () => {
   test('writes a session.heartbeat event via counter idempotency (counter=0)', async () => {
-    const { sessionDir } = await initScratchSession('stop-happy');
+    const { sessionDir, projectId } = await initScratchSession('stop-happy');
     const frozen = new Date('2026-04-16T10:00:00.000Z');
 
-    const store0 = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store0 = openStore(sessionDir, 'stop-happy', projectId);
     const lastSeqBefore = store0.eventCount();
     store0.close();
 
@@ -197,7 +224,7 @@ describe('runStop — heartbeat emission', () => {
     expect(captured.exitCode).toBeNull();
     expect(captured.stdout).toBe(''); // observational — no JSON response
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, 'stop-happy', projectId);
     try {
       const heartbeats = store.byType('session.heartbeat');
       expect(heartbeats).toHaveLength(1);
@@ -220,13 +247,20 @@ describe('runStop — heartbeat emission', () => {
   });
 
   test('heartbeat does NOT mutate state — currentStep unchanged', async () => {
-    const { sessionDir } = await initScratchSession('stop-nomutate');
+    const { sessionDir, projectId } = await initScratchSession('stop-nomutate');
 
-    // Snapshot state.json before
-    const { readFileSync } = await import('node:fs');
-    const stateBefore = JSON.parse(
-      readFileSync(join(sessionDir, 'state.json'), 'utf8'),
-    ) as { readonly currentStep: string };
+    // PR-FIN-2a-ii (T-2a.9.unified) retired `state.json`; derive state
+    // by replay over the partition-filtered event stream instead. The
+    // invariant under test is that `runStop` writes only a heartbeat
+    // event — the reducer must not transition currentStep.
+    const stepBefore = (() => {
+      const store = openStore(sessionDir, 'stop-nomutate', projectId);
+      try {
+        return resolveWorkflowState(sessionDir, store, 'stop-nomutate').currentStep;
+      } finally {
+        store.close();
+      }
+    })();
 
     await captureExit(() =>
       runStopWithOptions([], {
@@ -235,11 +269,16 @@ describe('runStop — heartbeat emission', () => {
       }),
     );
 
-    const stateAfter = JSON.parse(
-      readFileSync(join(sessionDir, 'state.json'), 'utf8'),
-    ) as { readonly currentStep: string };
+    const stepAfter = (() => {
+      const store = openStore(sessionDir, 'stop-nomutate', projectId);
+      try {
+        return resolveWorkflowState(sessionDir, store, 'stop-nomutate').currentStep;
+      } finally {
+        store.close();
+      }
+    })();
 
-    expect(stateAfter.currentStep).toBe(stateBefore.currentStep);
+    expect(stepAfter).toBe(stepBefore);
   });
 });
 
@@ -249,7 +288,7 @@ describe('runStop — heartbeat emission', () => {
 
 describe('runStop — same-millisecond collisions', () => {
   test('two invocations at the same ms both persist with counter 0 and 1', async () => {
-    const { sessionDir } = await initScratchSession('stop-collide');
+    const { sessionDir, projectId } = await initScratchSession('stop-collide');
     const frozen = new Date('2026-04-16T11:22:33.456Z');
 
     // Fire twice with the identical clock — the counter must
@@ -269,7 +308,7 @@ describe('runStop — same-millisecond collisions', () => {
       }),
     );
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, 'stop-collide', projectId);
     try {
       const heartbeats = store.byType('session.heartbeat');
       expect(heartbeats).toHaveLength(2);
@@ -287,7 +326,7 @@ describe('runStop — same-millisecond collisions', () => {
   });
 
   test('second invocation at a later ms resets the counter bucket to 0', async () => {
-    const { sessionDir } = await initScratchSession('stop-newms');
+    const { sessionDir, projectId } = await initScratchSession('stop-newms');
 
     const t1 = new Date('2026-04-16T11:22:33.456Z');
     const t2 = new Date('2026-04-16T11:22:34.789Z');
@@ -307,7 +346,7 @@ describe('runStop — same-millisecond collisions', () => {
       }),
     );
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    const store = openStore(sessionDir, 'stop-newms', projectId);
     try {
       const heartbeats = store.byType('session.heartbeat');
       expect(heartbeats).toHaveLength(2);
@@ -331,14 +370,14 @@ describe('runStop — same-millisecond collisions', () => {
 
 describe('runStop — bounded heartbeat tail-scan', () => {
   test('resolves same-ms counter against a 200-heartbeat history without scanning the full stream', async () => {
-    const { sessionDir } = await initScratchSession('stop-bound');
+    const { sessionDir, projectId } = await initScratchSession('stop-bound');
 
     // Seed 200 heartbeats across distinct milliseconds so the stop
     // handler has a long prior stream to walk. The final seeded row
     // shares the `frozen` bucket to force a same-ms collision at the
     // tail — the bounded scan must still find counter=0 and assign 1.
     const frozen = new Date('2026-04-16T12:00:00.000Z');
-    const seedStore = new EventStore(join(sessionDir, 'gobbi.db'));
+    const seedStore = openStore(sessionDir, 'stop-bound', projectId);
     try {
       seedStore.transaction(() => {
         for (let i = 0; i < 199; i += 1) {
@@ -378,7 +417,7 @@ describe('runStop — bounded heartbeat tail-scan', () => {
     }
 
     // Sanity — history is 200 rows deep before the stop fires.
-    const before = new EventStore(join(sessionDir, 'gobbi.db'));
+    const before = openStore(sessionDir, 'stop-bound', projectId);
     const beforeCount = before.byType('session.heartbeat').length;
     before.close();
     expect(beforeCount).toBe(200);
@@ -395,7 +434,7 @@ describe('runStop — bounded heartbeat tail-scan', () => {
       }),
     );
 
-    const after = new EventStore(join(sessionDir, 'gobbi.db'));
+    const after = openStore(sessionDir, 'stop-bound', projectId);
     try {
       const heartbeats = after.byType('session.heartbeat');
       expect(heartbeats).toHaveLength(201);
@@ -463,7 +502,8 @@ describe('runStop — missing session', () => {
 
 describe('runStop — meta.timeoutMs detection (E.11)', () => {
   test('no timeout event emitted when spec.meta.timeoutMs is unset', async () => {
-    const { sessionDir } = await initScratchSession('stop-tm-unset');
+    const sessionId = 'stop-tm-unset';
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
     // Scratch specs dir whose ideation spec omits timeoutMs entirely.
     const specsDir = makeTimeoutSpecsDir({
       omitTimeout: true,
@@ -472,76 +512,106 @@ describe('runStop — meta.timeoutMs detection (E.11)', () => {
     // Drive state.stepStartedAt 60s before `frozen` so elapsed would be
     // 60000 ms — irrelevant here, since the spec has no timeout.
     const frozen = new Date('2026-04-16T10:00:00.000Z');
-    stampStepStartedAt(sessionDir, new Date(frozen.getTime() - 60_000));
+    await stampStepStartedAt(
+      sessionDir,
+      sessionId,
+      projectId,
+      new Date(frozen.getTime() - 60_000),
+    );
+    // `stampStepStartedAt` emits one synthetic STEP_TIMEOUT to flip the
+    // session into `error` so RESUME can target ideation. Snapshot the
+    // post-stamp baseline so the assertions below measure the production
+    // stop handler's emit, not the helper's.
+    const baselineTimeouts = countTimeoutEvents(sessionDir, sessionId, projectId);
 
     await captureExit(() =>
       runStopWithOptions([], {
         sessionDir,
         specsDir,
-        payload: { session_id: 'stop-tm-unset' },
+        payload: { session_id: sessionId },
         now: () => frozen,
       }),
     );
 
     expect(captured.exitCode).toBeNull();
-    expect(countTimeoutEvents(sessionDir)).toBe(0);
+    expect(countTimeoutEvents(sessionDir, sessionId, projectId)).toBe(
+      baselineTimeouts,
+    );
   });
 
   test('no timeout event emitted when elapsedMs <= meta.timeoutMs', async () => {
-    const { sessionDir } = await initScratchSession('stop-tm-under');
+    const sessionId = 'stop-tm-under';
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
     const specsDir = makeTimeoutSpecsDir({ timeoutMs: 60_000 });
 
     // 30s elapsed — strictly under 60s budget.
     const frozen = new Date('2026-04-16T10:00:30.000Z');
-    stampStepStartedAt(sessionDir, new Date(frozen.getTime() - 30_000));
+    await stampStepStartedAt(
+      sessionDir,
+      sessionId,
+      projectId,
+      new Date(frozen.getTime() - 30_000),
+    );
+    const baselineTimeouts = countTimeoutEvents(sessionDir, sessionId, projectId);
 
     await captureExit(() =>
       runStopWithOptions([], {
         sessionDir,
         specsDir,
-        payload: { session_id: 'stop-tm-under' },
+        payload: { session_id: sessionId },
         now: () => frozen,
       }),
     );
 
     expect(captured.exitCode).toBeNull();
-    expect(countTimeoutEvents(sessionDir)).toBe(0);
+    expect(countTimeoutEvents(sessionDir, sessionId, projectId)).toBe(
+      baselineTimeouts,
+    );
     // State remains on the active step — no transition to error.
-    const state = readState(sessionDir);
-    expect(state?.currentStep).toBe('ideation');
+    expect(readCurrentStep(sessionDir, sessionId, projectId)).toBe('ideation');
   });
 
   test('emits workflow.step.timeout once when elapsedMs > meta.timeoutMs', async () => {
-    const { sessionDir } = await initScratchSession('stop-tm-over');
+    const sessionId = 'stop-tm-over';
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
     const specsDir = makeTimeoutSpecsDir({ timeoutMs: 60_000 });
 
     // 90s elapsed — over the 60s budget.
     const frozen = new Date('2026-04-16T10:01:30.000Z');
-    stampStepStartedAt(sessionDir, new Date(frozen.getTime() - 90_000));
+    await stampStepStartedAt(
+      sessionDir,
+      sessionId,
+      projectId,
+      new Date(frozen.getTime() - 90_000),
+    );
 
     await captureExit(() =>
       runStopWithOptions([], {
         sessionDir,
         specsDir,
-        payload: { session_id: 'stop-tm-over' },
+        payload: { session_id: sessionId },
         now: () => frozen,
       }),
     );
 
     expect(captured.exitCode).toBeNull();
 
-    const store = new EventStore(join(sessionDir, 'gobbi.db'));
+    // The production stop handler emits a timeout row whose
+    // `idempotency_key` is `${sessionId}:${ms}:workflow.step.timeout`
+    // with `ms` derived from `frozen`. Filter to that key so the
+    // synthetic stamp event (which has `step: 'planning'` and a
+    // different ms) is excluded.
+    const expectedKey = `${sessionId}:${frozen.getTime()}:workflow.step.timeout`;
+    const store = openStore(sessionDir, sessionId, projectId);
     try {
-      const timeouts = store.byType('workflow.step.timeout');
+      const timeouts = store
+        .byType('workflow.step.timeout')
+        .filter((row) => row.idempotency_key === expectedKey);
       expect(timeouts).toHaveLength(1);
 
       const row = timeouts[0]!;
       expect(row.actor).toBe('hook');
       expect(row.step).toBe('ideation');
-      // System idempotency key shape: sess:timestampMs:type.
-      expect(row.idempotency_key).toBe(
-        `stop-tm-over:${frozen.getTime()}:workflow.step.timeout`,
-      );
 
       const data = JSON.parse(row.data) as {
         readonly step: string;
@@ -556,16 +626,21 @@ describe('runStop — meta.timeoutMs detection (E.11)', () => {
     }
 
     // Reducer consumed the event — active step → error.
-    const state = readState(sessionDir);
-    expect(state?.currentStep).toBe('error');
+    expect(readCurrentStep(sessionDir, sessionId, projectId)).toBe('error');
   });
 
   test('idempotent: two stop invocations at the same ms emit exactly one timeout event', async () => {
-    const { sessionDir } = await initScratchSession('stop-tm-idem');
+    const sessionId = 'stop-tm-idem';
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
     const specsDir = makeTimeoutSpecsDir({ timeoutMs: 60_000 });
 
     const frozen = new Date('2026-04-16T10:01:30.000Z');
-    stampStepStartedAt(sessionDir, new Date(frozen.getTime() - 90_000));
+    await stampStepStartedAt(
+      sessionDir,
+      sessionId,
+      projectId,
+      new Date(frozen.getTime() - 90_000),
+    );
 
     // Fire twice at the identical clock. The first invocation flips the
     // step to `error` (not an active step), so the second short-circuits
@@ -576,7 +651,7 @@ describe('runStop — meta.timeoutMs detection (E.11)', () => {
       runStopWithOptions([], {
         sessionDir,
         specsDir,
-        payload: { session_id: 'stop-tm-idem' },
+        payload: { session_id: sessionId },
         now: () => frozen,
       }),
     );
@@ -584,21 +659,43 @@ describe('runStop — meta.timeoutMs detection (E.11)', () => {
       runStopWithOptions([], {
         sessionDir,
         specsDir,
-        payload: { session_id: 'stop-tm-idem' },
+        payload: { session_id: sessionId },
         now: () => frozen,
       }),
     );
 
-    expect(countTimeoutEvents(sessionDir)).toBe(1);
+    // Filter to the production handler's idempotency key — the synthetic
+    // stamp also produces a STEP_TIMEOUT row with a different key, so a
+    // raw `byType` count would conflate the two.
+    const expectedKey = `${sessionId}:${frozen.getTime()}:workflow.step.timeout`;
+    const store = openStore(sessionDir, sessionId, projectId);
+    try {
+      const productionTimeouts = store
+        .byType('workflow.step.timeout')
+        .filter((row) => row.idempotency_key === expectedKey);
+      expect(productionTimeouts).toHaveLength(1);
+    } finally {
+      store.close();
+    }
   });
 
   test('no crash, no event when state.stepStartedAt is null', async () => {
-    const { sessionDir } = await initScratchSession('stop-tm-null');
+    const sessionId = 'stop-tm-null';
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
     const specsDir = makeTimeoutSpecsDir({ timeoutMs: 60_000 });
 
-    // Fresh init leaves stepStartedAt === null. Don't stamp it.
-    const pre = readState(sessionDir);
-    expect(pre?.stepStartedAt).toBeNull();
+    // Fresh init leaves stepStartedAt === null. Don't stamp it. Verify
+    // via the partition-filtered event stream (PR-FIN-2a-ii: no
+    // state.json projection on disk).
+    {
+      const store = openStore(sessionDir, sessionId, projectId);
+      try {
+        const pre = resolveWorkflowState(sessionDir, store, sessionId);
+        expect(pre.stepStartedAt).toBeNull();
+      } finally {
+        store.close();
+      }
+    }
 
     const frozen = new Date('2026-04-16T10:00:00.000Z');
 
@@ -606,14 +703,15 @@ describe('runStop — meta.timeoutMs detection (E.11)', () => {
       runStopWithOptions([], {
         sessionDir,
         specsDir,
-        payload: { session_id: 'stop-tm-null' },
+        payload: { session_id: sessionId },
         now: () => frozen,
       }),
     );
 
     expect(captured.exitCode).toBeNull();
-    expect(countTimeoutEvents(sessionDir)).toBe(0);
-    expect(countHeartbeats(sessionDir)).toBe(1); // heartbeat still fires
+    expect(countTimeoutEvents(sessionDir, sessionId, projectId)).toBe(0);
+    // heartbeat still fires
+    expect(countHeartbeats(sessionDir, sessionId, projectId)).toBe(1);
   });
 
   test('clock skew: stepStartedAt in the future does not emit a timeout event', async () => {
@@ -622,27 +720,35 @@ describe('runStop — meta.timeoutMs detection (E.11)', () => {
     // drift between machines, ntp slew, or synthetic fixtures) yields a
     // negative elapsed and must NOT trigger a spurious timeout — even
     // if a future refactor flips the `<=` boundary to `<`.
-    const { sessionDir } = await initScratchSession('stop-tm-skew');
+    const sessionId = 'stop-tm-skew';
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
     const specsDir = makeTimeoutSpecsDir({ timeoutMs: 60_000 });
 
     const frozen = new Date('2026-04-16T10:00:00.000Z');
     // Stamp 5 minutes AFTER `frozen` → elapsedMs = -300_000.
-    stampStepStartedAt(sessionDir, new Date(frozen.getTime() + 300_000));
+    await stampStepStartedAt(
+      sessionDir,
+      sessionId,
+      projectId,
+      new Date(frozen.getTime() + 300_000),
+    );
+    const baselineTimeouts = countTimeoutEvents(sessionDir, sessionId, projectId);
 
     await captureExit(() =>
       runStopWithOptions([], {
         sessionDir,
         specsDir,
-        payload: { session_id: 'stop-tm-skew' },
+        payload: { session_id: sessionId },
         now: () => frozen,
       }),
     );
 
     expect(captured.exitCode).toBeNull();
-    expect(countTimeoutEvents(sessionDir)).toBe(0);
+    expect(countTimeoutEvents(sessionDir, sessionId, projectId)).toBe(
+      baselineTimeouts,
+    );
     // State remains on the active step — no transition to error.
-    const state = readState(sessionDir);
-    expect(state?.currentStep).toBe('ideation');
+    expect(readCurrentStep(sessionDir, sessionId, projectId)).toBe('ideation');
   });
 
   test('regression: default specsDir path leaves heartbeat-only behavior unchanged', async () => {
@@ -651,26 +757,34 @@ describe('runStop — meta.timeoutMs detection (E.11)', () => {
     // used, the stop handler emits only the heartbeat and no timeout
     // event — even if stepStartedAt is stamped. Protects against a
     // future accidental timeoutMs addition to a committed spec.
-    const { sessionDir } = await initScratchSession('stop-tm-default');
+    const sessionId = 'stop-tm-default';
+    const { sessionDir, projectId } = await initScratchSession(sessionId);
 
     const frozen = new Date('2026-04-16T10:00:00.000Z');
-    stampStepStartedAt(sessionDir, new Date(frozen.getTime() - 3_600_000));
+    await stampStepStartedAt(
+      sessionDir,
+      sessionId,
+      projectId,
+      new Date(frozen.getTime() - 3_600_000),
+    );
+    const baselineTimeouts = countTimeoutEvents(sessionDir, sessionId, projectId);
 
     await captureExit(() =>
       runStopWithOptions([], {
         sessionDir,
-        payload: { session_id: 'stop-tm-default' },
+        payload: { session_id: sessionId },
         now: () => frozen,
         // No specsDir override — uses DEFAULT_SPECS_DIR (committed specs).
       }),
     );
 
     expect(captured.exitCode).toBeNull();
-    expect(countTimeoutEvents(sessionDir)).toBe(0);
-    expect(countHeartbeats(sessionDir)).toBe(1);
+    expect(countTimeoutEvents(sessionDir, sessionId, projectId)).toBe(
+      baselineTimeouts,
+    );
+    expect(countHeartbeats(sessionDir, sessionId, projectId)).toBe(1);
     // Sanity — state still on the active step.
-    const state = readState(sessionDir);
-    expect(state?.currentStep).toBe('ideation');
+    expect(readCurrentStep(sessionDir, sessionId, projectId)).toBe('ideation');
     // DEFAULT_SPECS_DIR export is an absolute path — quick sanity so the
     // import is load-bearing.
     expect(DEFAULT_SPECS_DIR.length).toBeGreaterThan(0);
@@ -681,10 +795,14 @@ describe('runStop — meta.timeoutMs detection (E.11)', () => {
 // Test helpers
 // ---------------------------------------------------------------------------
 
-function countHeartbeats(sessionDir: string): number {
+function countHeartbeats(
+  sessionDir: string,
+  sessionId: string,
+  projectId: string,
+): number {
   const dbPath = join(sessionDir, 'gobbi.db');
   if (!existsSync(dbPath)) return 0;
-  const store = new EventStore(dbPath);
+  const store = openStore(sessionDir, sessionId, projectId);
   try {
     return store.byType('session.heartbeat').length;
   } finally {
@@ -692,10 +810,14 @@ function countHeartbeats(sessionDir: string): number {
   }
 }
 
-function countTimeoutEvents(sessionDir: string): number {
+function countTimeoutEvents(
+  sessionDir: string,
+  sessionId: string,
+  projectId: string,
+): number {
   const dbPath = join(sessionDir, 'gobbi.db');
   if (!existsSync(dbPath)) return 0;
-  const store = new EventStore(dbPath);
+  const store = openStore(sessionDir, sessionId, projectId);
   try {
     return store.byType('workflow.step.timeout').length;
   } finally {
@@ -704,22 +826,109 @@ function countTimeoutEvents(sessionDir: string): number {
 }
 
 /**
- * Stamp the session's state.json with a `stepStartedAt` timestamp so the
- * E.11 branch has a real reference point. Mutates the on-disk file in
- * place — the `resolveWorkflowState` warm path will read it.
+ * Read the current step from the partition-filtered event stream. Used
+ * in lieu of `readState(sessionDir)?.currentStep` after the JSON memory
+ * pivot — `state.json` is no longer materialised on disk.
  */
-function stampStepStartedAt(sessionDir: string, startedAt: Date): void {
-  const state = readState(sessionDir);
-  if (state === null) {
-    throw new Error(
-      `stampStepStartedAt: no state.json at ${sessionDir}`,
-    );
+function readCurrentStep(
+  sessionDir: string,
+  sessionId: string,
+  projectId: string,
+): string {
+  const store = openStore(sessionDir, sessionId, projectId);
+  try {
+    return resolveWorkflowState(sessionDir, store, sessionId).currentStep;
+  } finally {
+    store.close();
   }
-  const stamped: WorkflowState = {
-    ...state,
-    stepStartedAt: startedAt.toISOString(),
-  };
-  writeState(sessionDir, stamped);
+}
+
+/**
+ * Drive the session's `state.stepStartedAt` to a specific timestamp via
+ * the event log. PR-FIN-2a-ii (T-2a.9.unified) retired the on-disk
+ * `state.json` projection — `resolveWorkflowState` now derives state
+ * purely by replaying the partition-filtered event stream, so a state
+ * field can only be set by appending events that the reducer translates
+ * into the desired shape.
+ *
+ * The path: STEP_EXIT(ideation→planning) lands the session at planning
+ * with `stepStartedAt = ts`; STEP_TIMEOUT transitions to error;
+ * RESUME(target=ideation, ts=startedAt) brings the session back to
+ * ideation while the reducer's RESUME case stamps
+ * `stepStartedAt: ts ?? state.stepStartedAt` (per
+ * `workflow/reducer.ts:281`). Net result: currentStep === 'ideation'
+ * and stepStartedAt === startedAt.toISOString().
+ *
+ * The intermediate STEP_EXIT carries a placeholder ts ahead of the
+ * `startedAt` value so the synthetic timestamps stay monotonic — the
+ * reducer's audit gate doesn't enforce monotonic ts but the convention
+ * keeps fixture inspection straightforward.
+ */
+async function stampStepStartedAt(
+  sessionDir: string,
+  sessionId: string,
+  projectId: string,
+  startedAt: Date,
+): Promise<void> {
+  const store = openStore(sessionDir, sessionId, projectId);
+  try {
+    const state = resolveWorkflowState(sessionDir, store, sessionId);
+    // Step 1 — exit ideation → planning. Reducer stamps stepStartedAt
+    // from the engine-supplied ts; we use a synthetic past timestamp
+    // (1ms before `startedAt`) so the chain stays monotonic.
+    const exitTs = new Date(startedAt.getTime() - 1).toISOString();
+    const afterExit = await appendEventAndUpdateState(
+      store,
+      sessionDir,
+      state,
+      createStepExit({ step: 'ideation' }),
+      'cli',
+      sessionId,
+      'system',
+      undefined,
+      null,
+      undefined,
+      exitTs,
+    );
+    // Step 2 — STEP_TIMEOUT lands at error. ts unused by the reducer
+    // for STEP_TIMEOUT but supplied for idempotency-key disambiguation.
+    const timeoutTs = new Date(startedAt.getTime()).toISOString();
+    const afterTimeout = await appendEventAndUpdateState(
+      store,
+      sessionDir,
+      afterExit.state,
+      createStepTimeout({
+        step: afterExit.state.currentStep,
+        elapsedMs: 0,
+        configuredTimeoutMs: 0,
+      }),
+      'cli',
+      sessionId,
+      'tool-call',
+      'tc-stamp-timeout',
+      null,
+      undefined,
+      timeoutTs,
+    );
+    // Step 3 — RESUME back to ideation, ts = startedAt. The reducer
+    // stamps stepStartedAt on RESUME (per `workflow/reducer.ts:281`),
+    // so this is the timestamp the timeout-detection branch reads.
+    await appendEventAndUpdateState(
+      store,
+      sessionDir,
+      afterTimeout.state,
+      createResume({ targetStep: 'ideation', fromError: true }),
+      'cli',
+      sessionId,
+      'tool-call',
+      'tc-stamp-resume',
+      null,
+      undefined,
+      startedAt.toISOString(),
+    );
+  } finally {
+    store.close();
+  }
 }
 
 /**

--- a/packages/cli/src/commands/workflow/__tests__/transition.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/transition.test.ts
@@ -20,7 +20,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 
@@ -33,6 +33,7 @@ import {
 } from '../transition.js';
 import { WORKFLOW_COMMANDS } from '../../workflow.js';
 import { EventStore } from '../../../workflow/store.js';
+import { resolveWorkflowState } from '../../../workflow/engine.js';
 import { initialState } from '../../../workflow/state.js';
 import type { WorkflowState } from '../../../workflow/state.js';
 
@@ -121,21 +122,35 @@ function makeScratchRepo(): string {
 
 async function initScratchSession(
   sessionId: string,
-): Promise<{ sessionDir: string; repo: string }> {
+): Promise<{ sessionDir: string; repo: string; projectId: string }> {
   const repo = makeScratchRepo();
+  const projectId = basename(repo);
   await captureExit(() =>
     runInitWithOptions(
       ['--session-id', sessionId, '--task', 'transition-test'],
       { repoRoot: repo },
     ),
   );
-  const sessionDir = sessionDirForProject(repo, basename(repo), sessionId);
+  const sessionDir = sessionDirForProject(repo, projectId, sessionId);
   captured = { stdout: '', stderr: '', exitCode: null };
-  return { sessionDir, repo };
+  return { sessionDir, repo, projectId };
 }
 
-function openStore(sessionDir: string): EventStore {
-  return new EventStore(join(sessionDir, 'gobbi.db'));
+/**
+ * Open the per-session event store with explicit partition keys (PR-FIN-
+ * 2a-ii / T-2a.9.unified Option α). Tests pass the same `(sessionId,
+ * projectId)` pair init stamped at write time so the partition-aware
+ * read filter admits the session's events.
+ */
+function openStore(
+  sessionDir: string,
+  sessionId: string,
+  projectId: string,
+): EventStore {
+  return new EventStore(join(sessionDir, 'gobbi.db'), {
+    sessionId,
+    projectId,
+  });
 }
 
 // ===========================================================================
@@ -260,7 +275,7 @@ describe('buildEvent — keyword mapping', () => {
 
 describe('runTransitionWithOptions — happy paths', () => {
   test('COMPLETE from fresh ideation fires workflow.step.exit and advances state', async () => {
-    const { sessionDir } = await initScratchSession('trans-complete');
+    const { sessionDir, projectId } = await initScratchSession('trans-complete');
 
     await captureExit(() =>
       runTransitionWithOptions(['COMPLETE'], { sessionDir }),
@@ -271,7 +286,7 @@ describe('runTransitionWithOptions — happy paths', () => {
     expect(captured.stdout).toContain('Step: plan');
 
     // Verify the event landed in the store.
-    const store = openStore(sessionDir);
+    const store = openStore(sessionDir, 'trans-complete', projectId);
     try {
       const last = store.last('workflow.step.exit');
       expect(last).not.toBeNull();
@@ -282,7 +297,7 @@ describe('runTransitionWithOptions — happy paths', () => {
   });
 
   test('SKIP from plan fires workflow.step.skip and lands back at ideation', async () => {
-    const { sessionDir } = await initScratchSession('trans-skip');
+    const { sessionDir, projectId } = await initScratchSession('trans-skip');
 
     // Advance to plan via COMPLETE first.
     await captureExit(() =>
@@ -296,7 +311,7 @@ describe('runTransitionWithOptions — happy paths', () => {
     );
 
     expect(captured.exitCode).toBeNull();
-    const store = openStore(sessionDir);
+    const store = openStore(sessionDir, 'trans-skip', projectId);
     try {
       const last = store.last('workflow.step.skip');
       expect(last).not.toBeNull();
@@ -314,7 +329,7 @@ describe('runTransitionWithOptions — happy paths', () => {
   // This test drives the full workflow through to handoff and asserts
   // FINISH terminates the session.
   test('FINISH from handoff fires workflow.finish and reaches `done`', async () => {
-    const { sessionDir } = await initScratchSession('trans-handoff-finish');
+    const { sessionDir, projectId } = await initScratchSession('trans-handoff-finish');
 
     // Drive ideation → planning → execution → execution_eval. The
     // execution → execution_eval edge is unconditional in the
@@ -365,7 +380,7 @@ describe('runTransitionWithOptions — happy paths', () => {
     // After FINISH the runtime transition graph routes handoff → done.
     expect(captured.stdout).toContain('done');
 
-    const store = openStore(sessionDir);
+    const store = openStore(sessionDir, 'trans-handoff-finish', projectId);
     try {
       const finishRow = store.last('workflow.finish');
       expect(finishRow).not.toBeNull();
@@ -376,17 +391,25 @@ describe('runTransitionWithOptions — happy paths', () => {
       store.close();
     }
 
-    // state.json reflects the terminal `done` state via the same
-    // resolveWorkflowState fast path the runtime guards / status
-    // commands use.
-    const finalState = JSON.parse(
-      readFileSync(join(sessionDir, 'state.json'), 'utf8'),
-    ) as { readonly currentStep: string };
-    expect(finalState.currentStep).toBe('done');
+    // PR-FIN-2a-ii (T-2a.9.unified) retired `state.json`; derive the
+    // terminal step by replaying the partition-filtered event stream.
+    {
+      const store = openStore(sessionDir, 'trans-handoff-finish', projectId);
+      try {
+        const finalState = resolveWorkflowState(
+          sessionDir,
+          store,
+          'trans-handoff-finish',
+        );
+        expect(finalState.currentStep).toBe('done');
+      } finally {
+        store.close();
+      }
+    }
   });
 
   test('REVISE with --loop-target carries the target to EvalVerdictData', async () => {
-    const { sessionDir } = await initScratchSession('trans-revise');
+    const { sessionDir, projectId } = await initScratchSession('trans-revise');
 
     // Drive to execution_eval so REVISE is meaningful. The state machine
     // path from a fresh session without eval flags is:
@@ -408,7 +431,7 @@ describe('runTransitionWithOptions — happy paths', () => {
     );
 
     expect(captured.exitCode).toBeNull();
-    const store = openStore(sessionDir);
+    const store = openStore(sessionDir, 'trans-revise', projectId);
     try {
       const last = store.last('decision.eval.verdict');
       expect(last).not.toBeNull();
@@ -424,7 +447,7 @@ describe('runTransitionWithOptions — happy paths', () => {
   });
 
   test('--json emits a structured result on stdout', async () => {
-    const { sessionDir } = await initScratchSession('trans-json');
+    const { sessionDir, projectId } = await initScratchSession('trans-json');
 
     await captureExit(() =>
       runTransitionWithOptions(['COMPLETE', '--json'], { sessionDir }),
@@ -452,7 +475,7 @@ describe('runTransitionWithOptions — happy paths', () => {
 
 describe('runTransitionWithOptions — idempotency', () => {
   test('PASS with --tool-call-id uses the tool-call formula and dedupes on repeat', async () => {
-    const { sessionDir } = await initScratchSession('trans-idem');
+    const { sessionDir, projectId } = await initScratchSession('trans-idem');
 
     // Drive fresh session (ideation/discussing) to ideation_eval so PASS is
     // a valid verdict with a matching transition. The plan-off default
@@ -471,9 +494,10 @@ describe('runTransitionWithOptions — idempotency', () => {
         { repoRoot: evalRepo },
       ),
     );
+    const evalProjectId = basename(evalRepo);
     const evalSessionDir = sessionDirForProject(
       evalRepo,
-      basename(evalRepo),
+      evalProjectId,
       'trans-idem-eval',
     );
     captured = { stdout: '', stderr: '', exitCode: null };
@@ -502,7 +526,7 @@ describe('runTransitionWithOptions — idempotency', () => {
     expect(first.idempotencyKind).toBe('tool-call');
 
     // Count events after first PASS.
-    const store1 = openStore(evalSessionDir);
+    const store1 = openStore(evalSessionDir, 'trans-idem-eval', evalProjectId);
     const countAfterFirst = store1.byType('decision.eval.verdict').length;
     store1.close();
 
@@ -520,7 +544,7 @@ describe('runTransitionWithOptions — idempotency', () => {
     const second = JSON.parse(captured.stdout) as { persisted?: unknown };
     expect(second.persisted).toBe(false);
 
-    const store2 = openStore(evalSessionDir);
+    const store2 = openStore(evalSessionDir, 'trans-idem-eval', evalProjectId);
     try {
       expect(store2.byType('decision.eval.verdict').length).toBe(
         countAfterFirst,
@@ -540,7 +564,7 @@ describe('runTransitionWithOptions — idempotency', () => {
 
 describe('runTransitionWithOptions — error paths', () => {
   test('RESUME from a non-error state exits 1 with the reducer error on stderr', async () => {
-    const { sessionDir } = await initScratchSession('trans-reject');
+    const { sessionDir, projectId } = await initScratchSession('trans-reject');
 
     // Fresh init lands at ideation/discussing — not error, so RESUME fails
     // the reducer guard at `reducer.ts:177-187`.
@@ -553,7 +577,7 @@ describe('runTransitionWithOptions — error paths', () => {
   });
 
   test('unknown keyword exits 2 with the supported list on stderr', async () => {
-    const { sessionDir } = await initScratchSession('trans-unknown');
+    const { sessionDir, projectId } = await initScratchSession('trans-unknown');
 
     await captureExit(() =>
       runTransitionWithOptions(['FLY_AWAY'], { sessionDir }),
@@ -568,7 +592,7 @@ describe('runTransitionWithOptions — error paths', () => {
   });
 
   test('missing positional keyword exits 2 with usage', async () => {
-    const { sessionDir } = await initScratchSession('trans-miss');
+    const { sessionDir, projectId } = await initScratchSession('trans-miss');
 
     await captureExit(() =>
       runTransitionWithOptions([], { sessionDir }),

--- a/packages/cli/src/commands/workflow/capture-planning.ts
+++ b/packages/cli/src/commands/workflow/capture-planning.ts
@@ -169,7 +169,7 @@ export async function runCapturePlanningWithOptions(
     });
     const { kind, toolCallId } = idempotencyFor(payload.tool_call_id);
     try {
-      appendEventAndUpdateState(
+      await appendEventAndUpdateState(
         store,
         sessionDir,
         state,

--- a/packages/cli/src/commands/workflow/capture-subagent.ts
+++ b/packages/cli/src/commands/workflow/capture-subagent.ts
@@ -33,10 +33,15 @@
  *
  * ## Parent linkage
  *
- * `parent_seq` is best-effort. On each invocation we scan the most recent
- * `delegation.spawn` event and link to it when `data.subagentId ===
- * payload.agent_id`. When no match, we omit `parent_seq`. PR F will supply
- * `tool_call_id`-based precise linkage.
+ * `parent_seq` is best-effort. On each invocation we scan back through the
+ * `delegation.spawn` events and link to the one whose
+ * `data.tool_call_id` matches the SubagentStop payload's `tool_call_id` /
+ * `tool_use_id`. The `tool_call_id`-scoped match is the precise linkage
+ * needed when multiple subagents are spawned in parallel from a single
+ * orchestrator turn — the previous `last('delegation.spawn')` heuristic
+ * silently misattributed parent linkage in that case. When no match (older
+ * spawn events without the field, transcript missing the tool-call id), we
+ * omit `parent_seq`.
  *
  * ## Cost fields (PR E)
  *
@@ -48,7 +53,8 @@
  * @see `.claude/project/gobbi/reference/subagent-transcripts.md`
  */
 
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { readStdinJson } from '../../lib/stdin.js';
@@ -89,6 +95,7 @@ interface SubagentStopPayload {
   readonly stop_hook_active?: boolean;
   readonly session_id?: string;
   readonly tool_call_id?: string;
+  readonly tool_use_id?: string;
   /** Optional cost passthrough — schema owned by PR E. */
   readonly tokensUsed?: number;
   readonly cacheHitRatio?: number;
@@ -104,6 +111,7 @@ function asPayload(value: unknown): SubagentStopPayload {
     'last_assistant_message',
     'session_id',
     'tool_call_id',
+    'tool_use_id',
   ];
   const out: Record<string, unknown> = {};
   for (const key of keys) {
@@ -116,6 +124,21 @@ function asPayload(value: unknown): SubagentStopPayload {
   const cache = payload['cacheHitRatio'];
   if (isNumber(cache)) out['cacheHitRatio'] = cache;
   return out as SubagentStopPayload;
+}
+
+/**
+ * Resolve the canonical tool-call identifier for this SubagentStop. Claude
+ * Code's authoritative Hooks reference uses `tool_use_id`; existing tests
+ * carry `tool_call_id`. Returns whichever is a non-empty string, preferring
+ * `tool_use_id`. Used both to link back to a `delegation.spawn` row and to
+ * key event idempotency.
+ */
+function resolveToolCallId(payload: SubagentStopPayload): string | undefined {
+  const useId = payload.tool_use_id;
+  if (typeof useId === 'string' && useId !== '') return useId;
+  const callId = payload.tool_call_id;
+  if (typeof callId === 'string' && callId !== '') return callId;
+  return undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -202,6 +225,7 @@ export async function runCaptureSubagentWithOptions(
     const artifactsDir = join(sessionDir, 'artifacts');
     const successFilename = `${agentType}-r${round}.md`;
     const failureFilename = `delegation-fail-r${round}.md`;
+    const toolCallId = resolveToolCallId(payload);
 
     // Lazy step-subdir materialisation — when the current workflow step is
     // one of the five productive steps, ensure `<step>/` and `<step>/rawdata/`
@@ -213,8 +237,11 @@ export async function runCaptureSubagentWithOptions(
       ensureSessionStepDir(sessionDir, stepId);
     }
 
-    // --- 5. Parent-seq best-effort lookup -----------------------------
-    const parentSeq = findParentSpawnSeq(store, agentId);
+    // --- 5. Parent-seq lookup via tool_call_id -----------------------
+    // Precise linkage: the matching delegation.spawn carries the same
+    // `tool_call_id` PreToolUse recorded; parallel-subagent linkage works
+    // even when the orchestrator dispatched multiple Agents in one turn.
+    const parentSeq = findParentSpawnSeq(store, toolCallId);
 
     // --- 6. Three-case extraction + emission -------------------------
     if (transcriptPath === '' || !existsSync(transcriptPath)) {
@@ -234,7 +261,7 @@ export async function runCaptureSubagentWithOptions(
         agentId,
         reason,
         transcriptPath === '' ? undefined : transcriptPath,
-        payload.tool_call_id,
+        toolCallId,
         parentSeq,
       );
       emitArtifactWriteAfter(
@@ -244,7 +271,7 @@ export async function runCaptureSubagentWithOptions(
         sessionId,
         'delegation-fail',
         failureFilename,
-        payload.tool_call_id,
+        toolCallId,
       );
       return;
     }
@@ -268,7 +295,7 @@ export async function runCaptureSubagentWithOptions(
         agentId,
         explanation,
         transcriptPath,
-        payload.tool_call_id,
+        toolCallId,
         parentSeq,
       );
       emitArtifactWriteAfter(
@@ -278,7 +305,7 @@ export async function runCaptureSubagentWithOptions(
         sessionId,
         'delegation-fail',
         failureFilename,
-        payload.tool_call_id,
+        toolCallId,
       );
       return;
     }
@@ -286,6 +313,11 @@ export async function runCaptureSubagentWithOptions(
     // Case 1 — transcript present and parseable.
     writeArtifact(artifactsDir, successFilename, extracted);
     const artifactPath = join(artifactsDir, successFilename);
+    // Capture-time SHA-256 over the transcript bytes. Best-effort: if the
+    // file becomes unreadable between the existsSync probe above and the
+    // hash call (race against an aggressive cleanup), the field is omitted
+    // rather than failing the capture.
+    const transcriptSha256 = computeFileSha256(transcriptPath);
     emitDelegationComplete(
       store,
       sessionDir,
@@ -295,7 +327,8 @@ export async function runCaptureSubagentWithOptions(
       artifactPath,
       payload.tokensUsed,
       payload.cacheHitRatio,
-      payload.tool_call_id,
+      transcriptSha256,
+      toolCallId,
       parentSeq,
     );
     emitArtifactWriteAfter(
@@ -305,10 +338,27 @@ export async function runCaptureSubagentWithOptions(
       sessionId,
       'delegation',
       successFilename,
-      payload.tool_call_id,
+      toolCallId,
     );
   } finally {
     store.close();
+  }
+}
+
+/**
+ * Compute the SHA-256 hex digest of a file's bytes. Returns `undefined` when
+ * the file cannot be opened — caller omits the `transcriptSha256` field
+ * rather than failing the capture. Uses Node's `node:crypto` rather than
+ * `Bun.CryptoHasher` because this command is occasionally invoked under the
+ * Node-shimmed test harness and the synchronous node:crypto API matches the
+ * existing capture-time IO style here.
+ */
+function computeFileSha256(filePath: string): string | undefined {
+  try {
+    const bytes = readFileSync(filePath);
+    return createHash('sha256').update(bytes).digest('hex');
+  } catch {
+    return undefined;
   }
 }
 
@@ -351,28 +401,70 @@ async function extractLastAssistantText(
 // ---------------------------------------------------------------------------
 
 /**
- * Find the `seq` of the most recent `delegation.spawn` event whose data
- * carries `subagentId === agentId`. Returns `null` when no match — the
- * caller then emits the event without parent linkage.
+ * Find the `seq` of the `delegation.spawn` event whose data carries the
+ * given `tool_call_id` — the precise linkage between a SubagentStop and the
+ * PreToolUse spawn that initiated it. The lookup walks back through spawn
+ * events (newest first) so the most recent matching spawn wins, which is
+ * the right behavior when the same `tool_call_id` somehow appears twice
+ * (Claude Code retries, e.g.).
  *
- * Best-effort by design. PR F will supply `tool_call_id`-scoped precise
- * linkage.
+ * Returns `null` when:
+ *   - The caller has no `tool_call_id` to match against (older transcripts).
+ *   - No `delegation.spawn` row exists yet for this session.
+ *   - No spawn carries the matching `tool_call_id` (older spawn events
+ *     written before the field landed in PR-FIN-2a-ii).
+ *
+ * The previous heuristic — `last('delegation.spawn')` filtered by
+ * `subagentId === agent_id` — silently misattributed parent linkage when
+ * multiple subagents were spawned in parallel from a single orchestrator
+ * turn (Architecture H3 finding). The `tool_call_id`-scoped lookup makes
+ * the linkage precise even under parallel dispatch.
+ *
+ * The walk uses `lastN` (capped at 64 spawns) for the common case + falls
+ * through to `byType('delegation.spawn')` when the cap is exceeded — covers
+ * the hot path without an unbounded scan on long sessions.
  */
 function findParentSpawnSeq(
   store: ReadStore,
-  agentId: string,
+  toolCallId: string | undefined,
 ): number | null {
-  if (agentId === '') return null;
-  const row = store.last('delegation.spawn');
-  if (row === null) return null;
+  if (toolCallId === undefined || toolCallId === '') return null;
+
+  const recent = store.lastN('delegation.spawn', 64);
+  for (let i = recent.length - 1; i >= 0; i -= 1) {
+    const row = recent[i];
+    if (row === undefined) continue;
+    const seq = matchSpawnByToolCallId(row, toolCallId);
+    if (seq !== null) return seq;
+  }
+
+  // Cap-overflow fallback: scan the full set in newest-first order.
+  if (recent.length === 64) {
+    const all = store.byType('delegation.spawn');
+    for (let i = all.length - 1; i >= 0; i -= 1) {
+      const row = all[i];
+      if (row === undefined) continue;
+      const seq = matchSpawnByToolCallId(row, toolCallId);
+      if (seq !== null) return seq;
+    }
+  }
+
+  return null;
+}
+
+function matchSpawnByToolCallId(
+  row: { readonly seq: number; readonly data: string },
+  toolCallId: string,
+): number | null {
+  let data: unknown;
   try {
-    const data = JSON.parse(row.data) as unknown;
-    if (!isRecord(data)) return null;
-    if (data['subagentId'] !== agentId) return null;
-    return row.seq;
+    data = JSON.parse(row.data);
   } catch {
     return null;
   }
+  if (!isRecord(data)) return null;
+  if (data['tool_call_id'] !== toolCallId) return null;
+  return row.seq;
 }
 
 // ---------------------------------------------------------------------------
@@ -397,6 +489,7 @@ function emitDelegationComplete(
   artifactPath: string,
   tokensUsed: number | undefined,
   cacheHitRatio: number | undefined,
+  transcriptSha256: string | undefined,
   toolCallId: string | undefined,
   parentSeq: number | null,
 ): void {
@@ -405,6 +498,7 @@ function emitDelegationComplete(
     artifactPath,
     ...(tokensUsed !== undefined ? { tokensUsed } : {}),
     ...(cacheHitRatio !== undefined ? { cacheHitRatio } : {}),
+    ...(transcriptSha256 !== undefined ? { transcriptSha256 } : {}),
   });
   const { kind, toolCallId: tcid } = idempotencyFor(toolCallId);
   try {

--- a/packages/cli/src/commands/workflow/capture-subagent.ts
+++ b/packages/cli/src/commands/workflow/capture-subagent.ts
@@ -253,7 +253,7 @@ export async function runCaptureSubagentWithOptions(
       const artifactContent =
         `# Delegation failure (${agentType}, round ${round})\n\n${reason}\n`;
       writeArtifact(artifactsDir, failureFilename, artifactContent);
-      emitDelegationFail(
+      await emitDelegationFail(
         store,
         sessionDir,
         state,
@@ -264,7 +264,7 @@ export async function runCaptureSubagentWithOptions(
         toolCallId,
         parentSeq,
       );
-      emitArtifactWriteAfter(
+      await emitArtifactWriteAfter(
         store,
         sessionDir,
         state,
@@ -287,7 +287,7 @@ export async function runCaptureSubagentWithOptions(
       const artifactContent =
         `# Delegation failure (${agentType}, round ${round})\n\n${explanation}\n`;
       writeArtifact(artifactsDir, failureFilename, artifactContent);
-      emitDelegationFail(
+      await emitDelegationFail(
         store,
         sessionDir,
         state,
@@ -298,7 +298,7 @@ export async function runCaptureSubagentWithOptions(
         toolCallId,
         parentSeq,
       );
-      emitArtifactWriteAfter(
+      await emitArtifactWriteAfter(
         store,
         sessionDir,
         state,
@@ -318,7 +318,7 @@ export async function runCaptureSubagentWithOptions(
     // hash call (race against an aggressive cleanup), the field is omitted
     // rather than failing the capture.
     const transcriptSha256 = computeFileSha256(transcriptPath);
-    emitDelegationComplete(
+    await emitDelegationComplete(
       store,
       sessionDir,
       state,
@@ -331,7 +331,7 @@ export async function runCaptureSubagentWithOptions(
       toolCallId,
       parentSeq,
     );
-    emitArtifactWriteAfter(
+    await emitArtifactWriteAfter(
       store,
       sessionDir,
       state,
@@ -480,7 +480,7 @@ function writeArtifact(dir: string, filename: string, content: string): void {
 // Event emission helpers
 // ---------------------------------------------------------------------------
 
-function emitDelegationComplete(
+async function emitDelegationComplete(
   store: EventStore,
   sessionDir: string,
   state: WorkflowState,
@@ -492,7 +492,7 @@ function emitDelegationComplete(
   transcriptSha256: string | undefined,
   toolCallId: string | undefined,
   parentSeq: number | null,
-): void {
+): Promise<void> {
   const event = createDelegationComplete({
     subagentId: agentId,
     artifactPath,
@@ -502,7 +502,7 @@ function emitDelegationComplete(
   });
   const { kind, toolCallId: tcid } = idempotencyFor(toolCallId);
   try {
-    appendEventAndUpdateState(
+    await appendEventAndUpdateState(
       store,
       sessionDir,
       state,
@@ -518,7 +518,7 @@ function emitDelegationComplete(
   }
 }
 
-function emitDelegationFail(
+async function emitDelegationFail(
   store: EventStore,
   sessionDir: string,
   state: WorkflowState,
@@ -528,7 +528,7 @@ function emitDelegationFail(
   transcriptPath: string | undefined,
   toolCallId: string | undefined,
   parentSeq: number | null,
-): void {
+): Promise<void> {
   const event = createDelegationFail({
     subagentId: agentId,
     reason,
@@ -536,7 +536,7 @@ function emitDelegationFail(
   });
   const { kind, toolCallId: tcid } = idempotencyFor(toolCallId);
   try {
-    appendEventAndUpdateState(
+    await appendEventAndUpdateState(
       store,
       sessionDir,
       state,
@@ -565,7 +565,7 @@ function emitDelegationFail(
  * delegation.complete mutation (which touches `activeSubagents`), so
  * reading a slightly stale `state` is safe for this single append.
  */
-function emitArtifactWriteAfter(
+async function emitArtifactWriteAfter(
   store: EventStore,
   sessionDir: string,
   state: WorkflowState,
@@ -573,7 +573,7 @@ function emitArtifactWriteAfter(
   artifactType: string,
   filename: string,
   toolCallId: string | undefined,
-): void {
+): Promise<void> {
   const event = createArtifactWrite({
     step: state.currentStep,
     filename,
@@ -581,7 +581,7 @@ function emitArtifactWriteAfter(
   });
   const { kind, toolCallId: tcid } = idempotencyFor(toolCallId);
   try {
-    appendEventAndUpdateState(
+    await appendEventAndUpdateState(
       store,
       sessionDir,
       state,

--- a/packages/cli/src/commands/workflow/guard.ts
+++ b/packages/cli/src/commands/workflow/guard.ts
@@ -53,11 +53,13 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { readStdinJson } from '../../lib/stdin.js';
+import { isRecord, isString } from '../../lib/guards.js';
 import { EventStore } from '../../workflow/store.js';
 import {
   appendEventAndUpdateState,
   resolveWorkflowState,
 } from '../../workflow/engine.js';
+import { createDelegationSpawn } from '../../workflow/events/delegation.js';
 import {
   createGuardViolation,
   createGuardWarn,
@@ -81,12 +83,20 @@ import { resolvePartitionKeys, resolveSessionDir } from '../session.js';
  * about. Additional fields (`tool_call_id`, `agent_id`, etc.) are read via
  * optional index access; the type keeps the mandatory ones strict.
  *
- * Source: `v050-hooks.md:19–33`.
+ * The payload field naming is contested across the Claude Code schema: the
+ * canonical Hooks reference uses `tool_use_id`, but earlier surfaces and the
+ * existing test fixtures in this codebase use `tool_call_id`. Both are
+ * accepted here; downstream readers prefer `tool_use_id` then fall back to
+ * `tool_call_id` so live hooks (which carry `tool_use_id`) and existing test
+ * fixtures (which carry `tool_call_id`) both work.
+ *
+ * Source: `v050-hooks.md:19–33`, `v050-integration-tests.md:101`.
  */
 interface PreToolUsePayload {
   readonly tool_name: string;
   readonly session_id?: string;
   readonly tool_call_id?: string;
+  readonly tool_use_id?: string;
   readonly agent_id?: string;
   readonly tool_input?: unknown;
 }
@@ -104,10 +114,30 @@ function isPreToolUsePayload(value: unknown): value is PreToolUsePayload {
   ) {
     return false;
   }
+  if (
+    rec['tool_use_id'] !== undefined &&
+    typeof rec['tool_use_id'] !== 'string'
+  ) {
+    return false;
+  }
   if (rec['agent_id'] !== undefined && typeof rec['agent_id'] !== 'string') {
     return false;
   }
   return true;
+}
+
+/**
+ * Resolve the canonical `tool_use_id` / `tool_call_id` for this PreToolUse
+ * invocation. Returns `undefined` when neither is a non-empty string. Used by
+ * both the spawn-emit path (for `delegation.spawn.tool_call_id`) and the
+ * audit-event idempotency formula.
+ */
+function resolveToolCallId(payload: PreToolUsePayload): string | undefined {
+  const useId = payload.tool_use_id;
+  if (typeof useId === 'string' && useId !== '') return useId;
+  const callId = payload.tool_call_id;
+  if (typeof callId === 'string' && callId !== '') return callId;
+  return undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -264,6 +294,12 @@ export async function runGuardWithOptions(
     const matcher = overrides.matcher ?? DEFAULT_MATCHER;
     const matched = matcher.match(state.currentStep, payload.tool_name);
     if (matched.length === 0) {
+      // No matching guards — the guard is allowing the call. Emit the
+      // delegation.spawn audit BEFORE the allow response so a SIGKILL
+      // between stdout and the next event commits doesn't leak a spawn
+      // that never made it into the log. The store-side idempotency
+      // formula keeps retries deduped.
+      maybeEmitDelegationSpawn(store, sessionDir, state, sessionId, payload);
       emitAllow();
       return;
     }
@@ -289,6 +325,13 @@ export async function runGuardWithOptions(
           // Explicit allow short-circuits. Any already-accumulated warns
           // from earlier guards in the chain are surfaced alongside the
           // allow so the orchestrator still receives the advisory context.
+          maybeEmitDelegationSpawn(
+            store,
+            sessionDir,
+            state,
+            sessionId,
+            payload,
+          );
           emitAllow(warns.length > 0 ? warns.join('\n') : undefined);
           return;
         }
@@ -297,6 +340,8 @@ export async function runGuardWithOptions(
       }
     }
 
+    // Loop fell through with no deny — the guard is allowing the call.
+    maybeEmitDelegationSpawn(store, sessionDir, state, sessionId, payload);
     emitAllow(warns.length > 0 ? warns.join('\n') : undefined);
   } finally {
     store.close();
@@ -374,6 +419,108 @@ function writeWarnEvent(
   }
 }
 
+// ---------------------------------------------------------------------------
+// delegation.spawn emission (PR-FIN-2a-ii T-2a.8.0)
+// ---------------------------------------------------------------------------
+
+/**
+ * Tool name Claude Code uses for the Agent (subagent-spawning) tool. The
+ * canonical PreToolUse payload carries `tool_name: 'Task'`; the guard reads
+ * `tool_input.subagent_type` to discover the agent type. Cross-reference
+ * `v050-hooks.md:57-59` for the spawn-emit contract.
+ */
+const AGENT_TOOL_NAME = 'Task';
+
+/**
+ * Per `v050-hooks.md:59`, when the guard ALLOWS an Agent tool call, append a
+ * `delegation.spawn` event to the event store before returning the allow
+ * decision. This is the canonical spawn-emission site (lock 26 of the PR-FIN-
+ * 2a-ii ideation), retiring the previous SubagentStart-based emitter stub.
+ *
+ * Failure discipline: the audit append is best-effort (per the same fail-open
+ * contract that wraps the rest of this command). A throw inside the append
+ * path must NOT escape — we still return `allow` to Claude Code even if the
+ * audit write fails, otherwise hook-write errors would deadlock the
+ * orchestrator. Callers that need spawn linkage (`capture-subagent.ts`'s
+ * `findParentSpawnSeq`) tolerate the missing event and fall back to
+ * `parent_seq: null`.
+ *
+ * No-op when the tool is not the Agent tool, when `tool_input.subagent_type`
+ * is missing, or when no `tool_use_id` / `tool_call_id` is on the payload —
+ * without the tool-call id the spawn can't be linked back to its
+ * SubagentStop, defeating the purpose of recording it.
+ */
+function maybeEmitDelegationSpawn(
+  store: EventStore,
+  sessionDir: string,
+  state: WorkflowState,
+  sessionId: string,
+  payload: PreToolUsePayload,
+): void {
+  if (payload.tool_name !== AGENT_TOOL_NAME) return;
+
+  const toolCallId = resolveToolCallId(payload);
+  if (toolCallId === undefined) return;
+
+  const subagentType = extractSubagentType(payload.tool_input);
+  if (subagentType === undefined) return;
+
+  // `agent_id` rides through unchanged — when present (subagent calls
+  // recursing through Task) we use it as the subagent identifier; otherwise
+  // the tool-call-id doubles as a stable subagent identity. Both are
+  // PreToolUse-time identifiers; capture-subagent.ts will key parent linkage
+  // off `tool_call_id` regardless.
+  const subagentId =
+    payload.agent_id !== undefined && payload.agent_id !== ''
+      ? payload.agent_id
+      : toolCallId;
+
+  // Spawn emitter activates the dormant `claudeCodeVersion` field path
+  // (issue #92) for the first time in production — capture from env per
+  // the documented JSDoc contract.
+  const envVersion = process.env['CLAUDE_CODE_VERSION'];
+  const claudeCodeVersion =
+    envVersion !== undefined && envVersion !== '' ? envVersion : undefined;
+
+  const event = createDelegationSpawn({
+    agentType: subagentType,
+    step: state.currentStep,
+    subagentId,
+    timestamp: new Date().toISOString(),
+    tool_call_id: toolCallId,
+    ...(claudeCodeVersion !== undefined ? { claudeCodeVersion } : {}),
+  });
+
+  try {
+    appendEventAndUpdateState(
+      store,
+      sessionDir,
+      state,
+      event,
+      'hook',
+      sessionId,
+      'tool-call',
+      toolCallId,
+    );
+  } catch {
+    // Best-effort audit — the allow decision has already been computed and
+    // the response is about to be written. Swallow failures so the hook
+    // exits 0; the parent_seq lookup tolerates missing spawn rows.
+  }
+}
+
+/**
+ * Pull `subagent_type` out of the PreToolUse `tool_input` blob without
+ * trusting the shape. Returns the agent type string when the input is a
+ * record carrying a non-empty `subagent_type` string, `undefined` otherwise.
+ */
+function extractSubagentType(toolInput: unknown): string | undefined {
+  if (!isRecord(toolInput)) return undefined;
+  const value = toolInput['subagent_type'];
+  if (!isString(value) || value === '') return undefined;
+  return value;
+}
+
 interface IdempotencyChoice {
   readonly kind: 'tool-call' | 'system';
   readonly toolCallId: string | undefined;
@@ -381,14 +528,16 @@ interface IdempotencyChoice {
 
 /**
  * Pick the idempotency formula for the guard's event append. The hook
- * contract guarantees a `tool_call_id` on every PreToolUse payload in
- * practice, but we tolerate its absence by falling back to the timestamp-
- * based `'system'` formula. A retry with the same `tool_call_id` dedupes
- * at the store's `UNIQUE(idempotency_key) DO NOTHING` boundary.
+ * contract guarantees a tool-call identifier (`tool_use_id` per the canonical
+ * Hooks reference, or the legacy `tool_call_id`) on every PreToolUse payload
+ * in practice, but we tolerate its absence by falling back to the timestamp-
+ * based `'system'` formula. A retry with the same identifier dedupes at the
+ * store's `UNIQUE(idempotency_key) DO NOTHING` boundary.
  */
 function idempotencyFor(payload: PreToolUsePayload): IdempotencyChoice {
-  if (typeof payload.tool_call_id === 'string' && payload.tool_call_id !== '') {
-    return { kind: 'tool-call', toolCallId: payload.tool_call_id };
+  const toolCallId = resolveToolCallId(payload);
+  if (toolCallId !== undefined) {
+    return { kind: 'tool-call', toolCallId };
   }
   return { kind: 'system', toolCallId: undefined };
 }

--- a/packages/cli/src/commands/workflow/guard.ts
+++ b/packages/cli/src/commands/workflow/guard.ts
@@ -299,7 +299,7 @@ export async function runGuardWithOptions(
       // between stdout and the next event commits doesn't leak a spawn
       // that never made it into the log. The store-side idempotency
       // formula keeps retries deduped.
-      maybeEmitDelegationSpawn(store, sessionDir, state, sessionId, payload);
+      await maybeEmitDelegationSpawn(store, sessionDir, state, sessionId, payload);
       emitAllow();
       return;
     }
@@ -312,12 +312,12 @@ export async function runGuardWithOptions(
       switch (guard.effect) {
         case 'deny': {
           const reason = buildReason(guard, state.currentStep);
-          writeViolationEvent(store, sessionDir, state, guard, payload);
+          await writeViolationEvent(store, sessionDir, state, guard, payload);
           emitDeny(reason);
           return;
         }
         case 'warn': {
-          writeWarnEvent(store, sessionDir, state, guard, payload);
+          await writeWarnEvent(store, sessionDir, state, guard, payload);
           warns.push(buildReason(guard, state.currentStep));
           continue;
         }
@@ -325,7 +325,7 @@ export async function runGuardWithOptions(
           // Explicit allow short-circuits. Any already-accumulated warns
           // from earlier guards in the chain are surfaced alongside the
           // allow so the orchestrator still receives the advisory context.
-          maybeEmitDelegationSpawn(
+          await maybeEmitDelegationSpawn(
             store,
             sessionDir,
             state,
@@ -341,7 +341,7 @@ export async function runGuardWithOptions(
     }
 
     // Loop fell through with no deny — the guard is allowing the call.
-    maybeEmitDelegationSpawn(store, sessionDir, state, sessionId, payload);
+    await maybeEmitDelegationSpawn(store, sessionDir, state, sessionId, payload);
     emitAllow(warns.length > 0 ? warns.join('\n') : undefined);
   } finally {
     store.close();
@@ -352,13 +352,13 @@ export async function runGuardWithOptions(
 // Event emission
 // ---------------------------------------------------------------------------
 
-function writeViolationEvent(
+async function writeViolationEvent(
   store: EventStore,
   sessionDir: string,
   state: WorkflowState,
   guard: Guard,
   payload: PreToolUsePayload,
-): void {
+): Promise<void> {
   const event = createGuardViolation({
     guardId: guard.id,
     toolName: payload.tool_name,
@@ -371,7 +371,7 @@ function writeViolationEvent(
   // returning a decision. Swallow errors, keep the audit attempt, but do
   // NOT leak a non-zero exit.
   try {
-    appendEventAndUpdateState(
+    await appendEventAndUpdateState(
       store,
       sessionDir,
       state,
@@ -386,13 +386,13 @@ function writeViolationEvent(
   }
 }
 
-function writeWarnEvent(
+async function writeWarnEvent(
   store: EventStore,
   sessionDir: string,
   state: WorkflowState,
   guard: Guard & { readonly effect: 'warn' },
   payload: PreToolUsePayload,
-): void {
+): Promise<void> {
   const event = createGuardWarn({
     guardId: guard.id,
     toolName: payload.tool_name,
@@ -404,7 +404,7 @@ function writeWarnEvent(
   });
   const { kind, toolCallId } = idempotencyFor(payload);
   try {
-    appendEventAndUpdateState(
+    await appendEventAndUpdateState(
       store,
       sessionDir,
       state,
@@ -450,13 +450,13 @@ const AGENT_TOOL_NAME = 'Task';
  * without the tool-call id the spawn can't be linked back to its
  * SubagentStop, defeating the purpose of recording it.
  */
-function maybeEmitDelegationSpawn(
+async function maybeEmitDelegationSpawn(
   store: EventStore,
   sessionDir: string,
   state: WorkflowState,
   sessionId: string,
   payload: PreToolUsePayload,
-): void {
+): Promise<void> {
   if (payload.tool_name !== AGENT_TOOL_NAME) return;
 
   const toolCallId = resolveToolCallId(payload);
@@ -492,7 +492,7 @@ function maybeEmitDelegationSpawn(
   });
 
   try {
-    appendEventAndUpdateState(
+    await appendEventAndUpdateState(
       store,
       sessionDir,
       state,

--- a/packages/cli/src/commands/workflow/init.ts
+++ b/packages/cli/src/commands/workflow/init.ts
@@ -2,19 +2,30 @@
  * gobbi workflow init — initialise a workflow session directory.
  *
  * Creates `.gobbi/projects/<name>/sessions/<sessionId>/` under the detected
- * repo root, writes a `metadata.json` at schema v3, opens the SQLite event
- * store (`gobbi.db`), and appends the opening pair of events —
- * `workflow.start` followed by `workflow.eval.decide` — atomically inside
- * a single `store.transaction`.
+ * repo root, writes a `session.json` stub via {@link writeSessionStub},
+ * opens the SQLite event store (`gobbi.db`), and appends the opening pair
+ * of events — `workflow.start` followed by `workflow.eval.decide` —
+ * atomically inside a single `store.transaction`.
+ *
+ * PR-FIN-2a-ii (T-2a.8.5): the legacy `metadata.json` writer is retired in
+ * favour of `session.json` — a stub at init carrying only the 6 required-at-
+ * all-stages fields (`schemaVersion`, `sessionId`, `projectId`, `createdAt`,
+ * `gobbiVersion`, `task`). The full session.json is materialised at the
+ * memorization step's STEP_EXIT (T-2a.8.2). Until T-2a.9.tests prunes
+ * `cross-pass-invariant.test.ts`, the legacy `SessionMetadata` /
+ * `readMetadata` / `isValidMetadata` symbols remain exported as
+ * dead-code-but-still-imported back-compat surface; they are NOT consumed
+ * by the production init path.
  *
  * ## Idempotency
  *
- * The SessionStart hook fires on `startup | resume | compact`, so `init` is
- * invoked multiple times per logical session. A fresh invocation against an
- * existing directory is a no-op: the metadata is re-validated, no events are
- * emitted, and the command exits 0 silently. A corrupt `metadata.json` is
- * not transparently rewritten — it's reported on stderr with a non-zero exit
- * so the operator can see the drift.
+ * The SessionStart hook fires on `startup | resume | compact | clear`, so
+ * `init` is invoked multiple times per logical session. A fresh invocation
+ * against an existing directory is a no-op: the existing `session.json`
+ * stub is re-validated, no events are emitted, and the command exits 0
+ * silently. A corrupt `session.json` propagates the AJV/JSON parse failure
+ * from `readSessionJson` so the operator can see the drift rather than have
+ * it transparently rewritten.
  *
  * ## Session id resolution
  *
@@ -30,21 +41,21 @@
  *   1. `--project <name>` CLI flag (per-invocation override).
  *   2. `basename(repoRoot)` — the directory containing the repo.
  *
- * On existing-session re-init, `metadata.json.projectName` is authoritative.
+ * On existing-session re-init, `session.json.projectId` is authoritative.
  * If `--project <name>` is provided AND does not match the stamped
- * `projectName`, init exits 2 with a clear stderr message — sessions are
+ * `projectId`, init exits 2 with a clear stderr message — sessions are
  * bound to ONE project at birth and cannot be re-parented mid-flight.
  *
  * ## Schema
  *
- * `metadata.json` shape is at `schemaVersion: 3` — v3 carries the required
- * `projectName` field that names the project partition this session
- * belongs to. The metadata schemaVersion is decoupled from the
- * state-machine `WorkflowState.schemaVersion`.
+ * `session.json` shape is at `schemaVersion: 1` — see `lib/json-memory.ts`
+ * for the AJV schema and the full set of fields populated at the memorization
+ * step. The session.json schemaVersion is decoupled from the state-machine
+ * `WorkflowState.schemaVersion`.
  */
 
 import { parseArgs } from 'node:util';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 
 import { getRepoRoot } from '../../lib/repo.js';
@@ -55,6 +66,13 @@ import {
   resolveEvalDecision,
 } from '../../lib/settings-io.js';
 import { sessionDir as sessionDirForProject } from '../../lib/workspace-paths.js';
+import {
+  readSessionJson,
+  sessionJsonPath,
+  writeSessionStub,
+} from '../../lib/json-memory.js';
+import { readInstalledVersion } from '../../lib/version-check.js';
+import { ConfigCascadeError } from '../../lib/settings.js';
 import { EventStore } from '../../workflow/store.js';
 import { appendEventAndUpdateState, resolveWorkflowState } from '../../workflow/engine.js';
 import { initialState } from '../../workflow/state.js';
@@ -62,8 +80,6 @@ import {
   createWorkflowStart,
   createEvalDecide,
 } from '../../workflow/events/workflow.js';
-
-import { resolvePartitionKeys } from '../session.js';
 
 import { detectTechStack } from './tech-stack.js';
 
@@ -86,7 +102,7 @@ Options:
   --help, -h            Show this help message
 
 Idempotent: re-running against an existing session directory is a silent no-op.
-Re-init with --project must match metadata.projectName; mismatch exits 2.`;
+Re-init with --project must match session.projectId; mismatch exits 2.`;
 
 const PARSE_OPTIONS = {
   help: { type: 'boolean', short: 'h', default: false },
@@ -99,25 +115,24 @@ const PARSE_OPTIONS = {
 } as const;
 
 // ---------------------------------------------------------------------------
-// Metadata shape
+// Legacy metadata shape — deprecated; retained for back-compat
 // ---------------------------------------------------------------------------
+//
+// PR-FIN-2a-ii (T-2a.8.5) replaced the production metadata.json writer with
+// `writeSessionStub` (session.json). The legacy `SessionMetadata` /
+// `SessionConfigSnapshot` interfaces, the `readMetadata` reader, and
+// `isValidMetadata` predicate remain exported solely so
+// `__tests__/cross-pass-invariant.test.ts` (owned by T-2a.9.tests, Wave C)
+// continues to compile until that test is pruned. The production init path
+// no longer reads or writes metadata.json — reading these symbols at
+// runtime is a dead-code branch.
+//
+// DO NOT extend this surface. New session-time data lands on session.json
+// via `lib/json-memory.ts`.
 
 /**
- * On-disk shape of `metadata.json`. Schema v3 carries the required
- * `projectName` field for the multi-project layout.
- *
- *   - `sessionId` — matches the directory name.
- *   - `createdAt` — ISO-8601 timestamp, set once at init; never rewritten.
- *   - `projectRoot` — absolute path to the repo root at init time.
- *   - `projectName` — name of the project partition this session belongs to
- *     (see `.gobbi/projects/<projectName>/`). Resolved at init time via the
- *     `--project` flag / `basename(repoRoot)` ladder; never rewritten.
- *     Mid-session re-parent is rejected (see module docblock §Project name
- *     resolution).
- *   - `techStack` — output of {@link detectTechStack} (lowercase, deduped,
- *     alphabetically sorted; empty array when no signals match).
- *   - `configSnapshot` — the setup answers captured at init (task text,
- *     evaluation toggles, free-text context).
+ * @deprecated PR-FIN-2a-ii — metadata.json is no longer written. Retained
+ * solely for `cross-pass-invariant.test.ts` back-compat.
  */
 export interface SessionMetadata {
   readonly schemaVersion: 3;
@@ -129,6 +144,7 @@ export interface SessionMetadata {
   readonly configSnapshot: SessionConfigSnapshot;
 }
 
+/** @deprecated PR-FIN-2a-ii — see {@link SessionMetadata}. */
 export interface SessionConfigSnapshot {
   readonly task: string;
   readonly evalIdeation: boolean;
@@ -206,28 +222,46 @@ export async function runInitWithOptions(
   // sessionId across plausible project names so re-init with a
   // mismatching flag hits the mismatch gate rather than fresh-init-ing
   // a second session under the wrong project. Session is bound to ONE
-  // project at birth per metadata.projectName.
+  // project at birth per session.projectId (PR-FIN-2a-ii).
   const candidateProjectNames: readonly string[] = dedup([
     ...(projectFlag !== undefined ? [projectFlag] : []),
     basename(repoRoot),
   ]);
   for (const candidate of candidateProjectNames) {
-    const probeDir = sessionDirForProject(repoRoot, candidate, sessionId);
-    const probePath = join(probeDir, 'metadata.json');
+    const probePath = sessionJsonPath(repoRoot, candidate, sessionId);
     if (!existsSync(probePath)) continue;
-    const existing = readMetadata(probePath);
+    let existing;
+    try {
+      existing = readSessionJson(probePath);
+    } catch (err) {
+      // ConfigCascadeError carries the file path + AJV/parse details; fall
+      // through to the malformed-message exit so operators see remediation
+      // pointer, mirroring the original metadata.json malformed branch.
+      const detail =
+        err instanceof ConfigCascadeError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      process.stderr.write(
+        `gobbi workflow init: existing ${probePath} is malformed — remove or repair manually\n${detail}\n`,
+      );
+      process.exit(1);
+    }
     if (existing === null) {
+      // existsSync said yes, readSessionJson returned null — race or empty
+      // file. Treat as malformed.
       process.stderr.write(
         `gobbi workflow init: existing ${probePath} is malformed — remove or repair manually\n`,
       );
       process.exit(1);
     }
-    // Mismatch gate — a session's projectName is frozen at birth. An explicit
+    // Mismatch gate — a session's projectId is frozen at birth. An explicit
     // --project override on re-init must match the stamped value or we exit 2
     // so the operator cannot silently re-parent a session.
-    if (projectFlag !== undefined && projectFlag !== existing.projectName) {
+    if (projectFlag !== undefined && projectFlag !== existing.projectId) {
       process.stderr.write(
-        `[gobbi workflow init] session ${sessionId} is bound to project '${existing.projectName}'; --project=${projectFlag} not allowed\n`,
+        `[gobbi workflow init] session ${sessionId} is bound to project '${existing.projectId}'; --project=${projectFlag} not allowed\n`,
       );
       process.exit(2);
     }
@@ -239,34 +273,37 @@ export async function runInitWithOptions(
   const projectName = resolveProjectNameForInit(repoRoot, projectFlag);
 
   const sessionDir = sessionDirForProject(repoRoot, projectName, sessionId);
-  const metadataPath = join(sessionDir, 'metadata.json');
 
   mkdirSync(sessionDir, { recursive: true });
 
-  const configSnapshot: SessionConfigSnapshot = {
-    task: typeof values.task === 'string' ? values.task : '',
-    evalIdeation: values['eval-ideation'] === true,
-    evalPlanning: values['eval-planning'] === true,
-    context: typeof values.context === 'string' ? values.context : '',
-  };
+  const task = typeof values.task === 'string' ? values.task : '';
+  const evalIdeation = values['eval-ideation'] === true;
+  const evalPlanning = values['eval-planning'] === true;
 
-  const techStack = detectTechStack(repoRoot);
+  // Detect the tech stack so the value is observable in stderr drift checks
+  // (T-2a.9.tests still inspects the directory shape during cross-pass
+  // validation). Result is intentionally discarded here — session.json's
+  // 6-field stub does not carry it (ideation lock 5 — minimal carry-forward).
+  detectTechStack(repoRoot);
 
-  const metadata: SessionMetadata = {
-    schemaVersion: 3,
-    sessionId,
-    createdAt: new Date().toISOString(),
-    projectRoot: repoRoot,
+  // session.json stub carries the 6 required-at-all-stages fields per the
+  // ideation lock (schemaVersion, sessionId, projectId, createdAt,
+  // gobbiVersion, task). The full session.json with steps[] lands at the
+  // memorization step's STEP_EXIT (T-2a.8.2).
+  const createdAt = new Date().toISOString();
+  const gobbiVersion = await readInstalledVersion();
+  writeSessionStub({
+    repoRoot,
     projectName,
-    techStack,
-    configSnapshot,
-  };
+    sessionId,
+    task,
+    gobbiVersion,
+    createdAt,
+  });
 
-  writeFileSync(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, 'utf8');
-
-  // Resolve the cascaded settings AFTER metadata is written so the
-  // session-level `settings.json` (if one was seeded by a future Pass) is
-  // visible. The resolved cascade feeds `initialState` so
+  // Resolve the cascaded settings AFTER the session.json stub is written so
+  // the session-level `settings.json` (if one was seeded by a future Pass)
+  // is visible. The resolved cascade feeds `initialState` so
   // `state.maxFeedbackRounds` reflects the configured per-step
   // `workflow.{step}.maxIterations` instead of the hardcoded 3 (issue #134).
   const resolvedSettings = resolveSettings({
@@ -297,8 +334,19 @@ export async function runInitWithOptions(
   // state.json forward. See CV-9 (issue #163) for the regression that
   // motivated that pattern.
   const dbPath = join(sessionDir, 'gobbi.db');
-  const partitionKeys = resolvePartitionKeys(sessionDir);
-  const store = new EventStore(dbPath, partitionKeys);
+  // PR-FIN-2a-ii (T-2a.8.5): supply the partition keys explicitly rather
+  // than calling `resolvePartitionKeys(sessionDir)`. The legacy resolver
+  // reads `metadata.projectName` from `<sessionDir>/metadata.json`, which
+  // this code path no longer writes. We already have both values in this
+  // scope (`sessionId` from the resolver above; `projectName` from the
+  // PR-FIN-1c project-name resolution), so passing them in directly is
+  // strictly more correct than the disk-roundtrip — it also avoids
+  // depending on the dead `resolvePartitionKeys`/`resolveProjectIdFromMetadata`
+  // path that T-2a.9.unified will retire.
+  const store = new EventStore(dbPath, {
+    sessionId,
+    projectId: projectName,
+  });
   try {
     store.transaction(() => {
       // Start from a fresh state — this is a brand-new session, so
@@ -322,7 +370,7 @@ export async function runInitWithOptions(
 
       const startEvent = createWorkflowStart({
         sessionId,
-        timestamp: metadata.createdAt,
+        timestamp: createdAt,
       });
       const startResult = appendEventAndUpdateState(
         store,
@@ -354,8 +402,8 @@ export async function runInitWithOptions(
           ? resolveEvalDecision(resolvedSettings, 'memorization').enabled
           : false;
       const decideEvent = createEvalDecide({
-        ideation: configSnapshot.evalIdeation,
-        plan: configSnapshot.evalPlanning,
+        ideation: evalIdeation,
+        plan: evalPlanning,
         memorization: memorizationEnabled,
       });
       appendEventAndUpdateState(
@@ -447,8 +495,15 @@ export function resolveProjectNameForInit(
 }
 
 /**
- * Read and structurally validate a `metadata.json`. Returns `null` when the
- * file is malformed at any level — callers decide how to surface that.
+ * Read and structurally validate a legacy `metadata.json`. Returns `null`
+ * when the file is malformed at any level — callers decide how to surface
+ * that.
+ *
+ * @deprecated PR-FIN-2a-ii (T-2a.8.5) — `metadata.json` is no longer
+ * written by `gobbi workflow init`; the active per-session JSON is
+ * `session.json` (see `lib/json-memory.ts::readSessionJson`). This reader
+ * is retained only for `cross-pass-invariant.test.ts` until T-2a.9.tests
+ * prunes that suite.
  */
 export function readMetadata(path: string): SessionMetadata | null {
   let raw: string;

--- a/packages/cli/src/commands/workflow/init.ts
+++ b/packages/cli/src/commands/workflow/init.ts
@@ -11,11 +11,11 @@
  * favour of `session.json` — a stub at init carrying only the 6 required-at-
  * all-stages fields (`schemaVersion`, `sessionId`, `projectId`, `createdAt`,
  * `gobbiVersion`, `task`). The full session.json is materialised at the
- * memorization step's STEP_EXIT (T-2a.8.2). Until T-2a.9.tests prunes
- * `cross-pass-invariant.test.ts`, the legacy `SessionMetadata` /
- * `readMetadata` / `isValidMetadata` symbols remain exported as
- * dead-code-but-still-imported back-compat surface; they are NOT consumed
- * by the production init path.
+ * memorization step's STEP_EXIT (T-2a.8.2). T-2a.9.tests pruned
+ * `cross-pass-invariant.test.ts` to read `session.json` directly and
+ * removed the legacy `SessionMetadata` / `SessionConfigSnapshot` /
+ * `readMetadata` / `isValidMetadata` re-exports that were temporarily
+ * preserved here as dead-code back-compat surface.
  *
  * ## Idempotency
  *
@@ -55,11 +55,10 @@
  */
 
 import { parseArgs } from 'node:util';
-import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync } from 'node:fs';
 import { basename, join } from 'node:path';
 
 import { getRepoRoot } from '../../lib/repo.js';
-import { isRecord, isString, isNumber, isBoolean, isArray } from '../../lib/guards.js';
 import { ensureSettingsCascade } from '../../lib/ensure-settings-cascade.js';
 import {
   resolveSettings,
@@ -113,44 +112,6 @@ const PARSE_OPTIONS = {
   'eval-planning': { type: 'boolean', default: false },
   context: { type: 'string' },
 } as const;
-
-// ---------------------------------------------------------------------------
-// Legacy metadata shape — deprecated; retained for back-compat
-// ---------------------------------------------------------------------------
-//
-// PR-FIN-2a-ii (T-2a.8.5) replaced the production metadata.json writer with
-// `writeSessionStub` (session.json). The legacy `SessionMetadata` /
-// `SessionConfigSnapshot` interfaces, the `readMetadata` reader, and
-// `isValidMetadata` predicate remain exported solely so
-// `__tests__/cross-pass-invariant.test.ts` (owned by T-2a.9.tests, Wave C)
-// continues to compile until that test is pruned. The production init path
-// no longer reads or writes metadata.json — reading these symbols at
-// runtime is a dead-code branch.
-//
-// DO NOT extend this surface. New session-time data lands on session.json
-// via `lib/json-memory.ts`.
-
-/**
- * @deprecated PR-FIN-2a-ii — metadata.json is no longer written. Retained
- * solely for `cross-pass-invariant.test.ts` back-compat.
- */
-export interface SessionMetadata {
-  readonly schemaVersion: 3;
-  readonly sessionId: string;
-  readonly createdAt: string;
-  readonly projectRoot: string;
-  readonly projectName: string;
-  readonly techStack: readonly string[];
-  readonly configSnapshot: SessionConfigSnapshot;
-}
-
-/** @deprecated PR-FIN-2a-ii — see {@link SessionMetadata}. */
-export interface SessionConfigSnapshot {
-  readonly task: string;
-  readonly evalIdeation: boolean;
-  readonly evalPlanning: boolean;
-  readonly context: string;
-}
 
 // ---------------------------------------------------------------------------
 // Entry point
@@ -498,49 +459,3 @@ export function resolveProjectNameForInit(
   return basename(repoRoot);
 }
 
-/**
- * Read and structurally validate a legacy `metadata.json`. Returns `null`
- * when the file is malformed at any level — callers decide how to surface
- * that.
- *
- * @deprecated PR-FIN-2a-ii (T-2a.8.5) — `metadata.json` is no longer
- * written by `gobbi workflow init`; the active per-session JSON is
- * `session.json` (see `lib/json-memory.ts::readSessionJson`). This reader
- * is retained only for `cross-pass-invariant.test.ts` until T-2a.9.tests
- * prunes that suite.
- */
-export function readMetadata(path: string): SessionMetadata | null {
-  let raw: string;
-  try {
-    raw = readFileSync(path, 'utf8');
-  } catch {
-    return null;
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return null;
-  }
-  return isValidMetadata(parsed) ? parsed : null;
-}
-
-export function isValidMetadata(value: unknown): value is SessionMetadata {
-  if (!isRecord(value)) return false;
-  if (!isNumber(value['schemaVersion']) || value['schemaVersion'] !== 3) return false;
-  if (!isString(value['sessionId'])) return false;
-  if (!isString(value['createdAt'])) return false;
-  if (!isString(value['projectRoot'])) return false;
-  if (!isString(value['projectName'])) return false;
-  if (!isArray(value['techStack'])) return false;
-  for (const tag of value['techStack']) {
-    if (!isString(tag)) return false;
-  }
-  const snapshot = value['configSnapshot'];
-  if (!isRecord(snapshot)) return false;
-  if (!isString(snapshot['task'])) return false;
-  if (!isBoolean(snapshot['evalIdeation'])) return false;
-  if (!isBoolean(snapshot['evalPlanning'])) return false;
-  if (!isString(snapshot['context'])) return false;
-  return true;
-}

--- a/packages/cli/src/commands/workflow/init.ts
+++ b/packages/cli/src/commands/workflow/init.ts
@@ -343,14 +343,12 @@ export async function runInitWithOptions(
   // pattern.
   const dbPath = join(sessionDir, 'gobbi.db');
   // PR-FIN-2a-ii (T-2a.8.5): supply the partition keys explicitly rather
-  // than calling `resolvePartitionKeys(sessionDir)`. The legacy resolver
-  // reads `metadata.projectName` from `<sessionDir>/metadata.json`, which
-  // this code path no longer writes. We already have both values in this
-  // scope (`sessionId` from the resolver above; `projectName` from the
-  // PR-FIN-1c project-name resolution), so passing them in directly is
-  // strictly more correct than the disk-roundtrip — it also avoids
-  // depending on the dead `resolvePartitionKeys`/`resolveProjectIdFromMetadata`
-  // path that T-2a.9.unified will retire.
+  // than calling `resolvePartitionKeys(sessionDir)`. We already have
+  // both values in this scope (`sessionId` from the resolver above;
+  // `projectName` from the PR-FIN-1c project-name resolution), so
+  // passing them in directly is strictly more correct than the
+  // disk-roundtrip — it also avoids the path-derivation fallback that
+  // T-2a.9.unified retired alongside metadata.json.
   const store = new EventStore(dbPath, {
     sessionId,
     projectId: projectName,

--- a/packages/cli/src/commands/workflow/init.ts
+++ b/packages/cli/src/commands/workflow/init.ts
@@ -312,27 +312,35 @@ export async function runInitWithOptions(
     projectName,
   });
 
-  // Open the SQLite store and emit the opening events atomically inside a
-  // single transaction. `appendEventAndUpdateState` already uses IMMEDIATE
-  // locking; composing two calls under `store.transaction` yields a single
-  // outer SAVEPOINT (bun:sqlite promotes nested calls automatically), so a
-  // crash between the two appends rolls the pair back together.
+  // Open the SQLite store and emit the opening events sequentially.
   //
-  // Why no explicit `writeState` after this transaction:
-  // The inner calls go through `appendEventAndUpdateState`, which
-  // calls `backupState` + `writeState` itself on every append (see
-  // `engine.ts`). state.json is materialised twice during this block —
-  // once after `workflow.start`, once after `workflow.eval.decide` —
-  // and the final write reflects the post-decide state. No
-  // post-transaction projection is needed.
+  // PR-FIN-2a-ii (T-2a.8.2): `appendEventAndUpdateState` is async — its
+  // post-commit dispatch awaits the memorization session.json writer — so
+  // the two-event init pair can no longer share an outer
+  // `store.transaction(() => { ... })` envelope (bun:sqlite transaction
+  // callbacks cannot await). Each call still runs inside its own IMMEDIATE
+  // transaction with `backupState` + `writeState` discipline; the only
+  // invariant we lose is "both rolls back together on an inter-event crash".
   //
-  // Contrast with the `--force-memorization` branch in `resume.ts`:
-  // that path appends events directly via `store.append(...)` inside
-  // its raw transaction (NOT through `appendEventAndUpdateState`),
-  // bypassing the per-append state.json write. It therefore needs an
-  // explicit `backupState` + `writeState` after the commit to bring
-  // state.json forward. See CV-9 (issue #163) for the regression that
-  // motivated that pattern.
+  // The downgrade is acceptable here because the SessionStart hook is
+  // idempotent: a partial init (workflow.start committed, workflow.eval.decide
+  // not) re-runs cleanly on the next hook fire. The first call is a no-op
+  // (dedup'd at the idempotency UNIQUE), the second appends the missing
+  // decide event, and state.json converges. No orphan state can survive a
+  // re-init pass.
+  //
+  // state.json materialisation: each `appendEventAndUpdateState` call calls
+  // `backupState` + `writeState` itself, so the on-disk projection mirrors
+  // the post-decide state when both calls succeed. No post-call explicit
+  // `writeState` is needed.
+  //
+  // Contrast with the `--force-memorization` branch in `resume.ts`: that
+  // path appends events directly via `store.append(...)` inside its raw
+  // transaction (NOT through `appendEventAndUpdateState`), bypassing the
+  // per-append state.json write. It therefore needs an explicit
+  // `backupState` + `writeState` after the commit to bring state.json
+  // forward. See CV-9 (issue #163) for the regression that motivated that
+  // pattern.
   const dbPath = join(sessionDir, 'gobbi.db');
   // PR-FIN-2a-ii (T-2a.8.5): supply the partition keys explicitly rather
   // than calling `resolvePartitionKeys(sessionDir)`. The legacy resolver
@@ -348,74 +356,72 @@ export async function runInitWithOptions(
     projectId: projectName,
   });
   try {
-    store.transaction(() => {
-      // Start from a fresh state — this is a brand-new session, so
-      // `resolveWorkflowState` would return `initialState` anyway, but
-      // relying on it keeps the invariant explicit.
-      let state = resolveWorkflowState(sessionDir, store, sessionId);
-      // Empty database: initialState; if somehow we landed here with events,
-      // resolve still returns the derived state and we compose from there.
-      if (state.currentStep !== 'idle' && state.currentStep !== 'ideation') {
-        // Defensive: should never happen on a fresh session. Fall back to
-        // initialState rather than emit events against an unknown base.
-        state = initialState(sessionId, resolvedSettings);
-      } else if (state.currentStep === 'idle') {
-        // Fresh session — overlay the settings-derived feedback cap onto the
-        // initialState the cold fallback returned. The replay path inside
-        // `resolveWorkflowState` calls `initialState(sessionId)` without
-        // settings so the cascaded cap must be threaded in here. All other
-        // initialState fields are unchanged for an empty event stream.
-        state = initialState(sessionId, resolvedSettings);
-      }
+    // Start from a fresh state — this is a brand-new session, so
+    // `resolveWorkflowState` would return `initialState` anyway, but
+    // relying on it keeps the invariant explicit.
+    let state = resolveWorkflowState(sessionDir, store, sessionId);
+    // Empty database: initialState; if somehow we landed here with events,
+    // resolve still returns the derived state and we compose from there.
+    if (state.currentStep !== 'idle' && state.currentStep !== 'ideation') {
+      // Defensive: should never happen on a fresh session. Fall back to
+      // initialState rather than emit events against an unknown base.
+      state = initialState(sessionId, resolvedSettings);
+    } else if (state.currentStep === 'idle') {
+      // Fresh session — overlay the settings-derived feedback cap onto the
+      // initialState the cold fallback returned. The replay path inside
+      // `resolveWorkflowState` calls `initialState(sessionId)` without
+      // settings so the cascaded cap must be threaded in here. All other
+      // initialState fields are unchanged for an empty event stream.
+      state = initialState(sessionId, resolvedSettings);
+    }
 
-      const startEvent = createWorkflowStart({
-        sessionId,
-        timestamp: createdAt,
-      });
-      const startResult = appendEventAndUpdateState(
-        store,
-        sessionDir,
-        state,
-        startEvent,
-        'cli',
-        sessionId,
-        'system',
-      );
-
-      // PR-FIN-2a-i T-2a.7: stamp the resolved memorization-eval decision
-      // onto the EVAL_DECIDE payload so the new
-      // `memorization → memorization_eval` graph branch fires when the
-      // cascade carries `workflow.memorization.evaluate.mode === 'always'`.
-      // No `--eval-memorization` CLI flag exists today (memorization eval is
-      // settings-driven, not invocation-driven). For `'ask'` / `'auto'`
-      // modes the translation helper requires a user / orchestrator answer
-      // that init has no source for, so we resolve only the deterministic
-      // modes here and treat indeterminate modes as disabled at init —
-      // the cascade still records the user's preference and a future
-      // eval-checkpoint can resolve `'ask'` / `'auto'` interactively.
-      const memorizationMode =
-        resolvedSettings.workflow?.memorization?.evaluate?.mode;
-      const memorizationEnabled =
-        memorizationMode === undefined ||
-        memorizationMode === 'always' ||
-        memorizationMode === 'skip'
-          ? resolveEvalDecision(resolvedSettings, 'memorization').enabled
-          : false;
-      const decideEvent = createEvalDecide({
-        ideation: evalIdeation,
-        plan: evalPlanning,
-        memorization: memorizationEnabled,
-      });
-      appendEventAndUpdateState(
-        store,
-        sessionDir,
-        startResult.state,
-        decideEvent,
-        'cli',
-        sessionId,
-        'system',
-      );
+    const startEvent = createWorkflowStart({
+      sessionId,
+      timestamp: createdAt,
     });
+    const startResult = await appendEventAndUpdateState(
+      store,
+      sessionDir,
+      state,
+      startEvent,
+      'cli',
+      sessionId,
+      'system',
+    );
+
+    // PR-FIN-2a-i T-2a.7: stamp the resolved memorization-eval decision
+    // onto the EVAL_DECIDE payload so the new
+    // `memorization → memorization_eval` graph branch fires when the
+    // cascade carries `workflow.memorization.evaluate.mode === 'always'`.
+    // No `--eval-memorization` CLI flag exists today (memorization eval is
+    // settings-driven, not invocation-driven). For `'ask'` / `'auto'`
+    // modes the translation helper requires a user / orchestrator answer
+    // that init has no source for, so we resolve only the deterministic
+    // modes here and treat indeterminate modes as disabled at init —
+    // the cascade still records the user's preference and a future
+    // eval-checkpoint can resolve `'ask'` / `'auto'` interactively.
+    const memorizationMode =
+      resolvedSettings.workflow?.memorization?.evaluate?.mode;
+    const memorizationEnabled =
+      memorizationMode === undefined ||
+      memorizationMode === 'always' ||
+      memorizationMode === 'skip'
+        ? resolveEvalDecision(resolvedSettings, 'memorization').enabled
+        : false;
+    const decideEvent = createEvalDecide({
+      ideation: evalIdeation,
+      plan: evalPlanning,
+      memorization: memorizationEnabled,
+    });
+    await appendEventAndUpdateState(
+      store,
+      sessionDir,
+      startResult.state,
+      decideEvent,
+      'cli',
+      sessionId,
+      'system',
+    );
   } finally {
     store.close();
   }

--- a/packages/cli/src/commands/workflow/init.ts
+++ b/packages/cli/src/commands/workflow/init.ts
@@ -280,28 +280,19 @@ export async function runInitWithOptions(
   // the two-event init pair can no longer share an outer
   // `store.transaction(() => { ... })` envelope (bun:sqlite transaction
   // callbacks cannot await). Each call still runs inside its own IMMEDIATE
-  // transaction with `backupState` + `writeState` discipline; the only
-  // invariant we lose is "both rolls back together on an inter-event crash".
+  // SQLite transaction; the only invariant we lose is "both rolls back
+  // together on an inter-event crash".
   //
   // The downgrade is acceptable here because the SessionStart hook is
   // idempotent: a partial init (workflow.start committed, workflow.eval.decide
   // not) re-runs cleanly on the next hook fire. The first call is a no-op
   // (dedup'd at the idempotency UNIQUE), the second appends the missing
-  // decide event, and state.json converges. No orphan state can survive a
-  // re-init pass.
+  // decide event. No orphan state can survive a re-init pass.
   //
-  // state.json materialisation: each `appendEventAndUpdateState` call calls
-  // `backupState` + `writeState` itself, so the on-disk projection mirrors
-  // the post-decide state when both calls succeed. No post-call explicit
-  // `writeState` is needed.
-  //
-  // Contrast with the `--force-memorization` branch in `resume.ts`: that
-  // path appends events directly via `store.append(...)` inside its raw
-  // transaction (NOT through `appendEventAndUpdateState`), bypassing the
-  // per-append state.json write. It therefore needs an explicit
-  // `backupState` + `writeState` after the commit to bring state.json
-  // forward. See CV-9 (issue #163) for the regression that motivated that
-  // pattern.
+  // PR-FIN-2a-ii (T-2a.9.unified) also retired the per-session `state.json`
+  // projection — workflow state is derived on demand via `deriveState(...)`
+  // from workspace `state.db` events. Neither this path nor the resume
+  // `--force-memorization` branch writes `state.json` any longer.
   const dbPath = join(sessionDir, 'gobbi.db');
   // PR-FIN-2a-ii (T-2a.8.5): supply the partition keys explicitly rather
   // than calling `resolvePartitionKeys(sessionDir)`. We already have

--- a/packages/cli/src/commands/workflow/resume.ts
+++ b/packages/cli/src/commands/workflow/resume.ts
@@ -34,7 +34,6 @@ import { join } from 'node:path';
 import { EventStore } from '../../workflow/store.js';
 import {
   appendEventAndUpdateState,
-  deriveWorkflowState,
   resolveWorkflowState,
 } from '../../workflow/engine.js';
 import { createResume } from '../../workflow/events/workflow.js';
@@ -43,7 +42,6 @@ import {
   type PriorErrorSnapshot,
 } from '../../workflow/events/decision.js';
 import type { WorkflowState } from '../../workflow/state.js';
-import { backupState, writeState } from '../../workflow/state.js';
 import {
   compileResumePrompt,
   detectPathway,
@@ -259,9 +257,9 @@ export async function runResumeWithOptions(
       // Atomic two-event append. Per research Area 7, raw
       // `store.transaction(...)` guarantees both events land or neither —
       // `appendEventAndUpdateState` opens its own transaction per call and
-      // is not a safe substitute here. After the pair commits, refresh
-      // `state.json` once via `resolveWorkflowState` so downstream
-      // readers see the materialised state.
+      // is not a safe substitute here. Post-PR-FIN-2a-ii the engine no
+      // longer projects `state.json`; workflow state is derived on demand
+      // via `deriveState(...)` from workspace `state.db` events.
       const skipEvent = createEvalSkip({
         step: 'memorization',
         priorError,
@@ -301,34 +299,17 @@ export async function runResumeWithOptions(
         process.exit(1);
       }
 
-      // Refresh state.json after the raw transaction.
+      // No state.json refresh required.
       //
-      // The raw transaction bypassed the `writeState` call that lives
-      // inside `appendEventAndUpdateState`, so the on-disk `state.json`
-      // is still the pre-resume state at this point. `resolveWorkflowState`
-      // ALONE would not fix that — its fast path (`readState`) returns
-      // whatever `state.json` currently holds without re-deriving from
-      // events. Without the explicit write below, every subsequent
-      // `workflow status / next / guard` invocation reads stale state
-      // (currentStep: 'error') even though the event log says
-      // 'memorization'. See CV-9 in the v0.5.0 adversarial review
-      // campaign synthesis (issue #163) for the failure mode.
-      //
-      // The fix: force a full replay via `deriveWorkflowState` (cold
-      // path, ignores state.json) and then `writeState` to materialise
-      // the result, mirroring `appendEventAndUpdateState`'s discipline.
-      // The write happens OUTSIDE the SQLite transaction — the atomicity
-      // boundary is the two-event append; state.json is a downstream
-      // projection that follows the commit.
-      //
-      // `backupState` runs immediately before `writeState` to preserve
-      // the invariant that `state.json.backup` trails `state.json` by
-      // at most one state write — matching the discipline in
-      // `appendEventAndUpdateState` (engine.ts), which calls
-      // `backupState` as step 1 inside its transaction.
-      const derived = deriveWorkflowState(sessionId, store);
-      backupState(sessionDir);
-      writeState(sessionDir, derived);
+      // Pre-PR-FIN-2a-ii this branch had to call `backupState` +
+      // `writeState` to keep `<sessionDir>/state.json` in sync with the
+      // event log after the raw transaction (CV-9 in the v0.5.0
+      // adversarial review campaign, issue #163). PR-FIN-2a-ii retired
+      // the per-session `state.json` projection entirely — every
+      // subsequent reader (`workflow status / next / guard`) calls
+      // `resolveWorkflowState` which now pure-derives from workspace
+      // `state.db` events, so the two appended events above are
+      // immediately visible.
     } else {
       const resumeEvent = createResume({
         targetStep: target,

--- a/packages/cli/src/commands/workflow/resume.ts
+++ b/packages/cli/src/commands/workflow/resume.ts
@@ -336,7 +336,7 @@ export async function runResumeWithOptions(
       });
 
       try {
-        appendEventAndUpdateState(
+        await appendEventAndUpdateState(
           store,
           sessionDir,
           state,

--- a/packages/cli/src/commands/workflow/stop.ts
+++ b/packages/cli/src/commands/workflow/stop.ts
@@ -201,7 +201,7 @@ export async function runStopWithOptions(
 
     // --- 5. Heartbeat ---------------------------------------------------
     const now = overrides.now === undefined ? new Date() : overrides.now();
-    emitHeartbeat(store, sessionDir, state, sessionId, now);
+    await emitHeartbeat(store, sessionDir, state, sessionId, now);
 
     // --- 6. Timeout detection (PR E) -----------------------------------
     // Read `state.stepStartedAt` (E.10) and the current step spec's
@@ -247,19 +247,19 @@ export async function runStopWithOptions(
  * Two Stop invocations in the same wall-clock millisecond therefore
  * write `:0` and `:1` (both persist); a single invocation writes `:0`.
  */
-function emitHeartbeat(
+async function emitHeartbeat(
   store: EventStore,
   sessionDir: string,
   state: WorkflowState,
   sessionId: string,
   now: Date,
-): void {
+): Promise<void> {
   const timestamp = now.toISOString();
   const counter = computeHeartbeatCounter(store, now.getTime());
 
   const event = createSessionHeartbeat({ timestamp });
   try {
-    appendEventAndUpdateState(
+    await appendEventAndUpdateState(
       store,
       sessionDir,
       state,
@@ -421,7 +421,7 @@ async function detectAndEmitTimeout(
       elapsedMs,
       configuredTimeoutMs: timeoutMs,
     });
-    appendEventAndUpdateState(
+    await appendEventAndUpdateState(
       store,
       sessionDir,
       state,

--- a/packages/cli/src/commands/workflow/transition.ts
+++ b/packages/cli/src/commands/workflow/transition.ts
@@ -258,7 +258,7 @@ export async function runTransitionWithOptions(
 
     let result;
     try {
-      result = appendEventAndUpdateState(
+      result = await appendEventAndUpdateState(
         store,
         sessionDir,
         state,

--- a/packages/cli/src/lib/__tests__/json-memory.test.ts
+++ b/packages/cli/src/lib/__tests__/json-memory.test.ts
@@ -1,0 +1,1167 @@
+/**
+ * Tests for `lib/json-memory.ts` — types + AJV validators + read/write +
+ * sorted-rewrite primitives + memorization aggregator + project.json
+ * upsert helpers.
+ *
+ * Coverage:
+ *
+ *   1. AJV positive fixtures — init-stub, mid-session, complete (4
+ *      productive steps), aborted (with abortReason).
+ *   2. AJV negative fixtures — wrong schemaVersion, missing required field,
+ *      invalid date-time, extra field under additionalProperties: false.
+ *   3. Atomic write byte-determinism — same input twice → identical files.
+ *   4. Atomic write does not leak temp files on success.
+ *   5. writeSessionJson rejects invalid input (does NOT touch the file).
+ *   6. writeProjectJson + upsertProjectSession + upsertProjectGotcha sort
+ *      arrays at the writer call site.
+ *   7. v1→v2 schema-equivalence test — synthetic v2 oneOf schema validates
+ *      v1 fixtures (lock 28).
+ *   8. buildAgentCalls reads JSONL transcripts correctly.
+ *   9. buildAgentCalls falls back to glob discovery when env var unset.
+ *  10. aggregateSessionJson builds steps[] from a synthetic event sequence.
+ *  11. assertNeverProvider compiles + throws as expected.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import addFormatsPlugin from 'ajv-formats';
+import Ajv2020 from 'ajv/dist/2020.js';
+
+import { ConfigCascadeError } from '../settings.js';
+import {
+  aggregateSessionJson,
+  assertNeverProvider,
+  buildAgentCalls,
+  projectJsonPath,
+  readProjectJson,
+  readSessionJson,
+  sessionJsonPath,
+  upsertProjectGotcha,
+  upsertProjectSession,
+  validateSessionJson,
+  writeProjectJson,
+  writeSessionJson,
+  writeSessionStub,
+  type AgentEntry,
+  type AnthropicAgentEntry,
+  type ProjectJson,
+  type SessionJson,
+} from '../json-memory.js';
+
+// ajv-formats default-export interop.
+const addFormats: (ajv: Ajv2020) => Ajv2020 =
+  (addFormatsPlugin as unknown as { default?: typeof addFormatsPlugin }).default ??
+  (addFormatsPlugin as unknown as (ajv: Ajv2020) => Ajv2020);
+
+import type { ReadStore, CostAggregateRow } from '../../workflow/store.js';
+import type { EventRow } from '../../workflow/migrations.js';
+
+// ---------------------------------------------------------------------------
+// Scratch lifecycle
+// ---------------------------------------------------------------------------
+
+let scratchDir: string;
+
+beforeEach(() => {
+  scratchDir = mkdtempSync(join(tmpdir(), 'gobbi-json-memory-'));
+});
+
+afterEach(() => {
+  try {
+    rmSync(scratchDir, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers — fake stores + fixture factories
+// ---------------------------------------------------------------------------
+
+class FakeReadStore implements ReadStore {
+  private readonly rows: readonly EventRow[];
+  private readonly costs: readonly CostAggregateRow[];
+
+  constructor(rows: readonly EventRow[], costs: readonly CostAggregateRow[] = []) {
+    this.rows = rows;
+    this.costs = costs;
+  }
+
+  replayAll(): EventRow[] {
+    return [...this.rows];
+  }
+  byType(type: string): EventRow[] {
+    return this.rows.filter((r) => r.type === type);
+  }
+  byStep(step: string, type?: string): EventRow[] {
+    return this.rows.filter((r) => r.step === step && (type === undefined || r.type === type));
+  }
+  since(seq: number): EventRow[] {
+    return this.rows.filter((r) => r.seq > seq);
+  }
+  last(type: string): EventRow | null {
+    const filtered = this.rows.filter((r) => r.type === type);
+    return filtered.length === 0 ? null : (filtered[filtered.length - 1] ?? null);
+  }
+  lastN(type: string, n: number): readonly EventRow[] {
+    const filtered = this.rows.filter((r) => r.type === type);
+    return filtered.slice(-n);
+  }
+  lastNAny(n: number): readonly EventRow[] {
+    return this.rows.slice(-n);
+  }
+  eventCount(): number {
+    return this.rows.length;
+  }
+  aggregateDelegationCosts(): readonly CostAggregateRow[] {
+    return this.costs;
+  }
+}
+
+function makeRow(args: {
+  seq: number;
+  type: string;
+  step?: string | null;
+  ts?: string;
+  data?: Record<string, unknown>;
+  sessionId?: string | null;
+}): EventRow {
+  return {
+    seq: args.seq,
+    ts: args.ts ?? '2026-04-29T10:00:00.000Z',
+    schema_version: 7,
+    type: args.type,
+    step: args.step ?? null,
+    data: JSON.stringify(args.data ?? {}),
+    actor: 'orchestrator',
+    parent_seq: null,
+    idempotency_key: `key-${args.seq}`,
+    session_id: args.sessionId === undefined ? 'sess-1' : args.sessionId,
+    project_id: 'gobbi',
+  };
+}
+
+function fixtureStub(): SessionJson {
+  return {
+    schemaVersion: 1,
+    sessionId: 'sess-1',
+    projectId: 'gobbi',
+    createdAt: '2026-04-29T10:00:00.000Z',
+    finishedAt: null,
+    gobbiVersion: '0.5.0',
+    task: 'PR-FIN-2a-ii smoke task',
+  };
+}
+
+function fixtureAnthropicAgent(overrides: Partial<AnthropicAgentEntry> = {}): AnthropicAgentEntry {
+  return {
+    provider: 'anthropic',
+    id: 'agent-1',
+    seq: 5,
+    name: '__pi',
+    model: 'claude-opus-4-7',
+    skillsLoaded: [],
+    startedAt: '2026-04-29T10:01:00.000Z',
+    finishedAt: '2026-04-29T10:02:00.000Z',
+    outcome: 'complete',
+    costUsd: 0.001,
+    calls: [],
+    claudeCodeVersion: '2.1.121',
+    transcriptPath: null,
+    transcriptSha256: null,
+    tokensUsed: null,
+    cacheHitRatio: null,
+    sizeProxyBytes: null,
+    ...overrides,
+  };
+}
+
+function fixtureComplete(): SessionJson {
+  return {
+    ...fixtureStub(),
+    finishedAt: '2026-04-29T11:00:00.000Z',
+    steps: [
+      {
+        id: 'ideation',
+        startedAt: '2026-04-29T10:00:00.000Z',
+        finishedAt: '2026-04-29T10:10:00.000Z',
+        skippedAt: null,
+        timedOutAt: null,
+        iterations: [
+          {
+            round: 0,
+            startedAt: '2026-04-29T10:00:00.000Z',
+            finishedAt: '2026-04-29T10:10:00.000Z',
+            terminationReason: 'exit',
+            agents: [fixtureAnthropicAgent()],
+          },
+        ],
+      },
+      {
+        id: 'planning',
+        startedAt: '2026-04-29T10:10:00.000Z',
+        finishedAt: '2026-04-29T10:20:00.000Z',
+        skippedAt: null,
+        timedOutAt: null,
+        iterations: [
+          {
+            round: 0,
+            startedAt: '2026-04-29T10:10:00.000Z',
+            finishedAt: '2026-04-29T10:20:00.000Z',
+            terminationReason: 'exit',
+            substeps: [
+              {
+                id: 'discussion',
+                startedAt: '2026-04-29T10:10:00.000Z',
+                finishedAt: '2026-04-29T10:15:00.000Z',
+                agents: [],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'execution',
+        startedAt: '2026-04-29T10:20:00.000Z',
+        finishedAt: '2026-04-29T10:50:00.000Z',
+        skippedAt: null,
+        timedOutAt: null,
+        iterations: [
+          {
+            round: 0,
+            startedAt: '2026-04-29T10:20:00.000Z',
+            finishedAt: '2026-04-29T10:50:00.000Z',
+            terminationReason: 'exit',
+            agents: [],
+          },
+        ],
+      },
+      {
+        id: 'memorization',
+        startedAt: '2026-04-29T10:50:00.000Z',
+        finishedAt: null,
+        skippedAt: null,
+        timedOutAt: null,
+        iterations: [
+          {
+            round: 0,
+            startedAt: '2026-04-29T10:50:00.000Z',
+            finishedAt: null,
+            terminationReason: 'in-flight',
+          },
+        ],
+      },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AJV positive fixtures
+// ---------------------------------------------------------------------------
+
+describe('validateSessionJson — positive fixtures', () => {
+  test('init-stub (6 required fields, no steps)', () => {
+    const ok = validateSessionJson(fixtureStub());
+    expect(ok).toBe(true);
+  });
+
+  test('mid-session (steps present, finishedAt null)', () => {
+    const value: SessionJson = {
+      ...fixtureStub(),
+      steps: [
+        {
+          id: 'ideation',
+          startedAt: '2026-04-29T10:00:00.000Z',
+          finishedAt: null,
+          skippedAt: null,
+          timedOutAt: null,
+          iterations: [
+            {
+              round: 0,
+              startedAt: '2026-04-29T10:00:00.000Z',
+              finishedAt: null,
+              terminationReason: 'in-flight',
+            },
+          ],
+        },
+      ],
+    };
+    expect(validateSessionJson(value)).toBe(true);
+  });
+
+  test('complete (4 productive steps with both substeps and lifted agents)', () => {
+    expect(validateSessionJson(fixtureComplete())).toBe(true);
+  });
+
+  test('aborted (terminationReason "aborted")', () => {
+    const value: SessionJson = {
+      ...fixtureStub(),
+      finishedAt: '2026-04-29T10:30:00.000Z',
+      steps: [
+        {
+          id: 'ideation',
+          startedAt: '2026-04-29T10:00:00.000Z',
+          finishedAt: '2026-04-29T10:30:00.000Z',
+          skippedAt: null,
+          timedOutAt: null,
+          iterations: [
+            {
+              round: 0,
+              startedAt: '2026-04-29T10:00:00.000Z',
+              finishedAt: '2026-04-29T10:30:00.000Z',
+              terminationReason: 'aborted',
+            },
+          ],
+        },
+      ],
+    };
+    expect(validateSessionJson(value)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AJV negative fixtures
+// ---------------------------------------------------------------------------
+
+describe('validateSessionJson — negative fixtures', () => {
+  test('rejects wrong schemaVersion', () => {
+    const bad = { ...fixtureStub(), schemaVersion: 2 };
+    expect(validateSessionJson(bad)).toBe(false);
+  });
+
+  test('rejects missing required field (sessionId)', () => {
+    const { sessionId: _omit, ...bad } = fixtureStub();
+    expect(validateSessionJson(bad)).toBe(false);
+  });
+
+  test('rejects invalid date-time on createdAt', () => {
+    const bad = { ...fixtureStub(), createdAt: 'not-a-date' };
+    expect(validateSessionJson(bad)).toBe(false);
+  });
+
+  test('rejects extra field under additionalProperties: false', () => {
+    const bad = { ...fixtureStub(), bogus: 'extra' };
+    expect(validateSessionJson(bad)).toBe(false);
+  });
+
+  test('rejects empty sessionId', () => {
+    const bad = { ...fixtureStub(), sessionId: '' };
+    expect(validateSessionJson(bad)).toBe(false);
+  });
+
+  test('rejects unknown step.id literal', () => {
+    const bad = {
+      ...fixtureStub(),
+      steps: [
+        {
+          id: 'configuration',
+          startedAt: '2026-04-29T10:00:00.000Z',
+          finishedAt: null,
+          skippedAt: null,
+          timedOutAt: null,
+          iterations: [],
+        },
+      ],
+    };
+    expect(validateSessionJson(bad)).toBe(false);
+  });
+
+  test('rejects unknown terminationReason', () => {
+    const bad = {
+      ...fixtureStub(),
+      steps: [
+        {
+          id: 'ideation',
+          startedAt: '2026-04-29T10:00:00.000Z',
+          finishedAt: null,
+          skippedAt: null,
+          timedOutAt: null,
+          iterations: [
+            {
+              round: 0,
+              startedAt: '2026-04-29T10:00:00.000Z',
+              finishedAt: null,
+              terminationReason: 'cancelled', // not in the enum
+            },
+          ],
+        },
+      ],
+    };
+    expect(validateSessionJson(bad)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Read / write — atomic write + boundary parse
+// ---------------------------------------------------------------------------
+
+describe('writeSessionJson + readSessionJson', () => {
+  test('round-trips a SessionJson to disk and back', () => {
+    const filePath = join(scratchDir, 'session.json');
+    const value = fixtureComplete();
+    writeSessionJson(filePath, value);
+    const round = readSessionJson(filePath);
+    expect(round).toEqual(value);
+  });
+
+  test('writes byte-deterministic output for identical input', () => {
+    const filePath1 = join(scratchDir, 'a', 'session.json');
+    const filePath2 = join(scratchDir, 'b', 'session.json');
+    const value = fixtureComplete();
+    writeSessionJson(filePath1, value);
+    writeSessionJson(filePath2, value);
+    const a = readFileSync(filePath1, 'utf8');
+    const b = readFileSync(filePath2, 'utf8');
+    expect(a).toBe(b);
+  });
+
+  test('does not leak temp files on success', () => {
+    const filePath = join(scratchDir, 'session.json');
+    writeSessionJson(filePath, fixtureStub());
+    const entries = readdirSync(scratchDir);
+    expect(entries).toEqual(['session.json']);
+  });
+
+  test('refuses to write invalid input', () => {
+    const filePath = join(scratchDir, 'session.json');
+    const invalid = { schemaVersion: 99 } as unknown as SessionJson;
+    expect(() => writeSessionJson(filePath, invalid)).toThrow(ConfigCascadeError);
+    expect(existsSync(filePath)).toBe(false);
+  });
+
+  test('returns null when reading an absent file', () => {
+    expect(readSessionJson(join(scratchDir, 'nope.json'))).toBeNull();
+  });
+
+  test('throws ConfigCascadeError on malformed JSON', () => {
+    const filePath = join(scratchDir, 'broken.json');
+    writeFileSync(filePath, '{not json', 'utf8');
+    expect(() => readSessionJson(filePath)).toThrow(ConfigCascadeError);
+  });
+
+  test('throws ConfigCascadeError on schema-invalid JSON', () => {
+    const filePath = join(scratchDir, 'bad.json');
+    writeFileSync(filePath, JSON.stringify({ schemaVersion: 99 }), 'utf8');
+    expect(() => readSessionJson(filePath)).toThrow(ConfigCascadeError);
+  });
+});
+
+describe('writeSessionStub', () => {
+  test('writes a minimal stub at the canonical session.json path', () => {
+    writeSessionStub({
+      repoRoot: scratchDir,
+      projectName: 'gobbi',
+      sessionId: 'sess-1',
+      task: 'demo',
+      gobbiVersion: '0.5.0',
+      createdAt: '2026-04-29T10:00:00.000Z',
+    });
+    const filePath = sessionJsonPath(scratchDir, 'gobbi', 'sess-1');
+    const round = readSessionJson(filePath);
+    expect(round).not.toBeNull();
+    expect(round?.steps).toBeUndefined();
+    expect(round?.task).toBe('demo');
+    expect(round?.projectId).toBe('gobbi');
+  });
+
+  test('is idempotent — re-running with same args produces identical bytes', () => {
+    const args = {
+      repoRoot: scratchDir,
+      projectName: 'gobbi',
+      sessionId: 'sess-1',
+      task: 'demo',
+      gobbiVersion: '0.5.0',
+      createdAt: '2026-04-29T10:00:00.000Z',
+    };
+    writeSessionStub(args);
+    const first = readFileSync(sessionJsonPath(scratchDir, 'gobbi', 'sess-1'), 'utf8');
+    writeSessionStub(args);
+    const second = readFileSync(sessionJsonPath(scratchDir, 'gobbi', 'sess-1'), 'utf8');
+    expect(first).toBe(second);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// project.json — upsert helpers
+// ---------------------------------------------------------------------------
+
+describe('writeProjectJson + readProjectJson', () => {
+  test('round-trips a ProjectJson to disk and back', () => {
+    const filePath = join(scratchDir, 'gobbi', 'project.json');
+    const value: ProjectJson = {
+      schemaVersion: 1,
+      projectName: 'gobbi',
+      projectId: 'gobbi',
+      sessions: [],
+      gotchas: [],
+      decisions: [],
+      learnings: [],
+    };
+    writeProjectJson(filePath, value);
+    const round = readProjectJson(filePath);
+    expect(round).toEqual(value);
+  });
+});
+
+describe('upsertProjectSession', () => {
+  test('creates a fresh project.json when absent', () => {
+    const filePath = projectJsonPath(scratchDir, 'gobbi');
+    upsertProjectSession({
+      path: filePath,
+      entry: {
+        sessionId: 'sess-1',
+        createdAt: '2026-04-29T10:00:00.000Z',
+        finishedAt: null,
+        task: 'demo',
+      },
+    });
+    const round = readProjectJson(filePath);
+    expect(round?.projectName).toBe('gobbi');
+    expect(round?.sessions).toHaveLength(1);
+    expect(round?.sessions[0]?.sessionId).toBe('sess-1');
+  });
+
+  test('replaces an existing session by sessionId', () => {
+    const filePath = projectJsonPath(scratchDir, 'gobbi');
+    upsertProjectSession({
+      path: filePath,
+      entry: {
+        sessionId: 'sess-1',
+        createdAt: '2026-04-29T10:00:00.000Z',
+        finishedAt: null,
+        task: 'first',
+      },
+    });
+    upsertProjectSession({
+      path: filePath,
+      entry: {
+        sessionId: 'sess-1',
+        createdAt: '2026-04-29T10:00:00.000Z',
+        finishedAt: '2026-04-29T11:00:00.000Z',
+        task: 'updated',
+      },
+    });
+    const round = readProjectJson(filePath);
+    expect(round?.sessions).toHaveLength(1);
+    expect(round?.sessions[0]?.task).toBe('updated');
+    expect(round?.sessions[0]?.finishedAt).toBe('2026-04-29T11:00:00.000Z');
+  });
+
+  test('sorts sessions[] by createdAt ASC', () => {
+    const filePath = projectJsonPath(scratchDir, 'gobbi');
+    upsertProjectSession({
+      path: filePath,
+      entry: {
+        sessionId: 'sess-c',
+        createdAt: '2026-04-29T12:00:00.000Z',
+        finishedAt: null,
+        task: 'c',
+      },
+    });
+    upsertProjectSession({
+      path: filePath,
+      entry: {
+        sessionId: 'sess-a',
+        createdAt: '2026-04-29T10:00:00.000Z',
+        finishedAt: null,
+        task: 'a',
+      },
+    });
+    upsertProjectSession({
+      path: filePath,
+      entry: {
+        sessionId: 'sess-b',
+        createdAt: '2026-04-29T11:00:00.000Z',
+        finishedAt: null,
+        task: 'b',
+      },
+    });
+    const round = readProjectJson(filePath);
+    const ids = round?.sessions.map((s) => s.sessionId);
+    expect(ids).toEqual(['sess-a', 'sess-b', 'sess-c']);
+  });
+});
+
+describe('upsertProjectGotcha', () => {
+  test('sorts gotchas[] alphabetically by path', () => {
+    const filePath = projectJsonPath(scratchDir, 'gobbi');
+    upsertProjectGotcha({
+      path: filePath,
+      entry: {
+        path: 'zebra.md',
+        sha256: 'a'.repeat(64),
+        class: 'medium',
+        promotedAt: '2026-04-29T10:00:00.000Z',
+        promotedFromSession: 'sess-1',
+      },
+    });
+    upsertProjectGotcha({
+      path: filePath,
+      entry: {
+        path: 'apple.md',
+        sha256: 'b'.repeat(64),
+        class: 'medium',
+        promotedAt: '2026-04-29T10:00:00.000Z',
+        promotedFromSession: 'sess-1',
+      },
+    });
+    upsertProjectGotcha({
+      path: filePath,
+      entry: {
+        path: 'mango.md',
+        sha256: 'c'.repeat(64),
+        class: 'medium',
+        promotedAt: '2026-04-29T10:00:00.000Z',
+        promotedFromSession: 'sess-1',
+      },
+    });
+    const round = readProjectJson(filePath);
+    const paths = round?.gotchas.map((g) => g.path);
+    expect(paths).toEqual(['apple.md', 'mango.md', 'zebra.md']);
+  });
+
+  test('replaces an existing gotcha by path', () => {
+    const filePath = projectJsonPath(scratchDir, 'gobbi');
+    upsertProjectGotcha({
+      path: filePath,
+      entry: {
+        path: 'g.md',
+        sha256: 'a'.repeat(64),
+        class: 'medium',
+        promotedAt: '2026-04-29T10:00:00.000Z',
+        promotedFromSession: 'sess-1',
+      },
+    });
+    upsertProjectGotcha({
+      path: filePath,
+      entry: {
+        path: 'g.md',
+        sha256: 'b'.repeat(64),
+        class: 'high',
+        promotedAt: '2026-04-29T11:00:00.000Z',
+        promotedFromSession: 'sess-2',
+      },
+    });
+    const round = readProjectJson(filePath);
+    expect(round?.gotchas).toHaveLength(1);
+    expect(round?.gotchas[0]?.class).toBe('high');
+    expect(round?.gotchas[0]?.sha256).toBe('b'.repeat(64));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// v1 → v2 schema-equivalence test (lock 28)
+// ---------------------------------------------------------------------------
+
+describe('v1 → v2 schema-equivalence (Codex forward-compat)', () => {
+  test('a synthetic v2 oneOf agent schema validates v1 (Anthropic) fixtures', () => {
+    // Replicate the v1 anthropic agent schema fields in `oneOf` form with a
+    // synthetic codex arm. Pinning preconditions: provider is `const`,
+    // `required` includes `provider`, schemas are inline (no `$ref` at the
+    // discriminator). When v2 lands for real, these preconditions stay true
+    // and v1 fixtures continue to validate.
+    const v2Ajv = new Ajv2020({ strict: true, allErrors: true, discriminator: true });
+    addFormats(v2Ajv);
+
+    const anthropicArm = {
+      type: 'object',
+      additionalProperties: false,
+      required: [
+        'provider',
+        'id',
+        'seq',
+        'name',
+        'model',
+        'skillsLoaded',
+        'startedAt',
+        'finishedAt',
+        'outcome',
+        'costUsd',
+        'calls',
+        'claudeCodeVersion',
+        'transcriptPath',
+        'transcriptSha256',
+        'tokensUsed',
+        'cacheHitRatio',
+        'sizeProxyBytes',
+      ],
+      properties: {
+        provider: { const: 'anthropic' },
+        id: { type: 'string', minLength: 1 },
+        seq: { type: 'integer', minimum: 0 },
+        name: { type: 'string', minLength: 1 },
+        model: { type: ['string', 'null'] },
+        skillsLoaded: { type: 'array', items: { type: 'string' } },
+        startedAt: { type: ['string', 'null'], format: 'date-time' },
+        finishedAt: { type: ['string', 'null'], format: 'date-time' },
+        outcome: { type: ['string', 'null'], enum: ['complete', 'fail', 'running', null] },
+        costUsd: { type: ['number', 'null'], minimum: 0 },
+        calls: { type: 'array' },
+        claudeCodeVersion: { type: ['string', 'null'] },
+        transcriptPath: { type: ['string', 'null'] },
+        transcriptSha256: { type: ['string', 'null'] },
+        tokensUsed: { type: ['object', 'null'] },
+        cacheHitRatio: { type: ['number', 'null'], minimum: 0 },
+        sizeProxyBytes: { type: ['integer', 'null'], minimum: 0 },
+      },
+    };
+
+    const codexArm = {
+      type: 'object',
+      additionalProperties: false,
+      required: [
+        'provider',
+        'id',
+        'seq',
+        'name',
+        'model',
+        'skillsLoaded',
+        'startedAt',
+        'finishedAt',
+        'outcome',
+        'costUsd',
+        'calls',
+        'codexCliVersion',
+        'codexThreadId',
+        'rolloutPath',
+      ],
+      properties: {
+        provider: { const: 'codex' },
+        id: { type: 'string', minLength: 1 },
+        seq: { type: 'integer', minimum: 0 },
+        name: { type: 'string', minLength: 1 },
+        model: { type: ['string', 'null'] },
+        skillsLoaded: { type: 'array', items: { type: 'string' } },
+        startedAt: { type: ['string', 'null'], format: 'date-time' },
+        finishedAt: { type: ['string', 'null'], format: 'date-time' },
+        outcome: { type: ['string', 'null'], enum: ['complete', 'fail', 'running', null] },
+        costUsd: { type: ['number', 'null'], minimum: 0 },
+        calls: { type: 'array' },
+        codexCliVersion: { type: ['string', 'null'] },
+        codexThreadId: { type: ['string', 'null'] },
+        rolloutPath: { type: ['string', 'null'] },
+      },
+    };
+
+    const v2Schema = {
+      type: 'object',
+      discriminator: { propertyName: 'provider' },
+      required: ['provider'],
+      properties: {
+        provider: { type: 'string', enum: ['anthropic', 'codex'] },
+      },
+      oneOf: [anthropicArm, codexArm],
+    };
+
+    const validateV2 = v2Ajv.compile(v2Schema);
+
+    // v1 fixture must validate against the synthetic v2 oneOf.
+    const v1AnthropicAgent: AgentEntry = fixtureAnthropicAgent();
+    expect(validateV2(v1AnthropicAgent)).toBe(true);
+
+    // Sanity check — the discriminator IS doing work: a Codex-shaped record
+    // routes down the codex arm.
+    const codexShaped = {
+      provider: 'codex',
+      id: 'codex-agent-1',
+      seq: 7,
+      name: 'gobbi-agent',
+      model: 'gpt-5',
+      skillsLoaded: [],
+      startedAt: null,
+      finishedAt: null,
+      outcome: null,
+      costUsd: null,
+      calls: [],
+      codexCliVersion: '0.50.0',
+      codexThreadId: 'thread-abc',
+      rolloutPath: null,
+    };
+    expect(validateV2(codexShaped)).toBe(true);
+
+    // And an unknown provider literal is rejected (precondition check —
+    // the discriminator must fail closed).
+    const unknownProvider = { ...v1AnthropicAgent, provider: 'unknown' };
+    expect(validateV2(unknownProvider)).toBe(false);
+  });
+
+  test('schema-equivalence preconditions hold on v1 anthropic-agent schema', () => {
+    // The v1 schema must satisfy three preconditions for the discriminator
+    // widening to be safe — re-asserted here so a regression that breaks
+    // any of them fails this test, not the upstream codex PR.
+    //
+    // Precondition 1: `provider` is `const` (not just `enum`).
+    // Precondition 2: `required` includes `provider`.
+    // Precondition 3: schemas are inline (no `$ref` at the discriminator).
+    //
+    // These preconditions are encoded in the live `validateSessionJson`
+    // schema indirectly — we re-verify them by sending fixtures through
+    // and asserting the rejection cases.
+    const { provider: _omit, ...missingProvider } = fixtureAnthropicAgent();
+    // missingProvider lacks `provider` — feed it through a session.json
+    // wrapper to check the schema's required includes it.
+    const wrapper: SessionJson = {
+      ...fixtureStub(),
+      finishedAt: '2026-04-29T11:00:00.000Z',
+      steps: [
+        {
+          id: 'ideation',
+          startedAt: '2026-04-29T10:00:00.000Z',
+          finishedAt: '2026-04-29T10:10:00.000Z',
+          skippedAt: null,
+          timedOutAt: null,
+          iterations: [
+            {
+              round: 0,
+              startedAt: '2026-04-29T10:00:00.000Z',
+              finishedAt: '2026-04-29T10:10:00.000Z',
+              terminationReason: 'exit',
+              agents: [missingProvider as unknown as AnthropicAgentEntry],
+            },
+          ],
+        },
+      ],
+    };
+    expect(validateSessionJson(wrapper)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildAgentCalls — JSONL transcript walker
+// ---------------------------------------------------------------------------
+
+describe('buildAgentCalls', () => {
+  function writeTranscript(path: string, lines: readonly Record<string, unknown>[]): void {
+    mkdirSync(join(path, '..'), { recursive: true });
+    writeFileSync(path, lines.map((l) => JSON.stringify(l)).join('\n'), 'utf8');
+  }
+
+  test('reads JSONL transcript and folds usage into AgentCallEntry rows', async () => {
+    const transcriptDir = join(scratchDir, 'transcripts');
+    const sessionId = 'sess-1';
+    const subagentId = 'agent-x';
+    const transcriptPath = join(
+      transcriptDir,
+      sessionId,
+      'subagents',
+      `agent-${subagentId}.jsonl`,
+    );
+    writeTranscript(transcriptPath, [
+      {
+        type: 'assistant',
+        timestamp: '2026-04-29T10:00:01.000Z',
+        requestId: 'req-1',
+        message: {
+          model: 'claude-opus-4-7',
+          stop_reason: 'end_turn',
+          usage: {
+            input_tokens: 100,
+            output_tokens: 50,
+            cache_read_input_tokens: 10,
+            cache_creation_input_tokens: 5,
+          },
+        },
+      },
+      {
+        type: 'assistant',
+        timestamp: '2026-04-29T10:00:02.000Z',
+        requestId: 'req-2',
+        message: {
+          model: 'claude-opus-4-7',
+          stop_reason: 'tool_use',
+          usage: {
+            input_tokens: 200,
+            output_tokens: 80,
+            cache_read_input_tokens: 30,
+            cache_creation_input_tokens: 0,
+          },
+        },
+      },
+      // user line — should be skipped
+      { type: 'user', timestamp: '2026-04-29T10:00:03.000Z' },
+    ]);
+
+    const calls = await buildAgentCalls({
+      sessionId,
+      subagentId,
+      spawnSeq: 5,
+      transcriptDir,
+    });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.turnIndex).toBe(0);
+    expect(calls[0]?.seq).toBe(6);
+    expect(calls[0]?.inputTokens).toBe(100);
+    expect(calls[0]?.outputTokens).toBe(50);
+    expect(calls[0]?.cacheReadTokens).toBe(10);
+    expect(calls[0]?.cacheCreationTokens).toBe(5);
+    expect(calls[0]?.stopReason).toBe('end_turn');
+    expect(calls[0]?.requestId).toBe('req-1');
+    expect(calls[0]?.model).toBe('claude-opus-4-7');
+    expect(calls[1]?.turnIndex).toBe(1);
+    expect(calls[1]?.seq).toBe(7);
+  });
+
+  test('returns [] and emits stderr warning when no transcript found', async () => {
+    const calls = await buildAgentCalls({
+      sessionId: 'no-such-session',
+      subagentId: 'no-such-agent',
+      spawnSeq: 1,
+      transcriptDir: join(scratchDir, 'empty'),
+      // Force the glob fallback into a directory we control + leave empty.
+      claudeHome: scratchDir,
+    });
+    expect(calls).toEqual([]);
+  });
+
+  test('falls back to glob discovery under claudeHome when transcriptDir missing', async () => {
+    const sessionId = 'sess-2';
+    const subagentId = 'agent-y';
+    const encodedCwd = '-some-path';
+    const transcriptPath = join(
+      scratchDir,
+      '.claude',
+      'projects',
+      encodedCwd,
+      sessionId,
+      'subagents',
+      `agent-${subagentId}.jsonl`,
+    );
+    writeTranscript(transcriptPath, [
+      {
+        type: 'assistant',
+        timestamp: '2026-04-29T10:01:00.000Z',
+        requestId: 'r',
+        message: {
+          model: 'claude-opus-4-7',
+          stop_reason: 'end_turn',
+          usage: {
+            input_tokens: 1,
+            output_tokens: 1,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+          },
+        },
+      },
+    ]);
+    const calls = await buildAgentCalls({
+      sessionId,
+      subagentId,
+      spawnSeq: 0,
+      claudeHome: scratchDir,
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.inputTokens).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// aggregateSessionJson — synthetic event sequence
+// ---------------------------------------------------------------------------
+
+describe('aggregateSessionJson', () => {
+  test('builds steps[] from a synthetic 4-step event sequence', async () => {
+    const rows: EventRow[] = [
+      makeRow({
+        seq: 1,
+        type: 'workflow.start',
+        ts: '2026-04-29T10:00:00.000Z',
+        data: { sessionId: 'sess-1', timestamp: '2026-04-29T10:00:00.000Z' },
+      }),
+      makeRow({
+        seq: 2,
+        type: 'delegation.spawn',
+        step: 'ideation',
+        ts: '2026-04-29T10:00:01.000Z',
+        data: { agentType: '__pi', step: 'ideation', subagentId: 'agent-1', timestamp: '2026-04-29T10:00:01.000Z' },
+      }),
+      makeRow({
+        seq: 3,
+        type: 'delegation.complete',
+        step: 'ideation',
+        ts: '2026-04-29T10:00:02.000Z',
+        data: { subagentId: 'agent-1', artifactPath: '/some/path' },
+      }),
+      makeRow({
+        seq: 4,
+        type: 'workflow.step.exit',
+        step: 'ideation',
+        ts: '2026-04-29T10:10:00.000Z',
+        data: { step: 'ideation' },
+      }),
+      makeRow({
+        seq: 5,
+        type: 'workflow.step.exit',
+        step: 'planning',
+        ts: '2026-04-29T10:20:00.000Z',
+        data: { step: 'planning' },
+      }),
+      makeRow({
+        seq: 6,
+        type: 'workflow.step.exit',
+        step: 'execution',
+        ts: '2026-04-29T10:50:00.000Z',
+        data: { step: 'execution' },
+      }),
+      // memorization in-flight — no exit row yet
+      makeRow({
+        seq: 7,
+        type: 'workflow.step.skip',
+        step: 'memorization',
+        ts: '2026-04-29T10:51:00.000Z',
+        data: { step: 'memorization' },
+      }),
+    ];
+    const store = new FakeReadStore(rows, []);
+    const result = await aggregateSessionJson({
+      store,
+      sessionId: 'sess-1',
+      projectId: 'gobbi',
+      createdAt: '2026-04-29T10:00:00.000Z',
+      gobbiVersion: '0.5.0',
+      task: 'demo',
+      transcriptDir: join(scratchDir, 'no-transcript'),
+      claudeHome: scratchDir,
+    });
+
+    expect(validateSessionJson(result)).toBe(true);
+    expect(result.steps).toBeDefined();
+    expect(result.steps?.length).toBeGreaterThanOrEqual(4);
+
+    const ideation = result.steps?.find((s) => s.id === 'ideation');
+    expect(ideation?.iterations[0]?.terminationReason).toBe('exit');
+    expect(ideation?.iterations[0]?.agents).toBeDefined();
+    expect(ideation?.iterations[0]?.agents?.length).toBe(1);
+    expect(ideation?.iterations[0]?.agents?.[0]?.id).toBe('agent-1');
+    expect(ideation?.iterations[0]?.agents?.[0]?.outcome).toBe('complete');
+
+    const memorization = result.steps?.find((s) => s.id === 'memorization');
+    expect(memorization?.skippedAt).toBe('2026-04-29T10:51:00.000Z');
+    expect(memorization?.iterations[0]?.terminationReason).toBe('skip');
+  });
+
+  test('reuses aggregateDelegationCosts for per-agent costUsd', async () => {
+    const rows: EventRow[] = [
+      makeRow({
+        seq: 1,
+        type: 'delegation.spawn',
+        step: 'ideation',
+        data: { agentType: '__pi', step: 'ideation', subagentId: 'agent-1', timestamp: '2026-04-29T10:00:00.000Z' },
+      }),
+      makeRow({
+        seq: 2,
+        type: 'delegation.complete',
+        step: 'ideation',
+        data: { subagentId: 'agent-1' },
+      }),
+    ];
+    const costs: CostAggregateRow[] = [
+      {
+        step: 'ideation',
+        subagentId: 'agent-1',
+        // tokensJson is what aggregateDelegationCosts returns from json_extract.
+        tokensJson: JSON.stringify({
+          input_tokens: 1_000_000,
+          output_tokens: 0,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        }),
+        model: 'claude-opus-4-7',
+        bytes: null,
+      },
+    ];
+    const store = new FakeReadStore(rows, costs);
+    const result = await aggregateSessionJson({
+      store,
+      sessionId: 'sess-1',
+      projectId: 'gobbi',
+      createdAt: '2026-04-29T10:00:00.000Z',
+      gobbiVersion: '0.5.0',
+      task: 'demo',
+      transcriptDir: join(scratchDir, 'no-transcript'),
+      claudeHome: scratchDir,
+    });
+    const agent = result.steps?.[0]?.iterations[0]?.agents?.[0];
+    // 1M input tokens at $5 / 1M = $5.
+    expect(agent?.costUsd).toBe(5);
+  });
+
+  test('returns empty steps[] for an event-less session', async () => {
+    const store = new FakeReadStore([], []);
+    const result = await aggregateSessionJson({
+      store,
+      sessionId: 'sess-empty',
+      projectId: 'gobbi',
+      createdAt: '2026-04-29T10:00:00.000Z',
+      gobbiVersion: '0.5.0',
+      task: 'demo',
+      transcriptDir: join(scratchDir, 'no-transcript'),
+      claudeHome: scratchDir,
+    });
+    expect(result.steps).toEqual([]);
+    expect(validateSessionJson(result)).toBe(true);
+  });
+
+  test('finishedAt sourced from workflow.finish event when present', async () => {
+    const rows: EventRow[] = [
+      makeRow({
+        seq: 1,
+        type: 'workflow.start',
+        ts: '2026-04-29T10:00:00.000Z',
+        data: { sessionId: 'sess-1', timestamp: '2026-04-29T10:00:00.000Z' },
+      }),
+      makeRow({
+        seq: 2,
+        type: 'workflow.finish',
+        ts: '2026-04-29T11:00:00.000Z',
+        data: {},
+      }),
+    ];
+    const store = new FakeReadStore(rows, []);
+    const result = await aggregateSessionJson({
+      store,
+      sessionId: 'sess-1',
+      projectId: 'gobbi',
+      createdAt: '2026-04-29T10:00:00.000Z',
+      gobbiVersion: '0.5.0',
+      task: 'demo',
+      transcriptDir: join(scratchDir, 'no-transcript'),
+      claudeHome: scratchDir,
+    });
+    expect(result.finishedAt).toBe('2026-04-29T11:00:00.000Z');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertNeverProvider — exhaustiveness gate
+// ---------------------------------------------------------------------------
+
+describe('assertNeverProvider', () => {
+  test('throws when invoked with an unknown provider literal', () => {
+    // Forced runtime test — TypeScript catches this at compile time when
+    // a switch is non-exhaustive. The runtime check exists for the
+    // belt-and-braces case where a fresh fixture flows in from disk.
+    expect(() => assertNeverProvider('codex' as never)).toThrow();
+  });
+
+  test('compiles an exhaustive switch on AgentEntry["provider"]', () => {
+    // Type-level check — this function compiles only because the switch is
+    // exhaustive over `AgentProvider`. If a new provider literal is added
+    // without a matching case, tsc fails here.
+    const agent = fixtureAnthropicAgent();
+
+    function describeAgent(a: AgentEntry): string {
+      switch (a.provider) {
+        case 'anthropic':
+          return `${a.name}@anthropic`;
+        default:
+          return assertNeverProvider(a.provider);
+      }
+    }
+
+    expect(describeAgent(agent)).toBe('__pi@anthropic');
+  });
+});

--- a/packages/cli/src/lib/json-memory.ts
+++ b/packages/cli/src/lib/json-memory.ts
@@ -1,0 +1,1391 @@
+/**
+ * JSON memory I/O — `session.json` + `project.json` schemas, AJV validators,
+ * atomic writers, and the memorization-time aggregator that builds a
+ * fully-populated `SessionJson` from the workspace event store and the
+ * Anthropic JSONL transcripts under `~/.claude/projects/<encoded-cwd>/<sessionId>/subagents/`.
+ *
+ * # Authoritative shape
+ *
+ * The TS interfaces below are the source of truth for both files. The AJV
+ * schemas (`sessionJsonSchema`, `projectJsonSchema`) bind via
+ * `JSONSchemaType<T>` where the recursion depth permits, falling back to
+ * `as never` casts at the root only for the 5-level `SessionJson` shape per
+ * the `_schema/v1.ts:60-73` precedent. `tsc --noEmit` is the drift gate at
+ * every leaf where the type compiles cleanly.
+ *
+ * # Module layout (mirrors `lib/settings-io.ts` + `lib/canonical-json.ts`)
+ *
+ *   - Types — discriminated unions for `provider`, `outcome`, `step.id`,
+ *     `verdict`, `terminationReason`. Every consumer that branches on
+ *     `agent.provider` MUST end its switch with `assertNever(agent)` so a
+ *     future `'codex'` widening fails to compile at every reader.
+ *   - AJV — single instance compiled at module load
+ *     (`new Ajv2020({strict, allErrors, discriminator: true})` + `addFormats`).
+ *     Reuse `formatAjvErrors` from `settings-validator.ts` — DO NOT
+ *     instantiate a second formatter.
+ *   - Read — defensive boundary parse (returns `null` on absence, throws
+ *     `ConfigCascadeError('parse', …)` on malformed/invalid).
+ *   - Write — atomic temp+rename, AJV-validate before write, sorted-rewrite
+ *     primitives sort arrays at the writer call site (never inside the
+ *     stringifier).
+ *   - Aggregator — `aggregateSessionJson` is async because
+ *     `buildAgentCalls` walks JSONL transcripts via `parseJsonlFile`.
+ *
+ * # Sort discipline (lock 32)
+ *
+ * Every array in the persisted shape sorts deterministically before the
+ * writer stringifies:
+ *
+ *   - `steps[]` — state-machine order (`ideation`, `planning`, `execution`,
+ *     `memorization`); pre-arranged by the aggregator.
+ *   - `iterations[]` — by `round` ASC.
+ *   - `substeps[]` — by `seq` ASC of first nested event.
+ *   - `agents[]` — by `seq` ASC of first event mentioning the subagentId.
+ *   - `calls[]` — by `turnIndex` ASC (monotonically aligned with seq inside
+ *     one agent).
+ *   - `project.json.sessions[]` — by `createdAt` ASC.
+ *   - `project.json.gotchas[]` — by `path` ASC.
+ *   - `project.json.decisions[]` / `learnings[]` — by `recordedAt` ASC.
+ *
+ * # Provenance
+ *
+ *   - Agent-level `tokensUsed` is a SUM-fold over `agents[].calls[].*Tokens`
+ *     (lock 34). The `delegation.complete.tokensUsed` event payload is
+ *     statically `number` (Architecture C4) — DO NOT consume it. JSONL
+ *     transcripts are the canonical source for both call-level and
+ *     agent-level token data.
+ *   - Per-agent cost rollup reuses `aggregateDelegationCosts` from
+ *     `workflow/store.ts:294` (lock 36). DO NOT reinvent.
+ *   - `iterations[].terminationReason` derives from which terminal event
+ *     closed the iteration (`exit`/`skip`/`timeout`/`aborted`/`in-flight`).
+ *     `'in-flight'` is the memorization mid-run case — the iteration that
+ *     contains memorization itself has no terminal event because
+ *     memorization is the step writing this very file.
+ *   - JSONL transcript discovery (Plan-eval Overall H1):
+ *       1. `dirname($CLAUDE_TRANSCRIPT_PATH)/<sessionId>/subagents/agent-<id>.jsonl`
+ *       2. fallback glob `~/.claude/projects/<encoded-cwd>/<sessionId>/subagents/agent-*.jsonl`
+ *       3. if neither resolves, emit `agent.calls: []` + one-line stderr warning.
+ *
+ * # Concurrency caveat (lock 42)
+ *
+ * `project.json` writers (`gobbi gotcha promote` + memorization step) form a
+ * read-modify-write pair. Atomic temp+rename prevents torn writes; it does
+ * NOT prevent lossy merges if two terminals run concurrently. Solo-user
+ * context accepted; recovery path is manual edit / git-restore.
+ *
+ * # Codex forward-compat (lock 28)
+ *
+ * AJV is constructed with `discriminator: true` so future widening to
+ * `oneOf: [<anthropic>, <codex>]` keeps validating v1 fixtures unchanged.
+ * The schema-equivalence test in `__tests__/json-memory.test.ts` pins the
+ * preconditions: `provider` is `const`/`enum`, `required` includes
+ * `provider`, schemas are inline (no `$ref` at the discriminator).
+ */
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import addFormatsPlugin from 'ajv-formats';
+import Ajv2020, { type ValidateFunction } from 'ajv/dist/2020.js';
+
+import { isNumber, isRecord, isString } from './guards.js';
+import { parseJsonlFile } from './jsonl.js';
+import { ConfigCascadeError } from './settings.js';
+import { formatAjvErrors } from './settings-validator.js';
+import { projectDir, sessionDir } from './workspace-paths.js';
+import { derivedCost } from './cost-rates.js';
+import type { ReadStore, CostAggregateRow } from '../workflow/store.js';
+import type { EventRow } from '../workflow/migrations.js';
+
+// ajv-formats default export shape: TypeScript ESM interop — the runtime
+// value is the plugin function; the typings expose it under `.default`.
+// Cast through `unknown` to handle both shapes consistently.
+const addFormats: (ajv: Ajv2020) => Ajv2020 =
+  (addFormatsPlugin as unknown as { default?: typeof addFormatsPlugin }).default ??
+  (addFormatsPlugin as unknown as (ajv: Ajv2020) => Ajv2020);
+
+// ---------------------------------------------------------------------------
+// Discriminated unions
+// ---------------------------------------------------------------------------
+
+/**
+ * Agent provider discriminant. v1 ships only `'anthropic'`. The Codex arm
+ * lands as a strictly-additive widening: `| 'codex'` plus a parallel
+ * `CodexAgentEntry` interface and a `oneOf` schema branch. Pre-existing v1
+ * `session.json` files validate unchanged because `discriminator: true` on
+ * the AJV instance routes them down the `'anthropic'` arm.
+ *
+ * Every consumer that branches on `agent.provider` MUST end its switch with
+ * `assertNever(agent)`. Without it, a future `'codex'` literal compiles
+ * silently and the consumer skips the new arm at runtime (Architecture H1).
+ */
+export type AgentProvider = 'anthropic';
+
+export type DelegationOutcome = 'complete' | 'fail' | 'running';
+
+export type SessionStepId = 'ideation' | 'planning' | 'execution' | 'memorization';
+
+export type EvalVerdict = 'pass' | 'revise' | 'escalate';
+
+export type TerminationReason = 'exit' | 'skip' | 'timeout' | 'aborted' | 'in-flight';
+
+// ---------------------------------------------------------------------------
+// session.json — telemetry types (5-level recursion)
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-LLM-turn row produced by the JSONL transcript walker. One row per
+ * assistant message line; `turnIndex` is the 0-based index inside the
+ * subagent's transcript. Token fields are `null` when the line lacked a
+ * `message.usage` block (rare for Anthropic — typically only on synthetic
+ * lines or hand-crafted fixtures).
+ */
+export interface AnthropicAgentCallEntry {
+  readonly seq: number;
+  readonly turnIndex: number;
+  readonly model: string | null;
+  readonly ts: string | null;
+  readonly stopReason: string | null;
+  readonly requestId: string | null;
+  readonly inputTokens: number | null;
+  readonly outputTokens: number | null;
+  readonly cacheReadTokens: number | null;
+  readonly cacheCreationTokens: number | null;
+}
+
+export type AgentCallEntry = AnthropicAgentCallEntry;
+
+/**
+ * Anthropic `message.usage` shape, mirrored verbatim so a JSON.parse of the
+ * raw usage object round-trips into this interface without renaming.
+ */
+export interface AnthropicTokensUsed {
+  readonly input_tokens: number;
+  readonly output_tokens: number;
+  readonly cache_read_input_tokens: number;
+  readonly cache_creation_input_tokens: number;
+}
+
+/**
+ * Common agent-entry fields shared across providers. The provider-specific
+ * subtype carries the discriminant and the provider's identity fields.
+ */
+interface AgentEntryBase {
+  readonly id: string;
+  readonly seq: number;
+  readonly name: string;
+  readonly model: string | null;
+  readonly skillsLoaded: readonly string[];
+  readonly startedAt: string | null;
+  readonly finishedAt: string | null;
+  readonly outcome: DelegationOutcome | null;
+  readonly costUsd: number | null;
+  readonly calls: readonly AgentCallEntry[];
+}
+
+/**
+ * Anthropic agent entry. `tokensUsed` is the SUM-fold over `calls[]` token
+ * fields (lock 34) — never sourced from the `delegation.complete.tokensUsed`
+ * event payload (which is statically `number`).
+ */
+export interface AnthropicAgentEntry extends AgentEntryBase {
+  readonly provider: 'anthropic';
+  readonly claudeCodeVersion: string | null;
+  readonly transcriptPath: string | null;
+  readonly transcriptSha256: string | null;
+  readonly tokensUsed: AnthropicTokensUsed | null;
+  readonly cacheHitRatio: number | null;
+  readonly sizeProxyBytes: number | null;
+}
+
+export type AgentEntry = AnthropicAgentEntry;
+
+export interface SubstepEntry {
+  readonly id: string;
+  readonly startedAt: string;
+  readonly finishedAt: string | null;
+  readonly agents: readonly AgentEntry[];
+}
+
+/**
+ * One iteration through a productive step. Iterations contain EITHER a
+ * `substeps[]` axis (typical: ideation/planning/execution have
+ * discussion → research → delegation → evaluation substeps) OR a flat
+ * `agents[]` lift (typical: memorization, where the orchestrator-only
+ * pattern has no substep axis). Schema accepts both shapes; aggregator
+ * lifts agents up if no substep axis is detected.
+ */
+export interface IterationEntry {
+  readonly round: number;
+  readonly startedAt: string;
+  readonly finishedAt: string | null;
+  readonly terminationReason: TerminationReason;
+  readonly substeps?: readonly SubstepEntry[];
+  readonly agents?: readonly AgentEntry[];
+}
+
+export interface StepEntry {
+  readonly id: SessionStepId;
+  readonly startedAt: string;
+  readonly finishedAt: string | null;
+  readonly skippedAt: string | null;
+  readonly timedOutAt: string | null;
+  readonly iterations: readonly IterationEntry[];
+}
+
+/**
+ * Persisted shape of `<sessionDir>/session.json`. The 6 required fields are
+ * stamped at `gobbi workflow init` (the stub) and the writer at the
+ * memorization step's STEP_EXIT replaces the file with the same fields plus
+ * a populated `steps[]`. `finishedAt` is `null` until `workflow.finish` /
+ * `workflow.abort` fires.
+ *
+ * Stub-vs-complete distinguishability (lock 43): a `session.json` with no
+ * `steps` field is a stub. No new `status` field — readers infer state
+ * from field presence.
+ */
+export interface SessionJson {
+  readonly schemaVersion: 1;
+  readonly sessionId: string;
+  readonly projectId: string;
+  readonly createdAt: string;
+  readonly finishedAt: string | null;
+  readonly gobbiVersion: string;
+  readonly task: string;
+  readonly steps?: readonly StepEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// project.json — cross-session memory types
+// ---------------------------------------------------------------------------
+
+export interface ProjectJsonSession {
+  readonly sessionId: string;
+  readonly createdAt: string;
+  readonly finishedAt: string | null;
+  readonly task: string;
+  readonly handoffSummary?: string | null;
+}
+
+export interface ProjectJsonGotcha {
+  readonly path: string;
+  readonly sha256: string;
+  readonly class: string;
+  readonly promotedAt: string;
+  readonly promotedFromSession: string;
+}
+
+export interface ProjectJsonDecision {
+  readonly id: string;
+  readonly title: string;
+  readonly recordedAt: string;
+  readonly sessionId: string;
+}
+
+export interface ProjectJsonLearning {
+  readonly id: string;
+  readonly title: string;
+  readonly recordedAt: string;
+  readonly sessionId: string;
+}
+
+/**
+ * Persisted shape of `.gobbi/projects/<projectName>/project.json`. Tracked
+ * in git. Concurrent writers (gotcha promote + memorization) form a
+ * read-modify-write race; atomic temp+rename prevents torn writes but NOT
+ * lossy merges. Solo-user context accepted (lock 42).
+ */
+export interface ProjectJson {
+  readonly schemaVersion: 1;
+  readonly projectName: string;
+  readonly projectId: string;
+  readonly sessions: readonly ProjectJsonSession[];
+  readonly gotchas: readonly ProjectJsonGotcha[];
+  readonly decisions: readonly ProjectJsonDecision[];
+  readonly learnings: readonly ProjectJsonLearning[];
+}
+
+// ---------------------------------------------------------------------------
+// AJV — single instance, compiled at module load (mirror settings-validator.ts:376-388)
+// ---------------------------------------------------------------------------
+
+const ajv = new Ajv2020({ strict: true, allErrors: true, discriminator: true });
+addFormats(ajv);
+
+// ---------------------------------------------------------------------------
+// Inline schema constants
+// ---------------------------------------------------------------------------
+//
+// Schemas are written as untyped object literals (not annotated with
+// `JSONSchemaType<T>`) for two reasons:
+//
+//   1. `JSONSchemaType<SessionJson>` cannot represent the 5-level recursion
+//      with `oneOf` discriminators cleanly under EOPT — the same trade-off
+//      `_schema/v1.ts:60-73` documented for `StepSpecSchema`.
+//   2. The discriminator preconditions (`provider` is `const`, `required`
+//      includes `provider`, no `$ref` at the discriminator position) are
+//      asserted by the v1→v2 schema-equivalence test rather than by AJV's
+//      `JSONSchemaType` type. The test is the gate; the inline schema is
+//      the ground truth.
+//
+// Drift is mitigated by (a) the type-cast bind to `ValidateFunction<T>` at
+// the `compile` call site, (b) positive AJV fixtures hitting every required
+// field, and (c) the schema-equivalence test pinning the discriminator
+// preconditions.
+
+const anthropicTokensUsedSchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: [
+    'input_tokens',
+    'output_tokens',
+    'cache_read_input_tokens',
+    'cache_creation_input_tokens',
+  ],
+  properties: {
+    input_tokens: { type: 'integer', minimum: 0 },
+    output_tokens: { type: 'integer', minimum: 0 },
+    cache_read_input_tokens: { type: 'integer', minimum: 0 },
+    cache_creation_input_tokens: { type: 'integer', minimum: 0 },
+  },
+} as const;
+
+const anthropicAgentCallSchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: [
+    'seq',
+    'turnIndex',
+    'model',
+    'ts',
+    'stopReason',
+    'requestId',
+    'inputTokens',
+    'outputTokens',
+    'cacheReadTokens',
+    'cacheCreationTokens',
+  ],
+  properties: {
+    seq: { type: 'integer', minimum: 0 },
+    turnIndex: { type: 'integer', minimum: 0 },
+    model: { type: ['string', 'null'] },
+    ts: { type: ['string', 'null'], format: 'date-time' },
+    stopReason: { type: ['string', 'null'] },
+    requestId: { type: ['string', 'null'] },
+    inputTokens: { type: ['integer', 'null'], minimum: 0 },
+    outputTokens: { type: ['integer', 'null'], minimum: 0 },
+    cacheReadTokens: { type: ['integer', 'null'], minimum: 0 },
+    cacheCreationTokens: { type: ['integer', 'null'], minimum: 0 },
+  },
+} as const;
+
+/**
+ * Anthropic agent schema. `provider: { const: 'anthropic' }` is the
+ * v1→v2 schema-equivalence pin (lock 28) — the discriminator's
+ * preconditions are written here, not in the union schema. When v2 widens
+ * to `oneOf: [<this>, <codex>]`, AJV's `discriminator: true` keeps v1
+ * fixtures validating against this branch.
+ */
+const anthropicAgentSchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: [
+    'provider',
+    'id',
+    'seq',
+    'name',
+    'model',
+    'skillsLoaded',
+    'startedAt',
+    'finishedAt',
+    'outcome',
+    'costUsd',
+    'calls',
+    'claudeCodeVersion',
+    'transcriptPath',
+    'transcriptSha256',
+    'tokensUsed',
+    'cacheHitRatio',
+    'sizeProxyBytes',
+  ],
+  properties: {
+    provider: { const: 'anthropic' },
+    id: { type: 'string', minLength: 1 },
+    seq: { type: 'integer', minimum: 0 },
+    name: { type: 'string', minLength: 1 },
+    model: { type: ['string', 'null'] },
+    skillsLoaded: { type: 'array', items: { type: 'string' } },
+    startedAt: { type: ['string', 'null'], format: 'date-time' },
+    finishedAt: { type: ['string', 'null'], format: 'date-time' },
+    outcome: { type: ['string', 'null'], enum: ['complete', 'fail', 'running', null] },
+    costUsd: { type: ['number', 'null'], minimum: 0 },
+    calls: { type: 'array', items: anthropicAgentCallSchema },
+    claudeCodeVersion: { type: ['string', 'null'] },
+    transcriptPath: { type: ['string', 'null'] },
+    transcriptSha256: { type: ['string', 'null'] },
+    tokensUsed: { ...anthropicTokensUsedSchema, nullable: true } as unknown as Record<string, unknown>,
+    cacheHitRatio: { type: ['number', 'null'], minimum: 0 },
+    sizeProxyBytes: { type: ['integer', 'null'], minimum: 0 },
+  },
+} as const;
+
+const substepSchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['id', 'startedAt', 'finishedAt', 'agents'],
+  properties: {
+    id: { type: 'string', minLength: 1 },
+    startedAt: { type: 'string', format: 'date-time' },
+    finishedAt: { type: ['string', 'null'], format: 'date-time' },
+    agents: { type: 'array', items: anthropicAgentSchema },
+  },
+} as const;
+
+const iterationSchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['round', 'startedAt', 'finishedAt', 'terminationReason'],
+  properties: {
+    round: { type: 'integer', minimum: 0 },
+    startedAt: { type: 'string', format: 'date-time' },
+    finishedAt: { type: ['string', 'null'], format: 'date-time' },
+    terminationReason: { type: 'string', enum: ['exit', 'skip', 'timeout', 'aborted', 'in-flight'] },
+    substeps: { type: 'array', items: substepSchema },
+    agents: { type: 'array', items: anthropicAgentSchema },
+  },
+} as const;
+
+const stepSchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['id', 'startedAt', 'finishedAt', 'skippedAt', 'timedOutAt', 'iterations'],
+  properties: {
+    id: { type: 'string', enum: ['ideation', 'planning', 'execution', 'memorization'] },
+    startedAt: { type: 'string', format: 'date-time' },
+    finishedAt: { type: ['string', 'null'], format: 'date-time' },
+    skippedAt: { type: ['string', 'null'], format: 'date-time' },
+    timedOutAt: { type: ['string', 'null'], format: 'date-time' },
+    iterations: { type: 'array', items: iterationSchema },
+  },
+} as const;
+
+const sessionJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: [
+    'schemaVersion',
+    'sessionId',
+    'projectId',
+    'createdAt',
+    'finishedAt',
+    'gobbiVersion',
+    'task',
+  ],
+  properties: {
+    schemaVersion: { type: 'integer', const: 1 },
+    sessionId: { type: 'string', minLength: 1 },
+    projectId: { type: 'string', minLength: 1 },
+    createdAt: { type: 'string', format: 'date-time' },
+    finishedAt: { type: ['string', 'null'], format: 'date-time' },
+    gobbiVersion: { type: 'string', minLength: 1 },
+    task: { type: 'string' },
+    steps: { type: 'array', items: stepSchema },
+  },
+} as const;
+
+const projectJsonSessionSchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['sessionId', 'createdAt', 'finishedAt', 'task'],
+  properties: {
+    sessionId: { type: 'string', minLength: 1 },
+    createdAt: { type: 'string', format: 'date-time' },
+    finishedAt: { type: ['string', 'null'], format: 'date-time' },
+    task: { type: 'string' },
+    handoffSummary: { type: ['string', 'null'] },
+  },
+} as const;
+
+const projectJsonGotchaSchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['path', 'sha256', 'class', 'promotedAt', 'promotedFromSession'],
+  properties: {
+    path: { type: 'string', minLength: 1 },
+    sha256: { type: 'string', minLength: 1 },
+    class: { type: 'string', minLength: 1 },
+    promotedAt: { type: 'string', format: 'date-time' },
+    promotedFromSession: { type: 'string', minLength: 1 },
+  },
+} as const;
+
+const projectJsonDecisionSchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['id', 'title', 'recordedAt', 'sessionId'],
+  properties: {
+    id: { type: 'string', minLength: 1 },
+    title: { type: 'string', minLength: 1 },
+    recordedAt: { type: 'string', format: 'date-time' },
+    sessionId: { type: 'string', minLength: 1 },
+  },
+} as const;
+
+const projectJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: [
+    'schemaVersion',
+    'projectName',
+    'projectId',
+    'sessions',
+    'gotchas',
+    'decisions',
+    'learnings',
+  ],
+  properties: {
+    schemaVersion: { type: 'integer', const: 1 },
+    projectName: { type: 'string', minLength: 1 },
+    projectId: { type: 'string', minLength: 1 },
+    sessions: { type: 'array', items: projectJsonSessionSchema },
+    gotchas: { type: 'array', items: projectJsonGotchaSchema },
+    decisions: { type: 'array', items: projectJsonDecisionSchema },
+    learnings: { type: 'array', items: projectJsonDecisionSchema },
+  },
+} as const;
+
+/**
+ * Compiled `SessionJson` validator. The schema literal is untyped (see the
+ * inline-schema docblock above); the `as never` cast is the documented
+ * fallback per `best.md:401` and `_schema/v1.ts:60-73` precedent. Runtime
+ * narrowing is sound because the schema is the boundary contract — TS
+ * cannot type-check the recursive AJV shape without an enormous expansion.
+ */
+export const validateSessionJson: ValidateFunction<SessionJson> =
+  ajv.compile<SessionJson>(sessionJsonSchema as never);
+
+export const validateProjectJson: ValidateFunction<ProjectJson> =
+  ajv.compile<ProjectJson>(projectJsonSchema as never);
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Path to `.gobbi/projects/<projectName>/project.json` — git-tracked
+ * cross-session memory.
+ */
+export function projectJsonPath(repoRoot: string, projectName: string): string {
+  return path.join(projectDir(repoRoot, projectName), 'project.json');
+}
+
+/**
+ * Path to `.gobbi/projects/<projectName>/sessions/<sessionId>/session.json`
+ * — gitignored per-session telemetry.
+ */
+export function sessionJsonPath(
+  repoRoot: string,
+  projectName: string,
+  sessionId: string,
+): string {
+  return path.join(sessionDir(repoRoot, projectName, sessionId), 'session.json');
+}
+
+// ---------------------------------------------------------------------------
+// Read — defensive boundary parse
+// ---------------------------------------------------------------------------
+
+/**
+ * Read and AJV-validate `session.json`. Returns `null` when the file is
+ * absent (e.g., on a session that init'd before the JSON pivot). Throws
+ * `ConfigCascadeError('parse', …)` on JSON parse failure or schema
+ * violation — error messages name the file path for "remove or repair
+ * manually" remediation, matching the `init.ts` precedent for malformed
+ * `metadata.json`.
+ */
+export function readSessionJson(filePath: string): SessionJson | null {
+  return readValidatedJson(filePath, validateSessionJson);
+}
+
+/**
+ * Read and AJV-validate `project.json`. Returns `null` when the file is
+ * absent. Throws `ConfigCascadeError('parse', …)` on malformed/invalid.
+ */
+export function readProjectJson(filePath: string): ProjectJson | null {
+  return readValidatedJson(filePath, validateProjectJson);
+}
+
+function readValidatedJson<T>(
+  filePath: string,
+  validate: ValidateFunction<T>,
+): T | null {
+  if (!existsSync(filePath)) return null;
+
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, 'utf8');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new ConfigCascadeError('read', `Failed to read ${filePath}: ${message}`, {
+      path: filePath,
+      cause: err,
+    });
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new ConfigCascadeError('parse', `Invalid JSON in ${filePath}: ${message}`, {
+      path: filePath,
+      cause: err,
+    });
+  }
+
+  if (!validate(parsed)) {
+    const messages = formatAjvErrors(validate.errors);
+    throw new ConfigCascadeError('parse', `Invalid ${filePath}:\n${messages}`, {
+      path: filePath,
+    });
+  }
+
+  return parsed;
+}
+
+// ---------------------------------------------------------------------------
+// Write — atomic temp+rename, AJV-validate before write
+// ---------------------------------------------------------------------------
+
+/**
+ * Atomically write a `SessionJson` to `filePath`. Validates against the
+ * AJV schema first — refuses to write invalid bytes to disk.
+ *
+ * Insertion-order serialization (`JSON.stringify(value, null, 2)`) per
+ * `canonical-json.ts:50-52`. Atomic temp+rename per `settings-io.ts:241-244`.
+ *
+ * Sort discipline lives at the call site — this writer does NOT sort. The
+ * aggregator and upsert helpers handle sort order (lock 32).
+ */
+export function writeSessionJson(filePath: string, value: SessionJson): void {
+  if (!validateSessionJson(value)) {
+    const messages = formatAjvErrors(validateSessionJson.errors);
+    throw new ConfigCascadeError(
+      'parse',
+      `Refusing to write invalid session.json:\n${messages}`,
+      { path: filePath },
+    );
+  }
+  atomicWriteJson(filePath, value);
+}
+
+/** Atomic write for `ProjectJson`. Same contract as `writeSessionJson`. */
+export function writeProjectJson(filePath: string, value: ProjectJson): void {
+  if (!validateProjectJson(value)) {
+    const messages = formatAjvErrors(validateProjectJson.errors);
+    throw new ConfigCascadeError(
+      'parse',
+      `Refusing to write invalid project.json:\n${messages}`,
+      { path: filePath },
+    );
+  }
+  atomicWriteJson(filePath, value);
+}
+
+function atomicWriteJson(filePath: string, value: unknown): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  const payload = `${JSON.stringify(value, null, 2)}\n`;
+  const tmpPath = `${filePath}.tmp`;
+  writeFileSync(tmpPath, payload, 'utf8');
+  renameSync(tmpPath, filePath);
+}
+
+// ---------------------------------------------------------------------------
+// Stub writer — `gobbi workflow init` calls this with required-only fields
+// ---------------------------------------------------------------------------
+
+export interface WriteSessionStubArgs {
+  readonly repoRoot: string;
+  readonly projectName: string;
+  readonly sessionId: string;
+  readonly task: string;
+  readonly gobbiVersion: string;
+  readonly createdAt: string;
+}
+
+/**
+ * Write the init-time `session.json` stub: the 6 required fields, no
+ * `steps[]` (steps absent → reader convention "stub" per lock 43),
+ * `finishedAt: null`. Idempotent — same input produces identical bytes.
+ *
+ * `projectId === projectName` today (post-rename per ideation lock 3); the
+ * field name is retained for forward-compat with a future projectId surface
+ * that may diverge from the on-disk project name.
+ */
+export function writeSessionStub(args: WriteSessionStubArgs): void {
+  const { repoRoot, projectName, sessionId, task, gobbiVersion, createdAt } = args;
+  const stub: SessionJson = {
+    schemaVersion: 1,
+    sessionId,
+    projectId: projectName,
+    createdAt,
+    finishedAt: null,
+    gobbiVersion,
+    task,
+  };
+  const filePath = sessionJsonPath(repoRoot, projectName, sessionId);
+  writeSessionJson(filePath, stub);
+}
+
+// ---------------------------------------------------------------------------
+// Sort primitives — applied at writer call sites (lock 32)
+// ---------------------------------------------------------------------------
+
+function sortByCreatedAt<T extends { readonly createdAt: string }>(
+  rows: readonly T[],
+): readonly T[] {
+  return [...rows].sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+}
+
+function sortByPath<T extends { readonly path: string }>(
+  rows: readonly T[],
+): readonly T[] {
+  return [...rows].sort((a, b) => a.path.localeCompare(b.path));
+}
+
+function sortByRecordedAt<T extends { readonly recordedAt: string }>(
+  rows: readonly T[],
+): readonly T[] {
+  return [...rows].sort((a, b) => a.recordedAt.localeCompare(b.recordedAt));
+}
+
+// ---------------------------------------------------------------------------
+// project.json upsert helpers
+// ---------------------------------------------------------------------------
+
+export interface UpsertProjectSessionArgs {
+  readonly path: string;
+  readonly entry: ProjectJsonSession;
+  readonly projectName?: string;
+  readonly projectId?: string;
+}
+
+/**
+ * Insert or replace a `ProjectJsonSession` in `project.json.sessions[]`,
+ * keyed by `sessionId`. If the file does not exist, creates a fresh
+ * `ProjectJson` with `projectName` / `projectId` derived from
+ * `args.projectName` / `args.projectId` (or `path.basename(dirname(path))`
+ * if neither supplied).
+ *
+ * Sort by `createdAt` ASC; atomic write. Solo-user race acknowledged
+ * (lock 42) — concurrent writers can drop one update.
+ */
+export function upsertProjectSession(args: UpsertProjectSessionArgs): void {
+  const current = ensureProjectJson(args.path, args.projectName, args.projectId);
+  const sessions = upsertById(current.sessions, args.entry, (s) => s.sessionId);
+  const next: ProjectJson = {
+    ...current,
+    sessions: sortByCreatedAt(sessions),
+  };
+  writeProjectJson(args.path, next);
+}
+
+export interface UpsertProjectGotchaArgs {
+  readonly path: string;
+  readonly entry: ProjectJsonGotcha;
+  readonly projectName?: string;
+  readonly projectId?: string;
+}
+
+/**
+ * Insert or replace a `ProjectJsonGotcha` in `project.json.gotchas[]`,
+ * keyed by `path`. Writes a fresh `ProjectJson` if the file is absent.
+ * Sort by `path` ASC; atomic write.
+ */
+export function upsertProjectGotcha(args: UpsertProjectGotchaArgs): void {
+  const current = ensureProjectJson(args.path, args.projectName, args.projectId);
+  const gotchas = upsertById(current.gotchas, args.entry, (g) => g.path);
+  const next: ProjectJson = {
+    ...current,
+    gotchas: sortByPath(gotchas),
+  };
+  writeProjectJson(args.path, next);
+}
+
+function ensureProjectJson(
+  filePath: string,
+  projectName: string | undefined,
+  projectId: string | undefined,
+): ProjectJson {
+  const existing = readProjectJson(filePath);
+  if (existing !== null) return existing;
+  const fallbackName = path.basename(path.dirname(filePath));
+  return {
+    schemaVersion: 1,
+    projectName: projectName ?? fallbackName,
+    projectId: projectId ?? projectName ?? fallbackName,
+    sessions: [],
+    gotchas: [],
+    decisions: [],
+    learnings: [],
+  };
+}
+
+function upsertById<T>(
+  rows: readonly T[],
+  next: T,
+  keyOf: (row: T) => string,
+): readonly T[] {
+  const key = keyOf(next);
+  const filtered = rows.filter((row) => keyOf(row) !== key);
+  return [...filtered, next];
+}
+
+// ---------------------------------------------------------------------------
+// Memorization aggregator
+// ---------------------------------------------------------------------------
+
+export interface AggregateSessionJsonArgs {
+  readonly store: ReadStore;
+  readonly sessionId: string;
+  readonly projectId: string;
+  readonly createdAt: string;
+  readonly gobbiVersion: string;
+  readonly task: string;
+  /**
+   * Override for the parent directory containing `<sessionId>/subagents/`.
+   * Defaults to `dirname($CLAUDE_TRANSCRIPT_PATH)` (Plan-eval Overall H1
+   * primary discovery path). When unset and the env var is also unset, the
+   * fallback glob under `~/.claude/projects/<encoded-cwd>/<sessionId>/`
+   * runs; if both fail, agents emit `calls: []` + one-line stderr warning.
+   */
+  readonly transcriptDir?: string;
+  /**
+   * Optional override for the encoded cwd used in the fallback glob. When
+   * absent, the glob walks every `~/.claude/projects/<dir>/` looking for a
+   * matching `<sessionId>/subagents/` subdirectory.
+   */
+  readonly encodedCwd?: string;
+  /**
+   * Override for the `~/.claude` root used by the fallback glob. Test-only;
+   * defaults to `process.env.HOME ?? '/'`.
+   */
+  readonly claudeHome?: string;
+  /**
+   * Optional terminal-event override for `finishedAt`. Memorization writes
+   * before `workflow.finish` lands, so `finishedAt` is typically `null`
+   * during the post-commit dispatch in T-2a.8.2. Tests can supply a value.
+   */
+  readonly finishedAt?: string | null;
+}
+
+/**
+ * Build a fully-populated `SessionJson` from the workspace event store and
+ * the per-subagent JSONL transcripts. Async because `buildAgentCalls` walks
+ * JSONL streams (lock 33). Pure with respect to the caller — returns the
+ * value, never writes.
+ *
+ * Algorithm:
+ *
+ *   1. Replay every event row partitioned by `sessionId`.
+ *   2. Walk WORKFLOW step lifecycle events to build `steps[].iterations[]`
+ *      with `terminationReason`.
+ *   3. For each `delegation.spawn` event, build an `AgentEntry` with the
+ *      JSONL-derived `calls[]`. Tokens roll up via SUM-fold (lock 34).
+ *   4. Cost rolls up via `aggregateDelegationCosts` (lock 36).
+ *   5. Lift agents into substeps (when present) or directly into the
+ *      iteration's flat `agents[]` (memorization-style step shape).
+ *   6. Sort every array by `seq` ASC (lock 32).
+ */
+export async function aggregateSessionJson(
+  args: AggregateSessionJsonArgs,
+): Promise<SessionJson> {
+  const { store, sessionId, projectId, createdAt, gobbiVersion, task } = args;
+
+  const allRows = store.replayAll();
+  const rows = allRows.filter((row) => rowBelongsToSession(row, sessionId));
+
+  const finishRow =
+    rows.find((row) => row.type === 'workflow.finish') ??
+    rows.find((row) => row.type === 'workflow.abort') ??
+    null;
+  const finishedAt =
+    args.finishedAt !== undefined
+      ? args.finishedAt
+      : finishRow !== null
+        ? finishRow.ts
+        : null;
+
+  // Build agent entries — keyed by subagentId.
+  const costsBySubagent = buildCostsBySubagent(store);
+  const agentMap = new Map<string, AnthropicAgentEntry>();
+  for (const row of rows) {
+    if (row.type === 'delegation.spawn') {
+      const agent = await buildAgentFromSpawn(row, rows, costsBySubagent, args);
+      if (agent !== null) {
+        agentMap.set(agent.id, agent);
+      }
+    }
+  }
+
+  // Build steps with iterations + terminationReason. Substeps default to
+  // a single empty axis if no substep events exist; agents lift to the
+  // iteration's flat `agents[]` instead.
+  const steps = buildSteps(rows, agentMap);
+
+  return {
+    schemaVersion: 1,
+    sessionId,
+    projectId,
+    createdAt,
+    finishedAt,
+    gobbiVersion,
+    task,
+    steps,
+  };
+}
+
+function rowBelongsToSession(row: EventRow, sessionId: string): boolean {
+  // EventStore writes session_id on every v5+ row. Legacy rows (null) are
+  // tolerated — if every row in the store is null, the aggregator yields
+  // no agents, which is the documented degraded state.
+  if (row.session_id === null) return true;
+  return row.session_id === sessionId;
+}
+
+function buildCostsBySubagent(store: ReadStore): ReadonlyMap<string, number> {
+  const acc = new Map<string, number>();
+  let costs: readonly CostAggregateRow[];
+  try {
+    costs = store.aggregateDelegationCosts();
+  } catch {
+    return acc;
+  }
+  for (const cost of costs) {
+    if (cost.subagentId === null) continue;
+    const dollars = derivedCost(cost.tokensJson, cost.model);
+    acc.set(cost.subagentId, (acc.get(cost.subagentId) ?? 0) + dollars);
+  }
+  return acc;
+}
+
+async function buildAgentFromSpawn(
+  spawn: EventRow,
+  rows: readonly EventRow[],
+  costsBySubagent: ReadonlyMap<string, number>,
+  args: AggregateSessionJsonArgs,
+): Promise<AnthropicAgentEntry | null> {
+  const spawnData = parseEventData(spawn);
+  if (spawnData === null) return null;
+  const subagentId = readString(spawnData['subagentId']);
+  if (subagentId === null) return null;
+
+  const completeRow = findCompleteOrFail(rows, subagentId);
+  const completeData = completeRow !== null ? parseEventData(completeRow) : null;
+  const failData =
+    completeRow !== null && completeRow.type === 'delegation.fail' ? parseEventData(completeRow) : null;
+
+  const calls = await buildAgentCalls({
+    sessionId: args.sessionId,
+    subagentId,
+    spawnSeq: spawn.seq,
+    ...(args.transcriptDir !== undefined ? { transcriptDir: args.transcriptDir } : {}),
+    ...(args.encodedCwd !== undefined ? { encodedCwd: args.encodedCwd } : {}),
+    ...(args.claudeHome !== undefined ? { claudeHome: args.claudeHome } : {}),
+  });
+
+  const tokensUsed = sumCallTokens(calls);
+  const cacheHitRatio = computeCacheHitRatio(tokensUsed);
+
+  const transcriptPath =
+    failData !== null
+      ? readString(failData['transcriptPath'])
+      : completeData !== null
+        ? readString(completeData['artifactPath'])
+        : null;
+
+  const sizeProxyBytes =
+    completeData !== null ? readNumber(completeData['sizeProxyBytes']) : null;
+
+  const outcome: DelegationOutcome | null =
+    completeRow === null
+      ? 'running'
+      : completeRow.type === 'delegation.complete'
+        ? 'complete'
+        : 'fail';
+
+  const startedAt = readString(spawnData['timestamp']);
+  const finishedAt = completeRow !== null ? completeRow.ts : null;
+  const claudeCodeVersion = readString(spawnData['claudeCodeVersion']);
+  const name = readString(spawnData['agentType']) ?? subagentId;
+
+  // Model — first non-null model from calls[] (Anthropic JSONL records the
+  // model on every assistant line; first call wins).
+  const model =
+    calls.find((call): call is AnthropicAgentCallEntry & { model: string } =>
+      typeof call.model === 'string' && call.model.length > 0,
+    )?.model ?? null;
+
+  const costUsd = costsBySubagent.get(subagentId) ?? null;
+
+  return {
+    provider: 'anthropic',
+    id: subagentId,
+    seq: spawn.seq,
+    name,
+    model,
+    skillsLoaded: [],
+    startedAt,
+    finishedAt,
+    outcome,
+    costUsd,
+    calls,
+    claudeCodeVersion,
+    transcriptPath,
+    transcriptSha256: null,
+    tokensUsed,
+    cacheHitRatio,
+    sizeProxyBytes,
+  };
+}
+
+function findCompleteOrFail(
+  rows: readonly EventRow[],
+  subagentId: string,
+): EventRow | null {
+  for (const row of rows) {
+    if (row.type !== 'delegation.complete' && row.type !== 'delegation.fail') {
+      continue;
+    }
+    const data = parseEventData(row);
+    if (data === null) continue;
+    if (data['subagentId'] === subagentId) return row;
+  }
+  return null;
+}
+
+function parseEventData(row: EventRow): Record<string, unknown> | null {
+  try {
+    const parsed: unknown = JSON.parse(row.data);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function readString(value: unknown): string | null {
+  return isString(value) && value !== '' ? value : null;
+}
+
+function readNumber(value: unknown): number | null {
+  return isNumber(value) && Number.isFinite(value) ? value : null;
+}
+
+function sumCallTokens(
+  calls: readonly AnthropicAgentCallEntry[],
+): AnthropicTokensUsed | null {
+  if (calls.length === 0) return null;
+  let any = false;
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let cacheReadTokens = 0;
+  let cacheCreationTokens = 0;
+  for (const call of calls) {
+    if (typeof call.inputTokens === 'number') {
+      inputTokens += call.inputTokens;
+      any = true;
+    }
+    if (typeof call.outputTokens === 'number') {
+      outputTokens += call.outputTokens;
+      any = true;
+    }
+    if (typeof call.cacheReadTokens === 'number') {
+      cacheReadTokens += call.cacheReadTokens;
+      any = true;
+    }
+    if (typeof call.cacheCreationTokens === 'number') {
+      cacheCreationTokens += call.cacheCreationTokens;
+      any = true;
+    }
+  }
+  if (!any) return null;
+  return {
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    cache_read_input_tokens: cacheReadTokens,
+    cache_creation_input_tokens: cacheCreationTokens,
+  };
+}
+
+function computeCacheHitRatio(tokens: AnthropicTokensUsed | null): number | null {
+  if (tokens === null) return null;
+  if (tokens.input_tokens <= 0) return null;
+  return tokens.cache_read_input_tokens / tokens.input_tokens;
+}
+
+// ---------------------------------------------------------------------------
+// Step-and-iteration builder
+// ---------------------------------------------------------------------------
+
+const PRODUCTIVE_STEPS = ['ideation', 'planning', 'execution', 'memorization'] as const;
+
+type ProductiveStep = (typeof PRODUCTIVE_STEPS)[number];
+
+function isProductiveStep(value: string): value is ProductiveStep {
+  return (PRODUCTIVE_STEPS as readonly string[]).includes(value);
+}
+
+function buildSteps(
+  rows: readonly EventRow[],
+  agentMap: ReadonlyMap<string, AnthropicAgentEntry>,
+): readonly StepEntry[] {
+  const out: StepEntry[] = [];
+  for (const stepId of PRODUCTIVE_STEPS) {
+    const stepRows = rows.filter((row) => row.step === stepId);
+    if (stepRows.length === 0) continue;
+
+    const startedAt = stepRows[0]?.ts ?? null;
+    const exitRow = stepRows.find((row) => row.type === 'workflow.step.exit') ?? null;
+    const skipRow = stepRows.find((row) => row.type === 'workflow.step.skip') ?? null;
+    const timeoutRow = stepRows.find((row) => row.type === 'workflow.step.timeout') ?? null;
+    const abortRow = stepRows.find((row) => row.type === 'workflow.abort') ?? null;
+
+    const finishedAt =
+      exitRow !== null
+        ? exitRow.ts
+        : abortRow !== null
+          ? abortRow.ts
+          : null;
+
+    const iterations = buildIterations(stepId, stepRows, agentMap);
+
+    if (startedAt === null) continue;
+
+    out.push({
+      id: stepId,
+      startedAt,
+      finishedAt,
+      skippedAt: skipRow !== null ? skipRow.ts : null,
+      timedOutAt: timeoutRow !== null ? timeoutRow.ts : null,
+      iterations,
+    });
+  }
+  return out;
+}
+
+function buildIterations(
+  stepId: ProductiveStep,
+  stepRows: readonly EventRow[],
+  agentMap: ReadonlyMap<string, AnthropicAgentEntry>,
+): readonly IterationEntry[] {
+  // v1 simple iteration model: one round per step. The state machine
+  // currently emits one terminal event per step, so this is faithful.
+  // When loop iterations land (Wave D.1), this builder grows a round
+  // splitter; the schema accepts the wider shape unchanged.
+  const exit = stepRows.find((row) => row.type === 'workflow.step.exit') ?? null;
+  const skip = stepRows.find((row) => row.type === 'workflow.step.skip') ?? null;
+  const timeout = stepRows.find((row) => row.type === 'workflow.step.timeout') ?? null;
+  const abort = stepRows.find((row) => row.type === 'workflow.abort') ?? null;
+
+  const startedAt = stepRows[0]?.ts ?? null;
+  if (startedAt === null) return [];
+
+  const terminal = exit ?? skip ?? timeout ?? abort;
+  const finishedAt = terminal !== null ? terminal.ts : null;
+
+  let terminationReason: TerminationReason;
+  if (exit !== null) terminationReason = 'exit';
+  else if (skip !== null) terminationReason = 'skip';
+  else if (timeout !== null) terminationReason = 'timeout';
+  else if (abort !== null) terminationReason = 'aborted';
+  else terminationReason = 'in-flight';
+
+  // Lift agents directly under the iteration when no substep axis is
+  // detected. v1 does not emit substep markers; substeps[] stays absent.
+  const agents = collectAgentsForStep(stepRows, agentMap);
+
+  if (agents.length === 0) {
+    return [
+      {
+        round: 0,
+        startedAt,
+        finishedAt,
+        terminationReason,
+      },
+    ];
+  }
+
+  return [
+    {
+      round: 0,
+      startedAt,
+      finishedAt,
+      terminationReason,
+      agents,
+    },
+  ];
+}
+
+function collectAgentsForStep(
+  stepRows: readonly EventRow[],
+  agentMap: ReadonlyMap<string, AnthropicAgentEntry>,
+): readonly AnthropicAgentEntry[] {
+  const seen = new Set<string>();
+  const out: AnthropicAgentEntry[] = [];
+  for (const row of stepRows) {
+    if (row.type !== 'delegation.spawn') continue;
+    const data = parseEventData(row);
+    if (data === null) continue;
+    const subagentId = readString(data['subagentId']);
+    if (subagentId === null) continue;
+    if (seen.has(subagentId)) continue;
+    seen.add(subagentId);
+    const agent = agentMap.get(subagentId);
+    if (agent !== undefined) {
+      out.push(agent);
+    }
+  }
+  return out.sort((a, b) => a.seq - b.seq);
+}
+
+// ---------------------------------------------------------------------------
+// JSONL transcript walker — buildAgentCalls
+// ---------------------------------------------------------------------------
+
+export interface BuildAgentCallsArgs {
+  readonly sessionId: string;
+  readonly subagentId: string;
+  readonly spawnSeq: number;
+  readonly transcriptDir?: string;
+  readonly encodedCwd?: string;
+  readonly claudeHome?: string;
+}
+
+/**
+ * Walk the per-subagent JSONL transcript and build a list of
+ * `AgentCallEntry` rows — one per assistant message line. Discovery order:
+ *
+ *   1. `args.transcriptDir/<sessionId>/subagents/agent-<subagentId>.jsonl`
+ *   2. `dirname($CLAUDE_TRANSCRIPT_PATH)/<sessionId>/subagents/agent-<subagentId>.jsonl`
+ *   3. fallback glob: `<claudeHome>/.claude/projects/*\/<sessionId>/subagents/agent-<subagentId>.jsonl`
+ *
+ * If none of the above resolves, returns `[]` and emits a one-line stderr
+ * warning. Best-effort by design — older transcripts may have been GC'd.
+ *
+ * The `seq` field on each call is offset from `spawnSeq + 1 + turnIndex` so
+ * cross-array sort is deterministic — calls inside one agent always sort
+ * after the spawn event and in turn order.
+ */
+export async function buildAgentCalls(
+  args: BuildAgentCallsArgs,
+): Promise<readonly AnthropicAgentCallEntry[]> {
+  const transcriptPath = resolveTranscriptPath(args);
+  if (transcriptPath === null) {
+    process.stderr.write(
+      `[json-memory] no transcript found for subagent ${args.subagentId} in session ${args.sessionId}\n`,
+    );
+    return [];
+  }
+
+  const calls: AnthropicAgentCallEntry[] = [];
+  let turnIndex = 0;
+  for await (const line of parseJsonlFile(transcriptPath)) {
+    if (!isRecord(line)) continue;
+    if (line['type'] !== 'assistant') continue;
+    const message = line['message'];
+    if (!isRecord(message)) continue;
+
+    const usage = isRecord(message['usage']) ? message['usage'] : null;
+    const stopReason = readString(message['stop_reason']);
+    const requestId = readString(line['requestId']);
+    const ts = readString(line['timestamp']);
+    const model = readString(message['model']);
+
+    calls.push({
+      seq: args.spawnSeq + 1 + turnIndex,
+      turnIndex,
+      model,
+      ts,
+      stopReason,
+      requestId,
+      inputTokens: usage !== null ? readNumber(usage['input_tokens']) : null,
+      outputTokens: usage !== null ? readNumber(usage['output_tokens']) : null,
+      cacheReadTokens: usage !== null ? readNumber(usage['cache_read_input_tokens']) : null,
+      cacheCreationTokens: usage !== null ? readNumber(usage['cache_creation_input_tokens']) : null,
+    });
+    turnIndex += 1;
+  }
+
+  // Already in transcript-line order; explicit sort is a no-op insurance
+  // against generator interleaving (currently impossible, but cheap).
+  return calls.sort((a, b) => a.turnIndex - b.turnIndex);
+}
+
+function resolveTranscriptPath(args: BuildAgentCallsArgs): string | null {
+  const fileName = `agent-${args.subagentId}.jsonl`;
+
+  // Primary: explicit transcriptDir override.
+  if (args.transcriptDir !== undefined && args.transcriptDir !== '') {
+    const candidate = path.join(args.transcriptDir, args.sessionId, 'subagents', fileName);
+    if (existsSync(candidate)) return candidate;
+  }
+
+  // Secondary: dirname($CLAUDE_TRANSCRIPT_PATH)
+  const envTranscriptPath = process.env['CLAUDE_TRANSCRIPT_PATH'];
+  if (envTranscriptPath !== undefined && envTranscriptPath !== '') {
+    const envDir = path.dirname(envTranscriptPath);
+    const candidate = path.join(envDir, args.sessionId, 'subagents', fileName);
+    if (existsSync(candidate)) return candidate;
+  }
+
+  // Fallback glob: ~/.claude/projects/<encoded>/<sessionId>/subagents/agent-<id>.jsonl
+  const home = args.claudeHome ?? process.env['HOME'] ?? '';
+  if (home === '') return null;
+  const projectsRoot = path.join(home, '.claude', 'projects');
+  if (!existsSync(projectsRoot)) return null;
+
+  if (args.encodedCwd !== undefined && args.encodedCwd !== '') {
+    const candidate = path.join(
+      projectsRoot,
+      args.encodedCwd,
+      args.sessionId,
+      'subagents',
+      fileName,
+    );
+    if (existsSync(candidate)) return candidate;
+    return null;
+  }
+
+  // Walk every encoded-cwd dir looking for the matching session subdir.
+  let entries: readonly string[];
+  try {
+    entries = readdirSync(projectsRoot);
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    const candidate = path.join(projectsRoot, entry, args.sessionId, 'subagents', fileName);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Provider-discriminant exhaustiveness helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Compile-time exhaustiveness gate for `agent.provider`. Every consumer that
+ * branches on the discriminant MUST end its switch with a call to
+ * `assertNeverProvider(agent)` so widening the union to `'codex'` fails to
+ * compile at every reader (Architecture H1, lock 41).
+ *
+ * Local to this module — not re-exported from a shared helpers file —
+ * so the call site reads as part of the json-memory contract rather than
+ * as a generic utility.
+ */
+export function assertNeverProvider(value: never): never {
+  throw new Error(
+    `json-memory: unreachable agent provider — ${JSON.stringify(value)}`,
+  );
+}

--- a/packages/cli/src/workflow/__tests__/engine.test.ts
+++ b/packages/cli/src/workflow/__tests__/engine.test.ts
@@ -1,23 +1,17 @@
 /**
- * Engine-level tests for `resolveWorkflowState` — covers the state.json
- * fast path and the three-level fallback chain.
+ * Engine-level tests for `resolveWorkflowState` and
+ * `appendEventAndUpdateState`.
  *
- * Performance invariant: when state.json is present and valid, the
- * resolution path MUST NOT call `store.replayAll()`. Every hook (guard,
- * stop, capture-*) pays the cost of this function on every invocation,
- * so a full-table scan on the warm path would accumulate. A spy on
- * `replayAll` asserts the invariant explicitly.
+ * Per PR-FIN-2a-ii (T-2a.9.unified) the engine no longer maintains a
+ * `state.json` projection; every `resolveWorkflowState` call replays
+ * the partition-filtered event stream and runs the reducer.
+ * Partition-aware reads (Option α at the EventStore layer) cap the
+ * replay cost at the calling session's own events.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import fc from 'fast-check';
-import {
-  existsSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -27,11 +21,7 @@ import {
   ReducerRejectionError,
 } from '../engine.js';
 import { EventStore } from '../store.js';
-import {
-  backupState,
-  initialState,
-  writeState,
-} from '../state.js';
+import { initialState } from '../state.js';
 import type { WorkflowState, WorkflowStep } from '../state.js';
 import { WORKFLOW_EVENTS } from '../events/workflow.js';
 import type { Event } from '../events/index.js';
@@ -86,171 +76,43 @@ async function seedStartEvent(
 }
 
 // ===========================================================================
-// Fast path — state.json valid
+// resolveWorkflowState — pure event replay (PR-FIN-2a-ii / T-2a.9.unified)
 // ===========================================================================
 
-describe('resolveWorkflowState — state.json fast path', () => {
-  it('returns state.json without calling store.replayAll when state is valid', async () => {
+describe('resolveWorkflowState — pure event replay', () => {
+  it('replays the event stream every call (no state.json projection)', async () => {
     using store = new EventStore(':memory:');
-    const sessionId = 'engine-fast';
+    const sessionId = 'engine-replay';
 
-    // Seed one event so replayAll would have something non-trivial if
-    // it were called. appendEventAndUpdateState internally uses the
-    // transaction + state.json write path — the state.json on disk is
-    // the authoritative fast-path source.
     await seedStartEvent(store, testDir, sessionId);
-    expect(existsSync(join(testDir, 'state.json'))).toBe(true);
 
     const spied = instrumentReplayAll(store);
     const state = resolveWorkflowState(testDir, spied.store, sessionId);
 
-    // Fast path must not have triggered replayAll even once.
-    expect(spied.count()).toBe(0);
+    expect(spied.count()).toBe(1);
     expect(state.sessionId).toBe(sessionId);
     expect(state.currentStep).toBe('ideation');
   });
 
-  it('returns the exact state that was written to state.json', () => {
+  it('initial state when the event log is empty', () => {
     using store = new EventStore(':memory:');
-    const sessionId = 'engine-exact';
-
-    // Write state.json directly (no events) — confirms readState is the
-    // only source on the fast path, not deriveState.
-    const written: WorkflowState = {
-      ...initialState(sessionId),
-      currentStep: 'planning',
-      feedbackRound: 2,
-    };
-    writeState(testDir, written);
-
+    const sessionId = 'engine-empty';
     const state = resolveWorkflowState(testDir, store, sessionId);
-    expect(state.currentStep).toBe('planning');
-    expect(state.feedbackRound).toBe(2);
-  });
-});
-
-// ===========================================================================
-// Fallback — state.json missing → replay
-// ===========================================================================
-
-describe('resolveWorkflowState — state.json missing', () => {
-  it('falls through to replayAll when state.json is absent and no backup exists', async () => {
-    using store = new EventStore(':memory:');
-    const sessionId = 'engine-missing';
-
-    // Seed an event then delete state.json (and any backup) so only the
-    // SQLite store can answer.
-    await seedStartEvent(store, testDir, sessionId);
-    const statePath = join(testDir, 'state.json');
-    const backupPath = join(testDir, 'state.json.backup');
-    if (existsSync(statePath)) rmSync(statePath);
-    if (existsSync(backupPath)) rmSync(backupPath);
-
-    const spied = instrumentReplayAll(store);
-    const state = resolveWorkflowState(testDir, spied.store, sessionId);
-
-    // Replay was the only route to a valid state.
-    expect(spied.count()).toBe(1);
-    expect(state.currentStep).toBe('ideation');
     expect(state.sessionId).toBe(sessionId);
+    expect(state.currentStep).toBe('idle');
   });
 
-  it('does not call replayAll when backup covers the missing state.json', async () => {
+  it('every call replays — no state.json fast-path skipping the store', async () => {
     using store = new EventStore(':memory:');
-    const sessionId = 'engine-backup';
+    const sessionId = 'engine-no-fast-path';
 
-    // Seed → snapshot state.json to backup → delete state.json.
     await seedStartEvent(store, testDir, sessionId);
-    backupState(testDir);
-    rmSync(join(testDir, 'state.json'));
 
     const spied = instrumentReplayAll(store);
-    const state = resolveWorkflowState(testDir, spied.store, sessionId);
-
-    // Backup is a disk read — replay should still be skipped.
-    expect(spied.count()).toBe(0);
-    expect(state.currentStep).toBe('ideation');
-  });
-});
-
-// ===========================================================================
-// Fallback — state.json corrupt → replay
-// ===========================================================================
-
-describe('resolveWorkflowState — state.json corrupt', () => {
-  it('falls through to replayAll when state.json is unparseable and backup missing', async () => {
-    using store = new EventStore(':memory:');
-    const sessionId = 'engine-corrupt';
-
-    await seedStartEvent(store, testDir, sessionId);
-    // Corrupt state.json to force readState → null; drop backup so the
-    // middle fallback cannot rescue the resolution.
-    writeFileSync(join(testDir, 'state.json'), '{not json', 'utf8');
-    const backupPath = join(testDir, 'state.json.backup');
-    if (existsSync(backupPath)) rmSync(backupPath);
-
-    const spied = instrumentReplayAll(store);
-    const state = resolveWorkflowState(testDir, spied.store, sessionId);
-
-    expect(spied.count()).toBe(1);
-    expect(state.currentStep).toBe('ideation');
-  });
-
-  it('prefers backup over replay when state.json is corrupt but backup is valid', async () => {
-    using store = new EventStore(':memory:');
-    const sessionId = 'engine-corrupt-with-backup';
-
-    // Seed an event so the backup captures a valid state, then corrupt
-    // the primary.
-    await seedStartEvent(store, testDir, sessionId);
-    backupState(testDir);
-    writeFileSync(join(testDir, 'state.json'), 'corrupt', 'utf8');
-
-    const spied = instrumentReplayAll(store);
-    const state = resolveWorkflowState(testDir, spied.store, sessionId);
-
-    // Backup is still a file read — replay should not fire.
-    expect(spied.count()).toBe(0);
-    expect(state.currentStep).toBe('ideation');
-  });
-
-  it('falls through to replayAll when state.json has the wrong schema shape', async () => {
-    using store = new EventStore(':memory:');
-    const sessionId = 'engine-wrong-shape';
-
-    await seedStartEvent(store, testDir, sessionId);
-    // Parseable JSON, but missing required fields → isValidState false.
-    writeFileSync(
-      join(testDir, 'state.json'),
-      JSON.stringify({ note: 'not a WorkflowState' }),
-      'utf8',
-    );
-    const backupPath = join(testDir, 'state.json.backup');
-    if (existsSync(backupPath)) rmSync(backupPath);
-
-    const spied = instrumentReplayAll(store);
-    const state = resolveWorkflowState(testDir, spied.store, sessionId);
-
-    expect(spied.count()).toBe(1);
-    expect(state.currentStep).toBe('ideation');
-  });
-
-  it('does not leave the primary state.json content unchanged — resolveWorkflowState is read-only', async () => {
-    using store = new EventStore(':memory:');
-    const sessionId = 'engine-read-only';
-
-    // Confirm state.json content is untouched by resolveWorkflowState
-    // even when it falls through to replay. Greg-Young discipline:
-    // never rewrite on-disk state during a read.
-    await seedStartEvent(store, testDir, sessionId);
-    const corrupt = '{corrupt';
-    writeFileSync(join(testDir, 'state.json'), corrupt, 'utf8');
-    const backupPath = join(testDir, 'state.json.backup');
-    if (existsSync(backupPath)) rmSync(backupPath);
-
-    resolveWorkflowState(testDir, store, sessionId);
-
-    expect(readFileSync(join(testDir, 'state.json'), 'utf8')).toBe(corrupt);
+    resolveWorkflowState(testDir, spied.store, sessionId);
+    resolveWorkflowState(testDir, spied.store, sessionId);
+    resolveWorkflowState(testDir, spied.store, sessionId);
+    expect(spied.count()).toBe(3);
   });
 });
 
@@ -309,7 +171,7 @@ describe('appendEventAndUpdateState — reducer rejection audit', () => {
     expect(data.timestamp).toBe('2026-01-02T00:00:00.000Z');
   });
 
-  it('state on disk is unchanged after a rejection (backup restore)', async () => {
+  it('state from the event log is unchanged after a rejection (transaction rollback)', async () => {
     using store = new EventStore(':memory:');
     const sessionId = 'audit-emit-state';
 
@@ -335,52 +197,10 @@ describe('appendEventAndUpdateState — reducer rejection audit', () => {
       // Expected.
     }
 
+    // Re-derive — the rejected event's row was rolled back, so the
+    // replay returns the same state we observed before the attempt.
     const after = resolveWorkflowState(testDir, store, sessionId);
-    // Every field preserved.
     expect(after).toEqual(before);
-  });
-
-  it('filesystem-only failures do NOT emit an audit event', async () => {
-    using store = new EventStore(':memory:');
-    const sessionId = 'audit-emit-fs';
-
-    await seedStartEvent(store, testDir, sessionId);
-    const before = resolveWorkflowState(testDir, store, sessionId);
-
-    // Force writeState to fail by making testDir a non-writable path.
-    // Approach: instrument the store to replicate the FS-failure path by
-    // replacing the event data with an object that JSON-serialises but
-    // triggers `writeState` to throw via a tampered state directory.
-    //
-    // Simpler approach: pass a dir that does not exist and is not
-    // creatable — the mkdirSync call inside writeState throws with an
-    // EACCES/ENOENT surface. We simulate by pointing at a path under a
-    // file (writing through a file path returns ENOTDIR).
-    const blockedFile = join(testDir, 'not-a-dir-file');
-    writeFileSync(blockedFile, 'block');
-    const blockedDir = join(blockedFile, 'subpath'); // writeState → ENOTDIR
-
-    // Valid event — reducer accepts, but FS write fails.
-    const validEvent: Event = {
-      type: WORKFLOW_EVENTS.STEP_EXIT,
-      data: { step: 'ideation' },
-    };
-    await expect(
-      appendEventAndUpdateState(
-        store,
-        blockedDir,
-        { ...before, evalConfig: { ideation: false, planning: false } },
-        validEvent,
-        'cli',
-        sessionId,
-        'tool-call',
-        'tc-fs-fail',
-      ),
-    ).rejects.toThrow();
-
-    // No audit emitted — this was a FS failure, not a reducer rejection.
-    const audits = store.byType(WORKFLOW_EVENTS.INVALID_TRANSITION);
-    expect(audits).toHaveLength(0);
   });
 
   it('property test: reducer rejections always produce exactly one audit + original error', async () => {
@@ -401,18 +221,15 @@ describe('appendEventAndUpdateState — reducer rejection audit', () => {
           const sessionId = `prop-${step}`;
           const dir = mkdtempSync(join(tmpdir(), `gobbi-prop-${step}-`));
           try {
-            await seedStartEvent(store, dir, sessionId);
-
             // Fabricate a state where `workflow.abort` is invalid (any
-            // non-error active step triggers rejection).
+            // non-error active step triggers rejection). The engine
+            // reducer is now driven entirely by the in-memory `state`
+            // argument — there is no state.json projection to keep in
+            // sync, so the synthetic state is supplied directly.
             const state: WorkflowState = {
               ...initialState(sessionId),
               currentStep: step,
             };
-            // Overwrite state.json so the engine's backup matches our
-            // synthetic state, keeping the assertion about "state
-            // unchanged post-rejection" meaningful.
-            writeState(dir, state);
 
             const rejected: Event = {
               type: WORKFLOW_EVENTS.ABORT,
@@ -438,12 +255,17 @@ describe('appendEventAndUpdateState — reducer rejection audit', () => {
               thrown = err;
             }
 
-            // (a) state unchanged — resolveWorkflowState returns the same
-            // record.
-            const resolved = resolveWorkflowState(dir, store, sessionId);
-            if (resolved.currentStep !== step) {
+            // (a) the rejected event was rolled back — the only event in
+            // the store should be the audit row.
+            const replayed = store.replayAll();
+            if (replayed.length !== 1) {
               throw new Error(
-                `state mutated: expected ${step}, got ${resolved.currentStep}`,
+                `expected exactly 1 row in store after rejection, got ${replayed.length}`,
+              );
+            }
+            if (replayed[0]?.type !== WORKFLOW_EVENTS.INVALID_TRANSITION) {
+              throw new Error(
+                `expected single row to be the audit, got ${replayed[0]?.type ?? 'missing'}`,
               );
             }
 

--- a/packages/cli/src/workflow/__tests__/engine.test.ts
+++ b/packages/cli/src/workflow/__tests__/engine.test.ts
@@ -63,12 +63,16 @@ function instrumentReplayAll(store: EventStore): { store: EventStore; count: () 
   return { store, count: () => count };
 }
 
-function seedStartEvent(store: EventStore, dir: string, sessionId: string): WorkflowState {
+async function seedStartEvent(
+  store: EventStore,
+  dir: string,
+  sessionId: string,
+): Promise<WorkflowState> {
   const event: Event = {
     type: WORKFLOW_EVENTS.START,
     data: { sessionId, timestamp: '2026-01-01T00:00:00.000Z' },
   };
-  const result = appendEventAndUpdateState(
+  const result = await appendEventAndUpdateState(
     store,
     dir,
     initialState(sessionId),
@@ -86,7 +90,7 @@ function seedStartEvent(store: EventStore, dir: string, sessionId: string): Work
 // ===========================================================================
 
 describe('resolveWorkflowState — state.json fast path', () => {
-  it('returns state.json without calling store.replayAll when state is valid', () => {
+  it('returns state.json without calling store.replayAll when state is valid', async () => {
     using store = new EventStore(':memory:');
     const sessionId = 'engine-fast';
 
@@ -94,7 +98,7 @@ describe('resolveWorkflowState — state.json fast path', () => {
     // it were called. appendEventAndUpdateState internally uses the
     // transaction + state.json write path — the state.json on disk is
     // the authoritative fast-path source.
-    seedStartEvent(store, testDir, sessionId);
+    await seedStartEvent(store, testDir, sessionId);
     expect(existsSync(join(testDir, 'state.json'))).toBe(true);
 
     const spied = instrumentReplayAll(store);
@@ -130,13 +134,13 @@ describe('resolveWorkflowState — state.json fast path', () => {
 // ===========================================================================
 
 describe('resolveWorkflowState — state.json missing', () => {
-  it('falls through to replayAll when state.json is absent and no backup exists', () => {
+  it('falls through to replayAll when state.json is absent and no backup exists', async () => {
     using store = new EventStore(':memory:');
     const sessionId = 'engine-missing';
 
     // Seed an event then delete state.json (and any backup) so only the
     // SQLite store can answer.
-    seedStartEvent(store, testDir, sessionId);
+    await seedStartEvent(store, testDir, sessionId);
     const statePath = join(testDir, 'state.json');
     const backupPath = join(testDir, 'state.json.backup');
     if (existsSync(statePath)) rmSync(statePath);
@@ -151,12 +155,12 @@ describe('resolveWorkflowState — state.json missing', () => {
     expect(state.sessionId).toBe(sessionId);
   });
 
-  it('does not call replayAll when backup covers the missing state.json', () => {
+  it('does not call replayAll when backup covers the missing state.json', async () => {
     using store = new EventStore(':memory:');
     const sessionId = 'engine-backup';
 
     // Seed → snapshot state.json to backup → delete state.json.
-    seedStartEvent(store, testDir, sessionId);
+    await seedStartEvent(store, testDir, sessionId);
     backupState(testDir);
     rmSync(join(testDir, 'state.json'));
 
@@ -174,11 +178,11 @@ describe('resolveWorkflowState — state.json missing', () => {
 // ===========================================================================
 
 describe('resolveWorkflowState — state.json corrupt', () => {
-  it('falls through to replayAll when state.json is unparseable and backup missing', () => {
+  it('falls through to replayAll when state.json is unparseable and backup missing', async () => {
     using store = new EventStore(':memory:');
     const sessionId = 'engine-corrupt';
 
-    seedStartEvent(store, testDir, sessionId);
+    await seedStartEvent(store, testDir, sessionId);
     // Corrupt state.json to force readState → null; drop backup so the
     // middle fallback cannot rescue the resolution.
     writeFileSync(join(testDir, 'state.json'), '{not json', 'utf8');
@@ -192,13 +196,13 @@ describe('resolveWorkflowState — state.json corrupt', () => {
     expect(state.currentStep).toBe('ideation');
   });
 
-  it('prefers backup over replay when state.json is corrupt but backup is valid', () => {
+  it('prefers backup over replay when state.json is corrupt but backup is valid', async () => {
     using store = new EventStore(':memory:');
     const sessionId = 'engine-corrupt-with-backup';
 
     // Seed an event so the backup captures a valid state, then corrupt
     // the primary.
-    seedStartEvent(store, testDir, sessionId);
+    await seedStartEvent(store, testDir, sessionId);
     backupState(testDir);
     writeFileSync(join(testDir, 'state.json'), 'corrupt', 'utf8');
 
@@ -210,11 +214,11 @@ describe('resolveWorkflowState — state.json corrupt', () => {
     expect(state.currentStep).toBe('ideation');
   });
 
-  it('falls through to replayAll when state.json has the wrong schema shape', () => {
+  it('falls through to replayAll when state.json has the wrong schema shape', async () => {
     using store = new EventStore(':memory:');
     const sessionId = 'engine-wrong-shape';
 
-    seedStartEvent(store, testDir, sessionId);
+    await seedStartEvent(store, testDir, sessionId);
     // Parseable JSON, but missing required fields → isValidState false.
     writeFileSync(
       join(testDir, 'state.json'),
@@ -231,14 +235,14 @@ describe('resolveWorkflowState — state.json corrupt', () => {
     expect(state.currentStep).toBe('ideation');
   });
 
-  it('does not leave the primary state.json content unchanged — resolveWorkflowState is read-only', () => {
+  it('does not leave the primary state.json content unchanged — resolveWorkflowState is read-only', async () => {
     using store = new EventStore(':memory:');
     const sessionId = 'engine-read-only';
 
     // Confirm state.json content is untouched by resolveWorkflowState
     // even when it falls through to replay. Greg-Young discipline:
     // never rewrite on-disk state during a read.
-    seedStartEvent(store, testDir, sessionId);
+    await seedStartEvent(store, testDir, sessionId);
     const corrupt = '{corrupt';
     writeFileSync(join(testDir, 'state.json'), corrupt, 'utf8');
     const backupPath = join(testDir, 'state.json.backup');
@@ -255,12 +259,12 @@ describe('resolveWorkflowState — state.json corrupt', () => {
 // ===========================================================================
 
 describe('appendEventAndUpdateState — reducer rejection audit', () => {
-  it('emits workflow.invalid_transition AND re-throws the original error', () => {
+  it('emits workflow.invalid_transition AND re-throws the original error', async () => {
     using store = new EventStore(':memory:');
     const sessionId = 'audit-emit-basic';
 
     // Seed a valid start so the session is in `ideation`.
-    seedStartEvent(store, testDir, sessionId);
+    await seedStartEvent(store, testDir, sessionId);
 
     // Resolve the current state from disk — matches how callers observe
     // state between appends.
@@ -276,7 +280,7 @@ describe('appendEventAndUpdateState — reducer rejection audit', () => {
       data: { reason: 'synthetic rejection for audit test' },
     };
 
-    expect(() =>
+    await expect(
       appendEventAndUpdateState(
         store,
         testDir,
@@ -290,7 +294,7 @@ describe('appendEventAndUpdateState — reducer rejection audit', () => {
         undefined,
         '2026-01-02T00:00:00.000Z',
       ),
-    ).toThrow(ReducerRejectionError);
+    ).rejects.toThrow(ReducerRejectionError);
 
     // The audit event persisted.
     const audits = store.byType(WORKFLOW_EVENTS.INVALID_TRANSITION);
@@ -305,11 +309,11 @@ describe('appendEventAndUpdateState — reducer rejection audit', () => {
     expect(data.timestamp).toBe('2026-01-02T00:00:00.000Z');
   });
 
-  it('state on disk is unchanged after a rejection (backup restore)', () => {
+  it('state on disk is unchanged after a rejection (backup restore)', async () => {
     using store = new EventStore(':memory:');
     const sessionId = 'audit-emit-state';
 
-    seedStartEvent(store, testDir, sessionId);
+    await seedStartEvent(store, testDir, sessionId);
     const before = resolveWorkflowState(testDir, store, sessionId);
 
     const rejected: Event = {
@@ -317,7 +321,7 @@ describe('appendEventAndUpdateState — reducer rejection audit', () => {
       data: {},
     };
     try {
-      appendEventAndUpdateState(
+      await appendEventAndUpdateState(
         store,
         testDir,
         before,
@@ -336,11 +340,11 @@ describe('appendEventAndUpdateState — reducer rejection audit', () => {
     expect(after).toEqual(before);
   });
 
-  it('filesystem-only failures do NOT emit an audit event', () => {
+  it('filesystem-only failures do NOT emit an audit event', async () => {
     using store = new EventStore(':memory:');
     const sessionId = 'audit-emit-fs';
 
-    seedStartEvent(store, testDir, sessionId);
+    await seedStartEvent(store, testDir, sessionId);
     const before = resolveWorkflowState(testDir, store, sessionId);
 
     // Force writeState to fail by making testDir a non-writable path.
@@ -361,7 +365,7 @@ describe('appendEventAndUpdateState — reducer rejection audit', () => {
       type: WORKFLOW_EVENTS.STEP_EXIT,
       data: { step: 'ideation' },
     };
-    expect(() =>
+    await expect(
       appendEventAndUpdateState(
         store,
         blockedDir,
@@ -372,14 +376,14 @@ describe('appendEventAndUpdateState — reducer rejection audit', () => {
         'tool-call',
         'tc-fs-fail',
       ),
-    ).toThrow();
+    ).rejects.toThrow();
 
     // No audit emitted — this was a FS failure, not a reducer rejection.
     const audits = store.byType(WORKFLOW_EVENTS.INVALID_TRANSITION);
     expect(audits).toHaveLength(0);
   });
 
-  it('property test: reducer rejections always produce exactly one audit + original error', () => {
+  it('property test: reducer rejections always produce exactly one audit + original error', async () => {
     const arbActiveStep = fc.constantFrom<WorkflowStep>(
       'ideation',
       'planning',
@@ -390,14 +394,14 @@ describe('appendEventAndUpdateState — reducer rejection audit', () => {
       .date({ noInvalidDate: true })
       .map((d) => d.toISOString());
 
-    fc.assert(
-      fc.property(arbActiveStep, arbTs, (step, ts) => {
+    await fc.assert(
+      fc.asyncProperty(arbActiveStep, arbTs, async (step, ts) => {
         const store = new EventStore(':memory:');
         try {
           const sessionId = `prop-${step}`;
           const dir = mkdtempSync(join(tmpdir(), `gobbi-prop-${step}-`));
           try {
-            seedStartEvent(store, dir, sessionId);
+            await seedStartEvent(store, dir, sessionId);
 
             // Fabricate a state where `workflow.abort` is invalid (any
             // non-error active step triggers rejection).
@@ -417,7 +421,7 @@ describe('appendEventAndUpdateState — reducer rejection audit', () => {
 
             let thrown: unknown = null;
             try {
-              appendEventAndUpdateState(
+              await appendEventAndUpdateState(
                 store,
                 dir,
                 state,

--- a/packages/cli/src/workflow/__tests__/migrate-state-db.integration.test.ts
+++ b/packages/cli/src/workflow/__tests__/migrate-state-db.integration.test.ts
@@ -350,12 +350,12 @@ describe('Wave A.1.10 — replay-equivalence after migration', () => {
   });
 
   test('NULL project_id rows survive the migration round-trip when the store opens without an explicit projectId override', () => {
-    // The backfill at `store.ts:469-475` only runs when `sessionId !==
-    // null`, and the project_id UPDATE inside `backfillSessionAndProjectIds`
-    // only runs when `projectRootBasename !== null` (migrations.ts:281).
-    // Constructing the store with `projectId: undefined` and no resolvable
-    // metadata.json leaves `projectRootBasename` null, so legacy NULL
-    // project_id rows are preserved verbatim.
+    // The backfill at `store.ts` only runs when `sessionId !== null`,
+    // and the project_id UPDATE inside `backfillSessionAndProjectIds`
+    // only runs when `projectId !== null` (migrations.ts). Constructing
+    // the store with `projectId: undefined` (and no metadata fallback —
+    // dropped in PR-FIN-2a-ii / T-2a.9.unified) leaves `projectId` null,
+    // so legacy NULL project_id rows are preserved verbatim.
     const repo = makeScratch();
     const seed: readonly SeedRow[] = [
       {

--- a/packages/cli/src/workflow/__tests__/migrate-state-db.integration.test.ts
+++ b/packages/cli/src/workflow/__tests__/migrate-state-db.integration.test.ts
@@ -376,9 +376,9 @@ describe('Wave A.1.10 — replay-equivalence after migration', () => {
 
     migrateStateDbAt(dbPath, () => 1745000000000);
 
-    // No `projectId` override; the dirname of `dbPath` is `<repo>/.gobbi`
-    // which has no `metadata.json`, so `resolveProjectRootBasename`
-    // yields null and the backfill skips the project_id UPDATE.
+    // No `projectId` override; PR-FIN-2a-ii (T-2a.9.unified) retired the
+    // legacy `metadata.json` reader, so an unsupplied projectId stays
+    // `null` and the backfill skips the project_id UPDATE.
     using store = new EventStore(dbPath, { sessionId: SESSION });
     const replayed = store.replayAll();
     expect(replayed).toHaveLength(1);

--- a/packages/cli/src/workflow/__tests__/migrations.test.ts
+++ b/packages/cli/src/workflow/__tests__/migrations.test.ts
@@ -642,7 +642,7 @@ describe('v4 → v5 schema ALTER + backfill', () => {
       insert.run(1, '2026-04-01T00:00:00Z', 4, 'workflow.start', null, '{}', 'cli', null, 'k-1', null, null);
 
       const { backfillSessionAndProjectIds } = await import('../migrations.js');
-      // Missing metadata.json → projectRootBasename is null.
+      // No projectId supplied → projectId is null (post-T-2a.9.unified).
       backfillSessionAndProjectIds(db, 'sess-nometa', null);
 
       interface PartitionRow {

--- a/packages/cli/src/workflow/__tests__/session-json-writer.test.ts
+++ b/packages/cli/src/workflow/__tests__/session-json-writer.test.ts
@@ -1,0 +1,403 @@
+/**
+ * Tests for the memorization-step `session.json` writer (T-2a.8.2).
+ *
+ * Two layers:
+ *
+ *   - Direct invocation of `writeSessionJsonAtMemorizationExit` against a
+ *     synthetic session directory + seeded event store — asserts that the
+ *     stub's 6 carry-forward fields propagate verbatim, `steps[]`
+ *     materialises, and `project.json.sessions[]` gets the upsert row.
+ *   - Engine-integration via `appendEventAndUpdateState` — fires only on
+ *     `workflow.step.exit` for `step === 'memorization'`, never for
+ *     ideation/planning/execution exits, and survives a writer-level error
+ *     without corrupting the event store.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  spyOn,
+} from 'bun:test';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  projectJsonPath,
+  readProjectJson,
+  readSessionJson,
+  sessionJsonPath,
+  writeSessionStub,
+} from '../../lib/json-memory.js';
+import { appendEventAndUpdateState } from '../engine.js';
+import { writeSessionJsonAtMemorizationExit } from '../session-json-writer.js';
+import { EventStore } from '../store.js';
+import { initialState, writeState } from '../state.js';
+import type { WorkflowState } from '../state.js';
+import { WORKFLOW_EVENTS } from '../events/workflow.js';
+import type { Event } from '../events/index.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+let rootDir: string;
+
+beforeEach(() => {
+  rootDir = mkdtempSync(join(tmpdir(), 'gobbi-session-json-writer-'));
+});
+
+afterEach(() => {
+  rmSync(rootDir, { recursive: true, force: true });
+});
+
+interface SessionFixture {
+  readonly repoRoot: string;
+  readonly projectName: string;
+  readonly sessionId: string;
+  readonly sessionDir: string;
+}
+
+/**
+ * Materialise a session directory at the canonical layout
+ * `<repoRoot>/.gobbi/projects/<projectName>/sessions/<sessionId>` and
+ * write the init-time stub via the production helper.
+ */
+function makeSession(
+  projectName: string,
+  sessionId: string,
+  task = 'fixture task',
+): SessionFixture {
+  const repoRoot = rootDir;
+  const sessionDir = join(
+    repoRoot,
+    '.gobbi',
+    'projects',
+    projectName,
+    'sessions',
+    sessionId,
+  );
+  mkdirSync(sessionDir, { recursive: true });
+  writeSessionStub({
+    repoRoot,
+    projectName,
+    sessionId,
+    task,
+    gobbiVersion: '0.0.0-test',
+    createdAt: '2026-04-29T00:00:00.000Z',
+  });
+  return { repoRoot, projectName, sessionId, sessionDir };
+}
+
+/**
+ * Drive a session into `memorization` by stamping `state.json` directly so
+ * the engine accepts a STEP_EXIT for that step in a single append. Avoids
+ * threading the workflow through every intermediate step in the test.
+ */
+function seedMemorizationState(
+  fixture: SessionFixture,
+): WorkflowState {
+  const state: WorkflowState = {
+    ...initialState(fixture.sessionId),
+    currentStep: 'memorization',
+    stepStartedAt: '2026-04-29T00:30:00.000Z',
+  };
+  writeState(fixture.sessionDir, state);
+  return state;
+}
+
+// ---------------------------------------------------------------------------
+// Direct invocation — writer reads stub, materialises full shape
+// ---------------------------------------------------------------------------
+
+describe('writeSessionJsonAtMemorizationExit — direct', () => {
+  it('replaces the stub with a populated session.json carrying steps[]', async () => {
+    const fixture = makeSession('proj-direct', 'sess-direct', 'direct test');
+    const dbPath = join(fixture.sessionDir, 'gobbi.db');
+    using store = new EventStore(dbPath);
+
+    const filePath = await writeSessionJsonAtMemorizationExit({
+      sessionDir: fixture.sessionDir,
+      store,
+    });
+
+    expect(filePath).toBe(
+      sessionJsonPath(fixture.repoRoot, fixture.projectName, fixture.sessionId),
+    );
+    const written = readSessionJson(filePath!);
+    expect(written).not.toBeNull();
+    expect(written!.schemaVersion).toBe(1);
+    expect(written!.sessionId).toBe(fixture.sessionId);
+    expect(written!.projectId).toBe(fixture.projectName);
+    expect(written!.createdAt).toBe('2026-04-29T00:00:00.000Z');
+    expect(written!.gobbiVersion).toBe('0.0.0-test');
+    expect(written!.task).toBe('direct test');
+    // No workflow.finish landed → finishedAt stays null at memorization-time.
+    expect(written!.finishedAt).toBeNull();
+    // steps[] is the discriminator between stub and complete shape.
+    expect(Array.isArray(written!.steps)).toBe(true);
+  });
+
+  it('upserts the matching row into project.json.sessions[]', async () => {
+    const fixture = makeSession('proj-upsert', 'sess-upsert');
+    const dbPath = join(fixture.sessionDir, 'gobbi.db');
+    using store = new EventStore(dbPath);
+
+    await writeSessionJsonAtMemorizationExit({
+      sessionDir: fixture.sessionDir,
+      store,
+    });
+
+    const projectFile = projectJsonPath(fixture.repoRoot, fixture.projectName);
+    const project = readProjectJson(projectFile);
+    expect(project).not.toBeNull();
+    expect(project!.sessions).toHaveLength(1);
+    const session = project!.sessions[0]!;
+    expect(session.sessionId).toBe(fixture.sessionId);
+    expect(session.createdAt).toBe('2026-04-29T00:00:00.000Z');
+    expect(session.task).toBe('fixture task');
+    expect(session.finishedAt).toBeNull();
+  });
+
+  it('returns null when the session.json stub is absent', async () => {
+    // Make a session dir but DO NOT call writeSessionStub — the writer must
+    // fall through cleanly rather than fabricate the stub from thin air.
+    const repoRoot = rootDir;
+    const sessionDir = join(
+      repoRoot,
+      '.gobbi',
+      'projects',
+      'proj-no-stub',
+      'sessions',
+      'sess-no-stub',
+    );
+    mkdirSync(sessionDir, { recursive: true });
+    using store = new EventStore(join(sessionDir, 'gobbi.db'));
+
+    const result = await writeSessionJsonAtMemorizationExit({
+      sessionDir,
+      store,
+    });
+
+    expect(result).toBeNull();
+    // No file should have been created.
+    const expected = sessionJsonPath(
+      repoRoot,
+      'proj-no-stub',
+      'sess-no-stub',
+    );
+    expect(existsSync(expected)).toBe(false);
+  });
+
+  it('honours an explicit finishedAt override', async () => {
+    const fixture = makeSession('proj-finished', 'sess-finished');
+    const dbPath = join(fixture.sessionDir, 'gobbi.db');
+    using store = new EventStore(dbPath);
+
+    const finishedAt = '2026-04-29T01:00:00.000Z';
+    await writeSessionJsonAtMemorizationExit({
+      sessionDir: fixture.sessionDir,
+      store,
+      finishedAt,
+    });
+
+    const written = readSessionJson(
+      sessionJsonPath(fixture.repoRoot, fixture.projectName, fixture.sessionId),
+    );
+    expect(written!.finishedAt).toBe(finishedAt);
+
+    const project = readProjectJson(
+      projectJsonPath(fixture.repoRoot, fixture.projectName),
+    );
+    expect(project!.sessions[0]!.finishedAt).toBe(finishedAt);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Engine integration — STEP_EXIT memorization fires the writer
+// ---------------------------------------------------------------------------
+
+describe('engine memorization STEP_EXIT dispatch', () => {
+  it('fires the writer when STEP_EXIT commits with step === "memorization"', async () => {
+    const fixture = makeSession('proj-engine-mem', 'sess-engine-mem', 'engine memorization');
+    const prev = seedMemorizationState(fixture);
+
+    using store = new EventStore(join(fixture.sessionDir, 'gobbi.db'));
+    const stepExit: Event = {
+      type: WORKFLOW_EVENTS.STEP_EXIT,
+      data: { step: 'memorization' },
+    };
+    const result = await appendEventAndUpdateState(
+      store,
+      fixture.sessionDir,
+      prev,
+      stepExit,
+      'cli',
+      fixture.sessionId,
+      'tool-call',
+      'tc-mem-exit',
+      null,
+      undefined,
+      '2026-04-29T01:00:00.000Z',
+    );
+
+    expect(result.persisted).toBe(true);
+    const filePath = sessionJsonPath(
+      fixture.repoRoot,
+      fixture.projectName,
+      fixture.sessionId,
+    );
+    const written = readSessionJson(filePath);
+    expect(written).not.toBeNull();
+    expect(Array.isArray(written!.steps)).toBe(true);
+    // project.json upsert ran too.
+    const project = readProjectJson(
+      projectJsonPath(fixture.repoRoot, fixture.projectName),
+    );
+    expect(project!.sessions.map((s) => s.sessionId)).toContain(
+      fixture.sessionId,
+    );
+  });
+
+  it('does NOT fire the writer when STEP_EXIT commits with step !== "memorization"', async () => {
+    const fixture = makeSession('proj-engine-non-mem', 'sess-engine-non-mem');
+    // Seed a state where ideation can validly exit.
+    const prev: WorkflowState = {
+      ...initialState(fixture.sessionId),
+      currentStep: 'ideation',
+      stepStartedAt: '2026-04-29T00:00:30.000Z',
+    };
+    writeState(fixture.sessionDir, prev);
+
+    using store = new EventStore(join(fixture.sessionDir, 'gobbi.db'));
+    const stepExit: Event = {
+      type: WORKFLOW_EVENTS.STEP_EXIT,
+      data: { step: 'ideation' },
+    };
+    await appendEventAndUpdateState(
+      store,
+      fixture.sessionDir,
+      prev,
+      stepExit,
+      'cli',
+      fixture.sessionId,
+      'tool-call',
+      'tc-ide-exit',
+      null,
+      undefined,
+      '2026-04-29T00:45:00.000Z',
+    );
+
+    // session.json should still be the stub — no `steps[]`.
+    const filePath = sessionJsonPath(
+      fixture.repoRoot,
+      fixture.projectName,
+      fixture.sessionId,
+    );
+    const written = readSessionJson(filePath);
+    expect(written).not.toBeNull();
+    expect(written!.steps).toBeUndefined();
+
+    // No project.json should have been created — the upsert never ran.
+    const projectFile = projectJsonPath(
+      fixture.repoRoot,
+      fixture.projectName,
+    );
+    expect(existsSync(projectFile)).toBe(false);
+  });
+
+  it('does NOT fire the writer for non-STEP_EXIT events', async () => {
+    const fixture = makeSession('proj-non-exit', 'sess-non-exit');
+    using store = new EventStore(join(fixture.sessionDir, 'gobbi.db'));
+
+    const start: Event = {
+      type: WORKFLOW_EVENTS.START,
+      data: {
+        sessionId: fixture.sessionId,
+        timestamp: '2026-04-29T00:00:01.000Z',
+      },
+    };
+    await appendEventAndUpdateState(
+      store,
+      fixture.sessionDir,
+      initialState(fixture.sessionId),
+      start,
+      'cli',
+      fixture.sessionId,
+      'tool-call',
+      'tc-start',
+    );
+
+    // Stub still in place; no project.json created.
+    const written = readSessionJson(
+      sessionJsonPath(fixture.repoRoot, fixture.projectName, fixture.sessionId),
+    );
+    expect(written!.steps).toBeUndefined();
+    expect(
+      existsSync(projectJsonPath(fixture.repoRoot, fixture.projectName)),
+    ).toBe(false);
+  });
+
+  it('writer failure does NOT corrupt the event store', async () => {
+    const fixture = makeSession('proj-writer-fail', 'sess-writer-fail');
+    const prev = seedMemorizationState(fixture);
+
+    using store = new EventStore(join(fixture.sessionDir, 'gobbi.db'));
+
+    // Force the project.json upsert to fail by corrupting the file path with
+    // a directory in place of where the upsert wants to write. We can't
+    // easily intercept the writer's internals without a spy, so instead we
+    // pre-create `project.json` as a directory so the atomic
+    // temp+rename inside `writeProjectJson` raises EISDIR on rename.
+    const projectFile = projectJsonPath(
+      fixture.repoRoot,
+      fixture.projectName,
+    );
+    mkdirSync(projectFile, { recursive: true });
+
+    // Suppress the expected stderr line from the engine's catch block.
+    const stderrSpy = spyOn(process.stderr, 'write').mockImplementation(
+      () => true,
+    );
+    try {
+      const stepExit: Event = {
+        type: WORKFLOW_EVENTS.STEP_EXIT,
+        data: { step: 'memorization' },
+      };
+      const result = await appendEventAndUpdateState(
+        store,
+        fixture.sessionDir,
+        prev,
+        stepExit,
+        'cli',
+        fixture.sessionId,
+        'tool-call',
+        'tc-mem-fail',
+        null,
+        undefined,
+        '2026-04-29T01:00:00.000Z',
+      );
+
+      // Event store has the STEP_EXIT row — the failure was post-commit.
+      expect(result.persisted).toBe(true);
+      const exits = store.byType(WORKFLOW_EVENTS.STEP_EXIT);
+      expect(exits).toHaveLength(1);
+
+      // Engine logged the failure without re-throwing.
+      const stderrCalls = stderrSpy.mock.calls.flat().join('\n');
+      expect(stderrCalls).toContain('session.json memorization write failed');
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+});

--- a/packages/cli/src/workflow/__tests__/state.test.ts
+++ b/packages/cli/src/workflow/__tests__/state.test.ts
@@ -464,7 +464,7 @@ describe('resolveState', () => {
 // ===========================================================================
 
 describe('appendEventAndUpdateState deduplication', () => {
-  it('returns persisted=false and unchanged state on duplicate', () => {
+  it('returns persisted=false and unchanged state on duplicate', async () => {
     using store = new EventStore(':memory:');
 
     const state = makeState({ currentStep: 'idle' });
@@ -474,14 +474,14 @@ describe('appendEventAndUpdateState deduplication', () => {
     };
 
     // First append
-    const result1 = appendEventAndUpdateState(
+    const result1 = await appendEventAndUpdateState(
       store, testDir, state, event, 'cli', 'test-session', 'tool-call', 'tc-dedup',
     );
     expect(result1.persisted).toBe(true);
     expect(result1.state.currentStep).toBe('ideation');
 
     // Second append with same idempotency key
-    const result2 = appendEventAndUpdateState(
+    const result2 = await appendEventAndUpdateState(
       store, testDir, result1.state, event, 'cli', 'test-session', 'tool-call', 'tc-dedup',
     );
     expect(result2.persisted).toBe(false);
@@ -534,7 +534,7 @@ describe('restoreStateFromBackup', () => {
 // ===========================================================================
 
 describe('appendEventAndUpdateState crash-safety', () => {
-  it('rolls back the SQLite transaction when a filesystem write inside the transaction throws', () => {
+  it('rolls back the SQLite transaction when a filesystem write inside the transaction throws', async () => {
     using store = new EventStore(':memory:');
 
     const state = makeState({ currentStep: 'idle' });
@@ -558,11 +558,11 @@ describe('appendEventAndUpdateState crash-safety', () => {
 
     // The transaction should throw because the filesystem operation
     // inside it fails.
-    expect(() =>
+    await expect(
       appendEventAndUpdateState(
         store, testDir, state, event, 'cli', 'test-session', 'tool-call', 'tc-crash',
       ),
-    ).toThrow();
+    ).rejects.toThrow();
 
     // Clean up the directory-masquerading-as-state.json and restore from
     // the pre-seeded backup. The pre-operation state survived because we
@@ -577,7 +577,7 @@ describe('appendEventAndUpdateState crash-safety', () => {
     expect(store.eventCount()).toBe(0);
   });
 
-  it('propagates filesystem failure with no event persisted when no prior state existed', () => {
+  it('propagates filesystem failure with no event persisted when no prior state existed', async () => {
     using store = new EventStore(':memory:');
 
     // No state.json written — this simulates the first event ever.
@@ -593,11 +593,11 @@ describe('appendEventAndUpdateState crash-safety', () => {
     mkdirSync(join(testDir, 'state.json'));
     writeFileSync(join(testDir, 'state.json', 'sentinel'), 'x', 'utf8');
 
-    expect(() =>
+    await expect(
       appendEventAndUpdateState(
         store, testDir, state, event, 'cli', 'test-session', 'tool-call', 'tc-first',
       ),
-    ).toThrow();
+    ).rejects.toThrow();
 
     // SQLite transaction should have rolled back — no events persisted
     expect(store.eventCount()).toBe(0);

--- a/packages/cli/src/workflow/__tests__/state.test.ts
+++ b/packages/cli/src/workflow/__tests__/state.test.ts
@@ -530,77 +530,96 @@ describe('restoreStateFromBackup', () => {
 });
 
 // ===========================================================================
-// Engine: crash-safety — state.json restored on filesystem failure
+// Engine: transaction discipline — reducer rejection rolls the row back
+//
+// Pre-PR-FIN-2a-ii crash-safety relied on a `state.json` projection that
+// `appendEventAndUpdateState` wrote inside the SQLite transaction; a
+// filesystem failure on that write triggered the rollback path.
+// State.json was retired in T-2a.9.unified, so the only failure mode
+// inside the transaction now is a reducer rejection. The remaining
+// invariant under test: a thrown reducer keeps the event log clean
+// (no orphan row beyond the audit emit handled in engine.test.ts).
 // ===========================================================================
 
 describe('appendEventAndUpdateState crash-safety', () => {
-  it('rolls back the SQLite transaction when a filesystem write inside the transaction throws', async () => {
+  it('reducer rejection rolls back the rejected event row (only the audit row survives)', async () => {
     using store = new EventStore(':memory:');
 
-    const state = makeState({ currentStep: 'idle' });
-    const event: Event = {
+    // Drive the session into ideation so that workflow.abort is rejected
+    // by the reducer (abort requires error state).
+    const sessionId = 'test-session';
+    const startEvent: Event = {
       type: WORKFLOW_EVENTS.START,
-      data: { sessionId: 'test-session', timestamp: '2026-01-01T00:00:00Z' },
+      data: { sessionId, timestamp: '2026-01-01T00:00:00Z' },
+    };
+    await appendEventAndUpdateState(
+      store,
+      testDir,
+      makeState({ currentStep: 'idle' }),
+      startEvent,
+      'cli',
+      sessionId,
+      'tool-call',
+      'tc-start',
+    );
+    expect(store.eventCount()).toBe(1);
+
+    const stateAfterStart = makeState({ currentStep: 'ideation' });
+    const rejected: Event = {
+      type: WORKFLOW_EVENTS.ABORT,
+      data: { reason: 'invalid-from-ideation' },
     };
 
-    // Pre-seed a valid backup so the pre-existing on-disk state can be
-    // recovered by the test after the failure.
-    writeState(testDir, state);
-    copyFileSync(join(testDir, 'state.json'), join(testDir, 'state.json.backup'));
-
-    // Replace state.json with a non-empty directory so backupState()
-    // (which runs at the top of the transaction and does a copyFileSync
-    // from state.json to state.json.backup) throws EISDIR. Any throw
-    // inside the transaction rolls back the SQLite insert.
-    rmSync(join(testDir, 'state.json'));
-    mkdirSync(join(testDir, 'state.json'));
-    writeFileSync(join(testDir, 'state.json', 'sentinel'), 'x', 'utf8');
-
-    // The transaction should throw because the filesystem operation
-    // inside it fails.
     await expect(
       appendEventAndUpdateState(
-        store, testDir, state, event, 'cli', 'test-session', 'tool-call', 'tc-crash',
+        store,
+        testDir,
+        stateAfterStart,
+        rejected,
+        'cli',
+        sessionId,
+        'tool-call',
+        'tc-rejected-abort',
       ),
     ).rejects.toThrow();
 
-    // Clean up the directory-masquerading-as-state.json and restore from
-    // the pre-seeded backup. The pre-operation state survived because we
-    // took a backup before the failure.
-    rmSync(join(testDir, 'state.json'), { recursive: true, force: true });
-    copyFileSync(join(testDir, 'state.json.backup'), join(testDir, 'state.json'));
-    const restored = readState(testDir);
-    expect(restored).not.toBeNull();
-    expect(restored!.currentStep).toBe('idle');
-
-    // SQLite transaction should have rolled back — no events persisted
-    expect(store.eventCount()).toBe(0);
+    // The rejected row was rolled back — only the original start row +
+    // the audit row authored on the audit-emit branch survive.
+    const rows = store.replayAll();
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.type).toBe(WORKFLOW_EVENTS.START);
+    expect(rows[1]?.type).toBe(WORKFLOW_EVENTS.INVALID_TRANSITION);
   });
 
-  it('propagates filesystem failure with no event persisted when no prior state existed', async () => {
+  it('first-event reducer rejection leaves the store empty save the audit row', async () => {
     using store = new EventStore(':memory:');
 
-    // No state.json written — this simulates the first event ever.
+    // No prior events — the very first call rejects (abort from idle is
+    // rejected at the reducer).
+    const sessionId = 'test-session';
     const state = makeState({ currentStep: 'idle' });
-    const event: Event = {
-      type: WORKFLOW_EVENTS.START,
-      data: { sessionId: 'test-session', timestamp: '2026-01-01T00:00:00Z' },
+    const rejected: Event = {
+      type: WORKFLOW_EVENTS.ABORT,
+      data: { reason: 'invalid-from-idle' },
     };
-
-    // Create state.json as a non-empty directory so backupState() sees
-    // an existing entry (existsSync → true) and then tries copyFileSync
-    // on a directory, which throws.
-    mkdirSync(join(testDir, 'state.json'));
-    writeFileSync(join(testDir, 'state.json', 'sentinel'), 'x', 'utf8');
 
     await expect(
       appendEventAndUpdateState(
-        store, testDir, state, event, 'cli', 'test-session', 'tool-call', 'tc-first',
+        store,
+        testDir,
+        state,
+        rejected,
+        'cli',
+        sessionId,
+        'tool-call',
+        'tc-first-reject',
       ),
     ).rejects.toThrow();
 
-    // SQLite transaction should have rolled back — no events persisted
-    expect(store.eventCount()).toBe(0);
+    // The audit row survives; the rejected row was rolled back.
+    const rows = store.replayAll();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.type).toBe(WORKFLOW_EVENTS.INVALID_TRANSITION);
   });
 });
 

--- a/packages/cli/src/workflow/__tests__/step-readme-writer.test.ts
+++ b/packages/cli/src/workflow/__tests__/step-readme-writer.test.ts
@@ -305,7 +305,7 @@ describe('engine STEP_EXIT hook', () => {
     return state;
   }
 
-  it('writes the per-step README when STEP_EXIT commits for a productive step', () => {
+  it('writes the per-step README when STEP_EXIT commits for a productive step', async () => {
     const sessionId = 'engine-exit-productive';
     const sessionDir = makeSessionDir(rootDir, 'gobbi', sessionId);
     const prev = seedIdeationState(sessionDir, sessionId);
@@ -315,7 +315,7 @@ describe('engine STEP_EXIT hook', () => {
       type: WORKFLOW_EVENTS.STEP_EXIT,
       data: { step: 'ideation' },
     };
-    const result = appendEventAndUpdateState(
+    const result = await appendEventAndUpdateState(
       store,
       sessionDir,
       prev,
@@ -341,7 +341,7 @@ describe('engine STEP_EXIT hook', () => {
     expect(contents).toContain(`nextStep: ${result.state.currentStep}`);
   });
 
-  it('second STEP_EXIT for the same step overwrites the README cleanly', () => {
+  it('second STEP_EXIT for the same step overwrites the README cleanly', async () => {
     // The reducer only allows STEP_EXIT from the current step, so to exercise
     // the idempotency path we round-trip through the writer once via the
     // engine hook, then directly invoke the writer again with updated args.
@@ -356,7 +356,7 @@ describe('engine STEP_EXIT hook', () => {
       type: WORKFLOW_EVENTS.STEP_EXIT,
       data: { step: 'ideation' },
     };
-    const result = appendEventAndUpdateState(
+    const result = await appendEventAndUpdateState(
       store,
       sessionDir,
       prev,
@@ -391,7 +391,7 @@ describe('engine STEP_EXIT hook', () => {
     expect(fenceCount).toBe(2);
   });
 
-  it('does NOT write a README for non-STEP_EXIT events', () => {
+  it('does NOT write a README for non-STEP_EXIT events', async () => {
     const sessionId = 'engine-non-exit';
     const sessionDir = makeSessionDir(rootDir, 'gobbi', sessionId);
     // Fresh state → WORKFLOW.START is a valid transition.
@@ -400,7 +400,7 @@ describe('engine STEP_EXIT hook', () => {
       type: WORKFLOW_EVENTS.START,
       data: { sessionId, timestamp: '2026-04-20T09:00:00.000Z' },
     };
-    const result = appendEventAndUpdateState(
+    const result = await appendEventAndUpdateState(
       store,
       sessionDir,
       initialState(sessionId),
@@ -671,7 +671,7 @@ describe('engine STEP_EXIT hook', () => {
     }
   });
 
-  it('does NOT write a README when STEP_EXIT is deduplicated (persisted: false)', () => {
+  it('does NOT write a README when STEP_EXIT is deduplicated (persisted: false)', async () => {
     const sessionId = 'engine-exit-dedup';
     const sessionDir = makeSessionDir(rootDir, 'gobbi', sessionId);
     const prev = seedIdeationState(sessionDir, sessionId);
@@ -683,7 +683,7 @@ describe('engine STEP_EXIT hook', () => {
     };
 
     // First call commits + writes README.
-    appendEventAndUpdateState(
+    await appendEventAndUpdateState(
       store,
       sessionDir,
       prev,
@@ -707,7 +707,7 @@ describe('engine STEP_EXIT hook', () => {
 
     // Replay the SAME event with the same tool-call-id — the store dedupes,
     // the engine returns persisted: false, and the writer must not fire.
-    appendEventAndUpdateState(
+    await appendEventAndUpdateState(
       store,
       sessionDir,
       prev,

--- a/packages/cli/src/workflow/__tests__/store.test.ts
+++ b/packages/cli/src/workflow/__tests__/store.test.ts
@@ -1314,13 +1314,16 @@ describe('schema v5 — session_id + project_id columns', () => {
     }
   });
 
-  it('fresh-session append stamps session_id (dir basename) + project_id (metadata.projectName, #178)', () => {
+  it('fresh-session append stamps session_id (dir basename) + project_id (explicit opts, post-T-2a.9.unified)', () => {
     const { sessionDir, dbPath } = makeSessionDir(
       'sess-stamp',
       '/home/alice/projects/my-repo',
     );
     try {
-      using store = new EventStore(dbPath);
+      // PR-FIN-2a-ii / T-2a.9.unified: projectId must be passed
+      // explicitly; the legacy metadata.json reader was retired with
+      // metadata.json itself.
+      using store = new EventStore(dbPath, { projectId: 'my-repo' });
       store.append({
         ts: '2026-04-21T00:00:00.000Z',
         type: 'workflow.start',
@@ -1353,9 +1356,6 @@ describe('schema v5 — session_id + project_id columns', () => {
         // present.
         expect(rows).toHaveLength(1);
         expect(rows[0]?.session_id).toBe('sess-stamp');
-        // metadata.projectName, lifted from metadata.json at store-open
-        // time. The helper defaults projectName to basename(projectRoot)
-        // for legacy-shape continuity, so 'my-repo' here.
         expect(rows[0]?.project_id).toBe('my-repo');
       } finally {
         inspector.close();
@@ -1462,34 +1462,48 @@ describe('schema v5 — session_id + project_id columns', () => {
     using store = new EventStore(':memory:');
     const row = store.append(makeSystemInput({ sessionId: 'sess-mem' }));
     expect(row).not.toBeNull();
-    // The constructor could not resolve a session directory, so
-    // `this.sessionId` and `this.projectRootBasename` are null. The
-    // append fallback uses `input.sessionId` so the row still carries a
-    // sensible value; project_id stays NULL.
-    expect(row!.session_id).toBe('sess-mem');
+    // The constructor could not resolve a session directory and no
+    // explicit opts were passed, so both partition keys are NULL.
+    // PR-FIN-2a-ii (T-2a.9.unified) drops the `?? input.sessionId`
+    // append-time fallback — stamped values must match the bound
+    // values exactly so partition-aware reads find their own rows.
+    expect(row!.session_id).toBeNull();
     expect(row!.project_id).toBeNull();
+  });
+
+  it(':memory: store with explicit opts stamps both partition keys', () => {
+    using store = new EventStore(':memory:', {
+      sessionId: 'sess-explicit',
+      projectId: 'project-explicit',
+    });
+    const row = store.append(makeSystemInput({ sessionId: 'sess-explicit' }));
+    expect(row).not.toBeNull();
+    expect(row!.session_id).toBe('sess-explicit');
+    expect(row!.project_id).toBe('project-explicit');
   });
 });
 
 // ===========================================================================
-// EventStoreOptions — explicit partition-key constructor params (#146 A.1.2)
+// EventStoreOptions — explicit partition-key constructor params
 //
-// Wave A.1's workspace re-scope (`.gobbi/state.db`) requires explicit
-// partition-key overrides because the path-derivation fallback yields
-// `'.gobbi'` for session_id and `null` for project_id at the workspace
-// root. The legacy per-session callers (omitting the options object)
-// keep working unchanged via path derivation.
+// Production callers always pass both keys via opts; the workspace
+// `.gobbi/state.db` is the only writer surface and its filesystem path
+// carries no per-session signal. Tests using `<sessionDir>/gobbi.db`
+// continue to work via the sessionId path-derivation fallback (basename
+// of the containing directory). The legacy `metadata.json` projectId
+// reader was retired in PR-FIN-2a-ii (T-2a.9.unified) — projectId has
+// no path fallback, so a caller that omits it stamps `null` into the
+// column.
 //
 // Policy under test (mirrors the constructor's JSDoc):
 //   - non-empty string in opts → use verbatim
-//   - `null`     in opts → defer to derivation
-//   - `undefined` in opts → defer to derivation
-//   - `''`       in opts → defer to derivation (empty-string columns
-//                          would defeat the per-session partition query)
+//   - `null` / `undefined` in opts.sessionId → defer to path derivation
+//   - `null` / `undefined` in opts.projectId → stay null (no fallback)
+//   - `''` (empty string) → treated as "explicitly unset" for both keys
 // ===========================================================================
 
-describe('EventStoreOptions — explicit partition-key constructor params (#146 A.1.2)', () => {
-  it('falls back to path/metadata derivation when no opts are passed', () => {
+describe('EventStoreOptions — explicit partition-key constructor params', () => {
+  it('with no opts: sessionId path-derived, projectId stays NULL (no metadata fallback)', () => {
     const { sessionDir, dbPath } = makeSessionDir(
       'sess-fallback',
       '/home/alice/projects/repo-fallback',
@@ -1519,8 +1533,12 @@ describe('EventStoreOptions — explicit partition-key constructor params (#146 
             'SELECT session_id, project_id FROM events WHERE seq = 1',
           )
           .get();
+        // sessionId path-derived from basename(dirname(dbPath)).
         expect(row?.session_id).toBe('sess-fallback');
-        expect(row?.project_id).toBe('repo-fallback');
+        // projectId has no path fallback after PR-FIN-2a-ii — opts must
+        // be supplied explicitly. metadata.json on disk is no longer
+        // consulted.
+        expect(row?.project_id).toBeNull();
       } finally {
         inspector.close();
       }
@@ -1529,9 +1547,7 @@ describe('EventStoreOptions — explicit partition-key constructor params (#146 
     }
   });
 
-  it('explicit sessionId override beats path-derived basename', () => {
-    // Session dir basename would be `sess-on-disk`, but the override is
-    // `workspace-session` — the workspace re-scope use case.
+  it('explicit sessionId override beats path-derived basename; projectId stays NULL when omitted', () => {
     const { sessionDir, dbPath } = makeSessionDir(
       'sess-on-disk',
       '/home/alice/projects/dir-derived',
@@ -1564,8 +1580,8 @@ describe('EventStoreOptions — explicit partition-key constructor params (#146 
           )
           .get();
         expect(row?.session_id).toBe('workspace-session');
-        // projectId not overridden — derivation still runs.
-        expect(row?.project_id).toBe('dir-derived');
+        // projectId not supplied — stays NULL (no metadata fallback).
+        expect(row?.project_id).toBeNull();
       } finally {
         inspector.close();
       }
@@ -1574,12 +1590,10 @@ describe('EventStoreOptions — explicit partition-key constructor params (#146 
     }
   });
 
-  it('explicit projectId override beats metadata.json lookup', () => {
-    // metadata.projectRoot basename would be `metadata-derived`, but the
-    // override is `workspace-project`.
+  it('explicit projectId stamps the column directly — no metadata.json read', () => {
     const { sessionDir, dbPath } = makeSessionDir(
       'sess-proj-override',
-      '/home/alice/projects/metadata-derived',
+      '/home/alice/projects/metadata-ignored',
     );
     try {
       using store = new EventStore(dbPath, {
@@ -1608,7 +1622,7 @@ describe('EventStoreOptions — explicit partition-key constructor params (#146 
             'SELECT session_id, project_id FROM events WHERE seq = 1',
           )
           .get();
-        // sessionId not overridden — derivation still runs.
+        // sessionId not overridden — path derivation still runs.
         expect(row?.session_id).toBe('sess-proj-override');
         expect(row?.project_id).toBe('workspace-project');
       } finally {
@@ -1619,7 +1633,7 @@ describe('EventStoreOptions — explicit partition-key constructor params (#146 
     }
   });
 
-  it('null in opts is treated as "explicitly unset" and falls back to derivation', () => {
+  it('null in opts: sessionId falls back to path derivation, projectId stays NULL', () => {
     const { sessionDir, dbPath } = makeSessionDir(
       'sess-null-opts',
       '/home/alice/projects/null-derived',
@@ -1653,9 +1667,9 @@ describe('EventStoreOptions — explicit partition-key constructor params (#146 
             'SELECT session_id, project_id FROM events WHERE seq = 1',
           )
           .get();
-        // Both keys derived — null in opts did not stamp a NULL column.
+        // sessionId path-derived; projectId stays NULL (no fallback).
         expect(row?.session_id).toBe('sess-null-opts');
-        expect(row?.project_id).toBe('null-derived');
+        expect(row?.project_id).toBeNull();
       } finally {
         inspector.close();
       }
@@ -1664,7 +1678,7 @@ describe('EventStoreOptions — explicit partition-key constructor params (#146 
     }
   });
 
-  it('empty string in opts falls back to derivation (no empty-string columns)', () => {
+  it('empty string in opts: sessionId falls back, projectId stays NULL', () => {
     const { sessionDir, dbPath } = makeSessionDir(
       'sess-empty-opts',
       '/home/alice/projects/empty-derived',
@@ -1698,16 +1712,138 @@ describe('EventStoreOptions — explicit partition-key constructor params (#146 
             'SELECT session_id, project_id FROM events WHERE seq = 1',
           )
           .get();
-        // Empty strings did not reach the columns — derivation populated
-        // both keys.
+        // sessionId path-derived; projectId stays NULL (empty string is
+        // "explicitly unset" but no metadata fallback chain anymore).
         expect(row?.session_id).toBe('sess-empty-opts');
-        expect(row?.project_id).toBe('empty-derived');
+        expect(row?.project_id).toBeNull();
       } finally {
         inspector.close();
       }
     } finally {
       rmSync(join(sessionDir, '..'), { recursive: true, force: true });
     }
+  });
+});
+
+// ===========================================================================
+// Partition-aware reads (Option α — PR-FIN-2a-ii / T-2a.9.unified)
+//
+// Every read method bakes a `WHERE session_id IS $session_id AND
+// project_id IS $project_id` clause, so a store opened with bound
+// partition keys only sees its own rows even when the underlying table
+// holds events for multiple partitions.
+// ===========================================================================
+
+describe('partition-aware reads (Option α)', () => {
+  it('replayAll filters by bound (sessionId, projectId)', () => {
+    const tmpRoot = mkdtempSync(join(tmpdir(), 'gobbi-store-partition-'));
+    const dbPath = join(tmpRoot, 'state.db');
+    try {
+      // Author rows under partition A.
+      {
+        using storeA = new EventStore(dbPath, {
+          sessionId: 'sess-A',
+          projectId: 'proj-1',
+        });
+        storeA.append(
+          makeInput({ sessionId: 'sess-A', toolCallId: 'tc-A-1' }),
+        );
+        storeA.append(
+          makeInput({ sessionId: 'sess-A', toolCallId: 'tc-A-2' }),
+        );
+      }
+      // Author rows under partition B (different project).
+      {
+        using storeB = new EventStore(dbPath, {
+          sessionId: 'sess-B',
+          projectId: 'proj-2',
+        });
+        storeB.append(
+          makeInput({ sessionId: 'sess-B', toolCallId: 'tc-B-1' }),
+        );
+      }
+
+      // Read partition A: sees only its 2 rows.
+      {
+        using readerA = new EventStore(dbPath, {
+          sessionId: 'sess-A',
+          projectId: 'proj-1',
+        });
+        const rowsA = readerA.replayAll();
+        expect(rowsA).toHaveLength(2);
+        expect(rowsA.every((r) => r.session_id === 'sess-A')).toBe(true);
+        expect(rowsA.every((r) => r.project_id === 'proj-1')).toBe(true);
+      }
+
+      // Read partition B: sees only its 1 row.
+      {
+        using readerB = new EventStore(dbPath, {
+          sessionId: 'sess-B',
+          projectId: 'proj-2',
+        });
+        const rowsB = readerB.replayAll();
+        expect(rowsB).toHaveLength(1);
+        expect(rowsB[0]?.session_id).toBe('sess-B');
+        expect(rowsB[0]?.project_id).toBe('proj-2');
+      }
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('cross-partition rows are NOT visible to a partition-bound EventStore', () => {
+    const tmpRoot = mkdtempSync(join(tmpdir(), 'gobbi-store-partition-'));
+    const dbPath = join(tmpRoot, 'state.db');
+    try {
+      // Author rows under partition X only.
+      {
+        using storeX = new EventStore(dbPath, {
+          sessionId: 'sess-X',
+          projectId: 'proj-X',
+        });
+        storeX.append(
+          makeInput({ sessionId: 'sess-X', toolCallId: 'tc-X-1' }),
+        );
+      }
+      // Open a different partition Y. eventCount/byType/last all return
+      // empty even though the underlying table has 1 row.
+      {
+        using readerY = new EventStore(dbPath, {
+          sessionId: 'sess-Y',
+          projectId: 'proj-Y',
+        });
+        expect(readerY.eventCount()).toBe(0);
+        expect(readerY.byType('workflow.start')).toHaveLength(0);
+        expect(readerY.last('workflow.start')).toBeNull();
+        expect(readerY.lastN('workflow.start', 5)).toHaveLength(0);
+        expect(readerY.lastNAny(5)).toHaveLength(0);
+        expect(readerY.replayAll()).toHaveLength(0);
+        expect(readerY.since(0)).toHaveLength(0);
+      }
+      // Re-open X — still sees its row.
+      {
+        using readerX = new EventStore(dbPath, {
+          sessionId: 'sess-X',
+          projectId: 'proj-X',
+        });
+        expect(readerX.eventCount()).toBe(1);
+        expect(readerX.last('workflow.start')?.session_id).toBe('sess-X');
+      }
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('NULL partition keys match NULL columns via IS clause', () => {
+    using store = new EventStore(':memory:');
+    // No opts → both partition keys NULL → row stamps NULL → reads
+    // filter by NULL and find the row.
+    store.append(makeInput());
+    expect(store.eventCount()).toBe(1);
+    expect(store.replayAll()).toHaveLength(1);
+    expect(store.byType('workflow.start')).toHaveLength(1);
+    expect(store.last('workflow.start')?.session_id).toBeNull();
+    expect(store.last('workflow.start')?.project_id).toBeNull();
   });
 });
 

--- a/packages/cli/src/workflow/engine.ts
+++ b/packages/cli/src/workflow/engine.ts
@@ -8,11 +8,12 @@
  * The core SQLite mutation runs inside a synchronous `store.transaction(...)`
  * envelope — bun:sqlite transactions cannot await — so the mutation half of
  * `appendEventAndUpdateState` is sync-by-construction. The function itself
- * is `async` because the post-commit dispatch will host async side effects
- * (the memorization `session.json` writer landing in T-2a.8.2). The
- * post-commit dispatch fires AFTER the transaction has committed, so the
- * await landing outside the SQL boundary preserves the bun:sqlite invariant
- * while still giving callers a single composable Promise to await.
+ * is `async` because the post-commit dispatch awaits the memorization
+ * `session.json` writer (T-2a.8.2): the writer walks per-subagent JSONL
+ * transcripts via `aggregateSessionJson`, which is async. The post-commit
+ * dispatch fires AFTER the transaction has committed, so the await landing
+ * outside the SQL boundary preserves the bun:sqlite invariant while still
+ * giving callers a single composable Promise to await.
  *
  * Callers that compose multiple appends across an outer atomic boundary
  * (init's two-event pair) must drop the outer `store.transaction(...)` wrap
@@ -44,6 +45,7 @@ import {
   createWorkflowInvalidTransition,
 } from './events/workflow.js';
 import { writeStepReadmeForExit } from './step-readme-writer.js';
+import { writeSessionJsonAtMemorizationExit } from './session-json-writer.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -314,6 +316,38 @@ export async function appendEventAndUpdateState(
       const msg = err instanceof Error ? err.message : String(err);
       process.stderr.write(
         `gobbi: per-step README write failed — ${msg}\n`,
+      );
+    }
+  }
+
+  // Post-commit side effect: memorization-step `session.json` writer
+  // (T-2a.8.2 / PR-FIN-2a-ii).
+  //
+  // Fires only on a committed `workflow.step.exit` whose payload reports
+  // `step === 'memorization'`. The writer reads the init-time stub for the
+  // 6 carry-forward fields, runs the JSONL-walking aggregator, and atomically
+  // replaces `session.json` with the populated shape; it also upserts the
+  // matching `project.json.sessions[]` row.
+  //
+  // Same best-effort contract as the README writer: failures emit a
+  // single-line stderr and never propagate. The transaction has already
+  // committed; an aggregator throw cannot corrupt the event store. The
+  // stderr message names the writer so operators can distinguish a JSONL
+  // walk failure from the README path.
+  if (
+    appendResult.persisted &&
+    event.type === WORKFLOW_EVENTS.STEP_EXIT &&
+    event.data.step === 'memorization'
+  ) {
+    try {
+      await writeSessionJsonAtMemorizationExit({
+        sessionDir: dir,
+        store,
+      });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(
+        `gobbi: session.json memorization write failed — ${msg}\n`,
       );
     }
   }

--- a/packages/cli/src/workflow/engine.ts
+++ b/packages/cli/src/workflow/engine.ts
@@ -21,23 +21,28 @@
  * function. The two-event atomicity guarantee downgrades from "both rolls
  * back together" to "each commits or rolls back independently" — acceptable
  * for the SessionStart hook's idempotent re-run semantics.
+ *
+ * ## state.json retired (PR-FIN-2a-ii / T-2a.9.unified)
+ *
+ * Prior to PR-FIN-2a-ii every successful append also wrote a
+ * `state.json` projection alongside the bun:sqlite event row, with
+ * `state.json.backup` providing a restore-on-rollback safety net. Both
+ * files are dropped — the workspace `state.db` is now the only source
+ * of truth for workflow state. `resolveWorkflowState` derives state by
+ * replaying the partition-filtered event stream on every call;
+ * `appendEventAndUpdateState` runs the reducer purely in memory and
+ * returns the new state to the caller without persisting a JSON
+ * projection. Callers that previously relied on `state.json` for the
+ * warm-path read (next/status/guard/stop) accept the cold-path replay
+ * cost — partition-aware reads keep the cost bounded to the session's
+ * own events.
  */
-
-import { existsSync, unlinkSync } from 'node:fs';
-import { join } from 'node:path';
 
 import { EventStore } from './store.js';
 import type { AppendInput, ReadStore } from './store.js';
 import { reduce } from './reducer.js';
 import type { ReducerResult } from './reducer.js';
-import {
-  writeState,
-  backupState,
-  restoreStateFromBackup,
-  readState,
-  restoreBackup,
-  deriveState,
-} from './state.js';
+import { deriveState } from './state.js';
 import type { WorkflowState } from './state.js';
 import type { Event } from './events/index.js';
 import {
@@ -65,10 +70,9 @@ export interface AppendResult {
 //
 // The engine's `appendEventAndUpdateState` wraps its compound transaction
 // in a try-catch. Inside, the reducer can throw when it returns
-// `{ok: false}`. Filesystem-write failures (writeState) can also throw.
-// Both surface at the same catch. To emit the
-// `workflow.invalid_transition` audit event ONLY for reducer rejections
-// (not FS failures), the catch needs a typed discriminator.
+// `{ok: false}`. To emit the `workflow.invalid_transition` audit event
+// ONLY for reducer rejections (not other unexpected failures), the
+// catch needs a typed discriminator.
 //
 // A dedicated class is preferred over a message-prefix check — matches
 // the codebase's `extends Error` precedent and gives downstream tooling
@@ -99,16 +103,14 @@ export class ReducerRejectionError extends Error {
  *
  * Executes atomically inside a bun:sqlite IMMEDIATE transaction:
  *
- * 1. Backup current state.json
- * 2. Append event to the SQLite store (with deduplication)
- * 3. If deduplicated (null return), short-circuit — no state change
- * 4. Reduce to compute new state
- * 5. Write new state.json (synchronous atomic write)
+ * 1. Append event to the SQLite store (with deduplication)
+ * 2. If deduplicated (null return), short-circuit — no state change
+ * 3. Reduce to compute new state
  *
- * If the reducer rejects the event or a filesystem write fails, the
- * transaction rolls back — the SQLite insert is undone by the
- * transaction rollback, and state.json is restored from backup via
- * restoreStateFromBackup().
+ * If the reducer rejects the event, the transaction rolls back — the
+ * SQLite insert is undone. Per PR-FIN-2a-ii (T-2a.9.unified) there is
+ * no `state.json` projection: state lives only in the event store and
+ * is derived on read by `resolveWorkflowState`.
  *
  * `parentSeq` links the new event to a prior event's `seq` — used by
  * the capture commands (C.6) to connect `delegation.complete` /
@@ -128,6 +130,11 @@ export class ReducerRejectionError extends Error {
  * the caller scans existing heartbeats for the same ms to pick a non-
  * colliding counter, then passes the same `ts` down so the key uses the
  * same ms as the scan. When omitted, the engine uses wall-clock time.
+ *
+ * The `dir` parameter is retained for compatibility with downstream
+ * post-commit dispatch hooks (per-step README writer, memorization
+ * session.json writer) that still need a session directory to write
+ * navigational artifacts into.
  */
 export async function appendEventAndUpdateState(
   store: EventStore,
@@ -163,16 +170,7 @@ export async function appendEventAndUpdateState(
   let appendResult: AppendResult;
   try {
     appendResult = store.transaction(() => {
-      // Track whether state.json existed before the operation. When this
-      // is the first event ever, there is no state.json and therefore no
-      // backup — the catch block needs to know so it can delete state.json
-      // instead of restoring from a non-existent backup.
-      const hadPriorState = existsSync(join(dir, 'state.json'));
-
-      // 1. Backup current state
-      backupState(dir);
-
-      // 2. Append event to SQLite store
+      // 1. Append event to SQLite store
       const input: AppendInput = buildAppendInput({
         ts: effectiveTs,
         type: event.type,
@@ -192,45 +190,15 @@ export async function appendEventAndUpdateState(
         return { state, persisted: false };
       }
 
-      // 3. Reduce to get new state. On rejection, throw a typed
-      //    ReducerRejectionError — the OUTER catch distinguishes this
-      //    from filesystem failures and fires the audit-emit branch.
-      //    `effectiveTs` is passed as the event's wall-clock timestamp so
-      //    the reducer can stamp `stepStartedAt` on STEP_EXIT / RESUME
-      //    per L13 — the same ms that keyed the store-layer idempotency.
+      // 2. Reduce to get new state. On rejection, throw a typed
+      //    ReducerRejectionError — the OUTER catch fires the audit-emit
+      //    branch. `effectiveTs` is passed as the event's wall-clock
+      //    timestamp so the reducer can stamp `stepStartedAt` on
+      //    STEP_EXIT / RESUME per L13 — the same ms that keyed the
+      //    store-layer idempotency.
       const result: ReducerResult = reduce(state, event, effectiveTs);
       if (!result.ok) {
         throw new ReducerRejectionError(result.error, event, state);
-      }
-
-      // 4. Write new state.json (synchronous atomic write) — wrapped in
-      // try/catch so that a filesystem failure restores the backup before
-      // re-throwing, keeping state.json consistent with the SQLite rollback.
-      try {
-        writeState(dir, result.state);
-      } catch (err: unknown) {
-        // Restore state.json so it matches the rolled-back SQLite state.
-        // Wrap in its own try/catch so a restore failure (disk full,
-        // permissions) does not replace the original error.
-        try {
-          if (hadPriorState) {
-            // Normal case: restore the backup we created in step 1.
-            restoreStateFromBackup(dir);
-          } else {
-            // First-event edge case: no prior state.json existed, so no
-            // backup was created. Delete the newly-written state.json to
-            // return to the no-file state. resolveState() will fall through
-            // to deriveState() which replays from the (now empty) DB.
-            const statePath = join(dir, 'state.json');
-            if (existsSync(statePath)) {
-              unlinkSync(statePath);
-            }
-          }
-        } catch {
-          // Ignore restore/delete failure — the priority is propagating
-          // the original error so the SQLite transaction rolls back.
-        }
-        throw err;
       }
 
       return { state: result.state, persisted: true };
@@ -241,9 +209,9 @@ export async function appendEventAndUpdateState(
     // top-level transaction, NOT a savepoint of the rolled-back one.
     //
     // Only emit the `workflow.invalid_transition` audit for reducer
-    // rejections — filesystem failures (writeState) also land here but
-    // those are not "invalid transition" events; auditing them here
-    // would misattribute disk errors as reducer bugs.
+    // rejections — other unexpected failures (e.g. SQLite I/O) also land
+    // here but those are not "invalid transition" events; auditing them
+    // would misattribute infrastructure errors as reducer bugs.
     if (outerError instanceof ReducerRejectionError) {
       // Best-effort audit-append. If this inner transaction itself
       // throws (disk full, WAL lock, SQLite busy), swallow the audit
@@ -290,8 +258,9 @@ export async function appendEventAndUpdateState(
   // Post-commit side effect: per-step README writer (W5.1).
   //
   // Fires AFTER the core transaction has committed — the README is a
-  // non-authoritative navigation aid that mirrors info already in
-  // gobbi.db + state.json. Running it outside the transaction means a
+  // non-authoritative navigation aid that mirrors information already
+  // present in `WorkflowState` at exit time and the per-step
+  // `artifacts/` directory. Running it outside the transaction means a
   // filesystem error on README write cannot corrupt the event store,
   // and deduplicated (`persisted: false`) events skip the write entirely.
   //
@@ -432,40 +401,33 @@ function buildAppendInput(args: BuildAppendInputArgs): AppendInput {
 }
 
 // ---------------------------------------------------------------------------
-// State resolution — using concrete reduce function
+// State resolution — pure derive over the event log
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve workflow state from disk with full fallback chain.
+ * Resolve workflow state by replaying the partition-filtered event
+ * stream.
  *
- * Warm-path optimisation: state.json is the primary source on every
- * guard / stop / capture hook invocation. When it exists and parses to
- * a valid `WorkflowState`, return it directly — skipping the full SQLite
- * event replay. The replay only materialises on the cold fallback path
- * (state.json missing or corrupt), preserving PR A's crash-safety
- * invariants: backup restoration and event-sourced derivation still
- * cover any state.json that fails validation.
+ * Per PR-FIN-2a-ii (T-2a.9.unified) there is no `state.json`
+ * projection: the workspace `state.db` is the only source of truth.
+ * Every call replays via `store.replayAll()` and runs the reducer.
+ * Partition-aware reads (Option α at the EventStore layer) cap the
+ * replay cost at the calling session's own events — cross-session
+ * rows in the workspace `state.db` are filtered out at the SQL layer.
  *
- * Avoiding `store.replayAll()` on the happy path saves ~5–10 ms per
- * guard / stop / capture hook invocation at ~500-event scale and scales
- * linearly with event count thereafter.
+ * `dir` is retained for signature stability with the pre-pivot warm-
+ * path API; it is no longer consulted (no `state.json` to read). It
+ * stays in the signature so the 8 production callsites (`init.ts`,
+ * `next.ts`, `status.ts`, `transition.ts`, `resume.ts`, `guard.ts`,
+ * `stop.ts`, capture-{planning,subagent}) need no signature change in
+ * this PR.
  */
 export function resolveWorkflowState(
-  dir: string,
+  _dir: string,
   store: ReadStore,
   sessionId: string,
 ): WorkflowState {
-  // Fast path — valid state.json short-circuits the replay.
-  const primary = readState(dir);
-  if (primary !== null) return primary;
-
-  // First fallback — on-disk backup (used when state.json was mid-write
-  // during a crash, or corrupted after write). Still no replay needed.
-  const backup = restoreBackup(dir);
-  if (backup !== null) return backup;
-
-  // Cold fallback — derive from the full event stream. This is the only
-  // branch that pays the replayAll cost.
+  // _dir retained for signature stability — see function-level docblock.
   const events = store.replayAll();
   return deriveState(sessionId, events, reduce);
 }
@@ -474,6 +436,10 @@ export function resolveWorkflowState(
  * Derive workflow state from full event replay.
  *
  * Wraps state.ts deriveState() with the concrete reduce function.
+ * Equivalent to {@link resolveWorkflowState} after the state.json
+ * retirement; kept as a separate symbol for callers that historically
+ * forced a derive path even when state.json was present (`resume.ts`
+ * `--force-memorization` branch).
  */
 export function deriveWorkflowState(
   sessionId: string,

--- a/packages/cli/src/workflow/engine.ts
+++ b/packages/cli/src/workflow/engine.ts
@@ -5,8 +5,21 @@
  * preventing circular dependencies. All compound operations that need
  * both persistence and reduction go through this module.
  *
- * All operations are synchronous — they execute inside bun:sqlite
- * transactions which cannot contain async calls.
+ * The core SQLite mutation runs inside a synchronous `store.transaction(...)`
+ * envelope — bun:sqlite transactions cannot await — so the mutation half of
+ * `appendEventAndUpdateState` is sync-by-construction. The function itself
+ * is `async` because the post-commit dispatch will host async side effects
+ * (the memorization `session.json` writer landing in T-2a.8.2). The
+ * post-commit dispatch fires AFTER the transaction has committed, so the
+ * await landing outside the SQL boundary preserves the bun:sqlite invariant
+ * while still giving callers a single composable Promise to await.
+ *
+ * Callers that compose multiple appends across an outer atomic boundary
+ * (init's two-event pair) must drop the outer `store.transaction(...)` wrap
+ * because the bun:sqlite transaction callback cannot await the inner async
+ * function. The two-event atomicity guarantee downgrades from "both rolls
+ * back together" to "each commits or rolls back independently" — acceptable
+ * for the SessionStart hook's idempotent re-run semantics.
  */
 
 import { existsSync, unlinkSync } from 'node:fs';
@@ -114,7 +127,7 @@ export class ReducerRejectionError extends Error {
  * colliding counter, then passes the same `ts` down so the key uses the
  * same ms as the scan. When omitted, the engine uses wall-clock time.
  */
-export function appendEventAndUpdateState(
+export async function appendEventAndUpdateState(
   store: EventStore,
   dir: string,
   state: WorkflowState,
@@ -126,7 +139,7 @@ export function appendEventAndUpdateState(
   parentSeq?: number | null,
   counter?: number,
   ts?: string,
-): AppendResult {
+): Promise<AppendResult> {
   // Compute the effective timestamp ONCE — the same wall-clock reading is
   // used for (a) the rejected event's idempotency key (system/counter kinds
   // hash the ms) and (b) the audit-emit payload + audit idempotency key, so

--- a/packages/cli/src/workflow/events/__tests__/events.test.ts
+++ b/packages/cli/src/workflow/events/__tests__/events.test.ts
@@ -567,6 +567,38 @@ describe('factory functions', () => {
       expect('claudeCodeVersion' in event.data).toBe(false);
     });
 
+    // PR-FIN-2a-ii T-2a.8.0 — additive `tool_call_id` field on
+    // DelegationSpawnData. Round-trips through JSON.stringify and the
+    // omit-branch keeps the event shape identical to pre-field behavior.
+    it('createDelegationSpawn passes tool_call_id through when set', () => {
+      const event = createDelegationSpawn({
+        agentType: 'executor',
+        step: 'execution',
+        subagentId: 'sub-tcid',
+        timestamp: '2026-04-29T00:00:00Z',
+        tool_call_id: 'toolu_abc123',
+      });
+      expect(event.data).toEqual({
+        agentType: 'executor',
+        step: 'execution',
+        subagentId: 'sub-tcid',
+        timestamp: '2026-04-29T00:00:00Z',
+        tool_call_id: 'toolu_abc123',
+      });
+      const round = JSON.parse(JSON.stringify(event));
+      expect(round).toEqual(event);
+    });
+
+    it('createDelegationSpawn omits tool_call_id when caller omits it', () => {
+      const event = createDelegationSpawn({
+        agentType: 'executor',
+        step: 'execution',
+        subagentId: 'sub-no-tcid',
+        timestamp: '2026-04-29T00:00:00Z',
+      });
+      expect('tool_call_id' in event.data).toBe(false);
+    });
+
     it('createDelegationComplete with all optional fields', () => {
       const event = createDelegationComplete({
         subagentId: 'sub-1',
@@ -587,6 +619,32 @@ describe('factory functions', () => {
       const event = createDelegationComplete({ subagentId: 'sub-1' });
       expect(event.type).toBe(DELEGATION_EVENTS.COMPLETE);
       expect(event.data).toEqual({ subagentId: 'sub-1' });
+    });
+
+    // PR-FIN-2a-ii T-2a.8.0 — additive `transcriptSha256` field on
+    // DelegationCompleteData. Captured at SubagentStop time over the full
+    // transcript bytes; round-trips through JSON.stringify; absence
+    // preserved when caller omits it (no empty-string sentinel).
+    it('createDelegationComplete passes transcriptSha256 through when set', () => {
+      const event = createDelegationComplete({
+        subagentId: 'sub-sha',
+        artifactPath: '/path/to/artifact.md',
+        transcriptSha256:
+          'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+      });
+      expect(event.data).toEqual({
+        subagentId: 'sub-sha',
+        artifactPath: '/path/to/artifact.md',
+        transcriptSha256:
+          'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+      });
+      const round = JSON.parse(JSON.stringify(event));
+      expect(round).toEqual(event);
+    });
+
+    it('createDelegationComplete omits transcriptSha256 when caller omits it', () => {
+      const event = createDelegationComplete({ subagentId: 'sub-no-sha' });
+      expect('transcriptSha256' in event.data).toBe(false);
     });
 
     it('createDelegationFail', () => {

--- a/packages/cli/src/workflow/events/delegation.ts
+++ b/packages/cli/src/workflow/events/delegation.ts
@@ -47,6 +47,20 @@ export interface DelegationSpawnData {
    * post-Phase-2 velocity issue #92.
    */
   readonly claudeCodeVersion?: string | undefined;
+  /**
+   * The Claude Code PreToolUse `tool_use_id` (a.k.a. `tool_call_id`) of the
+   * Agent tool call that initiated this subagent. Captured at spawn time by
+   * the PreToolUse guard (see `commands/workflow/guard.ts`) so that the
+   * subsequent `delegation.complete` / `delegation.fail` events landed by
+   * `commands/workflow/capture-subagent.ts` can be linked back to their
+   * originating spawn precisely — even when multiple subagents are spawned in
+   * parallel from a single orchestrator turn. Without this field, parent-seq
+   * lookup must fall back to the `last('delegation.spawn')` heuristic, which
+   * misattributes parallel-subagent linkage. Optional so older events that
+   * predate the spawn-emitter (PR-FIN-2a-ii T-2a.8.0) continue to round-trip
+   * cleanly. Additive — mirrors `claudeCodeVersion` precedent.
+   */
+  readonly tool_call_id?: string | undefined;
 }
 
 export interface DelegationCompleteData {
@@ -62,6 +76,19 @@ export interface DelegationCompleteData {
    * to round-trip through v4 cleanly. Added by v0.5.0 Phase 2 PR E (E.2).
    */
   readonly sizeProxyBytes?: number | undefined;
+  /**
+   * SHA-256 hex digest of the subagent's transcript file at capture time.
+   * Lets downstream consumers (memory aggregation, audit replay) detect
+   * whether the file on disk has been mutated or rewritten since the
+   * SubagentStop hook fired — the digest is recorded once at capture and
+   * never updated. Computed via `node:crypto.createHash('sha256')` over the
+   * full file bytes when `agent_transcript_path` is set and readable; the
+   * field is omitted when the transcript is absent or unreadable. Optional
+   * so events written before this field landed continue to round-trip
+   * cleanly. Additive — mirrors `sizeProxyBytes` precedent. Added by
+   * PR-FIN-2a-ii T-2a.8.0.
+   */
+  readonly transcriptSha256?: string | undefined;
 }
 
 export interface DelegationFailData {

--- a/packages/cli/src/workflow/migrations.ts
+++ b/packages/cli/src/workflow/migrations.ts
@@ -43,7 +43,7 @@
  *   data. The schema ALTER + row backfill run inside the event store's
  *   open path — {@link ensureSchemaV5} adds the columns when missing;
  *   {@link backfillSessionAndProjectIds} populates NULL slots on pre-v5
- *   rows using the store's known `sessionId` + `projectRootBasename`.
+ *   rows using the store's known `sessionId` + `projectId`.
  * - v6 — Wave A.1.3 / orchestration Pass 4 (issue #146). Adds four new
  *   workspace-partitioned tables to the event store DB:
  *
@@ -293,8 +293,8 @@ export function ensureSchemaV5(db: Database): void {
  * NULL` guard — rows that already carry a value (v5 fresh-writes, or an
  * earlier backfill pass) are untouched.
  *
- * `projectRootBasename` may be `null` when `metadata.json` is missing or
- * malformed at store-open time; in that case `project_id` is left NULL
+ * `projectId` may be `null` when the caller did not supply an explicit
+ * `EventStoreOptions.projectId`; in that case `project_id` is left NULL
  * rather than stamped with a sentinel, keeping the absence of metadata
  * distinguishable at query time.
  *
@@ -304,16 +304,16 @@ export function ensureSchemaV5(db: Database): void {
 export function backfillSessionAndProjectIds(
   db: Database,
   sessionId: string,
-  projectRootBasename: string | null,
+  projectId: string | null,
 ): void {
   db.run(
     'UPDATE events SET session_id = ? WHERE session_id IS NULL',
     [sessionId],
   );
-  if (projectRootBasename !== null) {
+  if (projectId !== null) {
     db.run(
       'UPDATE events SET project_id = ? WHERE project_id IS NULL',
-      [projectRootBasename],
+      [projectId],
     );
   }
 }

--- a/packages/cli/src/workflow/session-json-writer.ts
+++ b/packages/cli/src/workflow/session-json-writer.ts
@@ -1,0 +1,218 @@
+/**
+ * Memorization-step `session.json` writer + `project.json` upsert.
+ *
+ * Mirrors the post-commit dispatch shape of `step-readme-writer.ts`: the
+ * engine's `appendEventAndUpdateState` calls into this module ONLY when the
+ * committed event is a `workflow.step.exit` for the `'memorization'` step.
+ * The writer reads the init-time `session.json` stub for the 6 carry-forward
+ * fields (`schemaVersion`, `sessionId`, `projectId`, `createdAt`,
+ * `gobbiVersion`, `task`), runs `aggregateSessionJson` to materialise the
+ * full telemetry shape (steps[] + iterations[] + agents[] + calls[]), and
+ * writes the result back atomically. The companion `project.json.sessions[]`
+ * row is upserted by `sessionId` so the cross-session memory projection
+ * picks up the new finished session immediately.
+ *
+ * # Async contract
+ *
+ * `aggregateSessionJson` walks per-subagent JSONL transcripts (see
+ * `lib/json-memory.ts:1279-1322`), so the writer is necessarily async.
+ * The engine's post-commit dispatch awaits it; failures are caught at the
+ * call site and surface as a single-line stderr — they MUST NOT mask the
+ * accepted state transition (lock 39, mirrored from `writeStepReadmeForExit`).
+ *
+ * # Stub vs. complete (lock 43)
+ *
+ * The init-time stub carries no `steps[]` field. Readers infer state from
+ * field presence — there is no `status` discriminator. This writer rebuilds
+ * the file with `steps[]` populated, leaving the 6 stub-required fields
+ * untouched. The schema validator in `lib/json-memory.ts::writeSessionJson`
+ * rejects malformed bytes before they hit disk, so a partial-aggregator
+ * failure cannot corrupt the on-disk shape.
+ *
+ * # Idempotency
+ *
+ * Re-firing the writer (e.g., a feedback-loop rewind that re-emits
+ * memorization STEP_EXIT) overwrites `session.json` with the freshly
+ * aggregated bytes. The `project.json.sessions[]` upsert is keyed by
+ * `sessionId` — duplicates are replaced, not appended.
+ *
+ * # finishedAt
+ *
+ * Memorization-time `finishedAt` is `null`: `workflow.finish` /
+ * `workflow.abort` lands AFTER memorization commits, so the aggregator
+ * cannot observe the closing event. The post-Handoff sweep (T-2a.9.unified)
+ * is responsible for the post-finish refresh; this writer's contract is
+ * "write the best-effort snapshot at memorization-exit".
+ */
+
+import { sep } from 'node:path';
+
+import {
+  aggregateSessionJson,
+  projectJsonPath,
+  readSessionJson,
+  sessionJsonPath,
+  upsertProjectSession,
+  writeSessionJson,
+  type SessionJson,
+} from '../lib/json-memory.js';
+import type { ReadStore } from './store.js';
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Arguments for {@link writeSessionJsonAtMemorizationExit}. The engine
+ * supplies `sessionDir` + `store` from the committed transaction context;
+ * the rest derive from {@link readSessionJson} on the init-time stub.
+ *
+ * `repoRoot` is required because both `sessionJsonPath` and `projectJsonPath`
+ * compose paths off the repo root rather than the session directory — the
+ * session directory is internal to the repo's `.gobbi/projects/<name>/`
+ * layout but the paths-helpers expect the workspace anchor explicitly.
+ *
+ * `finishedAt` is exposed so tests can pin the value; production callers
+ * leave it unset and the aggregator returns `null` (memorization fires
+ * before `workflow.finish`).
+ */
+export interface SessionJsonMemorizationExitArgs {
+  readonly sessionDir: string;
+  readonly store: ReadStore;
+  readonly finishedAt?: string | null;
+}
+
+/**
+ * Build a fully-populated `SessionJson` and write it (atomically) to
+ * `<sessionDir>/session.json`, then upsert the corresponding row into
+ * `<repoRoot>/.gobbi/projects/<projectName>/project.json::sessions[]`.
+ *
+ * Returns the absolute file path that was written, or `null` when the
+ * init-time stub is absent (the session predates the JSON pivot, or the
+ * caller fired this writer outside an initialised session). Throws on
+ * downstream failure so the engine's post-commit catch can log and move
+ * on — never throws from within the engine's transaction itself.
+ */
+export async function writeSessionJsonAtMemorizationExit(
+  args: SessionJsonMemorizationExitArgs,
+): Promise<string | null> {
+  const { sessionDir, store, finishedAt } = args;
+
+  const { repoRoot, projectName, sessionId } =
+    deriveSessionLocation(sessionDir);
+
+  const stubPath = sessionJsonPath(repoRoot, projectName, sessionId);
+  const stub = readSessionJson(stubPath);
+  if (stub === null) {
+    // No stub on disk — nothing to populate. This branch should not fire
+    // in normal flow (init writes the stub before the first event), but it
+    // keeps the writer resilient to misuse: the engine's post-commit
+    // dispatch logs and continues.
+    return null;
+  }
+
+  const populated: SessionJson = await aggregateSessionJson({
+    store,
+    sessionId: stub.sessionId,
+    projectId: stub.projectId,
+    createdAt: stub.createdAt,
+    gobbiVersion: stub.gobbiVersion,
+    task: stub.task,
+    ...(finishedAt !== undefined ? { finishedAt } : {}),
+  });
+
+  writeSessionJson(stubPath, populated);
+
+  // Upsert the project-level sessions[] row. `task` carries through from
+  // the stub; `finishedAt` mirrors what we just wrote into session.json so
+  // the two artifacts agree on closure state.
+  upsertProjectSession({
+    path: projectJsonPath(repoRoot, projectName),
+    entry: {
+      sessionId: stub.sessionId,
+      createdAt: stub.createdAt,
+      finishedAt: populated.finishedAt,
+      task: stub.task,
+    },
+    projectName,
+    projectId: stub.projectId,
+  });
+
+  return stubPath;
+}
+
+// ---------------------------------------------------------------------------
+// Path derivation — extract repo root + project name from session dir
+// ---------------------------------------------------------------------------
+
+/**
+ * Decompose an absolute session directory of the canonical shape
+ * `<repoRoot>/.gobbi/projects/<projectName>/sessions/<sessionId>` into the
+ * three parts the json-memory path helpers consume directly.
+ *
+ * Mirrors the path-segment heuristic in
+ * `step-readme-writer.ts::projectNameFromSessionDir`: the `'sessions'`
+ * segment is the anchor; the segment two before it is `'projects'`, and
+ * the segment between them is the project name. The session id is the
+ * trailing segment.
+ *
+ * Throws when the path does not match the canonical layout — this is a
+ * caller-bug surface, not user data, so failing loudly is correct
+ * (the engine's post-commit catch turns the throw into a stderr line).
+ */
+function deriveSessionLocation(sessionDir: string): {
+  readonly repoRoot: string;
+  readonly projectName: string;
+  readonly sessionId: string;
+} {
+  const parts = sessionDir.split(sep);
+  // Trailing-slash safety — drop empty segments.
+  const segments = parts.filter((segment) => segment.length > 0);
+
+  // Reverse-walk: `<sessionId>` is last, `'sessions'` second-last,
+  // `<projectName>` third-last, `'projects'` fourth-last, `'.gobbi'`
+  // fifth-last. Anything before that is the repo root.
+  const sessionsIdx = segments.lastIndexOf('sessions');
+  if (sessionsIdx < 3) {
+    throw new Error(
+      `session-json-writer: cannot derive project layout from sessionDir ${sessionDir}`,
+    );
+  }
+  if (segments[sessionsIdx - 2] !== 'projects') {
+    throw new Error(
+      `session-json-writer: expected 'projects' segment at depth ${sessionsIdx - 2} in ${sessionDir}`,
+    );
+  }
+  if (segments[sessionsIdx - 3] !== '.gobbi') {
+    throw new Error(
+      `session-json-writer: expected '.gobbi' segment at depth ${sessionsIdx - 3} in ${sessionDir}`,
+    );
+  }
+
+  const projectName = segments[sessionsIdx - 1];
+  const sessionId = segments[sessionsIdx + 1];
+  if (projectName === undefined || projectName.length === 0) {
+    throw new Error(
+      `session-json-writer: missing project name segment in ${sessionDir}`,
+    );
+  }
+  if (sessionId === undefined || sessionId.length === 0) {
+    throw new Error(
+      `session-json-writer: missing session id segment in ${sessionDir}`,
+    );
+  }
+
+  // Re-build the repo root from the segments preceding `.gobbi`. Preserve
+  // the absolute-path leading separator on POSIX so the caller can pass
+  // the result back into the path helpers without losing the root.
+  const rootSegments = segments.slice(0, sessionsIdx - 3);
+  const isAbsolute = sessionDir.startsWith(sep);
+  const repoRoot =
+    rootSegments.length === 0
+      ? isAbsolute
+        ? sep
+        : '.'
+      : (isAbsolute ? sep : '') + rootSegments.join(sep);
+
+  return { repoRoot, projectName, sessionId };
+}

--- a/packages/cli/src/workflow/step-readme-writer.ts
+++ b/packages/cli/src/workflow/step-readme-writer.ts
@@ -11,7 +11,7 @@
  * is NOT the authoritative artifact for the step (those are the per-step
  * synthesis files like `ideation.md` / `plan.md` / `execution.md`); it is
  * a CLI-maintained snapshot that mirrors information already present in
- * `gobbi.db` and `state.json`.
+ * `WorkflowState` at exit time and the per-step `artifacts/` directory.
  *
  * ## Discipline
  *

--- a/packages/cli/src/workflow/store.ts
+++ b/packages/cli/src/workflow/store.ts
@@ -5,21 +5,40 @@
  * Uses WAL mode, cached prepared statements via db.query(), and
  * ON CONFLICT(idempotency_key) DO NOTHING RETURNING * for atomic dedup.
  *
+ * ## Partition-aware reads (PR-FIN-2a-ii / T-2a.9.unified — Option α)
+ *
+ * Every read method (`replayAll`, `byType`, `byStep`, `since`, `last`,
+ * `lastN`, `lastNAny`, `eventCount`, `aggregateDelegationCosts`) bakes a
+ * `WHERE session_id=? AND project_id=?` clause derived from the
+ * constructor-bound partition keys. Production callers always supply
+ * explicit `EventStoreOptions{sessionId, projectId}` (the workspace
+ * `.gobbi/state.db` is the only writer surface; it carries events for
+ * every session in the workspace). With Option α the implicit filter
+ * matches caller intent — every query "scope to my session" — without
+ * threading a partition arg through every callsite.
+ *
+ * When either partition key is `null` (in-memory tests, fixture stores,
+ * `:memory:`), the filter degrades gracefully: a `null` projectId
+ * matches via `IS NULL` so legacy single-key tests (where project_id
+ * stayed unstamped) still see their events. Tests that need
+ * cross-partition reads must construct two stores or stamp matching
+ * partition keys at append time.
+ *
  * Schema v5+ adds explicit `session_id` and `project_id` columns to the
  * `events` table — previously these partition keys were only implicit
  * in the row's `idempotency_key` string. The column-level encoding makes
  * per-session and per-project queries a direct projection rather than a
  * string-parse. See DRIFT-3 in `.claude/project/gobbi/design/v050-features/gobbi-memory/review.md`
  * for the design rationale + backfill semantics (gobbi-memory Pass 2,
- * issue #118). `session_id` is read from the constructor's inferred
- * sessionId (derived from the session directory name); `project_id` is
- * `metadata.projectName` captured from the session's metadata.json
- * (schema v3+; previously `basename(projectRoot)` — see issue #178).
+ * issue #118). `session_id` is taken verbatim from `EventStoreOptions`
+ * (or path-derived as a test fallback); `project_id` is supplied
+ * explicitly via `EventStoreOptions.projectId` — the legacy
+ * `metadata.json` reader was retired in PR-FIN-2a-ii (T-2a.9.unified)
+ * because metadata.json is itself being dropped in this PR.
  */
 
 import { Database } from 'bun:sqlite';
-import { readFileSync } from 'node:fs';
-import { basename, dirname, join } from 'node:path';
+import { basename, dirname } from 'node:path';
 import {
   CURRENT_SCHEMA_VERSION,
   backfillSessionAndProjectIds,
@@ -186,23 +205,38 @@ VALUES ($ts, $schema_version, $type, $step, $data, $actor, $parent_seq, $idempot
 ON CONFLICT(idempotency_key) DO NOTHING
 RETURNING *`;
 
-const SQL_REPLAY_ALL = `SELECT * FROM events ORDER BY seq ASC`;
+// ---------------------------------------------------------------------------
+// Partition-filter clause — every read method scopes to the constructor-
+// bound `(sessionId, projectId)` pair. The clause uses `IS` (not `=`) so
+// `null` partition keys match `NULL` columns: legacy in-memory tests and
+// fixtures that stamp NULL partition keys still see their events, while
+// production callers (which always supply non-null keys) get an
+// equality filter that respects the partition.
+//
+// Equivalent to:
+//   WHERE (session_id = $session_id OR (session_id IS NULL AND $session_id IS NULL))
+//     AND (project_id = $project_id OR (project_id IS NULL AND $project_id IS NULL))
+// — but `IS` is the SQLite shortcut for the same null-aware comparison.
+// ---------------------------------------------------------------------------
+const PARTITION_CLAUSE = 'session_id IS $session_id AND project_id IS $project_id';
 
-const SQL_BY_TYPE = `SELECT * FROM events WHERE type = $type ORDER BY seq ASC`;
+const SQL_REPLAY_ALL = `SELECT * FROM events WHERE ${PARTITION_CLAUSE} ORDER BY seq ASC`;
 
-const SQL_BY_STEP = `SELECT * FROM events WHERE step = $step ORDER BY seq ASC`;
+const SQL_BY_TYPE = `SELECT * FROM events WHERE ${PARTITION_CLAUSE} AND type = $type ORDER BY seq ASC`;
 
-const SQL_BY_STEP_TYPE = `SELECT * FROM events WHERE step = $step AND type = $type ORDER BY seq ASC`;
+const SQL_BY_STEP = `SELECT * FROM events WHERE ${PARTITION_CLAUSE} AND step = $step ORDER BY seq ASC`;
 
-const SQL_SINCE = `SELECT * FROM events WHERE seq > $seq ORDER BY seq ASC`;
+const SQL_BY_STEP_TYPE = `SELECT * FROM events WHERE ${PARTITION_CLAUSE} AND step = $step AND type = $type ORDER BY seq ASC`;
 
-const SQL_LAST = `SELECT * FROM events WHERE type = $type ORDER BY seq DESC LIMIT 1`;
+const SQL_SINCE = `SELECT * FROM events WHERE ${PARTITION_CLAUSE} AND seq > $seq ORDER BY seq ASC`;
 
-const SQL_LAST_N = `SELECT * FROM events WHERE type = $type ORDER BY seq DESC LIMIT $n`;
+const SQL_LAST = `SELECT * FROM events WHERE ${PARTITION_CLAUSE} AND type = $type ORDER BY seq DESC LIMIT 1`;
 
-const SQL_LAST_N_ANY = `SELECT * FROM events ORDER BY seq DESC LIMIT $n`;
+const SQL_LAST_N = `SELECT * FROM events WHERE ${PARTITION_CLAUSE} AND type = $type ORDER BY seq DESC LIMIT $n`;
 
-const SQL_COUNT = `SELECT count(*) as cnt FROM events`;
+const SQL_LAST_N_ANY = `SELECT * FROM events WHERE ${PARTITION_CLAUSE} ORDER BY seq DESC LIMIT $n`;
+
+const SQL_COUNT = `SELECT count(*) as cnt FROM events WHERE ${PARTITION_CLAUSE}`;
 
 /**
  * Cost-rollup SELECT over all `delegation.complete` events, ordered by
@@ -235,7 +269,7 @@ SELECT
   json_extract(data, '$.model')                   AS model,
   json_extract(data, '$.sizeProxyBytes')          AS bytes
 FROM events
-WHERE type = 'delegation.complete'
+WHERE ${PARTITION_CLAUSE} AND type = 'delegation.complete'
 ORDER BY seq ASC
 `;
 
@@ -343,9 +377,10 @@ export interface WriteStore extends ReadStore {
  * Optional explicit partition-key overrides for the {@link EventStore}
  * constructor. Both fields participate in the same fallback policy:
  *
- * - A non-empty string overrides the on-disk derivation.
+ * - A non-empty string overrides the path-derivation fallback.
  * - `null`, `undefined`, or the empty string `''` defers to the
- *   path-derivation fallback (existing behavior).
+ *   path-derivation fallback (sessionId only — projectId has no
+ *   path fallback after PR-FIN-2a-ii / T-2a.9.unified).
  *
  * Empty-string and `null` are treated identically as "explicitly unset"
  * so callers cannot accidentally stamp empty-string columns on every
@@ -353,12 +388,13 @@ export interface WriteStore extends ReadStore {
  * query that powers `gobbi workflow status` and would silently degrade
  * the cost rollup.
  *
- * Wave A.1's workspace re-scope (`.gobbi/state.db`) needs both keys
- * supplied explicitly because the path derivation yields `'.gobbi'`
- * for the session id and `null` for the project id at workspace root.
- * Per-session callers (legacy `<sessionDir>/gobbi.db` layout) keep
- * working unchanged by passing no options object — Wave A.1.7 sweeps
- * the 11 callsites separately.
+ * Production callers always supply both keys explicitly (the workspace
+ * `.gobbi/state.db` is the only writer surface and its filesystem path
+ * carries no per-session signal). Tests using `<sessionDir>/gobbi.db`
+ * continue to work via the sessionId path fallback (basename of the
+ * containing directory). The legacy `metadata.json` projectId reader
+ * was retired in T-2a.9.unified — projectId has no path fallback, so a
+ * caller that omits it stamps `null` into the column.
  */
 export interface EventStoreOptions {
   readonly sessionId?: string | null;
@@ -380,7 +416,10 @@ function isExplicitOverride(
 
 // ---------------------------------------------------------------------------
 // Partition-key resolution helpers — used by the EventStore constructor
-// to derive `session_id` + `project_id` from on-disk layout.
+// when callers omit explicit `EventStoreOptions`. Production callers
+// always supply both keys; the path fallback exists only for the test
+// surface that constructs `new EventStore('<sessionDir>/gobbi.db')`
+// without an options object.
 // ---------------------------------------------------------------------------
 
 /**
@@ -396,43 +435,6 @@ function resolveSessionId(sessionDir: string | null): string | null {
   return name === '' ? null : name;
 }
 
-/**
- * Resolve `metadata.projectName` from the session's `metadata.json`.
- * Silent on every failure mode (missing file, parse error, unexpected
- * shape, missing or non-string `projectName`) — the project_id column
- * stays NULL until a future open recovers a valid metadata.
- *
- * Schema v3+ `metadata.json` carries `projectName` directly (see
- * `commands/workflow/init.ts::SessionMetadata`). The previous
- * `basename(projectRoot)` derivation read the repo root directory, so
- * a multi-project workspace stamped every event with the same
- * `project_id` regardless of which project the session belonged to
- * (issue #178).
- */
-function resolveProjectIdFromMetadata(
-  sessionDir: string | null,
-): string | null {
-  if (sessionDir === null) return null;
-  let raw: string;
-  try {
-    raw = readFileSync(join(sessionDir, 'metadata.json'), 'utf8');
-  } catch {
-    return null;
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return null;
-  }
-  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    return null;
-  }
-  const projectName = (parsed as Record<string, unknown>)['projectName'];
-  if (typeof projectName !== 'string' || projectName === '') return null;
-  return projectName;
-}
-
 // ---------------------------------------------------------------------------
 // EventStore class
 // ---------------------------------------------------------------------------
@@ -441,27 +443,42 @@ export class EventStore implements WriteStore {
   private readonly db: Database;
 
   /**
-   * Session partition key — derived from the session directory name (the
-   * parent of the `gobbi.db` file). Populated on every v5 INSERT so the
-   * per-session partition is queryable by column rather than by parsing
-   * the `idempotency_key` prefix. `null` when the store is opened on
-   * `:memory:` or any path where the containing directory is the
-   * filesystem root (tests).
+   * Session partition key — supplied verbatim via
+   * {@link EventStoreOptions}, or path-derived as a test fallback (the
+   * basename of the directory containing `gobbi.db`). Populated on
+   * every v5 INSERT so the per-session partition is queryable by column
+   * rather than by parsing the `idempotency_key` prefix. `null` when
+   * the store is opened on `:memory:` or any path where the containing
+   * directory is the filesystem root (tests).
    */
   private readonly sessionId: string | null;
 
   /**
-   * Project partition key — `metadata.projectName` read from the
-   * session's `metadata.json` at construction (schema v3+). `null` when
-   * `metadata.json` is missing, unreadable, malformed, or lacks a
-   * non-empty `projectName`. Populated on every v5 INSERT alongside
-   * `session_id`; NULL rows are left alone unless
-   * {@link backfillSessionAndProjectIds} stamps them during a later
-   * open. Field name retained for git-history continuity — semantically
-   * it is now the project name, not a directory basename (see issue
-   * #178).
+   * Project partition key — supplied verbatim via
+   * {@link EventStoreOptions.projectId}. After PR-FIN-2a-ii
+   * (T-2a.9.unified) there is no path-derivation fallback: the legacy
+   * `metadata.json` reader was retired alongside the metadata.json file
+   * itself. A caller that omits `projectId` stamps `null` into the
+   * column; partition-aware read queries (`SELECT … WHERE project_id IS
+   * NULL`) still match those rows.
+   *
+   * Populated on every v5 INSERT alongside `session_id`; NULL rows are
+   * left alone unless {@link backfillSessionAndProjectIds} stamps them
+   * during a later open. The field's prior identifier referenced the
+   * project-root basename derivation; issue #178 fixed that to
+   * `metadata.projectName`, and PR-FIN-2a-ii (T-2a.9.unified) retired
+   * the metadata.json read entirely in favour of explicit
+   * {@link EventStoreOptions.projectId}.
    */
-  private readonly projectRootBasename: string | null;
+  private readonly projectId: string | null;
+
+  /**
+   * Pre-computed partition-key bindings for every read prepared
+   * statement. Hoisted into a single object so the cached statements
+   * receive the same shape across calls — bun:sqlite's binding cache
+   * performs better when the parameter shape is stable.
+   */
+  private readonly partitionBindings: SqlBindings;
 
   // Cached prepared statements — db.query() returns cached compiled bytecode.
   // Using SqlBindings as the param type to satisfy bun-types' SQLQueryBindings
@@ -490,22 +507,15 @@ export class EventStore implements WriteStore {
    *    on the on-disk layout. `:memory:` and filesystem-root paths
    *    yield `null`.
    *
-   * The same two-step policy applies to `opts.projectId`:
-   *
-   * 1. Non-empty `opts.projectId` takes precedence.
-   * 2. Otherwise {@link resolveProjectIdFromMetadata} parses the
-   *    sibling `metadata.json` and extracts `metadata.projectName`
-   *    (schema v3+). Missing or malformed metadata yields `null`
-   *    (silent — the column stays NULL until a future open recovers
-   *    a valid metadata). Issue #178 fixed the previous derivation
-   *    `basename(metadata.projectRoot)` which conflated all
-   *    multi-project sessions onto the same project_id.
+   * For `opts.projectId` there is no path fallback after PR-FIN-2a-ii
+   * (T-2a.9.unified). The legacy `metadata.json` reader was retired
+   * alongside the metadata.json file. Production callers always supply
+   * `projectId` explicitly; tests that omit it stamp `null` and rely
+   * on the partition-aware read clause (`project_id IS NULL`) to match.
    *
    * Empty-string and `null` are treated identically as "explicitly
    * unset" — see {@link EventStoreOptions} for why empty strings
-   * cannot reach the column. Wave A.1's workspace mode supplies both
-   * keys; legacy per-session callers omit the options object and keep
-   * the original path-derived behavior.
+   * cannot reach the column.
    */
   constructor(pathOrMemory: string, opts?: EventStoreOptions) {
     this.db = new Database(pathOrMemory, { strict: true });
@@ -515,37 +525,43 @@ export class EventStore implements WriteStore {
     this.db.run('PRAGMA busy_timeout = 5000');
 
     // Resolve partition keys. Explicit non-empty overrides win; null,
-    // undefined, and the empty string defer to on-disk derivation.
-    // In-memory stores and filesystem-root paths yield null keys when
-    // no override is supplied.
+    // undefined, and the empty string defer to on-disk derivation
+    // (sessionId only) or stay null (projectId).
     const sessionDir =
       pathOrMemory === ':memory:' ? null : dirname(pathOrMemory);
     this.sessionId =
       isExplicitOverride(opts?.sessionId)
         ? opts.sessionId
         : resolveSessionId(sessionDir);
-    this.projectRootBasename =
-      isExplicitOverride(opts?.projectId)
-        ? opts.projectId
-        : resolveProjectIdFromMetadata(sessionDir);
+    this.projectId = isExplicitOverride(opts?.projectId)
+      ? opts.projectId
+      : null;
+
+    // Pre-bind the partition keys for every read statement. Same object
+    // reused across calls so bun:sqlite's binding cache stays warm.
+    this.partitionBindings = {
+      session_id: this.sessionId,
+      project_id: this.projectId,
+    };
 
     this.initSchema();
     // v4 → v5 row-level backfill. Idempotent — writes only to rows whose
     // partition keys are NULL (the legacy-v4 shape). Runs outside the
     // SQL_CREATE_TABLE / ALTER path because it depends on the resolved
-    // `sessionId` + `projectRootBasename`, which `initSchema` does not
-    // know about.
+    // `sessionId` + `projectId`, which `initSchema` does not know about.
     if (this.sessionId !== null) {
       backfillSessionAndProjectIds(
         this.db,
         this.sessionId,
-        this.projectRootBasename,
+        this.projectId,
       );
     }
 
-    // Cache all prepared statements with typed return values
+    // Cache all prepared statements with typed return values. Read
+    // statements bind the partition keys via $session_id + $project_id
+    // (Option α — see module header).
     this.stmtAppend = this.db.query<EventRow, [SqlBindings]>(SQL_APPEND);
-    this.stmtReplayAll = this.db.query<EventRow, []>(SQL_REPLAY_ALL);
+    this.stmtReplayAll = this.db.query<EventRow, [SqlBindings]>(SQL_REPLAY_ALL);
     this.stmtByType = this.db.query<EventRow, [SqlBindings]>(SQL_BY_TYPE);
     this.stmtByStep = this.db.query<EventRow, [SqlBindings]>(SQL_BY_STEP);
     this.stmtByStepType = this.db.query<EventRow, [SqlBindings]>(SQL_BY_STEP_TYPE);
@@ -553,10 +569,11 @@ export class EventStore implements WriteStore {
     this.stmtLast = this.db.query<EventRow, [SqlBindings]>(SQL_LAST);
     this.stmtLastN = this.db.query<EventRow, [SqlBindings]>(SQL_LAST_N);
     this.stmtLastNAny = this.db.query<EventRow, [SqlBindings]>(SQL_LAST_N_ANY);
-    this.stmtCount = this.db.query<{ cnt: number }, []>(SQL_COUNT);
-    this.stmtAggregateDelegationCosts = this.db.query<CostAggregateRow, []>(
-      SQL_AGGREGATE_DELEGATION_COSTS,
-    );
+    this.stmtCount = this.db.query<{ cnt: number }, [SqlBindings]>(SQL_COUNT);
+    this.stmtAggregateDelegationCosts = this.db.query<
+      CostAggregateRow,
+      [SqlBindings]
+    >(SQL_AGGREGATE_DELEGATION_COSTS);
   }
 
   // -------------------------------------------------------------------------
@@ -641,11 +658,13 @@ export class EventStore implements WriteStore {
   append(input: AppendInput): EventRow | null {
     const idempotencyKey = EventStore.computeIdempotencyKey(input);
     // With strict: true, bun:sqlite binds by name WITHOUT the $ prefix.
-    // Schema v5 stamps `session_id` + `project_id` explicitly. The
-    // constructor-resolved `sessionId` falls back to the input's
-    // `sessionId` when a store opened on `:memory:` (no session directory
-    // to infer from) still needs to author rows for a specific session
-    // during tests.
+    // Schema v5 stamps `session_id` + `project_id` explicitly using the
+    // constructor-bound partition keys (Option α — see module header).
+    // Stamped values must match the bound values exactly so the
+    // partition-aware read queries (`WHERE session_id IS $session_id
+    // AND project_id IS $project_id`) find their own rows. A `null`
+    // bound key produces a NULL stamp, which the `IS` operator matches
+    // null-aware on read.
     const params: SqlBindings = {
       ts: input.ts,
       schema_version: CURRENT_SCHEMA_VERSION,
@@ -655,8 +674,8 @@ export class EventStore implements WriteStore {
       actor: input.actor,
       parent_seq: input.parent_seq ?? null,
       idempotency_key: idempotencyKey,
-      session_id: this.sessionId ?? input.sessionId,
-      project_id: this.projectRootBasename,
+      session_id: this.sessionId,
+      project_id: this.projectId,
     };
     const row = this.stmtAppend.get(params);
     // Concurrent-writer durability mitigation (#146 A.1.9 / SC-ORCH-25):
@@ -729,32 +748,53 @@ export class EventStore implements WriteStore {
   // Read operations
   // -------------------------------------------------------------------------
 
-  /** Replay all events ordered by seq ASC. */
+  /**
+   * Replay all events for the constructor-bound `(sessionId, projectId)`
+   * partition, ordered by seq ASC. Cross-partition reads are not
+   * supported through this API — open a separate `EventStore` with
+   * matching partition keys.
+   */
   replayAll(): EventRow[] {
-    return this.stmtReplayAll.all();
+    return this.stmtReplayAll.all(this.partitionBindings);
   }
 
-  /** Return events filtered by type, ordered by seq ASC. */
+  /**
+   * Return events filtered by type within the bound partition, ordered
+   * by seq ASC.
+   */
   byType(type: string): EventRow[] {
-    return this.stmtByType.all({ type });
+    return this.stmtByType.all({ ...this.partitionBindings, type });
   }
 
-  /** Return events filtered by step (and optionally type), ordered by seq ASC. */
+  /**
+   * Return events filtered by step (and optionally type) within the
+   * bound partition, ordered by seq ASC.
+   */
   byStep(step: string, type?: string): EventRow[] {
     if (type !== undefined) {
-      return this.stmtByStepType.all({ step, type });
+      return this.stmtByStepType.all({
+        ...this.partitionBindings,
+        step,
+        type,
+      });
     }
-    return this.stmtByStep.all({ step });
+    return this.stmtByStep.all({ ...this.partitionBindings, step });
   }
 
-  /** Return events with seq > the given value, ordered by seq ASC. */
+  /**
+   * Return events with seq > the given value within the bound
+   * partition, ordered by seq ASC.
+   */
   since(seq: number): EventRow[] {
-    return this.stmtSince.all({ seq });
+    return this.stmtSince.all({ ...this.partitionBindings, seq });
   }
 
-  /** Return the most recent event of the given type, or null if none exist. */
+  /**
+   * Return the most recent event of the given type within the bound
+   * partition, or null if none exist.
+   */
   last(type: string): EventRow | null {
-    return this.stmtLast.get({ type });
+    return this.stmtLast.get({ ...this.partitionBindings, type });
   }
 
   /**
@@ -770,7 +810,7 @@ export class EventStore implements WriteStore {
    */
   lastN(type: string, n: number): readonly EventRow[] {
     if (n <= 0) return [];
-    return this.stmtLastN.all({ type, n });
+    return this.stmtLastN.all({ ...this.partitionBindings, type, n });
   }
 
   /**
@@ -783,12 +823,14 @@ export class EventStore implements WriteStore {
    */
   lastNAny(n: number): readonly EventRow[] {
     if (n <= 0) return [];
-    return this.stmtLastNAny.all({ n });
+    return this.stmtLastNAny.all({ ...this.partitionBindings, n });
   }
 
-  /** Return total event count (for diagnostics). */
+  /**
+   * Return total event count for the bound partition (for diagnostics).
+   */
   eventCount(): number {
-    const row = this.stmtCount.get();
+    const row = this.stmtCount.get(this.partitionBindings);
     return row?.cnt ?? 0;
   }
 
@@ -812,7 +854,7 @@ export class EventStore implements WriteStore {
    * raw-SQL surface.
    */
   aggregateDelegationCosts(): readonly CostAggregateRow[] {
-    return this.stmtAggregateDelegationCosts.all();
+    return this.stmtAggregateDelegationCosts.all(this.partitionBindings);
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

PR-FIN-2 finalization Wave 2 of 3 — the heavy lift. Drops the entire SQLite-based per-session memory machinery (`gobbi.db`, `state.json`, `state.json.backup`, `metadata.json`, `artifacts/`) and replaces it with two JSON files: `project.json` (per-project, git-tracked) and `session.json` (per-session, gitignored).

Closes #230.

## Why JSON, not SQLite

Solo-developer iteration during v0.5.0 finalization. Schema is unstable; binary-diff opacity in git makes per-iteration review unworkable. JSON files give text-diffable history, AJV gives type safety, sorted writes give stable diffs.

## Forward-compat for Codex

v1 schema reserves a `provider: 'anthropic'` discriminant on agents so the future Codex arm lands strictly-additively as `oneOf` widening — no schemaVersion bump required when Codex integration ships. AJV is configured with `discriminator: true` and a v1→v2 schema-equivalence test pre-shadows the widening.

## What landed

8 tasks across 4 waves (16 commits):

**Wave A** (parallel)
- **T-2a.8.0** PreToolUse guard emits `delegation.spawn` with `tool_call_id` linkage; `findParentSpawnSeq` switches from `last(...)` heuristic to scoped match; `transcriptSha256` capture-time hash; SubagentStart hook stub retired.
- **T-2a.8.1** new `lib/json-memory.ts` foundation (1391 lines): types, AJV validators, atomic writers, sorted-rewrite primitives, memorization aggregator (transcript-walking JSONL fallback), `upsertProjectSession`/`upsertProjectGotcha` helpers. Adds `ajv-formats@^3.0.1` as new prod dep.

**Wave B** (parallel)
- **T-2a.8.2** memorization STEP_EXIT writer wired into engine post-commit dispatch (mirrors `step-readme-writer.ts`). `appendEventAndUpdateState` becomes async; await cascades through 14 callsites.
- **T-2a.8.3** `gobbi gotcha promote` rewires to `upsertProjectGotcha`.
- **T-2a.8.5** `gobbi workflow init` writes `session.json` stub (6 required fields); drops `metadata.json` writer.

**Wave C** (sequential)
- **T-2a.9.unified** partition-aware `EventStore` refactor: every read SQL bakes `WHERE session_id IS $session_id AND project_id IS $project_id`. Drops `metadata.json` reader. Engine retires `state.json` read/write/backup paths. `EventStore.projectRootBasename → projectId` rename. `step-readme-writer.ts` docblock fix.
- **T-2a.9.tests** bulk-rewrite tests against new shape; partition-key plumbing through every test EventStore construction site; deprecated `SessionMetadata`/`readMetadata` exports removed.

**Wave D**
- **T-2a.10** `wipe-legacy-sessions` per-project predicate: sweeps 5 legacy artifacts (`gobbi.db, state.json, state.json.backup, metadata.json, artifacts/`) while preserving `session.json` + per-step subdirs. Active-session probe via state.db SQL.

## Test plan

- [x] `cd packages/cli && bun run build:safe` — clean
- [x] `bun test` from worktree root — 2197 pass / 9 skip / 8 todo / 0 fail (was 2106 pre-PR; +91 net)
- [x] `tsc --noEmit` — clean
- [x] AJV positive fixtures (init-stub, mid-session, complete, aborted) — pass
- [x] AJV negative fixtures (wrong schemaVersion, missing required, invalid date-time, extra field) — pass
- [x] v1→v2 schema-equivalence test (synthetic Codex `oneOf` arm validates v1 fixtures) — pass
- [x] Spawn-emitter ripple: 5 dormant code paths exercised in `__tests__/integration/guard-emits-spawn.test.ts`
- [x] Wipe-legacy reaper: 5 new tests + active-session-skip case

## Eval coverage

Three workflow stages each evaluated by 3 perspectives (project + overall + architecture). Plan revisions integrated 18 consensus tightenings before Execution started. Execution eval: 1 PASS, 2 REVISE — both REVISE verdicts converged on `resume.ts` dead state.json writes + stale comments in `resume.ts`/`init.ts`. Remediation commit `53fb0a8` removes the dead writes and rewrites the stale docblocks.

## Out of scope (deferred to follow-up PRs)

- Codex `provider: "codex"` writer arm — lands when Codex spawn integration ships (strictly additive, no schemaVersion bump)
- `OPENAI_MODEL_RATES` table in `lib/cost-rates.ts` — lands with Codex arm
- `gobbi memory backfill <session-id>` admin command for crashed-session recovery
- Roles × specialties matrix (`agents[].role/specialties`) — Wave D.1
- Per-LLM-turn duration field on `calls[]` — re-introduce when a real per-turn-duration source exists
- 3 docs collision files in PR-FIN-2a-iii: `gobbi-memory/README.md`, `orchestration/README.md`, `gobbi-memory/scenarios.md`
- `state.ts` orphan exports (`writeState`, `readState`, `backupState`, `restoreStateFromBackup`) — eval flagged for follow-up cleanup
- `paths.ts` hardening (Option A) — extend fallback chain to `<self>/../src/specs/`