### PR TITLE
feat(memory): PR-FIN-2a-iii — closing-cluster cleanup (8 of 8)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -10,7 +10,7 @@ MUST load this at session start, resume, `/clear`, and compaction. MUST follow t
 
 > **The logic of good work: Ideation → Planning → Execution → Memorization → Handoff.**
 
-Every non-trivial task follows these 5 productive steps. Evaluation runs as a sub-phase inside Ideation, Planning, and Execution — mandatory after Execution, optional at the earlier steps. The 6-step state machine (Configuration as the CLI init phase, plus the 5 productive steps) lives in `packages/cli/src/specs/` and is driven by `gobbi workflow init`. Workflow events write to per-session `gobbi.db` at `.gobbi/projects/<name>/sessions/<id>/gobbi.db`; cross-session memory lives in `.gobbi/gobbi.db` (workspace memories projection, git-tracked). Note: `prompt.patch.applied` events write to workspace `.gobbi/state.db` — full workspace consolidation of workflow events is Wave A.1 work, partially shipped.
+Every non-trivial task follows these 5 productive steps. Evaluation runs as a sub-phase inside Ideation, Planning, and Execution — mandatory after Execution, optional at the earlier steps. The 6-step state machine (Configuration as the CLI init phase, plus the 5 productive steps) lives in `packages/cli/src/specs/` and is driven by `gobbi workflow init`. Workflow events write to per-session `gobbi.db` at `.gobbi/projects/<name>/sessions/<id>/gobbi.db`. Note: `prompt.patch.applied` events write to workspace `.gobbi/state.db` — full workspace consolidation of workflow events is Wave A.1 work, partially shipped. Per-session telemetry lives in `<sessionDir>/session.json` (one file per session, generated at Memorization STEP_EXIT). Cross-session memory lives in `.gobbi/projects/<name>/project.json` (per-project, git-tracked). The retired files (`state.json`, `state.json.backup`, per-session `metadata.json`, session-root `artifacts/`) were unified into the JSON-memory shape in PR-FIN-2a-ii.
 
 **Ideation** — Explore what to do. PI agents (innovative + best stances) investigate the problem space with the user. Discuss until the approach is concrete enough to plan against. Optional evaluation.
 
@@ -46,6 +46,6 @@ MUST decompose work into small, specific tasks and track them with TaskCreate. E
 |----------|--------|
 | [gobbi skill](skills/gobbi/SKILL.md) | Entry point, session setup questions, skill map |
 | [_claude skill](skills/_claude/SKILL.md) | Documentation standard for `.claude/` authoring |
-| [`v050-overview.md`](../../../.gobbi/projects/gobbi/design/v050-overview.md) | v0.5.0 state machine, 6-step workflow, per-session/workspace DB split — authoritative architecture doc |
+| [`v050-overview.md`](../../../.gobbi/projects/gobbi/design/v050-overview.md) | v0.5.0 state machine, 6-step workflow, workspace `state.db` + per-session `gobbi.db` + JSON memory (`session.json` + `project.json`) — authoritative architecture doc |
 | [`v050-cli.md`](../../../.gobbi/projects/gobbi/design/v050-cli.md) | CLI command surface, `gobbi workflow *` and `gobbi project *` commands |
 | [rules/](rules/) | Naming conventions and project rules |

--- a/.gobbi/projects/gobbi/design/v050-features/gobbi-memory/README.md
+++ b/.gobbi/projects/gobbi/design/v050-features/gobbi-memory/README.md
@@ -1,6 +1,6 @@
 # gobbi-memory — Multi-Project Memory Model
 
-Feature description for gobbi's cross-session persistence model under `.gobbi/projects/{name}/`. Read this to understand how memory is organized per project, how `.claude/` relates to `.gobbi/` via a symlink farm, how the `gobbi install` bootstrap seeds a fresh repo, and how `gobbi project list|create|switch` manages the multi-project lifecycle. This is the design-of-record for Pass 2 redesign (session `35742566-2697-4318-bb06-558346b77b4a`), updated by **PR-FIN-2 finalization** (session `9755a2cb-0981-455b-915e-643de6de2500`, 2026-04-29) for the taxonomy expansion (`gotchas/` and `tmp/` promoted to top-level), the manifest removal (`.install-manifest.json` and 3-way merge logic dropped), the session structure simplification (`metadata.json`, `gobbi.db`, `state.json` dropped from session root), and the `memorization_eval` state-machine step addition.
+Feature description for gobbi's cross-session persistence model under `.gobbi/projects/{name}/`. Read this to understand how memory is organized per project, how `.claude/` relates to `.gobbi/` via a symlink farm, how the `gobbi install` bootstrap seeds a fresh repo, and how `gobbi project list|create|switch` manages the multi-project lifecycle. This is the design-of-record for Pass 2 redesign (session `35742566-2697-4318-bb06-558346b77b4a`), updated by **PR-FIN-2 finalization** (session `9755a2cb-0981-455b-915e-643de6de2500`, 2026-04-29) for the taxonomy expansion (`gotchas/` and `tmp/` promoted to top-level), the manifest removal (`.install-manifest.json` and 3-way merge logic dropped), the session-root simplification (`metadata.json`, `state.json`, session-root `artifacts/` dropped — per-session `gobbi.db` preserved as the per-session event store), and the `memorization_eval` state-machine step addition. PR-FIN-2a-ii (2026-04-30) landed the JSON memory pivot — durable memory now lives in git-tracked `project.json`; per-session telemetry in `session.json`.
 
 ---
 
@@ -12,13 +12,14 @@ Pass 2 replaces the Pass-1 layout — where skills/agents/rules/project-docs liv
 
 ## Directory shape
 
-**Updated by PR-FIN-2 finalization (2026-04-29):** `gotchas/` promoted to top-level (separated from `learnings/`); `tmp/` formalized as gitignored project-scoped scratch; `.install-manifest.json` removed (3-way merge logic dropped); session-root files reduced to `settings.json` only (`metadata.json`, `gobbi.db`, `state.json`, `state.json.backup`, `artifacts/` all dropped — operational state moves to workspace `.gobbi/gobbi.db` + `.gobbi/state.db`).
+**Updated by PR-FIN-2 finalization (2026-04-29):** `gotchas/` promoted to top-level (separated from `learnings/`); `tmp/` formalized as gitignored project-scoped scratch; `.install-manifest.json` removed (3-way merge logic dropped); session-root retirements (`metadata.json`, `state.json`, `state.json.backup`, session-root `artifacts/` all dropped) — durable cross-session memory moves to git-tracked `project.json`, in-flight per-session telemetry moves to `session.json`. **Per-session `gobbi.db` is preserved** as the per-session event store; workspace `.gobbi/state.db` partially holds workflow events (Wave A.1 in progress).
 
 | Path | Git | Purpose |
 |---|---|---|
 | `.gobbi/settings.json` | gitignored | Workspace-tier settings. |
-| `.gobbi/gobbi.db` | tracked | Cross-project memories projection + per-step operational metadata (sessionId, step timings, agent spawns, evaluation verdicts, artifact list). |
-| `.gobbi/state.db` | gitignored | Workspace-scoped state-machine event log. Per-session `gobbi.db` and `state.json` no longer exist; this DB is the single source of state-machine truth. |
+| `.gobbi/projects/{name}/project.json` | tracked | Cross-session promoted memory (sessions index, gotchas, decisions, learnings). Replaces the prior workspace `.gobbi/gobbi.db` SQLite memory projection. |
+| `.gobbi/state.db` | gitignored | Workspace-scoped state-machine event log (currently `prompt.patch.applied` only; full workflow-event consolidation is Wave A.1, partially shipped). |
+| `.gobbi/projects/{name}/sessions/{id}/gobbi.db` | gitignored | **Per-session event store — preserved.** Source of truth for per-session workflow events; powers `gobbi workflow status` / resume / state derivation; aggregated into `session.json` at memorization-step entry. |
 | `.gobbi/projects/` | tracked | Parent of all projects in this workspace. |
 | `.gobbi/projects/{name}/` | tracked except `sessions/`, `tmp/`, `worktrees/` | Root of one project. |
 | `.gobbi/projects/{name}/skills/` | tracked | Project's skill definitions; plugin-bundled and user-authored mixed; mirrored into `.claude/skills/` via per-file symlink farm. |
@@ -49,9 +50,9 @@ Everything about memory and configuration decomposes across three scopes:
 
 - **Workspace** — `.gobbi/settings.json` at the repo root. Cross-project defaults. One file; shared by every project in the workspace.
 - **Project** — `.gobbi/projects/{name}/settings.json` + the 12 taxonomy subdirectories. Each project is self-contained; renaming or deleting `{name}/` does not affect its siblings.
-- **Session** — `.gobbi/projects/{name}/sessions/{session_id}/`. One directory per workflow run, gitignored. Five step subdirectories (`ideation/`, `planning/`, `execution/`, `memorization/`, `handoff/`) — each holds a prose-summary `README.md` (written on `STEP_EXIT`), arbitrary freeform `*.md` topic files, a `rawdata/` directory of raw transcripts (Claude Code + subagent JSON/JSONL), and an `evaluation/` subdir for productive steps that run an `*_eval` step (`ideation`, `planning`, `execution`, `memorization`). The `README.md` at each step is **prose summary + index table**, not frontmatter — operational metadata (sessionId, step timings, agent spawns, verdicts, artifact lists) lives in `.gobbi/gobbi.db` keyed by `(session_id, step)`.
+- **Session** — `.gobbi/projects/{name}/sessions/{session_id}/`. One directory per workflow run, gitignored. Five step subdirectories (`ideation/`, `planning/`, `execution/`, `memorization/`, `handoff/`) — each holds a prose-summary `README.md` (written on `STEP_EXIT`), arbitrary freeform `*.md` topic files, a `rawdata/` directory of raw transcripts (Claude Code + subagent JSON/JSONL), and an `evaluation/` subdir for productive steps that run an `*_eval` step (`ideation`, `planning`, `execution`, `memorization`). The `README.md` at each step is **prose summary + index table**, not frontmatter — operational metadata (sessionId, step timings, agent spawns, verdicts, artifact lists) lives in per-session `gobbi.db` (event log) and is consolidated into `session.json` at memorization-step entry.
 
-Session-to-project binding is established at `gobbi workflow init`: the command resolves the project name from `--project <name>` flag → `basename(repoRoot)` (PR-FIN-1c project resolution; the prior `projects.active` registry was removed) and writes the binding into the workspace `.gobbi/gobbi.db` `sessions` row at session creation. Mid-flight project switch is not supported.
+Session-to-project binding is established at `gobbi workflow init`: the command resolves the project name from `--project <name>` flag → `basename(repoRoot)` (PR-FIN-1c project resolution; the prior `projects.active` registry was removed) and stamps the binding into the per-session `gobbi.db` and the `session.json` stub at init time. Mid-flight project switch is not supported.
 
 ---
 
@@ -101,13 +102,13 @@ Five step directories per session, all uniform:
 | `memorization/` | yes | yes | yes | yes (`memorization_eval` — **NEW** in PR-FIN-2) |
 | `handoff/` | yes | yes | yes | no |
 
-**`README.md` content** — prose summary of the step's outcome plus an index table listing every `*.md` topic file and every `rawdata/` artifact in the step dir with a one-line description. **No frontmatter** — operational metadata (sessionId, step timings, agent spawns, evaluation verdicts, artifact lists) lives in `.gobbi/gobbi.db` keyed by `(session_id, step)` and is queried by readers that need it. The `README.md` writer (CLI-only) renders the prose summary by reading those `gobbi.db` rows on `STEP_EXIT` and joining them with the file inventory of the step dir.
+**`README.md` content** — prose summary of the step's outcome plus an index table listing every `*.md` topic file and every `rawdata/` artifact in the step dir with a one-line description. **No frontmatter** — operational metadata (sessionId, step timings, agent spawns, evaluation verdicts, artifact lists) lives in `session.json` (per-session, written once at memorization-step entry by aggregating per-session `gobbi.db` events). The `README.md` writer (CLI-only) renders the prose summary by reading `WorkflowState` (derived from per-session `gobbi.db` events on `STEP_EXIT`) plus the per-step `artifacts/` inventory (the runtime spec subdir under `sessions/<id>/<step>/artifacts/`, distinct from the retired session-root `artifacts/` directory) and joins them with the file inventory of the step dir. Final consolidated session telemetry then lands in `session.json` at memorization-step entry. See `lib/json-memory.ts` for the JSON schemas and `workflow/session-json-writer.ts` for the writer.
 
 **`rawdata/`** — raw Claude Code transcript JSONL plus subagent transcript captures (one JSON/JSONL per subagent spawn). Subagents and the orchestrator's transcript both land here; this is the original-source archive for the step.
 
 **`evaluation/`** — flat `*.md` files, one per perspective (e.g., `architecture.md`, `project.md`, `overall.md`). Authoritative inputs to the corresponding `*_eval` step's verdict.
 
-**Memorization gets an evaluation loop (NEW):** unlike Pass 2, where memorization was a one-shot productive step, PR-FIN-2 adds `memorization_eval` to verify that the session's decisions, gotchas, learnings, and design changes actually landed in `.gobbi/gobbi.db` memories and on disk in the project's narrative dirs. The loop runs `[Memorize → memorization_eval → REVISE if not fully covered → Memorize → …]` until verdict PASS or `maxIterations` exceeded. State-machine implications are detailed in `../orchestration/README.md`.
+**Memorization gets an evaluation loop (NEW):** unlike Pass 2, where memorization was a one-shot productive step, PR-FIN-2 adds `memorization_eval` to verify that the session's decisions, gotchas, learnings, and design changes actually landed in `project.json` (durable cross-session memory) and on disk in the project's narrative dirs. The loop runs `[Memorize → memorization_eval → REVISE if not fully covered → Memorize → …]` until verdict PASS or `maxIterations` exceeded. State-machine implications are detailed in `../orchestration/README.md`.
 
 Writing is exit-only (D4 lock); in-flight visibility is via `gobbi workflow status --step <name>` rather than a mutable README.
 
@@ -115,12 +116,12 @@ Writing is exit-only (D4 lock); in-flight visibility is via `gobbi workflow stat
 
 ## State / event backward-compat
 
-Pass 2 renames the state-machine literal `'plan'` to `'planning'`. PR-FIN-2 drops per-session `gobbi.db` and `state.json` entirely — workflow state lives in workspace `.gobbi/state.db` only.
+Pass 2 renames the state-machine literal `'plan'` to `'planning'`. PR-FIN-2 drops session-root `metadata.json`, `state.json`, and `state.json.backup`; per-session `gobbi.db` is preserved as the per-session event store.
 
-- **Legacy `state.json` files** — sessions started under Pass 2 still have a `state.json` on disk. The `gobbi maintenance wipe-legacy-sessions` command deletes any session whose state row in `.gobbi/state.db` is terminal (`done`/`error`) AND has a stale on-disk layout. Active sessions are never touched.
-- **Legacy per-session `gobbi.db` files** — same wipe semantics; the file is removed when the session is cleaned.
+- **Legacy `state.json` files** — sessions started under Pass 2 still have a `state.json` on disk. The `gobbi maintenance wipe-legacy-sessions` command deletes the legacy file when the session reaches a terminal state. Active sessions are never touched.
+- **Legacy session-root `metadata.json` / `artifacts/`** — same wipe semantics; cleaned when the session is wiped.
 
-The pre-validation state normalization shim from Pass 2 is no longer needed under PR-FIN-2 because `state.json` is no longer read at all.
+The pre-validation state normalization shim from Pass 2 is no longer needed because `state.json` is no longer read at all — workflow state derives from per-session `gobbi.db` events.
 
 ---
 
@@ -150,7 +151,7 @@ Configuration (covered in `../gobbi-config/README.md`) answers "how does this wo
 
 ## Memory storage — two-tier JSON model (PR-FIN-2 Planning lock)
 
-**SUPERSEDES the prior `.gobbi/gobbi.db` SQLite design.** PR-FIN-2's Planning step locked a JSON-only model for cross-session memory and per-session operational metadata. The prior `.gobbi/gobbi.db` workspace SQLite file is **dropped entirely**. The `!.gobbi/gobbi.db` `.gitignore` exception is removed (no DB to track). SQLite remains in the workspace only as `.gobbi/state.db` — the gitignored runtime workflow event log.
+**SUPERSEDES the prior workspace `.gobbi/gobbi.db` SQLite memory design.** PR-FIN-2's Planning step locked a JSON-only model for cross-session memory (`project.json`) and per-session operational metadata (`session.json`). The workspace `.gobbi/gobbi.db` file is **dropped entirely**. SQLite remains in the workspace as `.gobbi/state.db` (gitignored runtime workflow event log; partial workspace consolidation per Wave A.1) and per-session as `<sessionDir>/gobbi.db` (the live per-session event store, preserved).
 
 **Why JSON, not SQLite.** Solo-developer iteration. Schema is unstable while v0.5.0 finalization is in flight. Binary-diff opacity in git makes review of every iteration commit unworkable. JSON files give text-diffable history; AJV schemas give type safety; sorted writes give stable diffs. Cross-session queries walk the filesystem on demand — at workspace scale (tens of sessions, hundreds of markdown files) this is fast enough without a materialized index.
 
@@ -177,21 +178,27 @@ Top-level fields:
 
 - `schemaVersion: 1`
 - `sessionId`, `projectId`, `createdAt`, `finishedAt`, `gobbiVersion`, `task`
-- `steps[]` — `{id, startedAt, finishedAt, feedbackRound, verdict?}`
-- `agents[]` — subagent spawns: `{id, name, stance, model, effort, role?, specialties?, startedAt, finishedAt, transcriptSha256}`
-- `agent_calls[]` — **provisional schema** (subject to revalidation when `gobbi stats` query surface lands): per-LLM-turn telemetry `{model, inputTokens, outputTokens, cacheRead, cacheWrite, durationMs, parentAgentId}`
-- `evaluations[]` — `{step, perspectives[], verdict, verdictAt}`
+- `steps[]` — one entry per productive step the session entered. Each step is **nested**, not flat:
+  - `{id, startedAt, finishedAt, skippedAt, timedOutAt, iterations[]}` per step.
+  - `iterations[]` — by feedback-round: `{round, startedAt, finishedAt, terminationReason, agents[] | substeps[]}`.
+  - `substeps[]` (optional axis — typical for ideation/planning/execution) — `{id, startedAt, finishedAt, agents[]}` for `discussion → research → delegation → evaluation`.
+  - `agents[]` — subagent spawns lifted onto either an iteration or a substep: `{id, name, stance, role?, specialties?, model, effort, provider, startedAt, finishedAt, transcriptSha256, tokensUsed (SUM-fold over calls[]), calls[]}`.
+  - `calls[]` — **provisional schema** (subject to revalidation when `gobbi stats` query surface lands): per-LLM-turn telemetry `{turnIndex, model, inputTokens, outputTokens, cacheRead, cacheWrite, durationMs, ...}`.
+- `evaluations[]` — `{step, perspectives[], verdict, verdictAt}`.
 
-All array fields sort by **`state.db.seq` ascending** (the workflow event-log sequence number) so parallel writers produce deterministic diffs.
+Sort axes (deterministic across parallel writers): `steps[]` by canonical step order; `iterations[]` by `round` ASC; `substeps[]` by `seq` ASC of first nested event; `agents[]` by `seq` ASC of first event mentioning the subagent id; `calls[]` by `turnIndex` ASC (monotonically aligned with the per-session `gobbi.db.seq` within an agent).
 
-Writer: memorization step writes `session.json` once at memorization-step entry by aggregating from `state.db` events + per-step rawdata transcripts. No per-step writers — single-write semantics avoid concurrency contention.
+Writer: memorization step writes `session.json` once at memorization-step entry by aggregating from per-session `gobbi.db` events + per-step rawdata transcripts (Anthropic JSONL under `~/.claude/projects/<encoded-cwd>/<sessionId>/subagents/`). No per-step writers — single-write semantics avoid concurrency contention. See `lib/json-memory.ts` (schemas + builder) and `workflow/session-json-writer.ts` (orchestration entry).
+
+**Concurrency caveat (solo-user assumption).** `project.json` writers (`gobbi gotcha promote`, memorization step) use whole-file read-modify-write without inter-process locking. The solo-user model assumes at most one writer at a time; if two sessions race a write, the loser's append is silently overwritten. Manual recovery: re-run the losing writer (e.g. re-promote the gotcha) after the conflict is detected via `git diff project.json`. A future multi-user redesign would replace this with file locking or move durable memory back to a transactional store.
 
 ### What's gone
 
-- **`.gobbi/gobbi.db`** — removed entirely. No workspace SQLite for memory.
-- **Per-session `gobbi.db`** — removed; events route to workspace `.gobbi/state.db`.
-- **`metadata.json`** — fields move into `session.json`.
-- **`state.json` + `state.json.backup`** — state is derived from `state.db` events; no on-disk JSON state file.
+- **`.gobbi/gobbi.db` (workspace)** — removed entirely. No workspace SQLite for memory; cross-session memory lives in git-tracked `project.json`.
+- **Per-session `gobbi.db`** — **NOT retired**: remains the live per-session event store under `sessions/<id>/gobbi.db`. Workspace consolidation onto `.gobbi/state.db` is Wave A.1 work (partially shipped — currently `prompt.patch.applied` only).
+- **Per-session `metadata.json`** — fields move into `session.json`. (The `metadata.json` homonym under `.claude/project/<name>/note/<task>/` belongs to the v0.4.x note-system and is unaffected.)
+- **Per-session `state.json` + `state.json.backup`** — state is derived from `gobbi.db` events; no on-disk JSON state file.
+- **Per-session session-root `artifacts/`** — removed. (The per-step runtime spec subdir `sessions/<id>/<step>/artifacts/` is a different directory and is preserved.)
 - **Per-step `README.md` frontmatter** — operational metadata moves to `session.json`. Per-step `README.md` becomes prose summary + index table only.
 - **`gobbi memory rebuild` command** — no projection to rebuild. The JSON files are the source of truth.
 - **Docs metadata manifest** — no materialized index of `.md` files. Search-by-content uses ripgrep; drift detection uses git status.
@@ -201,9 +208,9 @@ Writer: memorization step writes `session.json` once at memorization-step entry 
 
 `project.json` is git-tracked → cross-clone state survives. `session.json` is gitignored (lives inside the gitignored `sessions/`) → per-session operational metadata is workspace-local; only the durable extracts (decisions, gotchas, learnings) survive a clone via `project.json` and the markdown narrative dirs. This is intentional: in-flight session state is not portable across clones.
 
-### State.db — workspace event log (unchanged)
+### State.db — workspace event log (Wave A.1, partial)
 
-`.gobbi/state.db` remains the gitignored workspace-scoped append-only state-machine event log, partition-keyed by `(project_id, session_id)`. It powers `gobbi workflow status`, resume, and stats aggregation. The two-DB design from prior passes is now **one DB + two JSON files**: events in `state.db`, durable memory in `project.json`, in-flight session metadata in `session.json`.
+`.gobbi/state.db` is the gitignored workspace-scoped append-only event log, partition-keyed by `(project_id, session_id)`. It currently holds `prompt.patch.applied` events only; full workspace consolidation of workflow events is Wave A.1 work, partially shipped. Until A.1 completes, per-session `gobbi.db` remains the source of truth for workflow events powering `gobbi workflow status`, resume, and state derivation. The post-PR-FIN-2 split is **one workspace DB (`state.db`) + per-session `gobbi.db` event store + two-tier JSON memory (`session.json` + `project.json`)**: workspace prompt-patch events in `state.db`, per-session workflow events in `gobbi.db`, durable memory in `project.json`, in-flight session metadata in `session.json`.
 
 See `../orchestration/README.md` §3 for the workspace event-log details and the JSON-pivot impact on the spec graph (`memorization_eval` step).
 

--- a/.gobbi/projects/gobbi/design/v050-features/gobbi-memory/scenarios.md
+++ b/.gobbi/projects/gobbi/design/v050-features/gobbi-memory/scenarios.md
@@ -362,13 +362,9 @@ Evidence: Commit `fcd1171` (W4.4 snapshot regeneration).
 
 ## Active-session safeguards
 
-### G-MEM2-36 — `findStateActiveSessions` is the single source of truth
+### G-MEM2-36 — RETIRED (PR-FIN-2a-i)
 
-**Given** any command that must gate on active sessions (install, switch, wipe)
-**When** the command invokes `findStateActiveSessions(repoRoot)`
-**Then** the return is derived from `state.json.currentStep ∉ {done, error}` (state-based, not heuristic); all `.gobbi/projects/*/sessions/` are scanned.
-
-Evidence: `packages/cli/src/lib/session-scan.ts::findStateActiveSessions`. Commits `f428f18` (W3.3), `f257779` (W3 eval).
+The `findStateActiveSessions` helper was removed in PR-FIN-2a-i alongside the JSON-pivot retirement of per-session `state.json`. `gobbi gotcha promote` and `gobbi maintenance wipe-legacy-sessions` no longer guard on other in-flight sessions. A future redesign will reintroduce active-session detection on top of the per-session `gobbi.db` event-log shape. Historical scenario body preserved in git history.
 
 ---
 

--- a/.gobbi/projects/gobbi/design/v050-features/orchestration/README.md
+++ b/.gobbi/projects/gobbi/design/v050-features/orchestration/README.md
@@ -1,6 +1,6 @@
 # Orchestration — Deterministic Workflow Engine + JIT Prompt Injection
 
-Feature description for gobbi's v0.5.0 orchestration core: the L0–L3 layering, the deterministic state machine, the `state.db` / `gobbi.db` two-DB partition, the JIT prompt-footer pattern, the Inner-mode hook surface, the Outer-mode `gobbi workflow run` driver, and the `handoff` state-machine step. This is the design-of-record for Pass 4 (session `6e00d3d6-6833-4e8e-ae25-3f42165aebc3`), updated by **PR-FIN-2 finalization** (session `9755a2cb-0981-455b-915e-643de6de2500`, 2026-04-29) for the `memorization_eval` step addition (memorization now runs an evaluation loop), the workspace-DB-only lock (per-session `gobbi.db` and `state.json` removed), and the per-step session structure simplification (uniform `README.md` + freeform `*.md` + `rawdata/` + optional `evaluation/`). It supersedes the conceptual content in `../deterministic-orchestration.md` and absorbs the JIT framing from `../just-in-time-prompt-injection.md`. Wave A.2 will retire those two predecessor files.
+Feature description for gobbi's v0.5.0 orchestration core: the L0–L3 layering, the deterministic state machine, the workspace `state.db` + per-session `gobbi.db` event-store split, the two-tier JSON memory model (`session.json` + `project.json`), the JIT prompt-footer pattern, the Inner-mode hook surface, the Outer-mode `gobbi workflow run` driver, and the `handoff` state-machine step. This is the design-of-record for Pass 4 (session `6e00d3d6-6833-4e8e-ae25-3f42165aebc3`), updated by **PR-FIN-2 finalization** (session `9755a2cb-0981-455b-915e-643de6de2500`, 2026-04-29) for the `memorization_eval` step addition (memorization now runs an evaluation loop) and the per-step session structure simplification (uniform `README.md` + freeform `*.md` + `rawdata/` + optional `evaluation/`), and again by **PR-FIN-2a-ii** (2026-04-30) for the JSON memory pivot (per-session `state.json` retired; per-session `gobbi.db` preserved as the per-session event store). It supersedes the conceptual content in `../deterministic-orchestration.md` and absorbs the JIT framing from `../just-in-time-prompt-injection.md`. Wave A.2 will retire those two predecessor files.
 
 ---
 
@@ -76,11 +76,12 @@ The four layers each own a distinct slice of the orchestration stack. The user a
 
 | Storage | Git | Scope | Holds |
 |---|---|---|---|
-| `.gobbi/state.db` | gitignored | workspace | append-only state-machine event log; partition keys `(project_id, session_id)`; powers `gobbi workflow status` / resume / stats aggregation |
+| `.gobbi/state.db` | gitignored | workspace | append-only event log; partition keys `(project_id, session_id)`; currently `prompt.patch.applied` events only — full workspace consolidation of workflow events is Wave A.1 work, partially shipped |
+| `.gobbi/projects/{name}/sessions/{id}/gobbi.db` | gitignored | per-session | **preserved** per-session event store; source of truth for workflow events; powers `gobbi workflow status` / resume / state derivation; aggregated into `session.json` at memorization-step entry |
 | `.gobbi/projects/{name}/project.json` | **tracked** | per-project | cross-session promoted memory: sessions index, gotchas, decisions, learnings; AJV schema v1; sorted writes for stable git diffs |
-| `.gobbi/projects/{name}/sessions/{id}/session.json` | gitignored | per-session | consolidated per-session operational metadata: steps, agents, agent_calls (provisional), evaluations; AJV schema v1; written once at memorization-step entry by aggregating `state.db` events; arrays sorted by `state.db.seq` ascending |
+| `.gobbi/projects/{name}/sessions/{id}/session.json` | gitignored | per-session | consolidated per-session operational metadata: steps, agents, agent_calls (provisional), evaluations; AJV schema v1; written once at memorization-step entry by aggregating per-session `gobbi.db` events; arrays sorted by `gobbi.db.seq` ascending |
 
-Per-session `gobbi.db`, per-session `state.json` (+ `.backup`), per-session `metadata.json`, and per-session `artifacts/` are all removed entirely. `gobbi maintenance wipe-legacy-sessions` cleans up the on-disk legacy artifacts during the PR-FIN-2 cutover. The `EventStore` constructor takes explicit `(projectId, sessionId)` partition keys at every call site — no path-derivation fallback.
+Per-session `state.json` (+ `.backup`), per-session `metadata.json` (the per-session homonym — the v0.4.x note-system `metadata.json` under `.claude/project/<name>/note/<task>/` is unaffected), and per-session session-root `artifacts/` are removed entirely. `gobbi maintenance wipe-legacy-sessions` cleans up the on-disk legacy artifacts during the PR-FIN-2 cutover. The `EventStore` constructor takes explicit `(projectId, sessionId)` partition keys at every call site — no path-derivation fallback.
 
 **Why JSON, not SQLite, for memory.** Solo-developer iteration; schema is unstable while v0.5.0 finalization is in flight; binary-diff opacity in git makes review of every iteration commit unworkable. JSON gives text-diffable history, AJV gives boundary type safety, sorted writes give stable diffs, and cross-session queries walk the filesystem on demand (workspace scale is tens of sessions / hundreds of files — fast enough).
 
@@ -93,7 +94,7 @@ Per-session `gobbi.db`, per-session `state.json` (+ `.backup`), per-session `met
 
 ### 3.2 EventStore constructor must accept explicit partition keys
 
-`store.ts:369-370` derives `sessionId = basename(dirname(path))` from the DB path. For `.gobbi/state.db` that yields `'.gobbi'` as the session ID, and `resolveProjectRootBasename` reads `.gobbi/metadata.json` (absent), so `projectRootBasename` becomes permanently `null`. **Wave A.1 must add explicit partition-key parameters** to `EventStore`'s constructor: `new EventStore(path, { sessionId?: string; projectId?: string })`. Workspace-scoped callers supply both; the legacy path-derivation stays as a fallback during migration.
+`store.ts:369-370` derives `sessionId = basename(dirname(path))` from the DB path. For workspace `.gobbi/state.db` that yields `'.gobbi'` as the session ID, and the legacy project-name probe (since retired in PR-FIN-2a-ii) returned `null` because the per-session `metadata.json` no longer exists. The post-PR-FIN-2a-ii `EventStore` constructor takes explicit `(projectId, sessionId)` partition keys via `new EventStore(path, { sessionId?: string; projectId?: string })` — `resolvePartitionKeys` parses them from the session-dir path segments rather than reading any file. Workspace-scoped callers supply both keys explicitly.
 
 ### 3.3 `.gobbi/state.db` (workspace, gitignored, append-only event log + materialized views)
 
@@ -181,7 +182,7 @@ Verbatim from `packages/cli/src/workflow/events/workflow.ts:21-31`:
 
 | Event | Purpose |
 |---|---|
-| `workflow.start` | Inaugural event; pairs with `metadata.json` write; fixes `currentStep = 'ideation'` |
+| `workflow.start` | Inaugural event; pairs with the per-session `gobbi.db` open + `session.json` stub write at `gobbi workflow init`; fixes `currentStep = 'ideation'` |
 | `workflow.step.exit` | Productive step finished; reducer evaluates `evalEnabled` predicate to choose `<step>_eval` vs next productive step |
 | `workflow.step.skip` | User opted to skip a step (typically eval); routes to `ideation` per `index.json:200-247` |
 | `workflow.step.timeout` | Step's `meta.timeoutMs` exceeded; routes to `error` |
@@ -218,7 +219,7 @@ Token cost: ~180 tokens uncached; identical across same-step compilations so ful
 | **SubagentStop** | Read transcript, write to `.gobbi/projects/<name>/sessions/<id>/<step>/`, emit `delegation.complete`/`fail` (existing). | `commands/workflow/capture-subagent.ts` | Yes — same path issue |
 | **Stop** | Heartbeat + timeout + state flush (existing). **+ Missed-advancement safety net (new):** if no `step.advancement.observed` since the last `step.exit`/`start`/`resume` AND `turns_since_step_start ≥ 2`, inject `additionalContext` reminder; at `≥ 5` mark in `state_snapshots` and surface in `gobbi workflow status`. | `commands/workflow/stop.ts` | **Yes** — `stop.ts:181-183` looks for `<sessionDir>/gobbi.db`; same as `guard.ts` (System F-5). |
 | **UserPromptSubmit** | New: route `/gobbi` invocations; emit `decision.user` for workflow-control intents ("revise the plan", "evaluate first") for audit trail. | `commands/workflow/user-prompt.ts` (new) | n/a (new file) |
-| **SessionStart** | Idempotent init; **+ schema-drift detection (new):** if `metadata.json.schemaVersion < CURRENT_SCHEMA_VERSION`, run migration BEFORE appending any event. | `commands/workflow/init.ts` (extended) | **Yes** — `init.ts:281` opens the DB; needs the new path |
+| **SessionStart** | Idempotent init; **+ schema-drift detection (new):** if the per-session `gobbi.db` `schema_meta` row reports `schemaVersion < CURRENT_SCHEMA_VERSION`, run migration BEFORE appending any event. (Per-session `metadata.json` was retired in PR-FIN-2a-ii; the schema-version probe now reads the DB's `schema_meta` table.) | `commands/workflow/init.ts` (extended) | n/a — per-session `gobbi.db` path is unchanged |
 | **SessionEnd** (Claude Code 2.x) | Emit `session.end` event so abandoned-session detection is precise. Falls back to heartbeat-gap heuristic on older Claude Code. | `commands/workflow/session-end.ts` (new) | n/a |
 
 **Path-resolution sweep (Wave A.1 task A.1.7).** Every place the codebase grep'd `join(sessionDir, 'gobbi.db')` returns must change to either the workspace path or the explicit constructor params. Confirmed callsites: `commands/workflow/{guard,stop,init,next,status,resume,capture-subagent,capture-planning,transition}.ts`, `commands/session.ts:320`, `commands/gotcha/promote.ts:308`. (`commands/workflow/events.ts` has no direct DB path — it delegates to `runSessionEvents` in `commands/session.ts`.) The sweep MUST grep both `join(sessionDir, 'gobbi.db')` and `<sessionDir>/gobbi.db` patterns across `packages/cli/src/` to catch any callsite this list misses. Architecture F-3's fix recommendation is a `resolveDbPath(sessionDir)` helper in `commands/session.ts` so the path construction is a single source of truth — Wave A.1 must implement this helper rather than apply 11 independent substitutions.
@@ -278,8 +279,8 @@ The memorization step's compiled prompt names these paths so the agent reads the
 1. Step artifacts — `sessions/<id>/{ideation,planning,execution}/...md` and `_eval/evaluation.md` per step.
 2. Subagent transcripts — every file `capture-subagent.ts` wrote under `sessions/<id>/<step>/rawdata/`.
 3. `ExitPlanMode` captures — `sessions/<id>/planning/rawdata/`.
-4. Orchestrator transcript — `transcript_path` from hook payloads, recorded in `metadata.json`.
-5. Full event stream — `SELECT * FROM events WHERE session_id = ? ORDER BY seq` against workspace `state.db`.
+4. Orchestrator transcript — `transcript_path` from hook payloads, recorded in `session.json` (per-session telemetry, post-PR-FIN-2a-ii).
+5. Full event stream — `SELECT * FROM events ORDER BY seq` against the per-session `gobbi.db`. (Workspace `state.db` partial consolidation is Wave A.1; until that lands, per-session `gobbi.db` is the workflow-event source of truth.)
 6. Per-step `README.md` — when present (written by the STEP_EXIT writer per `gobbi-memory/scenarios.md G-MEM2-26`).
 7. Session-tier gotchas — `.gobbi/projects/<name>/learnings/gotchas/` written mid-session.
 

--- a/.gobbi/projects/gobbi/design/v050-overview.md
+++ b/.gobbi/projects/gobbi/design/v050-overview.md
@@ -95,7 +95,7 @@ V0.5.0 collapsed the v0.4.x seven-step cycle into the current 6-step workflow (C
   │            Handoff               │
   │                                  │
   │  Tight next-session summary      │
-  │  Writes handoff.md + gobbi.db    │
+  │  Writes handoff.md + project.json │
   └────────────────┬─────────────────┘
                    │  workflow.finish
                    ▼
@@ -116,7 +116,7 @@ Each step has a single defined responsibility:
 
 **Memorization** answers "what should persist." Read the conversation log, extract decisions, state, open questions, and gotchas. Write them where the next session can find them. Without Memorization, every session restarts from zero.
 
-**Handoff** answers "what does the next session need to know." Reads the memorization output and writes a tight summary: what was shipped, open threads, decisions to respect, and pointers to key artifacts. Emits `workflow.finish` and writes one `gobbi.db::memories` row with `class='handoff'`.
+**Handoff** answers "what does the next session need to know." Reads the memorization output and writes a tight summary: what was shipped, open threads, decisions to respect, and pointers to key artifacts. Emits `workflow.finish` and writes the handoff summary into the session's `project.json::sessions[]` entry alongside the freeform `handoff.md` file.
 
 ---
 
@@ -136,13 +136,15 @@ V0.5.0 resolves it with a hard directory split:
   Read-only during workflow         Runtime state — write freely
 
   CLAUDE.md                         settings.json              (workspace prefs — gitignored)
-  rules/          ← symlinks →      state.db                   (workspace prompt-patch journal — gitignored)
-  skills/         from .gobbi/      gobbi.db                   (workspace memories projection — tracked)
-  agents/         skills|agents|    projects/<name>/
-  settings.json   rules               settings.json            (project config — tracked)
+  rules/          ← symlinks →      state.db                   (workspace event log, partial — gitignored)
+  skills/         from .gobbi/      projects/<name>/
+  agents/         skills|agents|      settings.json            (project config — tracked)
+  settings.json   rules               project.json             (cross-session memory — tracked)
   hooks/                              sessions/<id>/           (per-session — gitignored)
                                       sessions/<id>/gobbi.db   (per-session event log — gitignored)
-                                    projects/<name>/learnings/ (gotchas, decisions)
+                                      sessions/<id>/session.json (per-session telemetry — gitignored)
+                                    projects/<name>/learnings/ (general post-mortems)
+                                    projects/<name>/gotchas/   (anti-patterns)
 ```
 
 `.claude/` is the static knowledge layer. During a workflow session, no agent writes to it. The hooks enforce this at the tool layer — a PreToolUse hook blocks any write to `.claude/` while a session is active. The `skills/`, `agents/`, and `rules/` entries in `.claude/` are per-file symlinks pointing into `.gobbi/projects/<name>/skills/`, `.gobbi/projects/<name>/agents/`, and `.gobbi/projects/<name>/rules/` — the symlink farm lets Claude Code load docs from `.claude/` without storing the canonical copies there.
@@ -210,7 +212,7 @@ The five components of v0.5.0 form a closed feedback loop:
 
 **Hooks** are the constraint layer. PreToolUse hooks enforce guards — blocking writes to `.claude/` during sessions, preventing scope violations, enforcing step preconditions. PostToolUse and SubagentStop hooks capture events — when a subagent finishes, its output is automatically recorded in the event store without the orchestrator needing to remember to collect it.
 
-**SQLite event store** is the source of truth for workflow state. Workflow events (step transitions, subagent results, evaluation verdicts) write to per-session `gobbi.db` at `.gobbi/projects/<name>/sessions/<id>/gobbi.db`. The workspace `state.db` at `.gobbi/state.db` currently holds only `prompt.patch.applied` events (Wave C.1); full workspace consolidation of workflow events is Wave A.1 work, partially shipped. The CLI reads the per-session event store to determine what to generate next; hooks write events. A separate workspace `gobbi.db` at `.gobbi/gobbi.db` holds the cross-session memories projection (decisions, gotchas, design notes, handoff rows) — git-tracked so it persists across sessions.
+**Storage** is **one workspace SQLite (`state.db`) + per-session `gobbi.db` event store + two-tier JSON memory (`session.json` + `project.json`)**. Workflow events (step transitions, subagent results, evaluation verdicts) write to per-session `gobbi.db` at `.gobbi/projects/<name>/sessions/<id>/gobbi.db` — the source of truth for workflow state. The workspace `state.db` at `.gobbi/state.db` currently holds only `prompt.patch.applied` events (Wave C.1); full workspace consolidation of workflow events is Wave A.1 work, partially shipped. The CLI reads the per-session event store to determine what to generate next; hooks write events. Per-session telemetry (steps, agents, agent_calls, evaluations) is consolidated once at memorization-step entry into `<sessionDir>/session.json` (gitignored). Cross-session promoted memory (sessions index, gotchas, decisions, learnings) lives in `.gobbi/projects/<name>/project.json` (git-tracked) — this replaces the prior workspace `.gobbi/gobbi.db` SQLite memories projection retired in PR-FIN-2a-ii.
 
 **Skills** still exist and still matter. They provide domain knowledge that the CLI incorporates into generated prompts as materials — git conventions, evaluation perspectives, documentation standards. Skills no longer drive orchestration; they inform it.
 

--- a/.gobbi/projects/gobbi/gotchas/paths-ts-needs-dist-specs-cp.md
+++ b/.gobbi/projects/gobbi/gotchas/paths-ts-needs-dist-specs-cp.md
@@ -1,0 +1,37 @@
+# `paths.ts` needs Option A fallback for dev-mode worktrees
+
+**Priority:** Medium
+**Reference:** PR-FIN-2a-iii (issue #232) — locks the three-candidate chain in `packages/cli/src/specs/paths.ts`.
+
+## What happened
+
+In dev-mode (a fresh worktree where `bun test` runs from the worktree root), `cli.js` lives at `packages/cli/dist/cli.js`, but `dist/specs/` may be empty before `build:safe` runs its post-build `cp src/specs dist/specs` step. The pre-Option A resolver had only two candidates:
+
+1. `<this-dir>/specs/` — the bundled-mode candidate. Misses on a fresh worktree because `dist/specs/` has not been seeded.
+2. `<this-dir>/` — the source-mode candidate. Misses too: when `cli.js` is the entry point, `<this-dir>` is `dist/`, which has no `index.json` of its own.
+
+Both candidates miss → `getSpecsDir` throws → every CLI command that loads the workflow graph (`graph.ts`, `next.ts`, `validate.ts`, `stop.ts`) blows up before doing useful work. The user-visible failure mode is `gobbi workflow next` exiting with `Cannot locate specs directory` immediately after a fresh `git worktree add`, with no obvious link to the missing `dist/specs/` copy.
+
+This was filed proactively from the PR-FIN-2a-i and PR-FIN-2a-ii evaluation rounds (where the resolver's two-candidate brittleness was repeatedly observed) and addressed in PR-FIN-2a-iii.
+
+## User feedback
+
+(No direct correction this session — the issue was pre-empted by the evaluators in PR-FIN-2a-i / 2a-ii. This gotcha is filed so future agents working on `paths.ts`, the build pipeline, or worktree bootstrap know why a third candidate is necessary.)
+
+## Correct approach
+
+The resolver in `packages/cli/src/specs/paths.ts` now tries three candidates in order:
+
+1. `<this-dir>/specs/` — bundled-mode (post-`build:safe`).
+2. `<this-dir>/` — source-mode (`bun test` resolving `paths.ts` from `src/specs/`).
+3. `<this-dir>/../src/specs/` — dev-worktree fallback. Only ever wins in repo-local worktrees where the bundled binary is invoked before `build:safe` populates `dist/specs/`. In a published npm package, `src/` is filtered by `package.json::files`, so candidate 3 fails gracefully and the throw fires — there is no dev-only resolution leaking into shipped artifacts.
+
+The throw message lists all three attempted paths so the failure is self-diagnosing.
+
+A path-stability unit test at `packages/cli/src/specs/__tests__/paths.test.ts` mocks `existsSync` to force all three candidates absent, parses the candidate paths back out of the throw message, and asserts each is absolute and stable across `process.cwd()` changes. The test does NOT assert existence — existence is mode-dependent (after `build:safe` runs, candidate 1 wins) and an existence assertion would either tautologically pass or flake based on whether `dist/specs/` had been seeded. Path-stability is the actual invariant: `paths.ts` uses `import.meta.url`-relative resolution, so candidate paths must not shift when the caller's cwd changes.
+
+## How to apply
+
+- Future edits to `paths.ts` MUST preserve all three candidates and the dist-first ordering. Do not collapse candidate 3 even if it "looks unused in CI" — CI runs `build:safe` first; humans on fresh worktrees do not.
+- Future edits to the build pipeline MUST keep the `cp src/specs dist/specs` step in `build:safe`. If that step is removed, the production candidate 1 stops resolving and the resolver falls through to candidate 2 or 3, which may or may not be present in shipped tarballs.
+- If a future change extends or replaces the candidate chain, update `paths.test.ts` to assert path-stability of every new candidate. Existence-based assertions remain off-limits.

--- a/.gobbi/projects/gobbi/skills/gobbi/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/gobbi/SKILL.md
@@ -133,7 +133,7 @@ This skill defines the agent principles, rules, and skill map you must follow.
 | [project-setup.md](project-setup.md) | Project-specific context and technology stack signals |
 | [notification-setup.md](notification-setup.md) | Notification channel and credential detection |
 | [git-setup.md](git-setup.md) | Git tooling and repository state detection |
-| [design/v050-overview.md](../../design/v050-overview.md) | v0.5.0 state machine, 6-step state machine, two-DB workspace split — authoritative architecture doc |
+| [design/v050-overview.md](../../design/v050-overview.md) | v0.5.0 state machine, 6-step state machine, workspace `state.db` + per-session `gobbi.db` + JSON memory (`session.json` + `project.json`) — authoritative architecture doc |
 
 ---
 

--- a/.gobbi/projects/gobbi/skills/gobbi/cli-setup.md
+++ b/.gobbi/projects/gobbi/skills/gobbi/cli-setup.md
@@ -75,7 +75,7 @@ The gobbi CLI manages workflow state, session configuration, notes, and validati
 
 | Command | Purpose |
 |---|---|
-| `gobbi workflow init` | Initialize a session directory under `.gobbi/sessions/{id}/`, write `metadata.json`, open `gobbi.db`, emit the first `workflow.start` event |
+| `gobbi workflow init` | Initialize a session directory under `.gobbi/sessions/{id}/`, open the per-session `gobbi.db` event store, write the `session.json` stub (6 required fields), emit the first `workflow.start` event |
 | `gobbi workflow guard` | Evaluate guard predicates against current workflow state before each tool call |
 | `gobbi workflow capture-subagent` | Record subagent completion — called by the SubagentStop hook |
 | `gobbi workflow capture-planning` | Record the current plan when ExitPlanMode fires |

--- a/.gobbi/projects/gobbi/skills/gobbi/project-setup.md
+++ b/.gobbi/projects/gobbi/skills/gobbi/project-setup.md
@@ -24,7 +24,7 @@ V0.5.0 splits runtime and static-knowledge into separate root directories:
 
 `.claude/` is the static-knowledge layer. Skills, rules, agents, and project docs live here. This directory is not written to during an active session — it is read-only during workflow.
 
-`.gobbi/` is the runtime layer. Per-session directories (`sessions/{session-id}/`) hold the event store (`gobbi.db`), `metadata.json`, and `state.json`. Notes recorded during an active session write to `.gobbi/sessions/{id}/` via `gobbi workflow capture-subagent`. This directory is gitignored and does not persist across repository clones.
+`.gobbi/` is the runtime layer. Per-session directories (`sessions/{session-id}/`) hold the per-session event store (`gobbi.db`) plus `session.json` (per-session telemetry, written once at memorization-step entry). Notes recorded during an active session write to `.gobbi/sessions/{id}/` via `gobbi workflow capture-subagent`. This directory is gitignored and does not persist across repository clones.
 
 When `gobbi workflow init` runs, it creates `.gobbi/sessions/{session-id}/` automatically. Detection below determines whether the static-knowledge layer is also ready.
 

--- a/packages/cli/src/__tests__/integration/jsonpivot-drift.test.ts
+++ b/packages/cli/src/__tests__/integration/jsonpivot-drift.test.ts
@@ -369,18 +369,6 @@ const ALLOW_LIST: readonly AllowListEntry[] = [
       'This test file declares the banned-token regexes as string literals and lists banned filenames in allow-list rationales — must allow-list itself.',
   },
 
-  // ---- STOP-and-ask cases (flagged in executor report) ---------------------
-  // The following entries cover files that are NOT in the executor's locked
-  // file list (workflow.ts:76, errors.sections.ts:339) but contain banned
-  // tokens of the same class. They are allow-listed here so the test passes;
-  // executor reports them in the final summary so the orchestrator can
-  // decide whether to extend scope or defer.
-  {
-    path: 'packages/cli/src/specs/errors.pathway-detect.ts',
-    tokens: new Set(['state.json']),
-    rationale:
-      'STOP-and-ask: line 327 `diagnosticHint` is a user-visible error message that references retired `state.json` — same class as errors.sections.ts:339. Out of executor scope; file as follow-up.',
-  },
 ];
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/__tests__/integration/jsonpivot-drift.test.ts
+++ b/packages/cli/src/__tests__/integration/jsonpivot-drift.test.ts
@@ -1,0 +1,536 @@
+/**
+ * JSON-pivot drift detector — fails if `state.json | state.json.backup |
+ * metadata.json` (per-session sense) re-appear in author-tracked docs or
+ * production code without an explicit file-level allow-list entry.
+ *
+ * Allow-list precedence (PR-FIN-2a-iii):
+ * - File-level allow-list = PRIMARY (auditable, in this test).
+ * - Inline marker comments `// [legacy:retired-2a-ii]` = DECORATIVE
+ *   documentation only. Not honored as a bypass.
+ *
+ * `gobbi.db` is NOT banned — it is the live per-session event store
+ * (14+ active call sites in `commands/session.ts`, `workflow/resume.ts`,
+ * `workflow/store.ts`, etc.).
+ *
+ * `metadata.json` is a homonym:
+ *   - Per-session sense (retired): `.gobbi/projects/<name>/sessions/<id>/metadata.json`
+ *   - Note-system sense (surviving): `.claude/project/<name>/note/<task>/metadata.json`
+ *
+ * The note-system files are allow-listed; the per-session sense should
+ * never re-appear except in legacy schema readers / migration code.
+ *
+ * Why a regex test rather than a structural one: the banned tokens are
+ * filenames, and a structural check would have to reproduce too much of
+ * the workflow lifecycle. A grep-style test catches the only failure mode
+ * we care about — a fresh PR re-introduces a present-tense reference to a
+ * retired filename — at zero runtime cost.
+ *
+ * @see `.gobbi/projects/gobbi/sessions/5cdd4fd9-52de-460b-a8fa-539c5ea533c0/ideation/ideation.md` Tier C.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Glob } from 'bun';
+
+const THIS_DIR = dirname(fileURLToPath(import.meta.url));
+
+// `__tests__/integration/jsonpivot-drift.test.ts` -> repo root.
+// Walk back: `integration` → `__tests__` → `src` → `cli` → `packages` → repo
+// root (5 levels). Mirrors `build-pipeline.test.ts`'s 3-level walk to
+// `packages/cli/` plus 2 more levels to the repo root.
+const REPO_ROOT = resolve(THIS_DIR, '..', '..', '..', '..', '..');
+
+// ---------------------------------------------------------------------------
+// Banned tokens
+// ---------------------------------------------------------------------------
+
+/**
+ * Word-boundary anchored regex for each retired token. The `\b` boundaries
+ * keep the matcher precise — `partial-state.json-thing` would NOT trip
+ * `BANNED_STATE_JSON`. The `state.json.backup` matcher subsumes the
+ * `state.json` substring inside `state.json.backup`, so `BANNED_STATE_JSON`
+ * is intentionally allowed to also match `state.json.backup` lines (they
+ * count as both a `state.json` and a `state.json.backup` violation —
+ * per-line listing is per-token, so the same line surfaces twice if it
+ * names the longer form). Case-sensitive.
+ */
+const BANNED_TOKENS: ReadonlyArray<{ name: string; pattern: RegExp }> = [
+  { name: 'state.json', pattern: /\bstate\.json\b/ },
+  { name: 'state.json.backup', pattern: /\bstate\.json\.backup\b/ },
+  { name: 'metadata.json', pattern: /\bmetadata\.json\b/ },
+];
+
+// ---------------------------------------------------------------------------
+// File scope
+// ---------------------------------------------------------------------------
+
+/**
+ * Repo-relative globs of files the detector scans. Every path is forward-
+ * slash anchored — `Bun.Glob` matches against forward-slash paths regardless
+ * of platform separator.
+ */
+const SCAN_GLOBS: readonly string[] = [
+  // Tracked author docs
+  '.claude/CLAUDE.md',
+  '.claude/skills/**/*.md',
+  '.gobbi/projects/gobbi/design/**/*.md',
+  '.gobbi/projects/gobbi/skills/**/*.md',
+  // Production code (test fixtures live under __tests__/, excluded below)
+  'packages/cli/src/**/*.ts',
+];
+
+/**
+ * Path-segment exclusions applied AFTER the include globs. A forward-slash-
+ * normalised relative path that contains any of these segments is dropped.
+ * Both production-code globs and test fixtures filter through here.
+ */
+const EXCLUDED_SEGMENTS: readonly string[] = [
+  '__tests__/',
+  // `migrations/` is documented as out-of-scope in the test's brief —
+  // there is currently no `migrations/` directory under `packages/cli/src/`,
+  // but if one is ever introduced for v1 schema fixtures it should be
+  // excluded by construction. `migrations.ts` (the file, not a dir) is
+  // covered by the file-level allow-list below.
+  '/migrations/',
+];
+
+// ---------------------------------------------------------------------------
+// Allow-list — file-level PRIMARY (auditable)
+// ---------------------------------------------------------------------------
+
+/**
+ * Allow-list entry. A file matches if its repo-relative forward-slash path
+ * matches `path` (a literal path or a glob via `isGlob`). When `lines` is
+ * supplied, only the listed line numbers (1-based) bypass the detector;
+ * other lines in the file still get checked. `rationale` is documentation
+ * only — not consumed by the test.
+ *
+ * `tokens` defaults to all banned tokens; supply a subset when the file
+ * legitimately mentions one specific retired filename only.
+ */
+interface AllowListEntry {
+  readonly path: string;
+  readonly isGlob?: boolean;
+  readonly lines?: ReadonlySet<number>;
+  readonly tokens?: ReadonlySet<string>;
+  readonly rationale: string;
+}
+
+const ALLOW_LIST: readonly AllowListEntry[] = [
+  // ---- Frozen historical session notes -------------------------------------
+  {
+    path: '.claude/project/gobbi/note/**/*.md',
+    isGlob: true,
+    rationale:
+      'Frozen v0.4.x session notes — historical record, not live docs. May reference retired filenames as part of past-state context.',
+  },
+
+  // ---- Note-system metadata.json homonym (surviving file) ------------------
+  {
+    path: '.gobbi/projects/gobbi/skills/_note/SKILL.md',
+    tokens: new Set(['metadata.json']),
+    rationale:
+      "Note-system metadata.json (`.claude/project/<name>/note/<task>/metadata.json`) — homonym of the retired per-session metadata.json. Surviving file; references must remain.",
+  },
+  {
+    path: '.gobbi/projects/gobbi/skills/_gobbi-cli/gotchas.md',
+    tokens: new Set(['metadata.json']),
+    rationale:
+      'Note-system metadata.json homonym — describes `gobbi note init` behaviour. Surviving file.',
+  },
+  {
+    path: '.gobbi/projects/gobbi/skills/_gobbi-cli/SKILL.md',
+    tokens: new Set(['metadata.json']),
+    rationale:
+      'Note-system metadata.json homonym — `gobbi note init` documentation.',
+  },
+  {
+    path: '.gobbi/projects/gobbi/skills/_gobbi-cli/commands.md',
+    tokens: new Set(['metadata.json']),
+    rationale:
+      'Note-system metadata.json homonym — `gobbi note init` command table entry.',
+  },
+  {
+    path: '.gobbi/projects/gobbi/skills/_gotcha/__system.md',
+    tokens: new Set(['state.json']),
+    rationale:
+      "Hook-state filename example (`/tmp/claude-state.json`) — generic illustrative path, not the retired per-session state.json.",
+  },
+  {
+    path: '.gobbi/projects/gobbi/skills/_typescript/SKILL.md',
+    tokens: new Set(['state.json']),
+    rationale:
+      "Lists `state.json` as an example of external JSON narrowed via `isValidState`. Educational reference; updates if/when `workflow/state.ts` orphans land (PR-FIN-2a-iii Tier B.2).",
+  },
+
+  // ---- _orchestration skill — entire dir is archived in PR-FIN-5 -----------
+  {
+    path: '.gobbi/projects/gobbi/skills/_orchestration/**/*.md',
+    isGlob: true,
+    rationale:
+      'Whole `_orchestration` skill dir is archival (carries an ARCHIVED.md sentinel; full removal is the next-cycle `gobbi-config-target-state` follow-up #13).',
+  },
+
+  // ---- Files that legitimately document the retirement (post-T1 state) -----
+  // T1 (Tier A docs sweep) updates these, but the retirement description
+  // itself names the retired files. Allow-listed because the legitimate
+  // textual content still mentions them.
+  {
+    path: '.claude/CLAUDE.md',
+    rationale:
+      'Canonical JSON-pivot paragraph names the retired files in describing what was retired (per ideation Tier A.5). Naming the retired files is necessary to document what was retired.',
+  },
+  {
+    path: '.gobbi/projects/gobbi/design/v050-features/gobbi-memory/README.md',
+    rationale:
+      'Documents the JSON-pivot retirement of session-root metadata.json / state.json / state.json.backup. Naming the retired files is necessary to describe what was retired.',
+  },
+  {
+    path: '.gobbi/projects/gobbi/design/v050-features/gobbi-memory/scenarios.md',
+    rationale:
+      'G-MEM2-31 / G-MEM2-32 (lines 313-326) describe legacy migration semantics; entire file allow-listed because Gherkin scenarios describe legacy migration semantics across multiple sections.',
+  },
+  {
+    path: '.gobbi/projects/gobbi/design/v050-features/orchestration/README.md',
+    rationale:
+      'Documents the per-session retirements at lines 83 / 184 / 221 / 281 — naming the retired files is necessary to describe what was retired.',
+  },
+  {
+    path: '.gobbi/projects/gobbi/design/v050-overview.md',
+    rationale:
+      'Architecture-of-record describes the v0.5.0 pivot history; references retired filenames as part of the historical narrative.',
+  },
+
+  // ---- Design-corpus follow-up sweep (out of 2a-iii scope per ideation) ----
+  // Per ideation §"Out of scope" item 2 — these files have stale present-tense
+  // statements that will be addressed in a follow-up issue. The allow-list
+  // entries are self-removing once the follow-up lands.
+  // TODO(follow-up): file an issue for design-corpus drift sweep and replace
+  // these allow-list entries with `// allow-listed until issue #N` markers
+  // once the issue number is assigned.
+  {
+    path: '.gobbi/projects/gobbi/design/structure.md',
+    rationale:
+      'Design-corpus drift — out-of-scope follow-up per ideation §"Out of scope" item 2 (lines 99/103/163).',
+  },
+  {
+    path: '.gobbi/projects/gobbi/design/v050-cli.md',
+    rationale:
+      'Design-corpus drift — out-of-scope follow-up (lines 57/59/61/72/76/84/86/114).',
+  },
+  {
+    path: '.gobbi/projects/gobbi/design/v050-prompts.md',
+    rationale:
+      'Design-corpus drift — out-of-scope follow-up (lines 21/25/27/34/149).',
+  },
+  {
+    path: '.gobbi/projects/gobbi/design/v050-hooks.md',
+    rationale:
+      'Design-corpus drift — out-of-scope follow-up; describes hook-driven state.json / metadata.json reads in present tense.',
+  },
+  {
+    path: '.gobbi/projects/gobbi/design/v050-session.md',
+    rationale:
+      'Session-architecture design doc — describes per-session state.json / metadata.json contracts in present tense. Out-of-scope follow-up.',
+  },
+  {
+    path: '.gobbi/projects/gobbi/design/v050-state-machine.md',
+    rationale:
+      'Reducer-replay narrative references state.json — out-of-scope follow-up.',
+  },
+  {
+    path: '.gobbi/projects/gobbi/design/v050-integration-tests.md',
+    rationale:
+      'Integration-test design references state.json reducer-replay assertions — out-of-scope follow-up.',
+  },
+  {
+    path: '.gobbi/projects/gobbi/design/v050-features/gobbi-config/checklist.md',
+    rationale:
+      'Pre-pivot checklist still lists metadata.json existence checks — out-of-scope follow-up.',
+  },
+  {
+    path: '.gobbi/projects/gobbi/design/v050-features/gobbi-config/scenarios.md',
+    rationale:
+      'Pre-pivot scenarios still assert metadata.json contents — out-of-scope follow-up.',
+  },
+  {
+    path: '.gobbi/projects/gobbi/design/v050-features/gobbi-memory/checklist.md',
+    rationale:
+      'Pre-pivot checklist references state.json.currentStep — out-of-scope follow-up.',
+  },
+  {
+    path: '.gobbi/projects/gobbi/design/v050-features/gobbi-memory/review.md',
+    rationale:
+      'Historical Pass-2 review notes mention state.json shim work — out-of-scope follow-up.',
+  },
+  {
+    path: '.gobbi/projects/gobbi/design/v050-features/orchestration/checklist.md',
+    rationale:
+      'Pre-pivot checklist names metadata.json — out-of-scope follow-up.',
+  },
+  {
+    path: '.gobbi/projects/gobbi/design/v050-features/orchestration/review.md',
+    rationale:
+      'Historical Pass-4 review GAP-9 references state.json atomicity — out-of-scope follow-up.',
+  },
+  {
+    path: '.gobbi/projects/gobbi/design/v050-features/orchestration/scenarios.md',
+    rationale:
+      'Pre-pivot scenarios still assert metadata.json contents — out-of-scope follow-up.',
+  },
+
+  // ---- Production code: legacy schema readers + retirement docblocks -------
+  {
+    path: 'packages/cli/src/workflow/state.ts',
+    rationale:
+      "Legacy `writeState` / `readState` / `backupState` / `restoreBackup` orphans — under removal in PR-FIN-2a-iii Tier B.2 (sibling task). Until B.2 lands, the file legitimately writes/reads `state.json` for migration-only paths.",
+  },
+  {
+    path: 'packages/cli/src/workflow/migrations.ts',
+    rationale:
+      'Migration code — historical schema readers must reference the v1 metadata.json filename to read pre-pivot session directories.',
+  },
+  {
+    path: 'packages/cli/src/workflow/store.ts',
+    rationale:
+      'Docblocks describe the metadata.json reader retirement (lines 36-37 / 395 / 460 / 470 / 511-512). Naming the retired file is necessary to document what was retired.',
+  },
+  {
+    path: 'packages/cli/src/workflow/engine.ts',
+    rationale:
+      'Docblocks describe the state.json projection retirement (lines 25-29 / 35 / 112 / 411 / 419 / 439 / 441). Naming the retired file is necessary to document what was retired.',
+  },
+  {
+    path: 'packages/cli/src/workflow/guard-specs.ts',
+    tokens: new Set(['state.json']),
+    rationale:
+      'Docblock example path (line 67) for `isAllowlistedPath` — illustrative, not a live read. Out-of-scope follow-up to update once design-corpus sweep lands.',
+  },
+  {
+    path: 'packages/cli/src/commands/workflow/guard.ts',
+    rationale:
+      'Docblock describes legacy state.json read path (line 17) — pre-pivot historical comment. Out-of-scope follow-up.',
+  },
+  {
+    path: 'packages/cli/src/commands/workflow/init.ts',
+    rationale:
+      'Docblock retirement notes describe the metadata.json -> session.json migration path (lines 13 / 200 / multiple). Naming the retired file is necessary to document what was retired.',
+  },
+  {
+    path: 'packages/cli/src/commands/workflow/resume.ts',
+    rationale:
+      'Docblock retirement notes describe the state.json projection retirement (lines 261 / 302 / 305 / 308). Naming the retired file is necessary to document what was retired.',
+  },
+  {
+    path: 'packages/cli/src/commands/install.ts',
+    rationale:
+      'Docblock notes describe install-gate retirement alongside per-session state.json (lines 55 / 226). Naming the retired file is necessary to document what was retired.',
+  },
+  {
+    path: 'packages/cli/src/commands/session.ts',
+    rationale:
+      'Docblock retirement notes describe the metadata.json reader retirement (lines 520 / 550). Naming the retired file is necessary to document what was retired.',
+  },
+  {
+    path: 'packages/cli/src/lib/json-memory.ts',
+    rationale:
+      'Docblock comment (line 604) references metadata.json in describing JSON-memory pivot.',
+  },
+  {
+    path: 'packages/cli/src/commands/maintenance/wipe-legacy-sessions.ts',
+    rationale:
+      'Wipe tool — its purpose IS to delete the retired filenames. The hardcoded literal list of retired filenames at lines 111-113 is load-bearing.',
+  },
+  {
+    path: 'packages/cli/src/commands/note.ts',
+    tokens: new Set(['metadata.json']),
+    rationale:
+      'Note-system metadata.json writer (homonym of retired session metadata.json) — surviving file.',
+  },
+
+  // ---- This test file itself -----------------------------------------------
+  {
+    path: 'packages/cli/src/__tests__/integration/jsonpivot-drift.test.ts',
+    rationale:
+      'This test file declares the banned-token regexes as string literals and lists banned filenames in allow-list rationales — must allow-list itself.',
+  },
+
+  // ---- STOP-and-ask cases (flagged in executor report) ---------------------
+  // The following entries cover files that are NOT in the executor's locked
+  // file list (workflow.ts:76, errors.sections.ts:339) but contain banned
+  // tokens of the same class. They are allow-listed here so the test passes;
+  // executor reports them in the final summary so the orchestrator can
+  // decide whether to extend scope or defer.
+  {
+    path: 'packages/cli/src/specs/errors.pathway-detect.ts',
+    tokens: new Set(['state.json']),
+    rationale:
+      'STOP-and-ask: line 327 `diagnosticHint` is a user-visible error message that references retired `state.json` — same class as errors.sections.ts:339. Out of executor scope; file as follow-up.',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Glob expansion + allow-list lookup
+// ---------------------------------------------------------------------------
+
+function toForwardSlash(p: string): string {
+  return sep === '/' ? p : p.split(sep).join('/');
+}
+
+function isExcluded(relPath: string): boolean {
+  const fwd = toForwardSlash(relPath);
+  for (const segment of EXCLUDED_SEGMENTS) {
+    if (fwd.includes(segment)) return true;
+  }
+  return false;
+}
+
+function findAllowEntry(
+  relPath: string,
+): AllowListEntry | undefined {
+  const fwd = toForwardSlash(relPath);
+  for (const entry of ALLOW_LIST) {
+    if (entry.isGlob === true) {
+      const glob = new Glob(entry.path);
+      if (glob.match(fwd)) return entry;
+    } else if (entry.path === fwd) {
+      return entry;
+    }
+  }
+  return undefined;
+}
+
+function expandScanGlobs(): readonly string[] {
+  const out = new Set<string>();
+  for (const pattern of SCAN_GLOBS) {
+    const glob = new Glob(pattern);
+    for (const match of glob.scanSync({
+      cwd: REPO_ROOT,
+      onlyFiles: true,
+      // `.claude/` and `.gobbi/` are dot-directories; without `dot: true` the
+      // glob matcher would skip them entirely.
+      dot: true,
+    })) {
+      const relPath = toForwardSlash(match);
+      if (isExcluded(relPath)) continue;
+      out.add(relPath);
+    }
+  }
+  return [...out].sort();
+}
+
+// ---------------------------------------------------------------------------
+// Match collection
+// ---------------------------------------------------------------------------
+
+interface Hit {
+  readonly relPath: string;
+  readonly lineNumber: number; // 1-based
+  readonly lineContent: string;
+  readonly token: string;
+}
+
+function collectHits(token: string, pattern: RegExp): readonly Hit[] {
+  const hits: Hit[] = [];
+  for (const relPath of expandScanGlobs()) {
+    const allow = findAllowEntry(relPath);
+    if (allow !== undefined) {
+      // File-level allow-list — does it cover THIS token?
+      if (allow.tokens === undefined || allow.tokens.has(token)) {
+        if (allow.lines === undefined) continue; // whole file allow-listed
+      }
+    }
+    let content: string;
+    try {
+      content = readFileSync(join(REPO_ROOT, relPath), 'utf8');
+    } catch {
+      continue;
+    }
+    const lines = content.split('\n');
+    for (let i = 0; i < lines.length; i += 1) {
+      const line = lines[i];
+      if (line === undefined) continue;
+      if (!pattern.test(line)) continue;
+      const lineNumber = i + 1;
+      // Per-line allow-list — when `allow.lines` is set the token is
+      // bypassed only on those specific lines.
+      if (
+        allow !== undefined &&
+        allow.lines !== undefined &&
+        allow.lines.has(lineNumber) &&
+        (allow.tokens === undefined || allow.tokens.has(token))
+      ) {
+        continue;
+      }
+      hits.push({
+        relPath,
+        lineNumber,
+        lineContent: line.trim(),
+        token,
+      });
+    }
+  }
+  return hits;
+}
+
+function formatHits(hits: readonly Hit[]): string {
+  if (hits.length === 0) return '(none)';
+  return hits
+    .map(
+      (h) =>
+        `  ${h.relPath}:${h.lineNumber}: ${h.lineContent.slice(0, 200)}${h.lineContent.length > 200 ? '…' : ''}`,
+    )
+    .join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('JSON-pivot drift detector (PR-FIN-2a-iii Tier C)', () => {
+  for (const banned of BANNED_TOKENS) {
+    test(`no unallowed references to \`${banned.name}\``, () => {
+      const hits = collectHits(banned.name, banned.pattern);
+      if (hits.length > 0) {
+        // Fail loud — message lists every file:line so the regression's
+        // source is obvious. Add the offending file to ALLOW_LIST with a
+        // documented rationale, OR remove the reference, to make the test
+        // pass again.
+        const message = [
+          `Found ${hits.length} unallowed reference(s) to \`${banned.name}\`:`,
+          formatHits(hits),
+          '',
+          `If the references are legitimate (e.g., docblocks documenting the`,
+          `retirement, migration code reading the v1 schema), add a file-level`,
+          `entry to ALLOW_LIST in this test with a clear rationale.`,
+          '',
+          `If the references are stale present-tense statements, fix them in`,
+          `the source file rather than expanding the allow-list.`,
+        ].join('\n');
+        // Use `expect(hits)` so the error path actually surfaces the message.
+        expect.unreachable(message);
+      }
+    });
+  }
+
+  test('cross-token sanity — at least one banned token is scanned', () => {
+    // Belt-and-braces: if BANNED_TOKENS is ever emptied by a refactor,
+    // the per-token tests above silently no-op. This guard fails loud.
+    expect(BANNED_TOKENS.length).toBeGreaterThan(0);
+  });
+
+  test('scan reaches the in-scope tree (sanity)', () => {
+    // Guards against a path-resolution bug that silently scans nothing.
+    // CLAUDE.md is always present in the repo; if the scan misses it,
+    // REPO_ROOT or SCAN_GLOBS is wrong.
+    const scanned = expandScanGlobs();
+    expect(scanned).toContain('.claude/CLAUDE.md');
+  });
+});
+
+// `relative` is imported to support future per-line allow-list helpers; it
+// is currently unused at runtime. Re-export to avoid a TS no-unused-imports
+// warning under strict mode without changing import order.
+export const _relative = relative;

--- a/packages/cli/src/__tests__/integration/jsonpivot-drift.test.ts
+++ b/packages/cli/src/__tests__/integration/jsonpivot-drift.test.ts
@@ -162,7 +162,7 @@ const ALLOW_LIST: readonly AllowListEntry[] = [
     path: '.gobbi/projects/gobbi/skills/_typescript/SKILL.md',
     tokens: new Set(['state.json']),
     rationale:
-      "Lists `state.json` as an example of external JSON narrowed via `isValidState`. Educational reference; updates if/when `workflow/state.ts` orphans land (PR-FIN-2a-iii Tier B.2).",
+      "Lists `state.json` as an example of external JSON narrowed via `isValidState`. Educational reference describing migration-only narrowing patterns (PR-FIN-2a-iii Tier B.2 retired the orphan exports; the documentation example survives).",
   },
 
   // ---- _orchestration skill — entire dir is archived in PR-FIN-5 -----------
@@ -285,7 +285,7 @@ const ALLOW_LIST: readonly AllowListEntry[] = [
   {
     path: 'packages/cli/src/workflow/state.ts',
     rationale:
-      "Legacy `writeState` / `readState` / `backupState` / `restoreBackup` orphans — under removal in PR-FIN-2a-iii Tier B.2 (sibling task). Until B.2 lands, the file legitimately writes/reads `state.json` for migration-only paths.",
+      "Migration-only paths reference `state.json` post-PR-FIN-2a-iii Tier B.2 (orphan exports removed). Surviving references describe the legacy on-disk shape that migration code converts away.",
   },
   {
     path: 'packages/cli/src/workflow/migrations.ts',
@@ -360,13 +360,6 @@ const ALLOW_LIST: readonly AllowListEntry[] = [
     tokens: new Set(['metadata.json']),
     rationale:
       'Note-system metadata.json writer (homonym of retired session metadata.json) — surviving file.',
-  },
-
-  // ---- This test file itself -----------------------------------------------
-  {
-    path: 'packages/cli/src/__tests__/integration/jsonpivot-drift.test.ts',
-    rationale:
-      'This test file declares the banned-token regexes as string literals and lists banned filenames in allow-list rationales — must allow-list itself.',
   },
 
 ];

--- a/packages/cli/src/__tests__/integration/jsonpivot-drift.test.ts
+++ b/packages/cli/src/__tests__/integration/jsonpivot-drift.test.ts
@@ -339,6 +339,18 @@ const ALLOW_LIST: readonly AllowListEntry[] = [
       'Docblock comment (line 604) references metadata.json in describing JSON-memory pivot.',
   },
   {
+    path: 'packages/cli/src/commands/workflow/next.ts',
+    tokens: new Set(['metadata.json']),
+    rationale:
+      'Docblock at the second `resolvePartitionKeys` callsite describes the post-PR-FIN-2a-ii retirement of the per-session metadata.json reader (PR-FIN-2a-iii Tier A.6 docs sweep). Naming the retired file is necessary to document what was retired.',
+  },
+  {
+    path: 'packages/cli/src/commands/workflow/tech-stack.ts',
+    tokens: new Set(['metadata.json']),
+    rationale:
+      'Module + `detectTechStack` docblocks describe the post-PR-FIN-2a-ii retirement of metadata.json.techStack and the still-pending session.json slot decision (PR-FIN-2a-iii Tier A.10). Function is kept live for the underlying signal; deletion vs. wiring is a deferred follow-up. Naming the retired file is necessary to document what was retired.',
+  },
+  {
     path: 'packages/cli/src/commands/maintenance/wipe-legacy-sessions.ts',
     rationale:
       'Wipe tool — its purpose IS to delete the retired filenames. The hardcoded literal list of retired filenames at lines 111-113 is load-bearing.',

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -73,7 +73,7 @@ export const WORKFLOW_COMMANDS: readonly WorkflowCommand[] = [
   {
     name: 'init',
     summary:
-      'Initialise the session directory (metadata.json, gobbi.db, opening events)',
+      'Initialise the session directory (gobbi.db event store, session.json stub, opening events)',
     run: async (args: string[]): Promise<void> => {
       const { runInit } = await import('./workflow/init.js');
       await runInit(args);

--- a/packages/cli/src/commands/workflow/next.ts
+++ b/packages/cli/src/commands/workflow/next.ts
@@ -236,9 +236,11 @@ export async function compileCurrentStep(
   // overlay `workflow.<step>.{agent,evaluate.agent}.{model,effort}` onto
   // every entry of `spec.delegation.agents[*]` per the step-driven mapping
   // (see `spec-loader.ts::loadSpecForRuntime` JSDoc + PR-FIN-1e ideation
-  // §2.3.1). The `partitionKeys.projectId` field carries the resolved
-  // project name from `<sessionDir>/metadata.json`; absent → falls back to
-  // `basename(repoRoot)` inside `resolveSettings`.
+  // §2.3.1). `resolvePartitionKeys` (see `commands/session.ts`) extracts
+  // `(sessionId, projectId)` purely from the session-dir path segments —
+  // post-PR-FIN-2a-ii there is no per-session `metadata.json` to read.
+  // When `projectId` is null (legacy-flat session layout) the cascade
+  // falls back to `basename(repoRoot)` inside `resolveSettings`.
   const repoRoot = getRepoRoot();
   const partitionKeys = resolvePartitionKeys(sessionDir);
   const resolvedSettings = resolveSettings({

--- a/packages/cli/src/commands/workflow/tech-stack.ts
+++ b/packages/cli/src/commands/workflow/tech-stack.ts
@@ -1,6 +1,11 @@
 /**
- * Tech-stack detection — a cheap, best-effort signal map used by
- * `gobbi workflow init` to populate `metadata.json.techStack`.
+ * Tech-stack detection — a cheap, best-effort signal map currently called
+ * by `gobbi workflow init` for observability. The `techStack` field is
+ * not yet persisted (deferred follow-up — see issue #N): post-PR-FIN-2a-ii
+ * the per-session `metadata.json` was retired, and a `techStack` slot has
+ * not yet landed in the `session.json` schema. The function is kept live so
+ * the underlying signal remains computed at init time even before a
+ * persistent destination exists; deletion vs. wiring is the open decision.
  *
  * ## Signal sources (ordered by cost)
  *
@@ -43,8 +48,10 @@ import { isRecord, isString } from '../../lib/guards.js';
  * Produce the tech-stack tag list for `projectRoot`. See the module docblock
  * for the output contract.
  *
- * Always returns — never throws. Callers write the result verbatim into
- * `metadata.json.techStack`.
+ * Always returns — never throws. Currently called by `init.ts` for
+ * observability; the `techStack` field is not yet persisted (deferred
+ * follow-up — see issue #N) since the per-session `metadata.json` was
+ * retired in PR-FIN-2a-ii and no `session.json` slot has replaced it yet.
  */
 export function detectTechStack(projectRoot: string): readonly string[] {
   const labels = new Set<string>();

--- a/packages/cli/src/commands/workflow/tech-stack.ts
+++ b/packages/cli/src/commands/workflow/tech-stack.ts
@@ -1,7 +1,7 @@
 /**
  * Tech-stack detection — a cheap, best-effort signal map currently called
  * by `gobbi workflow init` for observability. The `techStack` field is
- * not yet persisted (deferred follow-up — see issue #N): post-PR-FIN-2a-ii
+ * not yet persisted (deferred follow-up — see issue #234): post-PR-FIN-2a-ii
  * the per-session `metadata.json` was retired, and a `techStack` slot has
  * not yet landed in the `session.json` schema. The function is kept live so
  * the underlying signal remains computed at init time even before a
@@ -50,7 +50,7 @@ import { isRecord, isString } from '../../lib/guards.js';
  *
  * Always returns — never throws. Currently called by `init.ts` for
  * observability; the `techStack` field is not yet persisted (deferred
- * follow-up — see issue #N) since the per-session `metadata.json` was
+ * follow-up — see issue #234) since the per-session `metadata.json` was
  * retired in PR-FIN-2a-ii and no `session.json` slot has replaced it yet.
  */
 export function detectTechStack(projectRoot: string): readonly string[] {

--- a/packages/cli/src/lib/json-memory.ts
+++ b/packages/cli/src/lib/json-memory.ts
@@ -423,7 +423,7 @@ const anthropicAgentSchema = {
     claudeCodeVersion: { type: ['string', 'null'] },
     transcriptPath: { type: ['string', 'null'] },
     transcriptSha256: { type: ['string', 'null'] },
-    tokensUsed: { ...anthropicTokensUsedSchema, nullable: true } as unknown as Record<string, unknown>,
+    tokensUsed: { ...anthropicTokensUsedSchema, type: ['object', 'null'] as const },
     cacheHitRatio: { type: ['number', 'null'], minimum: 0 },
     sizeProxyBytes: { type: ['integer', 'null'], minimum: 0 },
   },
@@ -1130,10 +1130,6 @@ function computeCacheHitRatio(tokens: AnthropicTokensUsed | null): number | null
 const PRODUCTIVE_STEPS = ['ideation', 'planning', 'execution', 'memorization'] as const;
 
 type ProductiveStep = (typeof PRODUCTIVE_STEPS)[number];
-
-function isProductiveStep(value: string): value is ProductiveStep {
-  return (PRODUCTIVE_STEPS as readonly string[]).includes(value);
-}
 
 function buildSteps(
   rows: readonly EventRow[],

--- a/packages/cli/src/specs/__tests__/__snapshots__/errors.snap.test.ts.snap
+++ b/packages/cli/src/specs/__tests__/__snapshots__/errors.snap.test.ts.snap
@@ -223,7 +223,7 @@ exports[`errors — pathway-compiler snapshots unknown pathway compiles to a sta
 
 Pathway: unknown.
 
-The workflow is in the error step but the event store carries no evidence that attributes the error to one of the four observable pathways (crash, timeout, feedback cap, invalid transition). The classifier's diagnostic hint appears below — it usually indicates either an empty store (state.json written manually) or a store-read race during classification. Recovery means inspecting the hint to pick between retry-from-last-valid-state, force-memorization, and abort.
+The workflow is in the error step but the event store carries no evidence that attributes the error to one of the four observable pathways (crash, timeout, feedback cap, invalid transition). The classifier's diagnostic hint appears below — it usually indicates either an empty store (likely a fresh init or manual \`gobbi.db\` truncation) or a store-read race during classification. Recovery means inspecting the hint to pick between retry-from-last-valid-state, force-memorization, and abort.
 
 session.schemaVersion=4
 session.currentStep=error
@@ -243,7 +243,7 @@ Recovery options (no pathway-specific recommendation — inspect the diagnostic 
   - Abort the session:                  gobbi workflow transition --type abort"
 `;
 
-exports[`errors — pathway-compiler snapshots unknown pathway compiles to a stable prompt 2`] = `"34e819ce3ec72c826d23a45384c649a1b5ae4b3ff4804282dfc4909354e49d51"`;
+exports[`errors — pathway-compiler snapshots unknown pathway compiles to a stable prompt 2`] = `"badf1523de2730e83f6e35d3fc33ccf41dd7bd610434de37514b2d913c4eb029"`;
 
 exports[`errors — pathway-compiler snapshots unknown pathway compiles to a stable prompt 3`] = `
 [

--- a/packages/cli/src/specs/__tests__/__snapshots__/resume.snap.test.ts.snap
+++ b/packages/cli/src/specs/__tests__/__snapshots__/resume.snap.test.ts.snap
@@ -220,7 +220,7 @@ session.artifactCounts={}
 
 Unknown-pathway recap:
   reason=empty-store
-  diagnosticHint=The event store is empty — state.json appears to have been manually written into the error step without any triggering event.
+  diagnosticHint=The event store is empty — likely a fresh init or manual \`gobbi.db\` truncation without any triggering event.
 
 Target-entry framing:
   You are transitioning from error into planning.

--- a/packages/cli/src/specs/__tests__/paths.test.ts
+++ b/packages/cli/src/specs/__tests__/paths.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for `specs/paths.ts` — fallback chain path-stability invariants.
+ *
+ * # Why this test exists (PR-FIN-2a-iii Tier B.1)
+ *
+ * `paths.ts` resolves the canonical specs directory through three candidates:
+ *
+ *   1. `<this-dir>/specs/`            — bundled-mode (post-`build:safe`).
+ *   2. `<this-dir>/`                  — source-mode (`bun test` from author tree).
+ *   3. `<this-dir>/../src/specs/`     — dev-worktree fallback when the bundled
+ *                                       binary runs before `build:safe` populates
+ *                                       `dist/specs/`.
+ *
+ * Architecture eval F5 locks the test invariant: the third candidate must
+ * resolve to an **absolute path that does not depend on `process.cwd()`** —
+ * NOT existence. Existence is mode-dependent (after `build:safe` runs,
+ * candidate 1 wins and the third candidate is never inspected). Asserting
+ * existence would either tautologically pass or flake based on whether
+ * `dist/specs/` has been seeded; asserting absoluteness pins the actual
+ * invariant we care about: the resolved path is stable regardless of
+ * where the binary was invoked from.
+ *
+ * # Strategy
+ *
+ * `existsSync` is mocked at the module boundary so candidates 1 and 2 report
+ * absent. The throw path is then exercised — the error message lists all
+ * three attempted paths verbatim. We parse the candidate paths back out of
+ * the message, assert each is absolute, and re-run the resolver from a
+ * different `process.cwd()` to confirm the candidate paths do not shift.
+ *
+ * Mocking `existsSync` is module-scoped to this test file (bun:test
+ * `mock.module` semantics) so other suites continue using the real fs.
+ */
+
+import { afterAll, describe, expect, mock, test } from 'bun:test';
+import { isAbsolute } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Mock setup — toggle controls whether existsSync reports the resolver's
+// candidates as absent. The handle is queried at every existsSync call so
+// individual tests can flip behaviour without re-mocking the module.
+// ---------------------------------------------------------------------------
+
+interface ExistsState {
+  forceAllAbsent: boolean;
+}
+const STATE_KEY = '__gobbiPathsTestExistsState__';
+function getState(): ExistsState {
+  const slot = (globalThis as unknown as Record<string, ExistsState | undefined>)[STATE_KEY];
+  if (slot !== undefined) return slot;
+  const fresh: ExistsState = { forceAllAbsent: false };
+  (globalThis as unknown as Record<string, ExistsState>)[STATE_KEY] = fresh;
+  return fresh;
+}
+
+// Capture the real existsSync before the mock takes effect so tests that
+// want real fs semantics can reach through the toggle.
+const realFs = await import('node:fs');
+const realExistsSync = realFs.existsSync;
+
+mock.module('node:fs', () => ({
+  ...realFs,
+  existsSync: (path: string): boolean => {
+    if (getState().forceAllAbsent) return false;
+    return realExistsSync(path);
+  },
+}));
+
+// Dynamic import AFTER the mock is registered — module-scoped mocks only
+// apply to imports that resolve through them after registration.
+const { getSpecsDir } = await import('../paths.js');
+
+// ---------------------------------------------------------------------------
+// Test isolation — restore cwd after each navigation; clear forceAllAbsent.
+// ---------------------------------------------------------------------------
+
+const ORIGINAL_CWD = process.cwd();
+afterAll(() => {
+  getState().forceAllAbsent = false;
+  process.chdir(ORIGINAL_CWD);
+});
+
+// ---------------------------------------------------------------------------
+// PATHS-1 — Candidate-3 path-stability invariant.
+//
+// Force all three candidates to report absent so the resolver throws. The
+// thrown error lists the attempted paths; parse them back out, assert each
+// is absolute, and re-run from a different cwd to confirm none of the three
+// candidate paths depend on `process.cwd()`.
+// ---------------------------------------------------------------------------
+
+describe('getSpecsDir — fallback chain path-stability', () => {
+  test('PATHS-1: all three candidate paths are absolute and stable across process.cwd() changes', () => {
+    getState().forceAllAbsent = true;
+    try {
+      // First invocation — capture the candidate paths from the throw.
+      const firstPaths = collectAttemptedPaths();
+      expect(firstPaths).toHaveLength(3);
+      for (const candidate of firstPaths) {
+        expect(isAbsolute(candidate)).toBe(true);
+      }
+
+      // The third candidate is the dev-worktree fallback. It should end in
+      // `src/specs` (the relative leg `../src/specs` resolved against the
+      // bundle's own directory) — no normalisation surprises.
+      const candidate3 = firstPaths[2];
+      expect(candidate3).toBeDefined();
+      expect(candidate3!.endsWith(`${pathSep()}src${pathSep()}specs`)).toBe(true);
+
+      // Re-run from a different cwd. `paths.ts` uses `import.meta.url`-
+      // relative resolution, so changing cwd must NOT shift any of the
+      // attempted paths.
+      process.chdir('/');
+      const secondPaths = collectAttemptedPaths();
+      process.chdir(ORIGINAL_CWD);
+
+      expect(secondPaths).toEqual(firstPaths);
+    } finally {
+      getState().forceAllAbsent = false;
+      process.chdir(ORIGINAL_CWD);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Invoke `getSpecsDir()` expecting it to throw, then parse the three
+ * attempted paths out of the diagnostic. The error format is locked at
+ * `paths.ts`: `Tried: <p1>, <p2>, <p3>. In bundled mode, ...`.
+ */
+function collectAttemptedPaths(): readonly string[] {
+  let captured: Error | null = null;
+  try {
+    getSpecsDir();
+  } catch (err) {
+    captured = err instanceof Error ? err : new Error(String(err));
+  }
+  expect(captured).not.toBeNull();
+  const message = captured!.message;
+  const triedMatch = message.match(/Tried: (.+?)\. In bundled mode/);
+  expect(triedMatch).not.toBeNull();
+  const list = triedMatch![1]!.split(', ').map((s) => s.trim());
+  return list;
+}
+
+function pathSep(): string {
+  // platform-agnostic separator without importing 'path' twice.
+  return process.platform === 'win32' ? '\\' : '/';
+}

--- a/packages/cli/src/specs/errors.pathway-detect.ts
+++ b/packages/cli/src/specs/errors.pathway-detect.ts
@@ -324,7 +324,7 @@ export function detectPathway(
       kind: 'unknown',
       reason: 'empty-store',
       diagnosticHint:
-        'The event store is empty — state.json appears to have been manually written into the error step without any triggering event.',
+        'The event store is empty — likely a fresh init or manual `gobbi.db` truncation without any triggering event.',
     };
     return pathway;
   }

--- a/packages/cli/src/specs/errors.sections.ts
+++ b/packages/cli/src/specs/errors.sections.ts
@@ -336,7 +336,7 @@ The reducer rejected an event because the transition was not valid from the curr
  */
 export const STATIC_PREAMBLE_UNKNOWN = `Pathway: unknown.
 
-The workflow is in the error step but the event store carries no evidence that attributes the error to one of the four observable pathways (crash, timeout, feedback cap, invalid transition). The classifier's diagnostic hint appears below — it usually indicates either an empty store (state.json written manually) or a store-read race during classification. Recovery means inspecting the hint to pick between retry-from-last-valid-state, force-memorization, and abort.`;
+The workflow is in the error step but the event store carries no evidence that attributes the error to one of the four observable pathways (crash, timeout, feedback cap, invalid transition). The classifier's diagnostic hint appears below — it usually indicates either an empty store (likely a fresh init or manual \`gobbi.db\` truncation) or a store-read race during classification. Recovery means inspecting the hint to pick between retry-from-last-valid-state, force-memorization, and abort.`;
 
 // ---------------------------------------------------------------------------
 // Per-pathway dynamic render helpers — evidence + recovery-options text.

--- a/packages/cli/src/specs/paths.ts
+++ b/packages/cli/src/specs/paths.ts
@@ -13,19 +13,30 @@
  * This helper exposes the single resolution policy used by every
  * caller (`graph.ts`, `next.ts`, `validate.ts`, `stop.ts`). The
  * fallback chain is purely runtime — no build-time conditionals, no
- * marker files, no environment heuristics. It tries each candidate in
- * turn and gates on `existsSync(<candidate>/index.json)`:
+ * marker files, no environment heuristics. It tries each of three
+ * candidates in turn and gates on `existsSync(<candidate>/index.json)`:
  *
  *   1. Bundled-mode candidate — `<this-dir>/specs/`. When `paths.ts`
  *      is bundled into `dist/cli.js`, `<this-dir>` is `dist/`, so the
  *      sibling `specs/` subdir created by `build:safe`'s post-build
- *      `cp` lands at `dist/specs/`. This is the production path.
+ *      `cp` lands at `dist/specs/`. This is the production path and
+ *      the path that wins after `build:safe` has run in any mode.
  *   2. Source-mode candidate — `<this-dir>` itself. At author time
  *      `paths.ts` lives in `src/specs/`, so `<this-dir>` IS the specs
- *      directory. `bun test` and unit tests resolve here.
+ *      directory. Wins for `bun test` and unit tests that import
+ *      `paths.ts` directly from source without going through `dist`.
+ *   3. Dev-worktree fallback — `<this-dir>/../src/specs/`. Wins only
+ *      in repo-local worktrees where the binary at `dist/cli.js` is
+ *      executed before `build:safe` has populated `dist/specs/` (e.g.
+ *      a fresh-checkout worktree running tests via the bundled
+ *      entrypoint). The relative traversal lands on the source-tree
+ *      `src/specs/` sibling of `dist/`. In a published npm package
+ *      `src/` is filtered by `package.json::files` so this candidate
+ *      fails gracefully and the throw fires — no leak of dev-only
+ *      resolution into shipped artifacts.
  *
- * If neither candidate exists, `getSpecsDir` throws with both
- * attempted paths in the diagnostic so the failure is debuggable
+ * If none of the three candidates exists, `getSpecsDir` throws with
+ * all attempted paths in the diagnostic so the failure is debuggable
  * without source-diving.
  *
  * Tests still inject a custom `specsDir` via the `--dir` flag or
@@ -43,9 +54,9 @@ const THIS_DIR = dirname(fileURLToPath(import.meta.url));
 /**
  * Resolve the canonical specs directory at runtime.
  *
- * @throws when neither the bundled-mode nor source-mode candidate
- *   contains an `index.json`. The error message lists both attempted
- *   paths so the failure is self-diagnosing.
+ * @throws when none of the three candidates (bundled-mode, source-mode,
+ *   dev-worktree fallback) contains an `index.json`. The error message
+ *   lists all three attempted paths so the failure is self-diagnosing.
  */
 export function getSpecsDir(): string {
   // Bundled-mode candidate: <dist>/specs/ when paths.ts is in <dist>/cli.js.
@@ -55,10 +66,19 @@ export function getSpecsDir(): string {
   // Source-mode candidate: paths.ts itself lives in src/specs/.
   if (existsSync(join(THIS_DIR, 'index.json'))) return THIS_DIR;
 
+  // Dev-worktree fallback: <dist>/../src/specs/ when the bundled binary
+  // runs before build:safe populated dist/specs/. Candidate 3 only ever
+  // wins in repo-local worktrees where `bun test` runs from outside
+  // `src/specs/`. In a published package, `src/` is filtered by
+  // `package.json::files`.
+  const devSrc = join(THIS_DIR, '..', 'src', 'specs');
+  if (existsSync(join(devSrc, 'index.json'))) return devSrc;
+
   throw new Error(
-    `[specs/paths] Cannot locate specs directory. Tried: ${bundled}, ${THIS_DIR}. ` +
+    `[specs/paths] Cannot locate specs directory. Tried: ${bundled}, ${THIS_DIR}, ${devSrc}. ` +
       `In bundled mode, ensure 'build:safe' has run and 'dist/specs/' exists. ` +
-      `In source mode, ensure 'paths.ts' is co-located with 'index.json' under 'src/specs/'.`,
+      `In source mode, ensure 'paths.ts' is co-located with 'index.json' under 'src/specs/'. ` +
+      `In a dev worktree without 'build:safe', ensure 'src/specs/index.json' exists at the sibling of 'dist/'.`,
   );
 }
 

--- a/packages/cli/src/workflow/__tests__/migrations.test.ts
+++ b/packages/cli/src/workflow/__tests__/migrations.test.ts
@@ -1,6 +1,5 @@
 /**
- * Event schema migration tests — `workflow/migrations.ts` + integration with
- * `state.ts::readState` for v1 on-disk compat.
+ * Event schema migration tests — `workflow/migrations.ts`.
  *
  * Covers the Wave 2 (C.8-d) disciplines plus the v3 extensions from PR D.5:
  *
@@ -24,10 +23,6 @@
  *      snapshot round-trips through `JSON.stringify` / `JSON.parse` at the
  *      event-store boundary. Asserts CP11 reversibility is preserved by
  *      the wire format.
- *   6. v1 state.json on-disk compat — a state.json written by a pre-PR-C
- *      process is readable via `readState`; the in-memory resolved state
- *      has `lastVerdictOutcome: null` normalised in and violations default
- *      to `severity: 'error'`.
  *
  * Note on purity: migrateEvent's `data` parse-on-non-identity is a deliberate
  * part of every walk even when each hop is an identity transform — the
@@ -36,13 +31,10 @@
  */
 
 import { describe, test, expect } from 'bun:test';
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
-import { tmpdir } from 'node:os';
 
 import { CURRENT_SCHEMA_VERSION, migrateEvent } from '../migrations.js';
 import type { EventRow } from '../migrations.js';
-import { deriveState, readState } from '../state.js';
+import { deriveState } from '../state.js';
 import { reduce } from '../reducer.js';
 import type { PriorErrorSnapshot } from '../events/decision.js';
 import type { ErrorPathway } from '../../specs/errors.js';
@@ -1336,102 +1328,3 @@ describe('v6 → v7 schema ensureSchemaV7', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// 3. v1 state.json on-disk compat
-// ---------------------------------------------------------------------------
-
-describe('v1 state.json on-disk compat', () => {
-  test('readState normalises v1 state.json to the v2 in-memory shape', () => {
-    const testDir = mkdtempSync(join(tmpdir(), 'gobbi-migrations-test-'));
-    try {
-      // A state.json written by a pre-PR-C process — no `lastVerdictOutcome`,
-      // violations without `severity`, schemaVersion still 1. This is
-      // exactly the shape that survives on disk from v0.5.0 Phase 2 PR B.
-      const v1State = {
-        schemaVersion: 1,
-        sessionId: 'sess-v1-ondisk',
-        currentStep: 'plan',
-        currentSubstate: null,
-        completedSteps: ['ideation'],
-        evalConfig: null,
-        activeSubagents: [],
-        artifacts: {},
-        violations: [
-          {
-            guardId: 'g-scope',
-            toolName: 'Write',
-            reason: 'outside scope',
-            step: 'plan',
-            timestamp: '2026-01-01T00:00:03.000Z',
-            // severity absent — v1 didn't track it
-          },
-        ],
-        feedbackRound: 0,
-        maxFeedbackRounds: 3,
-        // lastVerdictOutcome absent — v1 didn't track it
-      };
-      writeFileSync(
-        join(testDir, 'state.json'),
-        JSON.stringify(v1State),
-        'utf8',
-      );
-
-      const resolved = readState(testDir);
-      expect(resolved).not.toBeNull();
-      if (resolved === null) throw new Error('unreachable');
-      expect(resolved.sessionId).toBe('sess-v1-ondisk');
-      // v1 on-disk 'plan' is normalised to the post-rename 'planning' literal
-      // on read (see `normaliseToLatestSchema` in state.ts).
-      expect(resolved.currentStep).toBe('planning');
-      // Normalisation: v1's absent lastVerdictOutcome becomes null in memory.
-      expect(resolved.lastVerdictOutcome).toBeNull();
-      // Normalisation: v1 violation without severity becomes 'error' in memory.
-      expect(resolved.violations).toHaveLength(1);
-      expect(resolved.violations[0]!.severity).toBe('error');
-    } finally {
-      rmSync(testDir, { recursive: true, force: true });
-    }
-  });
-
-  test('readState preserves v2 state.json unchanged', () => {
-    const testDir = mkdtempSync(join(tmpdir(), 'gobbi-migrations-test-'));
-    try {
-      const v2State = {
-        schemaVersion: 2,
-        sessionId: 'sess-v2-ondisk',
-        currentStep: 'execution',
-        currentSubstate: null,
-        completedSteps: ['ideation', 'plan'],
-        evalConfig: { ideation: false, plan: false },
-        activeSubagents: [],
-        artifacts: {},
-        violations: [
-          {
-            guardId: 'g-warn',
-            toolName: 'Write',
-            reason: 'secret-ish path',
-            step: 'execution',
-            timestamp: '2026-01-01T00:00:00.000Z',
-            severity: 'warning',
-          },
-        ],
-        feedbackRound: 0,
-        maxFeedbackRounds: 3,
-        lastVerdictOutcome: 'pass',
-      };
-      writeFileSync(
-        join(testDir, 'state.json'),
-        JSON.stringify(v2State),
-        'utf8',
-      );
-
-      const resolved = readState(testDir);
-      expect(resolved).not.toBeNull();
-      if (resolved === null) throw new Error('unreachable');
-      expect(resolved.lastVerdictOutcome).toBe('pass');
-      expect(resolved.violations[0]!.severity).toBe('warning');
-    } finally {
-      rmSync(testDir, { recursive: true, force: true });
-    }
-  });
-});

--- a/packages/cli/src/workflow/__tests__/session-json-writer.test.ts
+++ b/packages/cli/src/workflow/__tests__/session-json-writer.test.ts
@@ -42,7 +42,7 @@ import {
 import { appendEventAndUpdateState } from '../engine.js';
 import { writeSessionJsonAtMemorizationExit } from '../session-json-writer.js';
 import { EventStore } from '../store.js';
-import { initialState, writeState } from '../state.js';
+import { initialState } from '../state.js';
 import type { WorkflowState } from '../state.js';
 import { WORKFLOW_EVENTS } from '../events/workflow.js';
 import type { Event } from '../events/index.js';
@@ -100,9 +100,16 @@ function makeSession(
 }
 
 /**
- * Drive a session into `memorization` by stamping `state.json` directly so
- * the engine accepts a STEP_EXIT for that step in a single append. Avoids
- * threading the workflow through every intermediate step in the test.
+ * Drive a session into `memorization` by stamping a legacy `state.json`
+ * fixture directly so the engine accepts a STEP_EXIT for that step in a
+ * single append. Avoids threading the workflow through every intermediate
+ * step in the test.
+ *
+ * Production code no longer reads `state.json` (retired in PR-FIN-2a-ii);
+ * the fixture is preserved as a regression scaffold so the test's intent
+ * — that the engine's STEP_EXIT dispatch operates on the in-memory `prev`
+ * argument, not on a state.json projection — stays explicit at the call
+ * site.
  */
 function seedMemorizationState(
   fixture: SessionFixture,
@@ -112,7 +119,11 @@ function seedMemorizationState(
     currentStep: 'memorization',
     stepStartedAt: '2026-04-29T00:30:00.000Z',
   };
-  writeState(fixture.sessionDir, state);
+  writeFileSync(
+    join(fixture.sessionDir, 'state.json'),
+    JSON.stringify(state, null, 2),
+    'utf8',
+  );
   return state;
 }
 
@@ -271,13 +282,19 @@ describe('engine memorization STEP_EXIT dispatch', () => {
 
   it('does NOT fire the writer when STEP_EXIT commits with step !== "memorization"', async () => {
     const fixture = makeSession('proj-engine-non-mem', 'sess-engine-non-mem');
-    // Seed a state where ideation can validly exit.
+    // Seed a state where ideation can validly exit. Direct fs write of the
+    // legacy state.json shape — production code no longer reads it; the
+    // fixture is preserved as a regression scaffold.
     const prev: WorkflowState = {
       ...initialState(fixture.sessionId),
       currentStep: 'ideation',
       stepStartedAt: '2026-04-29T00:00:30.000Z',
     };
-    writeState(fixture.sessionDir, prev);
+    writeFileSync(
+      join(fixture.sessionDir, 'state.json'),
+      JSON.stringify(prev, null, 2),
+      'utf8',
+    );
 
     using store = new EventStore(join(fixture.sessionDir, 'gobbi.db'));
     const stepExit: Event = {

--- a/packages/cli/src/workflow/__tests__/state.test.ts
+++ b/packages/cli/src/workflow/__tests__/state.test.ts
@@ -1,20 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, copyFileSync, readFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import {
   initialState,
   isValidState,
-  writeState,
-  readState,
-  backupState,
-  restoreBackup,
-  restoreStateFromBackup,
   rowToEvent,
   deriveState,
-  resolveState,
-  normaliseToLatestSchema,
 } from '../state.js';
 import type { WorkflowState, ReduceFn } from '../state.js';
 import type { ResolvedSettings } from '../../lib/settings.js';
@@ -198,84 +191,6 @@ describe('initialState maxFeedbackRounds wiring', () => {
 });
 
 // ===========================================================================
-// writeState + readState
-// ===========================================================================
-
-describe('writeState + readState', () => {
-  it('round-trips a state to disk and back', () => {
-    const state = makeState({ currentStep: 'execution', feedbackRound: 2 });
-    writeState(testDir, state);
-    const read = readState(testDir);
-    expect(read).toEqual(state);
-  });
-
-  it('creates the directory if it does not exist', () => {
-    const nested = join(testDir, 'nested', 'deep');
-    const state = makeState();
-    writeState(nested, state);
-    const read = readState(nested);
-    expect(read).toEqual(state);
-  });
-
-  it('overwrites an existing state.json', () => {
-    const state1 = makeState({ currentStep: 'idle' });
-    const state2 = makeState({ currentStep: 'execution' });
-    writeState(testDir, state1);
-    writeState(testDir, state2);
-    const read = readState(testDir);
-    expect(read).toEqual(state2);
-  });
-});
-
-// ===========================================================================
-// readState returns null
-// ===========================================================================
-
-describe('readState returns null', () => {
-  it('returns null for missing file', () => {
-    expect(readState(testDir)).toBeNull();
-  });
-
-  it('returns null for invalid JSON', () => {
-    writeFileSync(join(testDir, 'state.json'), 'not-json{{{', 'utf8');
-    expect(readState(testDir)).toBeNull();
-  });
-
-  it('returns null for wrong shape', () => {
-    writeFileSync(join(testDir, 'state.json'), JSON.stringify({ foo: 'bar' }), 'utf8');
-    expect(readState(testDir)).toBeNull();
-  });
-});
-
-// ===========================================================================
-// backupState + restoreBackup
-// ===========================================================================
-
-describe('backupState + restoreBackup', () => {
-  it('creates a backup and restores it', () => {
-    const state = makeState({ currentStep: 'planning', feedbackRound: 1 });
-    writeState(testDir, state);
-    backupState(testDir);
-
-    // Corrupt the primary
-    writeFileSync(join(testDir, 'state.json'), 'corrupted', 'utf8');
-
-    const restored = restoreBackup(testDir);
-    expect(restored).toEqual(state);
-  });
-
-  it('backupState is a no-op when state.json does not exist', () => {
-    // Should not throw
-    backupState(testDir);
-    expect(restoreBackup(testDir)).toBeNull();
-  });
-
-  it('restoreBackup returns null when no backup exists', () => {
-    expect(restoreBackup(testDir)).toBeNull();
-  });
-});
-
-// ===========================================================================
 // rowToEvent
 // ===========================================================================
 
@@ -408,58 +323,6 @@ describe('deriveState', () => {
 });
 
 // ===========================================================================
-// resolveState
-// ===========================================================================
-
-describe('resolveState', () => {
-  it('prefers state.json when available', () => {
-    using store = new EventStore(':memory:');
-
-    // Write a state.json that says execution
-    const diskState = makeState({ currentStep: 'execution' });
-    writeState(testDir, diskState);
-
-    // Store has a start event (which would derive to ideation)
-    store.append(makeAppendInput({ toolCallId: 'tc-1' }));
-    const events = store.replayAll();
-
-    const resolved = resolveState(testDir, events, 'test-session', reduce);
-    expect(resolved.currentStep).toBe('execution');
-  });
-
-  it('falls back to backup when state.json is corrupt', () => {
-    using store = new EventStore(':memory:');
-
-    // Write valid state, backup it, then corrupt primary
-    const backupStateObj = makeState({ currentStep: 'planning' });
-    writeState(testDir, backupStateObj);
-    backupState(testDir);
-    writeFileSync(join(testDir, 'state.json'), 'corrupt', 'utf8');
-
-    store.append(makeAppendInput({ toolCallId: 'tc-1' }));
-    const events = store.replayAll();
-
-    const resolved = resolveState(testDir, events, 'test-session', reduce);
-    expect(resolved.currentStep).toBe('planning');
-  });
-
-  it('falls back to event replay when both state.json and backup are missing', () => {
-    using store = new EventStore(':memory:');
-
-    store.append(makeAppendInput({
-      toolCallId: 'tc-1',
-      type: WORKFLOW_EVENTS.START,
-      data: JSON.stringify({ sessionId: 'sess-1', timestamp: '2026-01-01T00:00:00Z' }),
-    }));
-    const events = store.replayAll();
-
-    // No state.json, no backup — derive from events
-    const resolved = resolveState(testDir, events, 'sess-1', reduce);
-    expect(resolved.currentStep).toBe('ideation');
-  });
-});
-
-// ===========================================================================
 // Engine: deduplication
 // ===========================================================================
 
@@ -493,39 +356,6 @@ describe('appendEventAndUpdateState deduplication', () => {
     // events.jsonl is no longer written — gobbi.db is the authoritative
     // source of truth for the event log.
     expect(existsSync(join(testDir, 'events.jsonl'))).toBe(false);
-  });
-});
-
-// ===========================================================================
-// restoreStateFromBackup
-// ===========================================================================
-
-describe('restoreStateFromBackup', () => {
-  it('copies backup back to state.json', () => {
-    const original = makeState({ currentStep: 'planning' });
-    writeState(testDir, original);
-    backupState(testDir);
-
-    // Advance state.json to a different step
-    const advanced = makeState({ currentStep: 'execution' });
-    writeState(testDir, advanced);
-
-    // Restore from backup
-    restoreStateFromBackup(testDir);
-
-    const restored = readState(testDir);
-    expect(restored).toEqual(original);
-  });
-
-  it('is a no-op when no backup exists', () => {
-    const state = makeState({ currentStep: 'execution' });
-    writeState(testDir, state);
-
-    // Should not throw and should not modify state.json
-    restoreStateFromBackup(testDir);
-
-    const read = readState(testDir);
-    expect(read).toEqual(state);
   });
 });
 
@@ -624,213 +454,6 @@ describe('appendEventAndUpdateState crash-safety', () => {
 });
 
 // ===========================================================================
-// normaliseToLatestSchema — Wave 4 backward-compat translation
-// ===========================================================================
-
-describe('normaliseToLatestSchema', () => {
-  it('translates currentStep: "plan" → "planning"', () => {
-    const input = { currentStep: 'plan' };
-    const result = normaliseToLatestSchema(input);
-    expect(result).toEqual({ currentStep: 'planning' });
-  });
-
-  it('translates currentStep: "plan_eval" → "planning_eval"', () => {
-    const input = { currentStep: 'plan_eval' };
-    const result = normaliseToLatestSchema(input);
-    expect(result).toEqual({ currentStep: 'planning_eval' });
-  });
-
-  it('translates completedSteps entries ["ideation", "plan"] → ["ideation", "planning"]', () => {
-    const input = { completedSteps: ['ideation', 'plan'] };
-    const result = normaliseToLatestSchema(input);
-    expect(result).toEqual({ completedSteps: ['ideation', 'planning'] });
-  });
-
-  it('translates completedSteps mixed old/new shapes', () => {
-    const input = { completedSteps: ['ideation', 'plan', 'planning', 'plan_eval'] };
-    const result = normaliseToLatestSchema(input) as { completedSteps: string[] };
-    expect(result.completedSteps).toEqual([
-      'ideation',
-      'planning',
-      'planning',
-      'planning_eval',
-    ]);
-  });
-
-  it('moves evalConfig.plan → evalConfig.planning', () => {
-    const input = { evalConfig: { ideation: false, plan: false } };
-    const result = normaliseToLatestSchema(input) as {
-      evalConfig: Record<string, unknown>;
-    };
-    expect(result.evalConfig).toEqual({ ideation: false, planning: false });
-    expect('plan' in result.evalConfig).toBe(false);
-  });
-
-  it('moves evalConfig.plan when value is true', () => {
-    const input = { evalConfig: { ideation: true, plan: true } };
-    const result = normaliseToLatestSchema(input) as {
-      evalConfig: Record<string, unknown>;
-    };
-    expect(result.evalConfig).toEqual({ ideation: true, planning: true });
-  });
-
-  it('preserves sibling evalConfig keys while renaming plan', () => {
-    const input = {
-      evalConfig: { ideation: false, plan: false, execution: true },
-    };
-    const result = normaliseToLatestSchema(input) as {
-      evalConfig: Record<string, unknown>;
-    };
-    expect(result.evalConfig).toEqual({
-      ideation: false,
-      planning: false,
-      execution: true,
-    });
-  });
-
-  it('is idempotent on already-new-shape input (no double translation)', () => {
-    const input = {
-      currentStep: 'planning',
-      completedSteps: ['ideation', 'planning'],
-      evalConfig: { ideation: false, planning: false },
-    };
-    const result = normaliseToLatestSchema(input);
-    expect(result).toEqual(input);
-  });
-
-  it('handles mixed-version state (some old literals, some new)', () => {
-    const input = {
-      currentStep: 'execution',
-      completedSteps: ['ideation', 'plan'],
-      evalConfig: { ideation: false, plan: false },
-    };
-    const result = normaliseToLatestSchema(input);
-    expect(result).toEqual({
-      currentStep: 'execution',
-      completedSteps: ['ideation', 'planning'],
-      evalConfig: { ideation: false, planning: false },
-    });
-  });
-
-  it('returns non-record input unchanged', () => {
-    expect(normaliseToLatestSchema(null)).toBeNull();
-    expect(normaliseToLatestSchema(42)).toBe(42);
-    expect(normaliseToLatestSchema('string')).toBe('string');
-    expect(normaliseToLatestSchema([1, 2, 3])).toEqual([1, 2, 3]);
-  });
-
-  it('does not touch unrelated fields', () => {
-    const input = {
-      sessionId: 'abc',
-      schemaVersion: 4,
-      artifacts: { plan: ['file.md'] }, // `plan` as artifact key is NOT renamed
-      feedbackRound: 2,
-    };
-    const result = normaliseToLatestSchema(input);
-    expect(result).toEqual(input);
-  });
-
-  it('prefers existing planning key over legacy plan when both present', () => {
-    // Defensive: if somehow both keys exist (only possible via hand-crafted
-    // bad data), the post-rename key wins — we drop the legacy key silently.
-    const input = {
-      evalConfig: { ideation: false, plan: true, planning: false },
-    };
-    const result = normaliseToLatestSchema(input) as {
-      evalConfig: Record<string, unknown>;
-    };
-    expect(result.evalConfig).toEqual({ ideation: false, planning: false });
-    expect('plan' in result.evalConfig).toBe(false);
-  });
-});
-
-// ===========================================================================
-// readState backward-compat — legacy on-disk `plan` literals survive W4
-// ===========================================================================
-
-describe('readState backward-compat (W4 step rename)', () => {
-  it('reads a legacy state.json with currentStep:"plan" + evalConfig.plan', () => {
-    const legacy = {
-      schemaVersion: 4,
-      sessionId: 'legacy-sess-1',
-      currentStep: 'plan',
-      currentSubstate: null,
-      completedSteps: ['ideation'],
-      evalConfig: { ideation: false, plan: false },
-      activeSubagents: [],
-      artifacts: {},
-      violations: [],
-      feedbackRound: 0,
-      maxFeedbackRounds: 3,
-      lastVerdictOutcome: null,
-      verificationResults: {},
-      stepStartedAt: null,
-    };
-    writeFileSync(join(testDir, 'state.json'), JSON.stringify(legacy), 'utf8');
-
-    const resolved = readState(testDir);
-    expect(resolved).not.toBeNull();
-    if (resolved === null) throw new Error('unreachable');
-    expect(resolved.currentStep).toBe('planning');
-    expect(resolved.evalConfig).toEqual({ ideation: false, planning: false });
-  });
-
-  it('reads a state.json with completedSteps containing "plan"', () => {
-    const legacy = {
-      schemaVersion: 4,
-      sessionId: 'legacy-sess-2',
-      currentStep: 'execution',
-      currentSubstate: null,
-      completedSteps: ['ideation', 'plan'],
-      evalConfig: { ideation: false, plan: false },
-      activeSubagents: [],
-      artifacts: {},
-      violations: [],
-      feedbackRound: 0,
-      maxFeedbackRounds: 3,
-      lastVerdictOutcome: null,
-      verificationResults: {},
-      stepStartedAt: null,
-    };
-    writeFileSync(join(testDir, 'state.json'), JSON.stringify(legacy), 'utf8');
-
-    const resolved = readState(testDir);
-    expect(resolved).not.toBeNull();
-    if (resolved === null) throw new Error('unreachable');
-    expect(resolved.currentStep).toBe('execution');
-    expect(resolved.completedSteps).toEqual(['ideation', 'planning']);
-  });
-
-  it('does not rewrite state.json (Greg Young discipline)', () => {
-    const legacy = {
-      schemaVersion: 4,
-      sessionId: 'legacy-sess-3',
-      currentStep: 'plan',
-      currentSubstate: null,
-      completedSteps: ['ideation'],
-      evalConfig: { ideation: false, plan: false },
-      activeSubagents: [],
-      artifacts: {},
-      violations: [],
-      feedbackRound: 0,
-      maxFeedbackRounds: 3,
-      lastVerdictOutcome: null,
-      verificationResults: {},
-      stepStartedAt: null,
-    };
-    const filePath = join(testDir, 'state.json');
-    const raw = JSON.stringify(legacy);
-    writeFileSync(filePath, raw, 'utf8');
-
-    readState(testDir);
-
-    // File unchanged — translation is in-memory-only.
-    const after = readFileSync(filePath, 'utf8');
-    expect(after).toBe(raw);
-  });
-});
-
-// ===========================================================================
 // deriveState backward-compat — legacy `step:"plan"` events replay cleanly
 // ===========================================================================
 
@@ -873,7 +496,7 @@ describe('deriveState backward-compat (W4 step rename)', () => {
       const rows = store.replayAll();
 
       // Drive deriveState through the fresh initial state (emulating cold-path
-      // replay after readState returned null on an old file).
+      // replay against the event store).
       // We need to craft a start event first so the reducer is happy.
       // Actually: with currentStep:'idle', STEP_EXIT requires currentStep to
       // match `step`. The first exit carries step:'ideation' but initialState

--- a/packages/cli/src/workflow/__tests__/step-readme-writer.test.ts
+++ b/packages/cli/src/workflow/__tests__/step-readme-writer.test.ts
@@ -32,7 +32,7 @@ import {
 } from '../step-readme-writer.js';
 import { appendEventAndUpdateState } from '../engine.js';
 import { EventStore } from '../store.js';
-import { initialState, writeState } from '../state.js';
+import { initialState } from '../state.js';
 import type { WorkflowState } from '../state.js';
 import { WORKFLOW_EVENTS } from '../events/workflow.js';
 import type { Event } from '../events/index.js';
@@ -292,8 +292,11 @@ describe('writeStepReadmeForExit', () => {
 
 describe('engine STEP_EXIT hook', () => {
   function seedIdeationState(sessionDir: string, sessionId: string): WorkflowState {
-    // Seed a state.json in the `ideation` productive step so STEP_EXIT is
-    // a valid transition. Callers drive the exit via the engine.
+    // Seed a legacy `state.json` fixture in the `ideation` productive step
+    // so STEP_EXIT is a valid transition. Callers drive the exit via the
+    // engine, which reads the in-memory `prev` argument — production code
+    // no longer reads `state.json` (retired in PR-FIN-2a-ii); the fixture
+    // is preserved as a regression scaffold.
     const state: WorkflowState = {
       ...initialState(sessionId),
       currentStep: 'ideation',
@@ -301,7 +304,11 @@ describe('engine STEP_EXIT hook', () => {
       stepStartedAt: '2026-04-20T09:00:00.000Z',
       artifacts: { ideation: ['ideation.md'] },
     };
-    writeState(sessionDir, state);
+    writeFileSync(
+      join(sessionDir, 'state.json'),
+      JSON.stringify(state, null, 2),
+      'utf8',
+    );
     return state;
   }
 

--- a/packages/cli/src/workflow/session-json-writer.ts
+++ b/packages/cli/src/workflow/session-json-writer.ts
@@ -65,12 +65,17 @@ import type { ReadStore } from './store.js';
 /**
  * Arguments for {@link writeSessionJsonAtMemorizationExit}. The engine
  * supplies `sessionDir` + `store` from the committed transaction context;
- * the rest derive from {@link readSessionJson} on the init-time stub.
+ * the carry-forward stub fields (`schemaVersion`, `sessionId`, `projectId`,
+ * `createdAt`, `gobbiVersion`, `task`) are read from the init-time
+ * `session.json` stub via {@link readSessionJson}.
  *
- * `repoRoot` is required because both `sessionJsonPath` and `projectJsonPath`
- * compose paths off the repo root rather than the session directory — the
- * session directory is internal to the repo's `.gobbi/projects/<name>/`
- * layout but the paths-helpers expect the workspace anchor explicitly.
+ * The repo root, project name, and session id are NOT caller-supplied —
+ * they are derived internally from `sessionDir` by `deriveSessionLocation`,
+ * which path-segment-parses the canonical
+ * `<repoRoot>/.gobbi/projects/<projectName>/sessions/<sessionId>` shape.
+ * `sessionJsonPath` and `projectJsonPath` then re-compose paths off the
+ * derived repo root rather than the session directory, because the
+ * paths-helpers expect the workspace anchor explicitly.
  *
  * `finishedAt` is exposed so tests can pin the value; production callers
  * leave it unset and the aggregator returns `null` (memorization fires

--- a/packages/cli/src/workflow/state.ts
+++ b/packages/cli/src/workflow/state.ts
@@ -1,30 +1,25 @@
 /**
- * Workflow state types, initial state factory, and persistence.
+ * Workflow state types, initial state factory, and event-derived state.
  *
  * Defines the WorkflowState interface, step/substate types, evaluation
  * configuration, active subagent tracking, and guard violation records.
  * State is immutable — all fields use readonly modifiers.
  *
- * Persistence functions are synchronous (writeFileSync, renameSync)
- * because they execute inside bun:sqlite transactions which cannot
- * contain async calls.
+ * Per PR-FIN-2a-ii (T-2a.9.unified) the per-session `state.json`
+ * projection (and its `state.json.backup` companion) was retired in
+ * favour of pure event-derived state via `deriveState`. This module
+ * therefore exposes types, the initial-state factory, the runtime
+ * shape guard, and the EventRow → WorkflowState replay path —
+ * filesystem persistence helpers no longer live here. PR-FIN-2a-iii
+ * removed the orphaned `writeState` / `readState` / `backupState` /
+ * `restoreBackup` / `restoreStateFromBackup` / `resolveState` /
+ * `normaliseToLatestSchema` exports + the private `normaliseReadState`
+ * helper that the four read paths shared.
  *
- * This module does NOT import from reducer.ts — deriveState and
- * resolveState accept a reduce function as a parameter to avoid
- * circular dependencies. engine.ts is the module that bridges
- * state.ts and reducer.ts.
+ * This module does NOT import from reducer.ts — `deriveState` accepts
+ * a reduce function as a parameter to avoid circular dependencies.
+ * engine.ts is the module that bridges state.ts and reducer.ts.
  */
-
-import {
-  writeFileSync,
-  readFileSync,
-  renameSync,
-  copyFileSync,
-  existsSync,
-  mkdirSync,
-} from 'node:fs';
-import { join } from 'node:path';
-import { randomUUID } from 'node:crypto';
 
 import { isRecord, isString, isNumber, isBoolean, isArray } from '../lib/guards.js';
 import type { ResolvedSettings } from '../lib/settings.js';
@@ -147,9 +142,9 @@ export interface ActiveSubagent {
 /**
  * One persisted guard record. Both `guard.violation` (error) and `guard.warn`
  * (warning) events append records here; the `severity` field discriminates
- * them. `severity` is optional for on-disk v1 backward-compat — pre-schema-v2
- * files never stored it. `readState` normalises absent severity to `'error'`
- * so in-memory state always carries the field.
+ * them. `severity` is optional for v1 event-payload backward-compat —
+ * pre-schema-v2 events never carried it; the v1→v2 migration in
+ * `migrations.ts` defaults absent severity to `'error'`.
  */
 export interface GuardViolationRecord {
   readonly guardId: string;
@@ -198,17 +193,14 @@ export interface WorkflowState {
    * the form `"sub-123:typecheck"`. Populated by E.3's `reduceVerification`
    * sub-reducer; read by E.8's verification-block dynamic section.
    *
-   * Empty record on a fresh state; v3 on-disk shapes are normalised in to
-   * `{}` on read (Greg Young discipline — the persisted file itself is not
-   * rewritten until the next `writeState`). Added by PR E (schema v4).
+   * Empty record on a fresh state. Added by PR E (schema v4).
    */
   readonly verificationResults: Readonly<Record<string, VerificationResultData>>;
 
   // E.10 ZONE: stepStartedAt field insertion
   /**
    * ISO-8601 timestamp of the current step's entry, or `null` when no
-   * step has been entered yet (fresh-init state, or pre-v4 on-disk
-   * shapes normalised on read).
+   * step has been entered yet (fresh-init state).
    *
    * Set by the reducer on `workflow.step.exit` (for the next step the
    * transition advances to) and on `workflow.resume` (for the target
@@ -411,8 +403,9 @@ export function isValidState(value: unknown): value is WorkflowState {
     if (!isString(v['reason'])) return false;
     if (!isString(v['step'])) return false;
     if (!isString(v['timestamp'])) return false;
-    // severity is optional (schema v2+); `undefined` passes for v1 on-disk
-    // compat and is normalised to `'error'` by readState.
+    // severity is optional (schema v2+); `undefined` passes for v1 event
+    // backward-compat. The v1→v2 migration in `migrations.ts` defaults
+    // absent severity to `'error'` before it reaches state.
     const severity = v['severity'];
     if (severity !== undefined) {
       if (!isString(severity)) return false;
@@ -425,8 +418,8 @@ export function isValidState(value: unknown): value is WorkflowState {
   if (!isNumber(value['maxFeedbackRounds'])) return false;
 
   // lastVerdictOutcome: 'pass' | 'revise' | null (schema v2+).
-  // `undefined` is tolerated for v1 on-disk compat and is normalised to
-  // `null` by readState.
+  // `undefined` is tolerated for v1 event backward-compat (the field
+  // didn't exist pre-PR-C; replay produces `null`).
   const outcome = value['lastVerdictOutcome'];
   if (outcome !== undefined) {
     if (outcome !== null && !isString(outcome)) return false;
@@ -434,11 +427,11 @@ export function isValidState(value: unknown): value is WorkflowState {
   }
 
   // verificationResults: Record<string, VerificationResultData> (schema v4+).
-  // `undefined` is tolerated for v1/v2/v3 on-disk compat and is normalised
-  // to `{}` by readState. When present, we validate the outer record shape
-  // and every entry's top-level key/type invariants — nested string/number
-  // fields are spot-checked for corruption detection rather than strict
-  // full-schema conformance (the same approach taken for `violations`).
+  // `undefined` is tolerated for v1/v2/v3 event backward-compat. When
+  // present, we validate the outer record shape and every entry's
+  // top-level key/type invariants — nested string/number fields are
+  // spot-checked for corruption detection rather than strict full-schema
+  // conformance (the same approach taken for `violations`).
   const verifResults = value['verificationResults'];
   if (verifResults !== undefined) {
     if (!isRecord(verifResults)) return false;
@@ -458,241 +451,15 @@ export function isValidState(value: unknown): value is WorkflowState {
   }
 
   // stepStartedAt: string | null (schema v4+).
-  // `undefined` is tolerated for v1/v2/v3 on-disk compat and is normalised
-  // to `null` by readState. When present, must be an ISO timestamp string
-  // or explicit `null` — numbers/objects/booleans are rejected.
+  // `undefined` is tolerated for v1/v2/v3 event backward-compat. When
+  // present, must be an ISO timestamp string or explicit `null` —
+  // numbers/objects/booleans are rejected.
   const startedAt = value['stepStartedAt'];
   if (startedAt !== undefined) {
     if (startedAt !== null && !isString(startedAt)) return false;
   }
 
   return true;
-}
-
-// ---------------------------------------------------------------------------
-// State persistence — synchronous for use inside bun:sqlite transactions
-// ---------------------------------------------------------------------------
-
-/**
- * Synchronous atomic write: write to temp file, then rename.
- * Creates the directory if it does not exist.
- */
-export function writeState(dir: string, state: WorkflowState): void {
-  mkdirSync(dir, { recursive: true });
-  const filePath = join(dir, 'state.json');
-  const tmpPath = join(dir, `state.json.${randomUUID()}.tmp`);
-  writeFileSync(tmpPath, JSON.stringify(state, null, 2), 'utf8');
-  renameSync(tmpPath, filePath);
-}
-
-/**
- * Translate legacy step literals in a parsed (but not-yet-validated)
- * `state.json` payload to the post-Wave-4 names BEFORE `isValidState`
- * runs. This is the backward-compatibility shim for sessions written
- * under the pre-rename shape (`'plan'` / `'plan_eval'` / `evalConfig.plan`).
- *
- * Translations applied:
- *
- *   - `currentStep: 'plan'`        → `'planning'`
- *   - `currentStep: 'plan_eval'`   → `'planning_eval'`
- *   - `completedSteps` entries     → same pair-wise rename
- *   - `evalConfig.plan`            → `evalConfig.planning` (key moves;
- *                                     the old key is dropped)
- *   - `evalConfig.plan_eval`       → `evalConfig.planning_eval`
- *     (defensive — schema never had this key in practice, but the
- *     symmetric treatment guards future drift)
- *
- * Everything else is untouched. We do NOT bump `schemaVersion` — that
- * field tracks state-shape migrations, not the post-W4 name alignment.
- * The next `writeState` promotes the on-disk file to the current shape
- * naturally, matching the Greg Young discipline that `normaliseReadState`
- * applies post-validation.
- *
- * Accepts `unknown` because it runs BEFORE `isValidState` — translation
- * must tolerate any parsed JSON shape. When the input is not a record
- * or does not carry the legacy literals, it is returned unchanged.
- *
- * Idempotent: running this over already-translated (new-shape) input
- * produces the same output (no legacy literals survive).
- */
-export function normaliseToLatestSchema(parsed: unknown): unknown {
-  if (!isRecord(parsed)) return parsed;
-
-  const out: Record<string, unknown> = { ...parsed };
-
-  // currentStep: string rename
-  const currentStep = out['currentStep'];
-  if (currentStep === 'plan') {
-    out['currentStep'] = 'planning';
-  } else if (currentStep === 'plan_eval') {
-    out['currentStep'] = 'planning_eval';
-  }
-
-  // completedSteps: array of strings, pair-wise rename
-  const completedSteps = out['completedSteps'];
-  if (isArray(completedSteps)) {
-    let mutated = false;
-    const translated: unknown[] = completedSteps.map((entry) => {
-      if (entry === 'plan') {
-        mutated = true;
-        return 'planning';
-      }
-      if (entry === 'plan_eval') {
-        mutated = true;
-        return 'planning_eval';
-      }
-      return entry;
-    });
-    if (mutated) {
-      out['completedSteps'] = translated;
-    }
-  }
-
-  // evalConfig: move the `plan` key to `planning` (same for plan_eval).
-  // Preserve every other key on the record.
-  const evalConfig = out['evalConfig'];
-  if (isRecord(evalConfig)) {
-    const hasLegacyPlan = Object.prototype.hasOwnProperty.call(evalConfig, 'plan');
-    const hasLegacyPlanEval = Object.prototype.hasOwnProperty.call(
-      evalConfig,
-      'plan_eval',
-    );
-    if (hasLegacyPlan || hasLegacyPlanEval) {
-      const nextEval: Record<string, unknown> = {};
-      for (const [key, value] of Object.entries(evalConfig)) {
-        if (key === 'plan') {
-          // Only rename if the post-rename key is not already set — new-shape
-          // writes always win (idempotency).
-          if (!Object.prototype.hasOwnProperty.call(evalConfig, 'planning')) {
-            nextEval['planning'] = value;
-          }
-          continue;
-        }
-        if (key === 'plan_eval') {
-          if (
-            !Object.prototype.hasOwnProperty.call(evalConfig, 'planning_eval')
-          ) {
-            nextEval['planning_eval'] = value;
-          }
-          continue;
-        }
-        nextEval[key] = value;
-      }
-      out['evalConfig'] = nextEval;
-    }
-  }
-
-  return out;
-}
-
-/**
- * Normalise a validated `WorkflowState` read from disk so in-memory state
- * always carries the current (v4) shape:
- *
- *   - Absent `lastVerdictOutcome` (v1) → `null`.
- *   - Absent `severity` on any violation (v1) → `'error'` (the pre-v2
- *     event `guard.violation` was error-severity by definition).
- *   - Absent `verificationResults` (v1/v2/v3) → `{}` (the pre-v4 state had
- *     no verification channel).
- *
- * We deliberately do NOT rewrite the on-disk file — this is Greg Young
- * discipline (see `v050-session.md`). Old files stay their original shape
- * until the next writeState() call naturally promotes them.
- */
-function normaliseReadState(state: WorkflowState): WorkflowState {
-  const violations = state.violations.map((v) =>
-    v.severity === undefined ? { ...v, severity: 'error' as const } : v,
-  );
-  return {
-    ...state,
-    lastVerdictOutcome: state.lastVerdictOutcome ?? null,
-    verificationResults: state.verificationResults ?? {},
-    stepStartedAt: state.stepStartedAt ?? null,
-    violations,
-  };
-}
-
-/**
- * Read state.json from disk.
- * Returns null if the file is absent, contains invalid JSON, or has
- * an unexpected shape.
- *
- * Applies two normalisation passes:
- *
- *   1. `normaliseToLatestSchema` — translates pre-Wave-4 step literals
- *      (`'plan'` → `'planning'`, `evalConfig.plan` → `evalConfig.planning`,
- *      etc.) so legacy on-disk state files survive the rename. Runs BEFORE
- *      `isValidState` because the validator rejects the old literals.
- *   2. `normaliseReadState` — fills in absent v2+ fields
- *      (`lastVerdictOutcome`, violation `severity`, `verificationResults`,
- *      `stepStartedAt`) on a validated state. Runs AFTER validation.
- *
- * The file itself is not rewritten in either pass — next `writeState`
- * naturally promotes.
- */
-export function readState(dir: string): WorkflowState | null {
-  const filePath = join(dir, 'state.json');
-  if (!existsSync(filePath)) return null;
-  try {
-    const raw = readFileSync(filePath, 'utf8');
-    const parsed: unknown = JSON.parse(raw);
-    const normalized = normaliseToLatestSchema(parsed);
-    if (!isValidState(normalized)) return null;
-    return normaliseReadState(normalized);
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Copy state.json to state.json.backup.
- * No-op if state.json does not exist.
- */
-export function backupState(dir: string): void {
-  const src = join(dir, 'state.json');
-  const dest = join(dir, 'state.json.backup');
-  if (existsSync(src)) {
-    copyFileSync(src, dest);
-  }
-}
-
-/**
- * Restore WorkflowState from the backup file.
- * Returns null if the backup is absent, invalid JSON, or wrong shape.
- *
- * Applies the same two-pass normalisation as {@link readState} —
- * `normaliseToLatestSchema` translates legacy step literals before
- * validation, `normaliseReadState` fills in absent v2+ fields after.
- */
-export function restoreBackup(dir: string): WorkflowState | null {
-  const filePath = join(dir, 'state.json.backup');
-  if (!existsSync(filePath)) return null;
-  try {
-    const raw = readFileSync(filePath, 'utf8');
-    const parsed: unknown = JSON.parse(raw);
-    const normalized = normaliseToLatestSchema(parsed);
-    if (!isValidState(normalized)) return null;
-    return normaliseReadState(normalized);
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Restore state.json from state.json.backup on disk.
- *
- * Unlike restoreBackup() which reads and returns the backup state,
- * this function copies the backup file back to state.json so that
- * subsequent resolveState() calls find the pre-operation state.
- *
- * No-op if the backup file does not exist.
- */
-export function restoreStateFromBackup(dir: string): void {
-  const backup = join(dir, 'state.json.backup');
-  const target = join(dir, 'state.json');
-  if (existsSync(backup)) {
-    copyFileSync(backup, target);
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -814,20 +581,3 @@ export function deriveState(
   return state;
 }
 
-/**
- * Resolve state using a three-level fallback chain:
- *
- * 1. Read state.json (primary)
- * 2. Read state.json.backup (fallback)
- * 3. Derive from full event replay (ultimate fallback)
- *
- * Always returns a valid WorkflowState.
- */
-export function resolveState(
-  dir: string,
-  events: readonly EventRow[],
-  sessionId: string,
-  reduceFn: ReduceFn,
-): WorkflowState {
-  return readState(dir) ?? restoreBackup(dir) ?? deriveState(sessionId, events, reduceFn);
-}


### PR DESCRIPTION
Closing PR for the PR-FIN finalization arc (8 of 8). Builds on PR #231 (a41014b — JSON memory pivot).

Closes #232.

## Summary

- **Tier A (10 doc/text files):** sweep retired \`state.json | state.json.backup | metadata.json\` (per-session sense) across design docs, CLAUDE.md, contemporary skill docs, and 2 code-comment locations. Preserves \`gobbi.db\` references — it remains the live per-session event store. Adds canonical JSON-pivot paragraph in CLAUDE.md as a copy-target.
- **Tier B (code cleanup):** paths.ts Option A fallback (3rd candidate \`<self>/../src/specs/\` for dev-mode worktrees) + path-stability test + new \`paths-ts-needs-dist-specs-cp.md\` gotcha; \`workflow/state.ts\` removes 7 orphan exports (\`writeState\`, \`readState\`, \`backupState\`, \`restoreBackup\`, \`restoreStateFromBackup\`, \`normaliseToLatestSchema\`, \`resolveState\`) + private \`normaliseReadState\` via 3-commit bisectability shape (~700 LoC test deletion); \`lib/json-memory.ts\` removes unused \`isProductiveStep\` helper + migrates \`tokensUsed\` from OpenAPI \`nullable: true\` to spread-preserving JSON-Schema-2020 \`{ ...spread, type: ['object','null'] as const }\` form; \`session-json-writer.ts\` docblock corrected (lines 65-78).
- **Tier C (regression test):** new \`packages/cli/src/__tests__/integration/jsonpivot-drift.test.ts\` bans the 3 retired tokens (NOT \`gobbi.db\`) across tracked author docs + production code with file-level allow-list (PRIMARY) and decorative inline marker comments. Closes the JSON-pivot drift class permanently.
- **Tier D (user-visible code refs):** \`commands/workflow.ts:76\` CLI help text + \`specs/errors.sections.ts:339\` user diagnostic + \`specs/errors.pathway-detect.ts:327\` diagnostic hint — all 3 user-visible mentions of retired files corrected.

## Cluster status

After this merges, the PR-FIN cluster is **8 of 8 done**.

## Architecture decisions locked

- **\`gobbi.db\` is NOT retired.** It remains the live per-session event store with 14+ active call sites. Only \`state.json\`, \`state.json.backup\`, \`metadata.json\` (per-session) and per-session \`artifacts/\` were retired by PR-FIN-2a-ii.
- **\`metadata.json\` is a homonym.** Per-session retired; note-system surviving (\`.claude/project/<name>/note/<task>/metadata.json\`). Drift-detector allow-list preserves the surviving sense.
- **Allow-list precedence:** file-level allow-list is PRIMARY (auditable, in the test). Inline marker comments \`// [legacy:retired-2a-ii]\` are DECORATIVE documentation only — the test does not parse them as a bypass.

## Verification

- \`mkdir -p packages/cli/dist && cd packages/cli && bun run build:safe && cd ../.. && bun test\` — 2172 pass / 0 fail (was 2197 pre-PR; net delta is orphan-test deletions minus drift-detector additions).
- 4-perspective Execution evaluation (project, overall, architecture, simplicity) — all 4 PASS.
- Build clean: \`bun build\` produces \`dist/cli.js\` 0.85 MB; \`dist/specs/index.json\` regenerated.

## Follow-up issues

- #233 — Design-corpus drift sweep (structure.md, v050-prompts.md, v050-cli.md, v050-features/README.md present-tense statements)
- #234 — \`tech-stack.ts\` underlying decision (wire into session.json or delete the call)
- #235 — Rename \`workflow/state.ts\` → \`workflow/state-derivation.ts\` post-orphan-removal
- #236 — \`gobbi memory check\` + \`gobbi memory backfill\` admin commands

## Test plan

- [x] \`bun test\` green (2172/0 fail)
- [x] \`bun run build:safe\` clean
- [x] \`bun x tsc --noEmit\` clean (typecheck)
- [x] Drift-detector test passes — \`state.json | state.json.backup | metadata.json\` references in production + tracked docs limited to allow-listed entries
- [x] \`gobbi.db\` references preserved (14+ active call sites unchanged)
- [x] 4-perspective Execution evaluation: all PASS
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)