### PR TITLE
feat(memory): PR-CFM-C — memory invariants & wiring (#199 + #201 + #197)

### DIFF
--- a/packages/cli/src/__tests__/hooks-contract.test.ts
+++ b/packages/cli/src/__tests__/hooks-contract.test.ts
@@ -241,6 +241,34 @@ describe('hooks contract — `.claude/settings.json`', () => {
     }
   });
 
+  describe('plugin manifest — PostToolUse Bash matcher (#197 dormant emitter)', () => {
+    // PR-CFM-C T5 wires the dormant `step.advancement.observed`
+    // emitter via a second PostToolUse matcher in the plugin manifest
+    // (Bash) routing to the same `gobbi hook post-tool-use`
+    // dispatcher. The hook fires on every Bash tool call but only
+    // appends an event when the command starts with
+    // `gobbi workflow transition` AND
+    // `workflow.observability.advancement.enabled === true`. The
+    // dispatcher branch lives in
+    // `commands/hook/post-tool-use.ts`; the emitter at
+    // `commands/workflow/capture-advancement.ts`.
+    test('plugins/gobbi/hooks/hooks.json registers Bash matcher routing to gobbi hook post-tool-use', () => {
+      const PLUGIN_MANIFEST_PATH = join(
+        REPO_ROOT,
+        'plugins',
+        'gobbi',
+        'hooks',
+        'hooks.json',
+      );
+      const manifest = readJson<HooksManifest>(PLUGIN_MANIFEST_PATH);
+      const postToolUse = manifest.hooks?.['PostToolUse'] ?? [];
+      const bashBlock = postToolUse.find((b) => b.matcher === 'Bash');
+      expect(bashBlock).toBeDefined();
+      const commands = (bashBlock?.hooks ?? []).map((h) => h.command);
+      expect(commands).toContain('gobbi hook post-tool-use');
+    });
+  });
+
   describe('per-event emitter shape', () => {
     // Of the five hooks enumerated above, only `guard` (PreToolUse) emits
     // JSON to stdout that Claude Code parses against a `hookSpecificOutput`

--- a/packages/cli/src/commands/hook/post-tool-use.ts
+++ b/packages/cli/src/commands/hook/post-tool-use.ts
@@ -1,26 +1,39 @@
 /**
  * gobbi hook post-tool-use — PostToolUse hook entrypoint.
  *
- * Replaces the direct `gobbi workflow capture-planning` registration on
- * the `ExitPlanMode` matcher. The plugin manifest still declares the
- * matcher (so this entrypoint only fires when Claude Code's PostToolUse
- * fires for `ExitPlanMode`), but the entrypoint additionally checks
- * `tool_name` defensively — a future per-repo override that registers
- * this command without a matcher should still no-op for non-ExitPlanMode
- * tools.
+ * Single dispatcher for every PostToolUse matcher registered in the
+ * plugin manifest. Two branches today:
+ *
+ *   1. `tool_name === 'ExitPlanMode'` → `capture-planning` (writes
+ *      `planning/plan.md` and emits `artifact.write`).
+ *   2. `tool_name === 'Bash'` AND command starts with
+ *      `gobbi workflow transition` → `capture-advancement` (appends
+ *      `step.advancement.observed` audit-only event when the
+ *      `workflow.observability.advancement.enabled` gate is on; dormant
+ *      otherwise).
+ *
+ * Each branch checks `tool_name` defensively — the plugin manifest
+ * already gates registration via `matcher`, but a per-repo override
+ * might broaden the registration. The defensive check keeps the hot
+ * path lean for non-matching tools.
  *
  * ## Hook contract
  *
- * Observational hook — always exits 0. capture-planning's
- * implementation already silently no-ops on any failure path; this
- * wrapper preserves those semantics.
+ * Observational hook — always exits 0. Both delegate handlers silently
+ * no-op on any failure path; this wrapper preserves those semantics by
+ * catching any thrown error and writing a one-line stderr diagnostic.
  *
- * @see `commands/workflow/capture-planning.ts` — body invoked here.
+ * @see `commands/workflow/capture-planning.ts`
+ * @see `commands/workflow/capture-advancement.ts`
  */
 
 import { readStdinJson } from '../../lib/stdin.js';
 import { isRecord, isString } from '../../lib/guards.js';
 import { runCapturePlanningWithOptions } from '../workflow/capture-planning.js';
+import {
+  isBashTransitionInvocation,
+  runCaptureAdvancementWithOptions,
+} from '../workflow/capture-advancement.js';
 
 export async function runHookPostToolUse(args: string[]): Promise<void> {
   if (args.includes('--help') || args.includes('-h')) {
@@ -29,19 +42,36 @@ export async function runHookPostToolUse(args: string[]): Promise<void> {
   }
 
   // Read stdin ONCE in the hook entrypoint. Pass the parsed payload
-  // through to capture-planning so it does not re-read.
+  // through to each branch so it does not re-read.
   const payload = await readStdinJson<unknown>();
 
   try {
+    // Branch 1 — ExitPlanMode → capture-planning.
+    //
     // Defensive matcher check — only invoke capture-planning when the
-    // payload's `tool_name` is `ExitPlanMode`. The plugin manifest
-    // already gates registration to that matcher, but a per-repo
-    // override might broaden it. capture-planning itself is safe to
-    // call for any tool (it returns early when `tool_input.plan` is
-    // missing), but skipping the call entirely keeps the hot path
-    // lean for non-matching tools.
-    if (isRecord(payload) && isString(payload['tool_name']) && payload['tool_name'] === 'ExitPlanMode') {
+    // payload's `tool_name` is `ExitPlanMode`. capture-planning itself
+    // is safe to call for any tool (it returns early when
+    // `tool_input.plan` is missing), but skipping the call entirely
+    // keeps the hot path lean for non-matching tools.
+    if (
+      isRecord(payload) &&
+      isString(payload['tool_name']) &&
+      payload['tool_name'] === 'ExitPlanMode'
+    ) {
       await runCapturePlanningWithOptions(args, { payload });
+    }
+
+    // Branch 2 — Bash + `gobbi workflow transition` → capture-advancement.
+    //
+    // The `isBashTransitionInvocation` matcher already checks both
+    // `tool_name === 'Bash'` and the command prefix, so the dispatcher
+    // can call it once and let the handler take it from there. The
+    // handler is also safe to call unconditionally (it re-validates
+    // every gate internally), but routing through the matcher here
+    // keeps `gobbi hook post-tool-use` cheap for the common
+    // non-matching Bash invocation.
+    if (isBashTransitionInvocation(payload)) {
+      await runCaptureAdvancementWithOptions(args, { payload });
     }
 
     // TODO(PR-FIN-1d) — dispatch notify for PostToolUse triggers.
@@ -54,8 +84,13 @@ export async function runHookPostToolUse(args: string[]): Promise<void> {
 const USAGE = `Usage: gobbi hook post-tool-use
 
 PostToolUse hook entrypoint. Reads the Claude Code PostToolUse payload on
-stdin and (for ExitPlanMode invocations) persists tool_input.plan to the
-session's planning/plan.md, emitting an artifact.write event.
+stdin and dispatches to one of two handlers:
+
+  - ExitPlanMode → capture-planning (writes planning/plan.md +
+    artifact.write event).
+  - Bash + 'gobbi workflow transition' → capture-advancement (appends
+    step.advancement.observed audit-only event when the
+    workflow.observability.advancement.enabled gate is on).
 
 Observational hook — always exits 0.
 

--- a/packages/cli/src/commands/maintenance.ts
+++ b/packages/cli/src/commands/maintenance.ts
@@ -68,6 +68,17 @@ export const MAINTENANCE_COMMANDS: readonly MaintenanceCommand[] = [
       await runMigrateStateDb(args);
     },
   },
+  {
+    name: 'verify-state-projections',
+    summary:
+      'Diff event-derived state against project.json projection; exits 1 on any divergence',
+    run: async (args: string[]): Promise<void> => {
+      const { runVerifyStateProjections } = await import(
+        './maintenance/verify-state-projections.js'
+      );
+      await runVerifyStateProjections(args);
+    },
+  },
 ];
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/commands/maintenance/__tests__/verify-state-projections.test.ts
+++ b/packages/cli/src/commands/maintenance/__tests__/verify-state-projections.test.ts
@@ -1,0 +1,649 @@
+/**
+ * Unit tests for `gobbi maintenance verify-state-projections` — registry
+ * wiring, dispatcher routing, pre-flight error envelopes, happy + drift
+ * paths, `--json` contract, and idempotency.
+ *
+ * Test surface (9) per PR-CFM-C ideation §5.6:
+ *
+ *   1. Subcommand registry lists `verify-state-projections`.
+ *   2. Dispatcher routes `--help` and the new name correctly.
+ *   3. Happy path: scratch repo with no divergences exits 0.
+ *   4. Drift detected: scratch repo with hand-edited project.json exits 1
+ *      with divergence.
+ *   5. Missing state.db exits 1 with `DB_MISSING` envelope under `--json`.
+ *   6. Missing project.json exits 1 with `PROJECT_MISSING` envelope.
+ *   7. `parseArgs` failure exits 2 with `PARSE_ARGS` envelope.
+ *   8. `--json` shape matches `VerifyStateProjectionsResult` contract.
+ *   9. Idempotency: re-running on the same scratch produces deterministic
+ *      result (modulo `elapsedMs`).
+ *
+ * Tests build a scratch state.db with raw SQL (mirroring
+ * `wipe-legacy-sessions.test.ts::makeStateDb`) plus a project.json on
+ * disk via `writeProjectJson`. The reducer is the real `reduce` for
+ * non-throwing paths.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  MAINTENANCE_COMMANDS,
+  runMaintenanceWithRegistry,
+} from '../../maintenance.js';
+import {
+  runVerifyStateProjectionsWithOptions,
+  verifyStateProjectionsAt,
+  type VerifyStateProjectionsResult,
+} from '../verify-state-projections.js';
+import {
+  writeProjectJson,
+  type ProjectJson,
+  type ProjectJsonSession,
+} from '../../../lib/json-memory.js';
+import { reduce } from '../../../workflow/reducer.js';
+
+// ---------------------------------------------------------------------------
+// stdout/stderr capture + process.exit trap
+// ---------------------------------------------------------------------------
+
+interface Captured {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+}
+
+class ExitCalled extends Error {
+  constructor(readonly code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+let captured: Captured;
+let origStdoutWrite: typeof process.stdout.write;
+let origStderrWrite: typeof process.stderr.write;
+let origLog: typeof console.log;
+let origExit: typeof process.exit;
+
+beforeEach(() => {
+  captured = { stdout: '', stderr: '', exitCode: null };
+  origStdoutWrite = process.stdout.write;
+  origStderrWrite = process.stderr.write;
+  origLog = console.log;
+  origExit = process.exit;
+
+  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+    captured.stdout +=
+      typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+    captured.stderr +=
+      typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    return true;
+  }) as typeof process.stderr.write;
+  console.log = (...args: unknown[]): void => {
+    captured.stdout += args.map(String).join(' ') + '\n';
+  };
+  process.exit = ((code?: number | string | null): never => {
+    captured.exitCode = typeof code === 'number' ? code : 0;
+    throw new ExitCalled(captured.exitCode);
+  }) as typeof process.exit;
+});
+
+afterEach(() => {
+  process.stdout.write = origStdoutWrite;
+  process.stderr.write = origStderrWrite;
+  console.log = origLog;
+  process.exit = origExit;
+});
+
+async function captureExit(fn: () => Promise<void>): Promise<void> {
+  try {
+    await fn();
+  } catch (err) {
+    if (err instanceof ExitCalled) return;
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scratch repo helpers
+// ---------------------------------------------------------------------------
+
+const scratchDirs: string[] = [];
+
+afterEach(() => {
+  while (scratchDirs.length > 0) {
+    const d = scratchDirs.pop();
+    if (d !== undefined) {
+      try {
+        rmSync(d, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    }
+  }
+});
+
+function makeRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gobbi-verify-state-'));
+  scratchDirs.push(dir);
+  return dir;
+}
+
+interface SeedEvent {
+  readonly sessionId: string;
+  readonly projectId: string;
+  readonly type: string;
+  readonly step?: string | null;
+  readonly data?: Record<string, unknown>;
+  readonly ts?: string;
+}
+
+/**
+ * Build a v5-shape state.db at `<repo>/.gobbi/state.db` and seed it with
+ * the supplied events. Mirrors `wipe-legacy-sessions.test.ts::makeStateDb`
+ * with the addition of `step` + `data` columns so we can drive the
+ * reducer through a real workflow sequence.
+ *
+ * The EventStore opening this file later will idempotently upgrade the
+ * schema to v7 via `ensureSchemaV5/V6/V7`, so v5 columns are sufficient.
+ */
+function seedStateDb(repo: string, rows: readonly SeedEvent[]): string {
+  const gobbiDir = join(repo, '.gobbi');
+  mkdirSync(gobbiDir, { recursive: true });
+  const dbPath = join(gobbiDir, 'state.db');
+  const db = new Database(dbPath, { strict: true });
+  try {
+    db.run(
+      `CREATE TABLE events (
+         seq INTEGER PRIMARY KEY,
+         ts TEXT NOT NULL,
+         schema_version INTEGER NOT NULL,
+         type TEXT NOT NULL,
+         step TEXT,
+         data TEXT NOT NULL DEFAULT '{}',
+         actor TEXT NOT NULL,
+         parent_seq INTEGER,
+         idempotency_key TEXT NOT NULL UNIQUE,
+         session_id TEXT,
+         project_id TEXT
+       )`,
+    );
+    const stmt = db.query(
+      `INSERT INTO events (ts, schema_version, type, step, data, actor, idempotency_key, session_id, project_id)
+       VALUES ($ts, 5, $type, $step, $data, 'test', $key, $sessionId, $projectId)`,
+    );
+    let seq = 0;
+    for (const row of rows) {
+      seq += 1;
+      const data = row.data ?? {
+        sessionId: row.sessionId,
+        timestamp: row.ts ?? '2026-04-29T10:00:00.000Z',
+      };
+      stmt.run({
+        ts: row.ts ?? '2026-04-29T10:00:00.000Z',
+        type: row.type,
+        step: row.step ?? null,
+        data: JSON.stringify(data),
+        key: `${row.sessionId}:${seq}:${row.type}`,
+        sessionId: row.sessionId,
+        projectId: row.projectId,
+      });
+    }
+  } finally {
+    db.close();
+  }
+  return dbPath;
+}
+
+/**
+ * Build a complete `idle → done` event stream for a single session,
+ * matching the reducer's accepted transitions. Mirrors `buildDoneStream`
+ * in `lib/__tests__/memory-projection-diff.test.ts` so the diff library
+ * exercises the same fixture shape on both sides of the boundary.
+ */
+function buildDoneEvents(sessionId: string, projectId: string): SeedEvent[] {
+  return [
+    { sessionId, projectId, type: 'workflow.start' },
+    {
+      sessionId,
+      projectId,
+      type: 'workflow.step.exit',
+      step: 'ideation',
+      data: { step: 'ideation' },
+    },
+    {
+      sessionId,
+      projectId,
+      type: 'workflow.step.exit',
+      step: 'planning',
+      data: { step: 'planning' },
+    },
+    {
+      sessionId,
+      projectId,
+      type: 'workflow.step.exit',
+      step: 'execution',
+      data: { step: 'execution' },
+    },
+    {
+      sessionId,
+      projectId,
+      type: 'decision.eval.verdict',
+      step: 'execution_eval',
+      data: { verdict: 'pass' },
+    },
+    {
+      sessionId,
+      projectId,
+      type: 'workflow.step.exit',
+      step: 'memorization',
+      data: { step: 'memorization' },
+    },
+    {
+      sessionId,
+      projectId,
+      type: 'workflow.finish',
+      ts: '2026-04-29T11:00:00.000Z',
+      data: {},
+    },
+  ];
+}
+
+/**
+ * Write a `project.json` for the supplied repo + project name with the
+ * given session rows. Returns the path the file was written to so tests
+ * can manipulate it directly.
+ */
+function seedProjectJson(
+  repo: string,
+  projectName: string,
+  sessions: readonly ProjectJsonSession[],
+): string {
+  const projectDir = join(repo, '.gobbi', 'projects', projectName);
+  mkdirSync(projectDir, { recursive: true });
+  const filePath = join(projectDir, 'project.json');
+  const value: ProjectJson = {
+    schemaVersion: 1,
+    projectName,
+    projectId: projectName,
+    sessions,
+    gotchas: [],
+    decisions: [],
+    learnings: [],
+  };
+  writeProjectJson(filePath, value);
+  return filePath;
+}
+
+// ===========================================================================
+// 1. Registry presence
+// ===========================================================================
+
+describe('MAINTENANCE_COMMANDS — registry includes verify-state-projections', () => {
+  test('exposes `verify-state-projections` with a non-empty summary', () => {
+    const names = MAINTENANCE_COMMANDS.map((c) => c.name);
+    expect(names).toContain('verify-state-projections');
+    const entry = MAINTENANCE_COMMANDS.find(
+      (c) => c.name === 'verify-state-projections',
+    );
+    expect(entry).toBeDefined();
+    expect(entry?.summary.length).toBeGreaterThan(0);
+  });
+});
+
+// ===========================================================================
+// 2. Dispatcher wiring
+// ===========================================================================
+
+describe('runMaintenanceWithRegistry — verify-state-projections wiring', () => {
+  test('--help lists verify-state-projections alongside the other entries', async () => {
+    await captureExit(() =>
+      runMaintenanceWithRegistry(['--help'], MAINTENANCE_COMMANDS),
+    );
+    expect(captured.stdout).toContain('verify-state-projections');
+    expect(captured.stdout).toContain('migrate-state-db');
+    expect(captured.stdout).toContain('wipe-legacy-sessions');
+  });
+
+  test('verify-state-projections --help prints command-specific usage', async () => {
+    await captureExit(() =>
+      runMaintenanceWithRegistry(
+        ['verify-state-projections', '--help'],
+        MAINTENANCE_COMMANDS,
+      ),
+    );
+    expect(captured.stdout).toContain(
+      'Usage: gobbi maintenance verify-state-projections',
+    );
+    expect(captured.stdout).toContain('--db');
+    expect(captured.stdout).toContain('--project');
+    expect(captured.stdout).toContain('--project-name');
+    expect(captured.stdout).toContain('--json');
+    // The pre-pivot caveat must surface in USAGE per Project eval F2.
+    expect(captured.stdout).toContain(
+      'sessions predating the JSON memory pivot may appear as row-missing',
+    );
+  });
+});
+
+// ===========================================================================
+// 3. Happy path — no divergences
+// ===========================================================================
+
+describe('runVerifyStateProjections — happy path', () => {
+  test('scratch repo with matching project.json exits 0 with no divergences', async () => {
+    const repo = makeRepo();
+    const projectName = 'gobbi';
+    const sessionId = 'sess-happy';
+
+    seedStateDb(repo, buildDoneEvents(sessionId, projectName));
+    seedProjectJson(repo, projectName, [
+      {
+        sessionId,
+        createdAt: '2026-04-29T10:00:00.000Z',
+        finishedAt: '2026-04-29T11:00:00.000Z',
+        task: 'demo',
+      },
+    ]);
+
+    await captureExit(() =>
+      runVerifyStateProjectionsWithOptions(
+        ['--project-name', projectName],
+        { repoRoot: repo },
+      ),
+    );
+
+    expect(captured.exitCode).toBeNull();
+    expect(captured.stdout).toContain('divergences: 0');
+    expect(captured.stdout).toContain('sessions checked: 1');
+  });
+});
+
+// ===========================================================================
+// 4. Drift detected — exits 1 with divergence
+// ===========================================================================
+
+describe('runVerifyStateProjections — drift detected', () => {
+  test('scratch repo with hand-edited project.json (finishedAt: null) exits 1', async () => {
+    const repo = makeRepo();
+    const projectName = 'gobbi';
+    const sessionId = 'sess-drift';
+
+    seedStateDb(repo, buildDoneEvents(sessionId, projectName));
+    // Hand-edit: workflow.finish committed but row finishedAt is null.
+    seedProjectJson(repo, projectName, [
+      {
+        sessionId,
+        createdAt: '2026-04-29T10:00:00.000Z',
+        finishedAt: null,
+        task: 'demo',
+      },
+    ]);
+
+    await captureExit(() =>
+      runVerifyStateProjectionsWithOptions(
+        ['--project-name', projectName],
+        { repoRoot: repo },
+      ),
+    );
+
+    expect(captured.exitCode).toBe(1);
+    expect(captured.stdout).toContain('divergences: 1');
+    expect(captured.stdout).toContain(sessionId);
+    expect(captured.stdout).toContain('finishedAt');
+  });
+});
+
+// ===========================================================================
+// 5. Missing state.db — DB_MISSING under --json
+// ===========================================================================
+
+describe('runVerifyStateProjections — DB_MISSING', () => {
+  test('--json with missing state.db emits structured envelope, exits 1', async () => {
+    const repo = makeRepo();
+    const projectName = 'gobbi';
+    // project.json present, state.db absent.
+    seedProjectJson(repo, projectName, []);
+    const missingDb = join(repo, '.gobbi', 'state.db');
+    expect(existsSync(missingDb)).toBe(false);
+
+    await captureExit(() =>
+      runVerifyStateProjectionsWithOptions(
+        ['--json', '--project-name', projectName],
+        { repoRoot: repo },
+      ),
+    );
+
+    expect(captured.exitCode).toBe(1);
+    const lines = captured.stderr.split('\n').filter((l) => l.length > 0);
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0] as string) as Record<string, unknown>;
+    expect(parsed['status']).toBe('error');
+    expect(parsed['code']).toBe('DB_MISSING');
+    expect(typeof parsed['message']).toBe('string');
+    expect(parsed['path']).toBe(missingDb);
+    // stdout stays clean on the failure path.
+    expect(captured.stdout).toBe('');
+  });
+});
+
+// ===========================================================================
+// 6. Missing project.json — PROJECT_MISSING under --json
+// ===========================================================================
+
+describe('runVerifyStateProjections — PROJECT_MISSING', () => {
+  test('--json with missing project.json emits structured envelope, exits 1', async () => {
+    const repo = makeRepo();
+    const projectName = 'gobbi';
+    // state.db present (empty events), project.json absent.
+    seedStateDb(repo, []);
+    const missingProject = join(
+      repo,
+      '.gobbi',
+      'projects',
+      projectName,
+      'project.json',
+    );
+    expect(existsSync(missingProject)).toBe(false);
+
+    await captureExit(() =>
+      runVerifyStateProjectionsWithOptions(
+        ['--json', '--project-name', projectName],
+        { repoRoot: repo },
+      ),
+    );
+
+    expect(captured.exitCode).toBe(1);
+    const lines = captured.stderr.split('\n').filter((l) => l.length > 0);
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0] as string) as Record<string, unknown>;
+    expect(parsed['status']).toBe('error');
+    expect(parsed['code']).toBe('PROJECT_MISSING');
+    expect(typeof parsed['message']).toBe('string');
+    expect(parsed['path']).toBe(missingProject);
+    expect(captured.stdout).toBe('');
+  });
+});
+
+// ===========================================================================
+// 7. parseArgs failure — PARSE_ARGS exits 2
+// ===========================================================================
+
+describe('runVerifyStateProjections — PARSE_ARGS', () => {
+  test('unknown flag under --json emits envelope without USAGE, exits 2', async () => {
+    const repo = makeRepo();
+
+    await captureExit(() =>
+      runVerifyStateProjectionsWithOptions(
+        ['--json', '--no-such-flag'],
+        { repoRoot: repo },
+      ),
+    );
+
+    expect(captured.exitCode).toBe(2);
+    // The JSON failure path must NOT dump the prose USAGE block.
+    expect(captured.stderr).not.toContain(
+      'Usage: gobbi maintenance verify-state-projections',
+    );
+    const lines = captured.stderr.split('\n').filter((l) => l.length > 0);
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0] as string) as Record<string, unknown>;
+    expect(parsed['status']).toBe('error');
+    expect(parsed['code']).toBe('PARSE_ARGS');
+    expect(typeof parsed['message']).toBe('string');
+    // path is not yet resolved at parseArgs failure time — must be absent.
+    expect('path' in parsed).toBe(false);
+  });
+});
+
+// ===========================================================================
+// 8. --json shape contract
+// ===========================================================================
+
+describe('runVerifyStateProjections — --json shape', () => {
+  test('emits VerifyStateProjectionsResult contract on a clean scratch repo', async () => {
+    const repo = makeRepo();
+    const projectName = 'gobbi';
+    const sessionId = 'sess-json';
+
+    const dbPath = seedStateDb(repo, buildDoneEvents(sessionId, projectName));
+    const projectJsonFile = seedProjectJson(repo, projectName, [
+      {
+        sessionId,
+        createdAt: '2026-04-29T10:00:00.000Z',
+        finishedAt: '2026-04-29T11:00:00.000Z',
+        task: 'demo',
+      },
+    ]);
+
+    // Deterministic clock so elapsedMs is predictable.
+    let tick = 1_745_000_000_000;
+    await captureExit(() =>
+      runVerifyStateProjectionsWithOptions(
+        ['--json', '--project-name', projectName],
+        {
+          repoRoot: repo,
+          now: () => {
+            tick += 7;
+            return tick;
+          },
+        },
+      ),
+    );
+
+    expect(captured.exitCode).toBeNull();
+    const trimmed = captured.stdout.trim();
+    const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+
+    expect(parsed['stateDbPath']).toBe(dbPath);
+    expect(parsed['projectJsonPath']).toBe(projectJsonFile);
+    expect(parsed['sessionsChecked']).toBe(1);
+    expect(Array.isArray(parsed['divergences'])).toBe(true);
+    expect((parsed['divergences'] as readonly unknown[]).length).toBe(0);
+    expect(typeof parsed['elapsedMs']).toBe('number');
+    expect((parsed['elapsedMs'] as number) >= 0).toBe(true);
+  });
+});
+
+// ===========================================================================
+// 9. Idempotency — re-running produces the same result (modulo elapsedMs)
+// ===========================================================================
+
+describe('runVerifyStateProjections — idempotency', () => {
+  test('re-running on the same scratch produces identical divergences', async () => {
+    const repo = makeRepo();
+    const projectName = 'gobbi';
+    const sessionId = 'sess-idem';
+
+    seedStateDb(repo, buildDoneEvents(sessionId, projectName));
+    seedProjectJson(repo, projectName, [
+      {
+        sessionId,
+        createdAt: '2026-04-29T10:00:00.000Z',
+        // Force one divergence — finishedAt null when finish event committed.
+        finishedAt: null,
+        task: 'demo',
+      },
+    ]);
+
+    // First run.
+    await captureExit(() =>
+      runVerifyStateProjectionsWithOptions(
+        ['--json', '--project-name', projectName],
+        { repoRoot: repo },
+      ),
+    );
+    expect(captured.exitCode).toBe(1);
+    const first = JSON.parse(captured.stdout.trim()) as {
+      readonly stateDbPath: string;
+      readonly projectJsonPath: string | null;
+      readonly sessionsChecked: number;
+      readonly divergences: readonly unknown[];
+      readonly elapsedMs: number;
+    };
+
+    // Reset capture between runs.
+    captured.stdout = '';
+    captured.stderr = '';
+    captured.exitCode = null as number | null;
+
+    // Second run on the same scratch.
+    await captureExit(() =>
+      runVerifyStateProjectionsWithOptions(
+        ['--json', '--project-name', projectName],
+        { repoRoot: repo },
+      ),
+    );
+    expect(captured.exitCode).toBe(1);
+    const second = JSON.parse(captured.stdout.trim()) as typeof first;
+
+    // Everything except elapsedMs must match exactly.
+    expect(second.stateDbPath).toBe(first.stateDbPath);
+    expect(second.projectJsonPath).toBe(first.projectJsonPath);
+    expect(second.sessionsChecked).toBe(first.sessionsChecked);
+    expect(second.divergences).toEqual(first.divergences);
+  });
+});
+
+// ===========================================================================
+// Pure helper — verifyStateProjectionsAt
+// ===========================================================================
+
+describe('verifyStateProjectionsAt', () => {
+  test('returns the structured result without writing to stdout', async () => {
+    const repo = makeRepo();
+    const projectName = 'gobbi';
+    const sessionId = 'sess-pure';
+
+    const dbPath = seedStateDb(repo, buildDoneEvents(sessionId, projectName));
+    const projectJsonFile = seedProjectJson(repo, projectName, [
+      {
+        sessionId,
+        createdAt: '2026-04-29T10:00:00.000Z',
+        finishedAt: '2026-04-29T11:00:00.000Z',
+        task: 'demo',
+      },
+    ]);
+
+    const result: VerifyStateProjectionsResult = verifyStateProjectionsAt(
+      dbPath,
+      projectJsonFile,
+      reduce,
+    );
+
+    expect(result.stateDbPath).toBe(dbPath);
+    expect(result.projectJsonPath).toBe(projectJsonFile);
+    expect(result.sessionsChecked).toBe(1);
+    expect(result.divergences).toEqual([]);
+    expect(result.elapsedMs).toBeGreaterThanOrEqual(0);
+
+    // No stdout/stderr from the pure helper itself.
+    expect(captured.stdout).toBe('');
+    expect(captured.stderr).toBe('');
+  });
+});

--- a/packages/cli/src/commands/maintenance/verify-state-projections.ts
+++ b/packages/cli/src/commands/maintenance/verify-state-projections.ts
@@ -1,0 +1,558 @@
+/**
+ * gobbi maintenance verify-state-projections — diff event-derived state
+ * against the `project.json` handoff projection per session.
+ *
+ * ## Context (v0.5.0 PR-CFM-C — issue #201)
+ *
+ * After PR-FIN-2a-ii's JSON memory pivot the cross-session memory lives in
+ * `.gobbi/projects/<projectName>/project.json`. The same workflow events
+ * that drive the per-session `gobbi.db` also feed the workspace
+ * `.gobbi/state.db` event store; the two sources MUST agree on the
+ * "session is finished" invariant by the time `workflow.finish` lands.
+ * This command surfaces drift as operator-actionable divergences.
+ *
+ * Mirrors the pure-core / argv-shell shape of
+ * {@link runMigrateStateDb} in `migrate-state-db.ts`:
+ *
+ *   - `runVerifyStateProjections(args)` — argv shell with `process.exit`.
+ *   - `runVerifyStateProjectionsWithOptions(args, overrides)` — test seam.
+ *   - `verifyStateProjectionsAt(stateDbPath, projectJsonPath, reduceFn, now?)`
+ *     — pure-core helper.
+ *
+ * ## Library boundary
+ *
+ * The actual divergence detection lives in
+ * `packages/cli/src/lib/memory-projection-diff.ts` — a pure library shared
+ * with future PR-B `gobbi memory check`. This command is a thin shell:
+ *
+ *   1. Resolve `state.db` path (default `<repoRoot>/.gobbi/state.db`).
+ *   2. Resolve `project.json` path (default
+ *      `<repoRoot>/.gobbi/projects/<projectName>/project.json`).
+ *   3. Open a `ReadStore` against the state.db.
+ *   4. Read project.json (or `null` when absent — operator error).
+ *   5. Call `memoryProjectionDiff()` with the production reducer.
+ *   6. Render pretty or `--json` output; exit 0 on no-divergences, 1 on
+ *      any divergence (or on missing files), 2 on parseArgs failure.
+ *
+ * ## Pre-pivot legacy session caveat
+ *
+ * Sessions that predate the JSON memory pivot (PR-FIN-2a-ii) may have
+ * events but no `project.json` row. They surface as `row-missing`
+ * divergences on first run. Solo-user accepts the noise per
+ * engineering-merit policy; the caveat is surfaced in the USAGE text and
+ * the PR description, not via a `--ignore-pre-pivot` flag.
+ *
+ * ## Exit codes
+ *
+ *   - `0` — verify ran AND zero divergences.
+ *   - `1` — verify ran AND ≥ 1 divergence (operator-action signal). Also:
+ *           `DB_MISSING` or `PROJECT_MISSING`. The `--json` envelope's
+ *           `code` field discriminates the missing-file case.
+ *   - `2` — `parseArgs` rejected (`PARSE_ARGS`).
+ *
+ * ## Output
+ *
+ * Pretty form (default):
+ *
+ *     gobbi maintenance verify-state-projections
+ *     state.db:    /repo/.gobbi/state.db
+ *     project.json: /repo/.gobbi/projects/gobbi/project.json
+ *     sessions checked: 17
+ *     divergences: 2
+ *       - 6f9a3c2e-... finishedAt: events have workflow.finish at ..., row finishedAt is null
+ *       - 8b1d9e0f-... row-missing: events have workflow.finish, no row in project.json.sessions[]
+ *     elapsed: 12 ms
+ *
+ * Structured form (`--json`):
+ *
+ *     {"stateDbPath":"...","projectJsonPath":"...","sessionsChecked":17,
+ *      "divergences":[...],"elapsedMs":12}
+ *
+ * Error envelope (`--json` failure path):
+ *
+ *     {"status":"error","code":"PROJECT_MISSING","message":"...","path":"..."}
+ *
+ * @see `packages/cli/src/lib/memory-projection-diff.ts` — pure library
+ *      that implements the divergence detection.
+ * @see `packages/cli/src/commands/maintenance/migrate-state-db.ts` —
+ *      sibling command (pure-core/argv-shell pattern mirror).
+ */
+
+import { Database } from 'bun:sqlite';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { parseArgs } from 'node:util';
+
+import {
+  memoryProjectionDiff,
+  type MemoryDivergence,
+} from '../../lib/memory-projection-diff.js';
+import { readProjectJson } from '../../lib/json-memory.js';
+import { getRepoRoot } from '../../lib/repo.js';
+import { projectDir, workspaceRoot } from '../../lib/workspace-paths.js';
+import type {
+  CostAggregateRow,
+  ReadStore,
+} from '../../workflow/store.js';
+import { reduce } from '../../workflow/reducer.js';
+import type { EventRow } from '../../workflow/migrations.js';
+import type { ReduceFn } from '../../workflow/types.js';
+
+// ---------------------------------------------------------------------------
+// Usage
+// ---------------------------------------------------------------------------
+
+const USAGE = `Usage: gobbi maintenance verify-state-projections [options]
+
+Diff event-derived state against the project.json handoff projection per
+session. Exits 0 when both sources agree, 1 on any divergence (or when a
+required file is missing), 2 on argv parse error.
+
+Note: sessions predating the JSON memory pivot may appear as row-missing; this is expected.
+
+Options:
+  --db <path>             Path to state.db (default: <repoRoot>/.gobbi/state.db)
+  --project <path>        Path to project.json (default: derived from
+                          --project-name + repoRoot)
+  --project-name <name>   Project name override (default: basename(repoRoot))
+  --json                  Emit a JSON object instead of the human-readable
+                          summary. Under --json, error paths emit a structured
+                          envelope of shape {"status":"error","code":"<code>",
+                          "message":"...","path":"..."} to stderr instead of
+                          plain text.
+  --help, -h              Show this help message`;
+
+// ---------------------------------------------------------------------------
+// Overrides (for tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Test-time overrides. Production callers pass `{}`; tests thread a
+ * scratch repo root + deterministic clock through these so the rendered
+ * output is predictable.
+ */
+export interface VerifyStateProjectionsOverrides {
+  /** Override repo root (defaults to `getRepoRoot()`). */
+  readonly repoRoot?: string;
+  /**
+   * Override `Date.now()` for the `elapsedMs` measurement. Tests pass a
+   * monotonically-incrementing clock so `elapsedMs` is reproducible.
+   */
+  readonly now?: () => number;
+  /**
+   * Override the production reducer. Tests use this to force a
+   * `events.replay_threw` divergence without corrupting on-disk events.
+   */
+  readonly reduceFn?: ReduceFn;
+}
+
+// ---------------------------------------------------------------------------
+// Result + error shapes
+// ---------------------------------------------------------------------------
+
+/**
+ * Structured result emitted under `--json`. Returned from
+ * {@link verifyStateProjectionsAt} so tests can assert without parsing
+ * stdout. Matches the contract documented in PR-CFM-C ideation §5.
+ */
+export interface VerifyStateProjectionsResult {
+  readonly stateDbPath: string;
+  readonly projectJsonPath: string | null;
+  readonly divergences: readonly MemoryDivergence[];
+  readonly sessionsChecked: number;
+  readonly elapsedMs: number;
+}
+
+/**
+ * Stable error code surface for the `--json` failure path. Mirrors the
+ * deliberately-narrow set used by `migrate-state-db.ts` so consumers
+ * piping to `jq` get the same discriminator shape across maintenance
+ * commands.
+ *
+ *   - `DB_MISSING`      — pre-flight `existsSync` returned false for the
+ *                         resolved state.db path.
+ *   - `PROJECT_MISSING` — pre-flight `existsSync` returned false for the
+ *                         resolved project.json path.
+ *   - `PARSE_ARGS`      — `parseArgs` rejected the supplied flags. Maps to
+ *                         exit code 2 (argv error) rather than 1.
+ */
+export type VerifyStateProjectionsErrorCode =
+  | 'DB_MISSING'
+  | 'PROJECT_MISSING'
+  | 'PARSE_ARGS';
+
+/**
+ * Structured error envelope emitted on stderr under `--json` when the
+ * command fails. `path` carries the resolved target when known at the
+ * failure point — absent on `PARSE_ARGS` (argv parsing fires before path
+ * resolution).
+ */
+export interface VerifyStateProjectionsErrorEnvelope {
+  readonly status: 'error';
+  readonly code: VerifyStateProjectionsErrorCode;
+  readonly message: string;
+  readonly path?: string;
+}
+
+/**
+ * Emit an error to stderr in the shape demanded by `jsonFlag`. Pretty
+ * form preserves the conventional `gobbi maintenance verify-state-projections:
+ * <message>` shape; JSON form emits a single-line structured envelope.
+ */
+function writeErrorEnvelope(
+  jsonFlag: boolean,
+  code: VerifyStateProjectionsErrorCode,
+  message: string,
+  targetPath: string | undefined,
+): void {
+  if (jsonFlag) {
+    const envelope: VerifyStateProjectionsErrorEnvelope =
+      targetPath !== undefined
+        ? { status: 'error', code, message, path: targetPath }
+        : { status: 'error', code, message };
+    process.stderr.write(`${JSON.stringify(envelope)}\n`);
+    return;
+  }
+  process.stderr.write(
+    `gobbi maintenance verify-state-projections: ${message}\n`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public entry points
+// ---------------------------------------------------------------------------
+
+export async function runVerifyStateProjections(args: string[]): Promise<void> {
+  await runVerifyStateProjectionsWithOptions(args, {});
+}
+
+export async function runVerifyStateProjectionsWithOptions(
+  args: string[],
+  overrides: VerifyStateProjectionsOverrides,
+): Promise<void> {
+  if (args.includes('--help') || args.includes('-h')) {
+    process.stdout.write(`${USAGE}\n`);
+    return;
+  }
+
+  // Detect `--json` ahead of `parseArgs` so the failure-path envelope is
+  // available even when argv parsing itself throws. Mirrors
+  // `migrate-state-db.ts` precedent.
+  const jsonFlag =
+    args.includes('--json') || args.some((a) => a.startsWith('--json='));
+
+  // --- 1. Parse flags ----------------------------------------------------
+  let dbFlag: string | undefined;
+  let projectFlag: string | undefined;
+  let projectNameFlag: string | undefined;
+  try {
+    const { values } = parseArgs({
+      args,
+      allowPositionals: false,
+      options: {
+        db: { type: 'string' },
+        project: { type: 'string' },
+        'project-name': { type: 'string' },
+        json: { type: 'boolean', default: false },
+        help: { type: 'boolean', short: 'h', default: false },
+      },
+    });
+    dbFlag = values.db;
+    projectFlag = values.project;
+    projectNameFlag = values['project-name'];
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    writeErrorEnvelope(jsonFlag, 'PARSE_ARGS', message, undefined);
+    if (!jsonFlag) {
+      process.stderr.write(`${USAGE}\n`);
+    }
+    process.exit(2);
+  }
+
+  // --- 2. Resolve target paths ------------------------------------------
+  const repoRoot = overrides.repoRoot ?? getRepoRoot();
+  const stateDbPath = dbFlag ?? path.join(workspaceRoot(repoRoot), 'state.db');
+
+  const projectJsonPath = ((): string => {
+    if (projectFlag !== undefined) return projectFlag;
+    const projectName = projectNameFlag ?? path.basename(repoRoot);
+    return path.join(projectDir(repoRoot, projectName), 'project.json');
+  })();
+
+  // --- 3. Pre-flight: required files must exist -------------------------
+  if (!existsSync(stateDbPath)) {
+    writeErrorEnvelope(
+      jsonFlag,
+      'DB_MISSING',
+      `state.db not found: ${stateDbPath}`,
+      stateDbPath,
+    );
+    process.exit(1);
+  }
+  if (!existsSync(projectJsonPath)) {
+    writeErrorEnvelope(
+      jsonFlag,
+      'PROJECT_MISSING',
+      `project.json not found: ${projectJsonPath}`,
+      projectJsonPath,
+    );
+    process.exit(1);
+  }
+
+  // --- 4. Run verification ----------------------------------------------
+  const reduceFn = overrides.reduceFn ?? reduce;
+  const result = verifyStateProjectionsAt(
+    stateDbPath,
+    projectJsonPath,
+    reduceFn,
+    overrides.now,
+  );
+
+  // --- 5. Render --------------------------------------------------------
+  if (jsonFlag) {
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+  } else {
+    process.stdout.write(renderPretty(result));
+  }
+
+  // --- 6. Exit code based on divergence count ---------------------------
+  if (result.divergences.length > 0) {
+    process.exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Verification core (pure-ish — no argv, no process.exit, no stdout)
+// ---------------------------------------------------------------------------
+
+/**
+ * Open `stateDbPath`, read `projectJsonPath` (or treat as `null`), and
+ * call {@link memoryProjectionDiff} with the supplied reducer. Returns
+ * the structured result; the caller handles exit-code mapping and
+ * rendering.
+ *
+ * The function is exported for tests so they can assert the result
+ * shape without re-running the argv parsing path. Production callers go
+ * through {@link runVerifyStateProjectionsWithOptions}.
+ *
+ * `now` defaults to `Date.now`; tests pass a fixed clock so the
+ * `elapsedMs` measurement is deterministic in JSON snapshots.
+ *
+ * Note: passes `stateDbPath: string` (not a constructed `EventStore`)
+ * so the signature matches the post-#199 dominant pattern in sister
+ * helpers — the function-takes-a-string convention. Internally opens a
+ * cross-partition `ReadStore` for the duration of the diff (the
+ * production `EventStore` is partition-bound; verification needs to walk
+ * EVERY session in the workspace state.db) and closes it before return.
+ */
+export function verifyStateProjectionsAt(
+  stateDbPath: string,
+  projectJsonPath: string | null,
+  reduceFn: ReduceFn,
+  now?: () => number,
+): VerifyStateProjectionsResult {
+  const memory =
+    projectJsonPath === null ? null : readProjectJson(projectJsonPath);
+
+  const store = new WorkspaceReadStore(stateDbPath);
+  try {
+    const args =
+      now !== undefined
+        ? { store, memory, reduceFn, now }
+        : { store, memory, reduceFn };
+    const result = memoryProjectionDiff(args);
+    return {
+      stateDbPath,
+      projectJsonPath,
+      divergences: result.divergences,
+      sessionsChecked: result.sessionsChecked,
+      elapsedMs: result.elapsedMs,
+    };
+  } finally {
+    store.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// WorkspaceReadStore — cross-partition ReadStore for the workspace state.db
+// ---------------------------------------------------------------------------
+
+/**
+ * Read-only `ReadStore` adapter that returns every row in the events
+ * table, NOT scoped to a single `(sessionId, projectId)` partition.
+ *
+ * The production `EventStore` is partition-bound by design (its read
+ * methods filter on the constructor-supplied keys, see
+ * `workflow/store.ts:209-223`). Verification needs to walk EVERY session
+ * in the workspace state.db — `memoryProjectionDiff` groups rows by the
+ * `session_id` column itself rather than by partition binding. This
+ * adapter exposes that cross-partition view via the same `ReadStore`
+ * interface the library already accepts.
+ *
+ * The adapter does NOT auto-migrate the schema (no `ensureSchemaV5/V6/V7`
+ * call): verification opens a possibly-old DB and should not silently
+ * mutate it. The `events` table is the only object queried; if it is
+ * missing the call falls through to an empty result (the missing-DB
+ * pre-flight in {@link runVerifyStateProjectionsWithOptions} catches the
+ * common case before reaching here).
+ *
+ * Only `replayAll()` is exercised by the diff library today; the other
+ * methods are implemented for completeness so the adapter satisfies the
+ * `ReadStore` contract without surprising future callers.
+ */
+class WorkspaceReadStore implements ReadStore {
+  private readonly db: Database;
+
+  constructor(stateDbPath: string) {
+    this.db = new Database(stateDbPath, { strict: true, readonly: true });
+  }
+
+  close(): void {
+    this.db.close();
+  }
+
+  replayAll(): EventRow[] {
+    return this.db
+      .query<EventRow, []>('SELECT * FROM events ORDER BY seq ASC')
+      .all();
+  }
+
+  byType(type: string): EventRow[] {
+    return this.db
+      .query<EventRow, [string]>(
+        'SELECT * FROM events WHERE type = ? ORDER BY seq ASC',
+      )
+      .all(type);
+  }
+
+  byStep(step: string, type?: string): EventRow[] {
+    if (type !== undefined) {
+      return this.db
+        .query<EventRow, [string, string]>(
+          'SELECT * FROM events WHERE step = ? AND type = ? ORDER BY seq ASC',
+        )
+        .all(step, type);
+    }
+    return this.db
+      .query<EventRow, [string]>(
+        'SELECT * FROM events WHERE step = ? ORDER BY seq ASC',
+      )
+      .all(step);
+  }
+
+  since(seq: number): EventRow[] {
+    return this.db
+      .query<EventRow, [number]>(
+        'SELECT * FROM events WHERE seq > ? ORDER BY seq ASC',
+      )
+      .all(seq);
+  }
+
+  last(type: string): EventRow | null {
+    return this.db
+      .query<EventRow, [string]>(
+        'SELECT * FROM events WHERE type = ? ORDER BY seq DESC LIMIT 1',
+      )
+      .get(type);
+  }
+
+  lastN(type: string, n: number): readonly EventRow[] {
+    return this.db
+      .query<EventRow, [string, number]>(
+        'SELECT * FROM events WHERE type = ? ORDER BY seq DESC LIMIT ?',
+      )
+      .all(type, n);
+  }
+
+  lastNAny(n: number): readonly EventRow[] {
+    return this.db
+      .query<EventRow, [number]>(
+        'SELECT * FROM events ORDER BY seq DESC LIMIT ?',
+      )
+      .all(n);
+  }
+
+  eventCount(): number {
+    const row = this.db
+      .query<{ cnt: number }, []>('SELECT count(*) as cnt FROM events')
+      .get();
+    return row?.cnt ?? 0;
+  }
+
+  aggregateDelegationCosts(): readonly CostAggregateRow[] {
+    return this.db
+      .query<CostAggregateRow, []>(
+        `SELECT
+           step                                            AS step,
+           json_extract(data, '$.subagentId')              AS subagentId,
+           json_extract(data, '$.tokensUsed')              AS tokensJson,
+           json_extract(data, '$.model')                   AS model,
+           json_extract(data, '$.sizeProxyBytes')          AS bytes
+         FROM events
+         WHERE type = 'delegation.complete'
+         ORDER BY seq ASC`,
+      )
+      .all();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a {@link VerifyStateProjectionsResult} for terminal output.
+ * Mirrors `migrate-state-db.ts::renderPretty` shape: header line, then a
+ * sequence of `key: value` lines, one trailing newline.
+ *
+ * Each divergence renders as a bulleted line with the `sessionId`,
+ * `field`, and a witness phrase derived from `fromEvents` / `fromMemory`
+ * / `note`. A sessionId truncation does NOT happen — operators need the
+ * full id to grep events with.
+ */
+export function renderPretty(result: VerifyStateProjectionsResult): string {
+  const lines: string[] = [
+    'gobbi maintenance verify-state-projections',
+    `state.db:    ${result.stateDbPath}`,
+    `project.json: ${result.projectJsonPath ?? '(none)'}`,
+    `sessions checked: ${result.sessionsChecked}`,
+    `divergences: ${result.divergences.length}`,
+  ];
+  for (const div of result.divergences) {
+    lines.push(`  - ${div.sessionId} ${renderDivergence(div)}`);
+  }
+  lines.push(`elapsed: ${result.elapsedMs} ms`);
+  lines.push('');
+  return lines.join('\n');
+}
+
+/**
+ * Render a single divergence as a human-readable phrase. The shape
+ * follows the example in PR-CFM-C ideation §5:
+ *
+ *   - `finishedAt: events have workflow.finish at <ts>, row finishedAt is null`
+ *   - `row-missing: events have workflow.finish, no row in project.json.sessions[]`
+ *   - `task: events have <X>, memory has <Y>`
+ *   - `events.replay_threw: <note>`
+ *   - `events.empty: <note>`
+ */
+function renderDivergence(div: MemoryDivergence): string {
+  switch (div.field) {
+    case 'finishedAt':
+      return `finishedAt: events have ${div.fromEvents ?? '(none)'}, row finishedAt is null`;
+    case 'row-missing':
+      return `row-missing: events have ${div.fromEvents ?? '(none)'}, no row in project.json.sessions[]`;
+    case 'task':
+      return `task: events have ${div.fromEvents ?? '(none)'}, memory has ${div.fromMemory ?? '(none)'}`;
+    case 'events.replay_threw':
+      return `events.replay_threw: ${div.note ?? 'reducer threw during replay'}`;
+    case 'events.empty':
+      return `events.empty: ${div.note ?? 'project.json row exists with no events'}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exports for tests
+// ---------------------------------------------------------------------------
+
+export { USAGE as VERIFY_STATE_PROJECTIONS_USAGE };

--- a/packages/cli/src/commands/prompt/__tests__/patch.test.ts
+++ b/packages/cli/src/commands/prompt/__tests__/patch.test.ts
@@ -13,9 +13,13 @@
  */
 
 import { describe, test, expect } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { Operation } from 'fast-json-patch';
 
-import { mergeTestOp } from '../patch.js';
+import { mergeTestOp, readLastPatch } from '../patch.js';
+import { EventStore } from '../../../workflow/store.js';
 
 describe('mergeTestOp', () => {
   test('case 1 — no test op anywhere: synthesizes /version test at index 0', () => {
@@ -110,5 +114,82 @@ describe('mergeTestOp', () => {
       path: '/version',
       value: 1,
     });
+  });
+});
+
+describe('readLastPatch — supplied stateDbPath honored', () => {
+  // Regression test for #199. Pre-fix, `readLastPatch` ignored its
+  // EventStore arg and always opened `workspaceRoot(getRepoRoot())/state.db`
+  // via the now-deleted `stateDbPathFromStore` helper. After the fix, the
+  // helper takes `stateDbPath: string` directly. This test pins the
+  // contract: a future re-introduction of an in-helper hardcoded path
+  // would trip this test.
+  test('readLastPatch reads from supplied stateDbPath, not a hardcoded one', () => {
+    const tmpA = mkdtempSync(join(tmpdir(), 'gobbi-patch-readlast-a-'));
+    const tmpB = mkdtempSync(join(tmpdir(), 'gobbi-patch-readlast-b-'));
+    try {
+      // Path A — a state.db with one prompt_patches row for `ideation`.
+      const dbPathA = join(tmpA, 'state.db');
+      const sessionId = 'patch-test-session';
+      const projectId = 'patch-test-project';
+      const ts = '2026-04-30T00:00:00.000Z';
+      const promptId = 'ideation' as const;
+      const patchId = 'sha256:fixture-patch-id';
+      const preHash = 'sha256:fixture-pre-hash';
+      const postHash = 'sha256:fixture-post-hash';
+
+      const store = new EventStore(dbPathA, { sessionId, projectId });
+      try {
+        store.appendWithProjection(
+          {
+            ts,
+            type: 'prompt.patch.applied',
+            actor: 'operator',
+            idempotencyKind: 'content',
+            contentId: `${promptId}:${patchId}`,
+            sessionId,
+            data: JSON.stringify({ promptId, patchId }),
+          },
+          (db, row) => {
+            db.run(
+              `INSERT INTO prompt_patches (session_id, project_id, prompt_id, parent_seq, event_seq, patch_id, patch_json, pre_hash, post_hash, applied_at, applied_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+              [
+                sessionId,
+                projectId,
+                promptId,
+                null,
+                row.seq,
+                patchId,
+                '[]',
+                preHash,
+                postHash,
+                Date.parse(ts),
+                'operator',
+              ],
+            );
+          },
+        );
+      } finally {
+        store.close();
+      }
+
+      // Path B — an empty scratch dir; no state.db file.
+      const dbPathB = join(tmpB, 'state.db');
+
+      // Sanity: path A has the row.
+      const fromA = readLastPatch(dbPathA, promptId);
+      expect(fromA).not.toBeNull();
+      expect(fromA?.patchId).toBe(patchId);
+      expect(fromA?.postHash).toBe(postHash);
+
+      // Contract: passing a different (empty/absent) path returns null,
+      // proving the helper honors the supplied path rather than reaching
+      // for a hardcoded workspace state.db.
+      const fromB = readLastPatch(dbPathB, promptId);
+      expect(fromB).toBeNull();
+    } finally {
+      rmSync(tmpA, { recursive: true, force: true });
+      rmSync(tmpB, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/cli/src/commands/prompt/patch.ts
+++ b/packages/cli/src/commands/prompt/patch.ts
@@ -509,7 +509,7 @@ export async function runPromptPatchOnFiles(
         // (NOT the events idempotency `contentId`, which is namespaced
         // by promptId per Architecture F-4).
         const dedupedSeq = readPatchSeqByContent(
-          store,
+          stateDbPath,
           inputs.promptId,
           genesisPatchId,
         );
@@ -523,7 +523,7 @@ export async function runPromptPatchOnFiles(
       }
     } else {
       // Chain exists — link to the last row.
-      const last = readLastPatch(store, inputs.promptId);
+      const last = readLastPatch(stateDbPath, inputs.promptId);
       if (last !== null) {
         parentPatchId = last.patchId;
         parentSeq = last.seq;
@@ -764,41 +764,45 @@ function readPatchSeqByEventSeqOnDb(
   return row === null ? null : row.seq;
 }
 
-/**
- * Read the workspace state.db path from an EventStore. The path is
- * not exposed on the public surface — use a process-environment hint
- * via repoRoot resolution. For C.1 we already know the path
- * (`workspaceRoot(repoRoot)/state.db`) so this helper just restates
- * it.
- */
-function stateDbPathFromStore(_store: EventStore): string {
-  return join(workspaceRoot(getRepoRoot()), 'state.db');
-}
-
 interface LastPatchRow {
   readonly seq: number;
   readonly patchId: string;
   readonly postHash: string;
 }
 
-function readLastPatch(
-  store: EventStore,
+/**
+ * Read the most recent `prompt_patches` row for the given `promptId`.
+ * The caller supplies the workspace `state.db` path explicitly — this
+ * helper does NOT resolve it from the repo root or the supplied
+ * EventStore. Mirrors the dominant pattern in sister helpers
+ * `readLastPostHash` and `readPatchByContent` (issue #199). Returns
+ * `null` when the file does not exist or the table has no matching row.
+ */
+export function readLastPatch(
+  stateDbPath: string,
   promptId: PromptId,
 ): LastPatchRow | null {
-  const db = new Database(stateDbPathFromStore(store), { readonly: true });
+  if (!existsSync(stateDbPath)) return null;
+  const db = new Database(stateDbPath, { readonly: true });
   try {
     interface Row {
       readonly seq: number;
       readonly patch_id: string;
       readonly post_hash: string;
     }
-    const row = db
-      .query<Row, [string]>(
-        `SELECT seq, patch_id, post_hash FROM prompt_patches WHERE prompt_id = ? ORDER BY seq DESC LIMIT 1`,
-      )
-      .get(promptId);
-    if (row === null) return null;
-    return { seq: row.seq, patchId: row.patch_id, postHash: row.post_hash };
+    // Tolerate the prompt_patches table not yet existing (fresh
+    // workspace, never opened by a v7 store).
+    try {
+      const row = db
+        .query<Row, [string]>(
+          `SELECT seq, patch_id, post_hash FROM prompt_patches WHERE prompt_id = ? ORDER BY seq DESC LIMIT 1`,
+        )
+        .get(promptId);
+      if (row === null) return null;
+      return { seq: row.seq, patchId: row.patch_id, postHash: row.post_hash };
+    } catch {
+      return null;
+    }
   } finally {
     db.close();
   }
@@ -831,23 +835,36 @@ function readLastPostHash(
   }
 }
 
+/**
+ * Read the `prompt_patches` row matching `(promptId, patchId)`. The
+ * caller supplies the workspace `state.db` path explicitly — this helper
+ * does NOT resolve it from the repo root or the supplied EventStore.
+ * Mirrors the dominant pattern in sister helpers `readLastPostHash` and
+ * `readPatchByContent` (issue #199). Returns `null` when the file does
+ * not exist or no row matches.
+ */
 function readPatchSeqByContent(
-  store: EventStore,
+  stateDbPath: string,
   promptId: PromptId,
   patchId: string,
 ): { seq: number; patchId: string } | null {
-  const db = new Database(stateDbPathFromStore(store), { readonly: true });
+  if (!existsSync(stateDbPath)) return null;
+  const db = new Database(stateDbPath, { readonly: true });
   try {
     interface Row {
       readonly seq: number;
       readonly patch_id: string;
     }
-    const row = db
-      .query<Row, [string, string]>(
-        `SELECT seq, patch_id FROM prompt_patches WHERE prompt_id = ? AND patch_id = ?`,
-      )
-      .get(promptId, patchId);
-    return row === null ? null : { seq: row.seq, patchId: row.patch_id };
+    try {
+      const row = db
+        .query<Row, [string, string]>(
+          `SELECT seq, patch_id FROM prompt_patches WHERE prompt_id = ? AND patch_id = ?`,
+        )
+        .get(promptId, patchId);
+      return row === null ? null : { seq: row.seq, patchId: row.patch_id };
+    } catch {
+      return null;
+    }
   } finally {
     db.close();
   }

--- a/packages/cli/src/commands/workflow/__tests__/capture-advancement.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/capture-advancement.test.ts
@@ -1,0 +1,626 @@
+/**
+ * Unit tests for `gobbi workflow capture-advancement` — the
+ * PostToolUse(Bash) hook handler for the dormant
+ * `step.advancement.observed` audit emitter.
+ *
+ * Coverage (PR-CFM-C T5 / issue #197):
+ *
+ *   1. No-op when `workflow.observability.advancement.enabled=false`
+ *      (the default — the emitter is dormant on a fresh workspace).
+ *   2. No-op when `tool_name !== 'Bash'`.
+ *   3. No-op when the Bash command does not start with
+ *      `gobbi workflow transition`.
+ *   4. No-op when `session_id` is missing.
+ *   5. No-op when `tool_call_id` is missing.
+ *   6. No-op when the session directory does not resolve.
+ *   7. No-op when `gobbi.db` does not exist on disk.
+ *   8. Happy path — when the gate is flipped, exactly one
+ *      `step.advancement.observed` row lands in the events table.
+ *   9. Idempotency — re-firing with the same `tool_call_id`
+ *      deduplicates (1 row, not 2).
+ *  10. Distinctness — two transitions with different `tool_call_id`s
+ *      produce two rows.
+ *  11. Architectural fence — `appendEventAndUpdateState` is NEVER
+ *      called from `capture-advancement.ts`. The load-bearing
+ *      assertion reads the source file and asserts the literal token
+ *      is absent. See `workflow/events/step-advancement.ts:30-41` and
+ *      gotcha `state-db-redesign.md` §1 for the full rationale.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+
+import { runInitWithOptions } from '../init.js';
+import { runCaptureAdvancementWithOptions } from '../capture-advancement.js';
+import { sessionDir as sessionDirForProject } from '../../../lib/workspace-paths.js';
+import {
+  loadSettingsAtLevel,
+  writeSettingsAtLevel,
+} from '../../../lib/settings-io.js';
+import { EventStore } from '../../../workflow/store.js';
+import type { Settings } from '../../../lib/settings.js';
+
+// ---------------------------------------------------------------------------
+// stdout/stderr capture + process.exit trap — mirrors capture-planning.test.ts
+// ---------------------------------------------------------------------------
+
+interface Captured {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+}
+
+class ExitCalled extends Error {
+  constructor(readonly code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+let captured: Captured;
+let origStdoutWrite: typeof process.stdout.write;
+let origStderrWrite: typeof process.stderr.write;
+let origExit: typeof process.exit;
+
+beforeEach(() => {
+  captured = { stdout: '', stderr: '', exitCode: null };
+  origStdoutWrite = process.stdout.write;
+  origStderrWrite = process.stderr.write;
+  origExit = process.exit;
+
+  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+    captured.stdout +=
+      typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+    captured.stderr +=
+      typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    return true;
+  }) as typeof process.stderr.write;
+  process.exit = ((code?: number | string | null): never => {
+    captured.exitCode = typeof code === 'number' ? code : 0;
+    throw new ExitCalled(captured.exitCode);
+  }) as typeof process.exit;
+});
+
+afterEach(() => {
+  process.stdout.write = origStdoutWrite;
+  process.stderr.write = origStderrWrite;
+  process.exit = origExit;
+});
+
+async function captureExit(fn: () => Promise<void>): Promise<void> {
+  try {
+    await fn();
+  } catch (err) {
+    if (err instanceof ExitCalled) return;
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scratch dirs
+// ---------------------------------------------------------------------------
+
+const scratchDirs: string[] = [];
+
+afterEach(() => {
+  while (scratchDirs.length > 0) {
+    const d = scratchDirs.pop();
+    if (d !== undefined) {
+      try {
+        rmSync(d, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    }
+  }
+});
+
+function makeScratchRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gobbi-capture-advancement-'));
+  scratchDirs.push(dir);
+  return dir;
+}
+
+interface ScratchSession {
+  readonly sessionDir: string;
+  readonly repo: string;
+  readonly projectId: string;
+}
+
+async function initScratchSession(
+  sessionId: string,
+): Promise<ScratchSession> {
+  const repo = makeScratchRepo();
+  const projectId = basename(repo);
+  await captureExit(() =>
+    runInitWithOptions(
+      ['--session-id', sessionId, '--task', 'capture-advancement-test'],
+      { repoRoot: repo },
+    ),
+  );
+  const sessionDir = join(
+    repo,
+    '.gobbi',
+    'projects',
+    projectId,
+    'sessions',
+    sessionId,
+  );
+  captured = { stdout: '', stderr: '', exitCode: null };
+  return { sessionDir, repo, projectId };
+}
+
+/**
+ * Flip `workflow.observability.advancement.enabled = true` at the
+ * workspace level so the cascade resolves to enabled. Default-off
+ * behaviour stays the negative case (test 1); flipping on is the
+ * happy-path precondition for tests 8-10.
+ */
+function enableAdvancementGate(repo: string): void {
+  const existing = loadSettingsAtLevel(repo, 'workspace') ?? {
+    schemaVersion: 1,
+  };
+  const next: Settings = {
+    ...existing,
+    schemaVersion: 1,
+    workflow: {
+      ...(existing.workflow ?? {}),
+      observability: { advancement: { enabled: true } },
+    },
+  };
+  writeSettingsAtLevel(repo, 'workspace', next);
+}
+
+/**
+ * Open the per-session event store with explicit partition keys (PR-FIN-
+ * 2a-ii / T-2a.9.unified Option α). Mirrors `capture-planning.test.ts`.
+ */
+function openStore(
+  sessionDir: string,
+  sessionId: string,
+  projectId: string,
+): EventStore {
+  return new EventStore(join(sessionDir, 'gobbi.db'), {
+    sessionId,
+    projectId,
+  });
+}
+
+interface PayloadOverrides {
+  readonly tool_name?: string;
+  readonly session_id?: string | null;
+  readonly tool_call_id?: string | null;
+  readonly command?: string;
+}
+
+function transitionPayload(
+  sessionId: string,
+  toolCallId: string,
+  overrides: PayloadOverrides = {},
+): object {
+  const base: Record<string, unknown> = {
+    tool_name: overrides.tool_name ?? 'Bash',
+    tool_input: { command: overrides.command ?? 'gobbi workflow transition COMPLETE' },
+  };
+  if (overrides.session_id !== null) {
+    base['session_id'] = overrides.session_id ?? sessionId;
+  }
+  if (overrides.tool_call_id !== null) {
+    base['tool_call_id'] = overrides.tool_call_id ?? toolCallId;
+  }
+  return base;
+}
+
+// ---------------------------------------------------------------------------
+// 1. No-op when `enabled=false` (default)
+// ---------------------------------------------------------------------------
+
+describe('runCaptureAdvancement — settings gate (default off)', () => {
+  test('default-disabled cascade → no event row written', async () => {
+    const { sessionDir, repo, projectId } =
+      await initScratchSession('cap-adv-default-off');
+    // Explicitly do NOT call enableAdvancementGate(repo) — the default
+    // cascade resolves `enabled=false`.
+
+    await captureExit(() =>
+      runCaptureAdvancementWithOptions([], {
+        sessionDir,
+        repoRoot: repo,
+        payload: transitionPayload('cap-adv-default-off', 'tc-1'),
+      }),
+    );
+
+    expect(captured.exitCode).toBeNull();
+    expect(captured.stdout).toBe('');
+
+    const store = openStore(sessionDir, 'cap-adv-default-off', projectId);
+    try {
+      expect(store.byType('step.advancement.observed')).toHaveLength(0);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. No-op when tool_name != 'Bash'
+// ---------------------------------------------------------------------------
+
+describe('runCaptureAdvancement — wrong tool_name', () => {
+  test('tool_name=ExitPlanMode → no event row, even when gate is on', async () => {
+    const { sessionDir, repo, projectId } =
+      await initScratchSession('cap-adv-not-bash');
+    enableAdvancementGate(repo);
+
+    await captureExit(() =>
+      runCaptureAdvancementWithOptions([], {
+        sessionDir,
+        repoRoot: repo,
+        payload: transitionPayload('cap-adv-not-bash', 'tc-1', {
+          tool_name: 'ExitPlanMode',
+        }),
+      }),
+    );
+
+    const store = openStore(sessionDir, 'cap-adv-not-bash', projectId);
+    try {
+      expect(store.byType('step.advancement.observed')).toHaveLength(0);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. No-op when Bash command does not start with `gobbi workflow transition`
+// ---------------------------------------------------------------------------
+
+describe('runCaptureAdvancement — non-transition Bash command', () => {
+  test('Bash echo invocation → no event row, even when gate is on', async () => {
+    const { sessionDir, repo, projectId } =
+      await initScratchSession('cap-adv-non-transition');
+    enableAdvancementGate(repo);
+
+    await captureExit(() =>
+      runCaptureAdvancementWithOptions([], {
+        sessionDir,
+        repoRoot: repo,
+        payload: transitionPayload('cap-adv-non-transition', 'tc-1', {
+          command: 'echo hello world',
+        }),
+      }),
+    );
+
+    const store = openStore(sessionDir, 'cap-adv-non-transition', projectId);
+    try {
+      expect(store.byType('step.advancement.observed')).toHaveLength(0);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. No-op when session_id missing
+// ---------------------------------------------------------------------------
+
+describe('runCaptureAdvancement — missing session_id', () => {
+  test('payload without session_id → no event row, no crash', async () => {
+    const { sessionDir, repo, projectId } =
+      await initScratchSession('cap-adv-no-session-id');
+    enableAdvancementGate(repo);
+
+    await captureExit(() =>
+      runCaptureAdvancementWithOptions([], {
+        sessionDir,
+        repoRoot: repo,
+        payload: transitionPayload('cap-adv-no-session-id', 'tc-1', {
+          session_id: null,
+        }),
+      }),
+    );
+
+    expect(captured.exitCode).toBeNull();
+    const store = openStore(sessionDir, 'cap-adv-no-session-id', projectId);
+    try {
+      expect(store.byType('step.advancement.observed')).toHaveLength(0);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. No-op when tool_call_id missing
+// ---------------------------------------------------------------------------
+
+describe('runCaptureAdvancement — missing tool_call_id', () => {
+  test('payload without tool_call_id → no event row, no crash', async () => {
+    const { sessionDir, repo, projectId } =
+      await initScratchSession('cap-adv-no-tool-call-id');
+    enableAdvancementGate(repo);
+
+    await captureExit(() =>
+      runCaptureAdvancementWithOptions([], {
+        sessionDir,
+        repoRoot: repo,
+        payload: transitionPayload('cap-adv-no-tool-call-id', 'tc-1', {
+          tool_call_id: null,
+        }),
+      }),
+    );
+
+    expect(captured.exitCode).toBeNull();
+    const store = openStore(sessionDir, 'cap-adv-no-tool-call-id', projectId);
+    try {
+      expect(store.byType('step.advancement.observed')).toHaveLength(0);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. No-op when session dir doesn't resolve
+// ---------------------------------------------------------------------------
+
+describe('runCaptureAdvancement — unresolvable session dir', () => {
+  test('nonexistent session dir → silent exit, no crash', async () => {
+    const repo = makeScratchRepo();
+    enableAdvancementGate(repo);
+    const fakeDir = sessionDirForProject(repo, basename(repo), 'not-real');
+    expect(existsSync(fakeDir)).toBe(false);
+
+    await captureExit(() =>
+      runCaptureAdvancementWithOptions([], {
+        sessionDir: fakeDir,
+        repoRoot: repo,
+        payload: transitionPayload('not-real', 'tc-1'),
+      }),
+    );
+
+    expect(captured.exitCode).toBeNull();
+    expect(captured.stdout).toBe('');
+    // No DB was created; no row to assert.
+    expect(existsSync(join(fakeDir, 'gobbi.db'))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. No-op when gobbi.db does not exist
+// ---------------------------------------------------------------------------
+
+describe('runCaptureAdvancement — missing gobbi.db', () => {
+  test('session dir exists but gobbi.db absent → silent exit', async () => {
+    const { sessionDir, repo } = await initScratchSession('cap-adv-no-db');
+    enableAdvancementGate(repo);
+
+    // Remove the gobbi.db that init created so the existsSync gate fires.
+    const dbPath = join(sessionDir, 'gobbi.db');
+    if (existsSync(dbPath)) {
+      rmSync(dbPath);
+    }
+
+    await captureExit(() =>
+      runCaptureAdvancementWithOptions([], {
+        sessionDir,
+        repoRoot: repo,
+        payload: transitionPayload('cap-adv-no-db', 'tc-1'),
+      }),
+    );
+
+    expect(captured.exitCode).toBeNull();
+    expect(existsSync(dbPath)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Happy path — gate on + matching invocation → one row
+// ---------------------------------------------------------------------------
+
+describe('runCaptureAdvancement — happy path', () => {
+  test('gate on + Bash transition → exactly one step.advancement.observed row', async () => {
+    const { sessionDir, repo, projectId } =
+      await initScratchSession('cap-adv-happy');
+    enableAdvancementGate(repo);
+
+    await captureExit(() =>
+      runCaptureAdvancementWithOptions([], {
+        sessionDir,
+        repoRoot: repo,
+        payload: transitionPayload('cap-adv-happy', 'tc-happy-1'),
+      }),
+    );
+
+    expect(captured.exitCode).toBeNull();
+    expect(captured.stdout).toBe('');
+
+    const store = openStore(sessionDir, 'cap-adv-happy', projectId);
+    try {
+      const rows = store.byType('step.advancement.observed');
+      expect(rows).toHaveLength(1);
+      const row = rows[0]!;
+
+      // The row-level `step` column MUST be set (NOT only inside
+      // `data`) so subsequent `lastNAny(1)[0]?.step` reads return the
+      // actual current step. This is the load-bearing assertion for
+      // the carry-forward Architecture F3 (Medium-100) finding.
+      expect(row.step).toBeTypeOf('string');
+      expect(row.step?.length).toBeGreaterThan(0);
+
+      // Actor matches the hook contract.
+      expect(row.actor).toBe('hook');
+
+      // Data shape — the event factory's payload is preserved.
+      const data = JSON.parse(row.data) as {
+        readonly step: string;
+        readonly toolCallId: string;
+        readonly timestamp: string;
+      };
+      expect(data.toolCallId).toBe('tc-happy-1');
+      expect(typeof data.timestamp).toBe('string');
+      expect(data.timestamp.length).toBeGreaterThan(0);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. Idempotency — same tool_call_id → 1 row
+// ---------------------------------------------------------------------------
+
+describe('runCaptureAdvancement — idempotency', () => {
+  test('two firings with the same tool_call_id → one row (deduped)', async () => {
+    const { sessionDir, repo, projectId } =
+      await initScratchSession('cap-adv-idempotent');
+    enableAdvancementGate(repo);
+
+    const payload = transitionPayload('cap-adv-idempotent', 'tc-dedup');
+
+    await captureExit(() =>
+      runCaptureAdvancementWithOptions([], {
+        sessionDir,
+        repoRoot: repo,
+        payload,
+      }),
+    );
+    captured = { stdout: '', stderr: '', exitCode: null };
+    await captureExit(() =>
+      runCaptureAdvancementWithOptions([], {
+        sessionDir,
+        repoRoot: repo,
+        payload,
+      }),
+    );
+
+    const store = openStore(sessionDir, 'cap-adv-idempotent', projectId);
+    try {
+      const rows = store.byType('step.advancement.observed');
+      expect(rows).toHaveLength(1);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. Distinctness — distinct tool_call_ids → 2 rows
+// ---------------------------------------------------------------------------
+
+describe('runCaptureAdvancement — distinctness', () => {
+  test('two firings with different tool_call_ids → two rows', async () => {
+    const { sessionDir, repo, projectId } =
+      await initScratchSession('cap-adv-distinct');
+    enableAdvancementGate(repo);
+
+    await captureExit(() =>
+      runCaptureAdvancementWithOptions([], {
+        sessionDir,
+        repoRoot: repo,
+        payload: transitionPayload('cap-adv-distinct', 'tc-A'),
+      }),
+    );
+    captured = { stdout: '', stderr: '', exitCode: null };
+    await captureExit(() =>
+      runCaptureAdvancementWithOptions([], {
+        sessionDir,
+        repoRoot: repo,
+        payload: transitionPayload('cap-adv-distinct', 'tc-B'),
+      }),
+    );
+
+    const store = openStore(sessionDir, 'cap-adv-distinct', projectId);
+    try {
+      const rows = store.byType('step.advancement.observed');
+      expect(rows).toHaveLength(2);
+      // Distinct tool_call_ids in the data payload — no two rows share
+      // an idempotency key.
+      const toolCallIds = rows.map((row) => {
+        const data = JSON.parse(row.data) as { readonly toolCallId: string };
+        return data.toolCallId;
+      });
+      expect(new Set(toolCallIds)).toEqual(new Set(['tc-A', 'tc-B']));
+    } finally {
+      store.close();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 11. Architectural fence — reducer NEVER invoked from capture-advancement
+// ---------------------------------------------------------------------------
+
+describe('runCaptureAdvancement — architectural fence', () => {
+  test('capture-advancement.ts source contains NO `appendEventAndUpdateState(` call site', () => {
+    // Load-bearing static assertion. The architectural fence is that
+    // `step.advancement.observed` is audit-only and MUST NOT enter the
+    // reducer (see `workflow/events/step-advancement.ts:30-41` and
+    // gotcha `state-db-redesign.md` §1). The TypeScript surface
+    // already prevents `appendEventAndUpdateState({ type:
+    // 'step.advancement.observed', ... })` from compiling because
+    // `StepAdvancementEvent` is not a member of the reducer's `Event`
+    // union — but a future change could:
+    //
+    //   (a) widen the `Event` union by mistake, then route this event
+    //       through the reducer-aware path;
+    //   (b) reach for a generic `<any>` cast to bypass the type
+    //       check;
+    //   (c) accidentally swap the call from `store.append()` to
+    //       `appendEventAndUpdateState()` while refactoring.
+    //
+    // None of those would leave a runtime trace that a "row count"
+    // assertion could observe (state_snapshots is a Wave-E-1 table no
+    // code writes to today; reducer-routed audit failures swallow
+    // silently; engine-audit branches don't fire for plain Errors).
+    //
+    // Reading the source and asserting the call-site token is absent
+    // is the load-bearing check: if a future diff re-introduces the
+    // call, the source contains the `(` and this test fails. The
+    // pattern matches `appendEventAndUpdateState(` (open paren) AND
+    // `await appendEventAndUpdateState` (call expression with await,
+    // no whitespace before paren in a future minimised form). The
+    // module's docblock and the in-code comment naming the invariant
+    // mention the word in prose without parens or `await` — those
+    // are intentionally allowed and document the fence.
+    const src = readFileSync(
+      join(import.meta.dir, '..', 'capture-advancement.ts'),
+      'utf8',
+    );
+    expect(src).not.toMatch(/appendEventAndUpdateState\s*\(/);
+    expect(src).not.toMatch(/await\s+appendEventAndUpdateState\b/);
+  });
+
+  test('happy-path append does not produce a workflow.invalid_transition audit', async () => {
+    // Secondary runtime check — paired with the static assertion
+    // above. If a future refactor routed this event through the
+    // reducer, the reducer's `assertNever` would throw and the
+    // engine's `workflow.invalid_transition` audit would fire (when
+    // the throw was a `ReducerRejectionError`). Asserting zero such
+    // audit rows confirms the bypass actually happened at runtime,
+    // not just at the source-string level.
+    const { sessionDir, repo, projectId } =
+      await initScratchSession('cap-adv-fence-runtime');
+    enableAdvancementGate(repo);
+
+    await captureExit(() =>
+      runCaptureAdvancementWithOptions([], {
+        sessionDir,
+        repoRoot: repo,
+        payload: transitionPayload('cap-adv-fence-runtime', 'tc-fence'),
+      }),
+    );
+
+    const store = openStore(sessionDir, 'cap-adv-fence-runtime', projectId);
+    try {
+      expect(store.byType('step.advancement.observed')).toHaveLength(1);
+      expect(store.byType('workflow.invalid_transition')).toHaveLength(0);
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/packages/cli/src/commands/workflow/capture-advancement.ts
+++ b/packages/cli/src/commands/workflow/capture-advancement.ts
@@ -1,0 +1,303 @@
+/**
+ * gobbi workflow capture-advancement — PostToolUse(Bash) hook handler.
+ *
+ * Reads a Claude Code PostToolUse JSON payload on stdin (fired for the
+ * `Bash` tool whose command starts with `gobbi workflow transition`),
+ * appends one `step.advancement.observed` audit-only event to the
+ * per-session event store. The Stop-hook missed-advancement consumer
+ * (future PR) reads these events to decide whether to inject a "you
+ * forgot to call transition" reminder.
+ *
+ * ## Hook contract
+ *
+ * > **Observational hook — no permissionDecision, always exit 0.**
+ *
+ * PostToolUse cannot block the tool call. Every failure path silently
+ * no-ops and the helper always exits cleanly. The canonical outcome is
+ * the `step.advancement.observed` event row; stdout is intentionally
+ * empty.
+ *
+ * ## Architectural fence — bypass the reducer
+ *
+ * `step.advancement.observed` is audit-only and MUST NOT enter the
+ * reducer. This module commits via `store.append()` directly, NEVER
+ * through `appendEventAndUpdateState`. See
+ * `workflow/events/step-advancement.ts:30-41` and gotcha
+ * `state-db-redesign.md` §1 for the full rationale. The TypeScript
+ * surface enforces the bypass (`StepAdvancementEvent` is not a member of
+ * the reducer's `Event` union); this module additionally names the
+ * invariant in a comment at the call site.
+ *
+ * ## Settings gate
+ *
+ * The emitter is dormant by default. `workflow.observability.advancement.enabled`
+ * (PR-CFM-C T4) gates the entire path — when the resolved cascade does
+ * not yield `enabled === true`, the helper returns immediately with no
+ * event write. Operators flip the flag via `gobbi config set` to
+ * activate the audit data stream.
+ *
+ * @see `commands/workflow/capture-planning.ts` — sibling pattern (audit
+ *      event without a settings gate; productive event flows through
+ *      the reducer instead).
+ */
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { readStdinJson } from '../../lib/stdin.js';
+import { isRecord, isString } from '../../lib/guards.js';
+import { getRepoRoot } from '../../lib/repo.js';
+import { resolveSettings } from '../../lib/settings-io.js';
+import { EventStore } from '../../workflow/store.js';
+import { createStepAdvancementObserved } from '../../workflow/events/step-advancement.js';
+import { resolvePartitionKeys, resolveSessionDir } from '../session.js';
+
+// ---------------------------------------------------------------------------
+// Hook payload shape
+// ---------------------------------------------------------------------------
+
+/**
+ * Subset of the PostToolUse JSON payload this command reads. The matcher
+ * narrows the input to `tool_name === 'Bash'` invocations whose
+ * `tool_input.command` starts with `gobbi workflow transition`. Anything
+ * else is a silent no-op.
+ *
+ * Source: `v050-hooks.md` §PostToolUse.
+ */
+interface PostToolUsePayload {
+  readonly tool_name?: string;
+  readonly session_id?: string;
+  readonly tool_call_id?: string;
+  readonly tool_input?: {
+    readonly command?: string;
+  };
+}
+
+function asPayload(value: unknown): PostToolUsePayload {
+  if (!isRecord(value)) return {};
+  const out: Record<string, unknown> = {};
+  if (isString(value['tool_name'])) out['tool_name'] = value['tool_name'];
+  if (isString(value['session_id'])) out['session_id'] = value['session_id'];
+  if (isString(value['tool_call_id'])) {
+    out['tool_call_id'] = value['tool_call_id'];
+  }
+  const toolInput = value['tool_input'];
+  if (isRecord(toolInput)) {
+    const ti: Record<string, unknown> = {};
+    if (isString(toolInput['command'])) ti['command'] = toolInput['command'];
+    out['tool_input'] = ti;
+  }
+  return out as PostToolUsePayload;
+}
+
+/**
+ * Defensive matcher — the plugin manifest already gates registration to
+ * `tool_name === 'Bash'`, but a per-repo override might broaden it.
+ * Returns `true` only when both the tool name AND the command prefix
+ * match, so a Bash invocation that shells out to anything other than
+ * `gobbi workflow transition` is a silent no-op.
+ *
+ * The regex tolerates leading whitespace (so `"  gobbi workflow transition COMPLETE"`
+ * matches) and uses `\b` to ensure `transition` is a complete token —
+ * `gobbi workflow transitionx` would NOT match.
+ */
+const TRANSITION_COMMAND_RE = /^\s*gobbi\s+workflow\s+transition\b/;
+
+export function isBashTransitionInvocation(payload: unknown): boolean {
+  if (!isRecord(payload)) return false;
+  const toolName = payload['tool_name'];
+  if (!isString(toolName) || toolName !== 'Bash') return false;
+  const toolInput = payload['tool_input'];
+  if (!isRecord(toolInput)) return false;
+  const command = toolInput['command'];
+  if (!isString(command)) return false;
+  return TRANSITION_COMMAND_RE.test(command);
+}
+
+// ---------------------------------------------------------------------------
+// Entry points
+// ---------------------------------------------------------------------------
+
+export interface CaptureAdvancementOverrides {
+  /** Override the resolved session directory (tests-only). */
+  readonly sessionDir?: string;
+  /** Seed the payload directly (tests-only). */
+  readonly payload?: unknown;
+  /**
+   * Override the resolved repo root for `resolveSettings()` (tests-only).
+   * When omitted, the helper derives repoRoot path-wise from `sessionDir`
+   * (`<repoRoot>/.gobbi/projects/<name>/sessions/<id>`) and falls back to
+   * `getRepoRoot()` if the derivation fails.
+   */
+  readonly repoRoot?: string;
+}
+
+export async function runCaptureAdvancement(args: string[]): Promise<void> {
+  await runCaptureAdvancementWithOptions(args);
+}
+
+/**
+ * Testable entry point — same behaviour as {@link runCaptureAdvancement}
+ * but accepts overrides for session directory, repo root, and stdin
+ * payload. The implementation walks every short-circuit gate in order:
+ *
+ *   1. `--help` / `-h` flag.
+ *   2. `tool_name === 'Bash'` AND command starts with `gobbi workflow transition`.
+ *   3. `session_id` present AND `tool_call_id` present.
+ *   4. Session directory resolves AND `gobbi.db` exists.
+ *   5. `workflow.observability.advancement.enabled === true` in the
+ *      cascade. (Most operators leave this off; the gate keeps the
+ *      emitter dormant.)
+ *
+ * Each gate failing returns silently. Past every gate, a single
+ * `store.append()` writes the audit row. Best-effort try/catch wraps the
+ * append — observational hooks never fail the tool call.
+ */
+export async function runCaptureAdvancementWithOptions(
+  args: string[],
+  overrides: CaptureAdvancementOverrides = {},
+): Promise<void> {
+  if (args.includes('--help') || args.includes('-h')) {
+    process.stdout.write(`${USAGE}\n`);
+    return;
+  }
+
+  // --- 1. Acquire payload ------------------------------------------------
+  const rawPayload =
+    overrides.payload !== undefined
+      ? overrides.payload
+      : await readStdinJson<unknown>();
+
+  if (!isBashTransitionInvocation(rawPayload)) {
+    return;
+  }
+  const payload = asPayload(rawPayload);
+
+  // --- 2. Required scope keys --------------------------------------------
+  const sessionId = payload.session_id;
+  const toolCallId = payload.tool_call_id;
+  if (sessionId === undefined || sessionId === '') return;
+  if (toolCallId === undefined || toolCallId === '') return;
+
+  // --- 3. Resolve session ------------------------------------------------
+  const sessionDir =
+    overrides.sessionDir ?? resolveSessionDir(sessionId);
+  if (sessionDir === null) {
+    return;
+  }
+
+  const dbPath = join(sessionDir, 'gobbi.db');
+  if (!existsSync(dbPath)) {
+    return;
+  }
+
+  // --- 4. Settings gate --------------------------------------------------
+  // `resolveSettings({ repoRoot })` is SYNCHRONOUS — no `await`. The
+  // signature requires `repoRoot`; tests pass an explicit override, the
+  // production hook path falls back to `getRepoRoot()` (which uses
+  // `git rev-parse`).
+  const repoRoot = overrides.repoRoot ?? getRepoRoot();
+  const partitionKeys = resolvePartitionKeys(sessionDir);
+  let enabled = false;
+  try {
+    const settings = resolveSettings({
+      repoRoot,
+      sessionId,
+      ...(partitionKeys.projectId !== null
+        ? { projectName: partitionKeys.projectId }
+        : {}),
+    });
+    enabled =
+      settings.workflow?.observability?.advancement?.enabled === true;
+  } catch {
+    // Cascade read/parse failure → treat as disabled (observational hook
+    // contract: never fail the tool call). The dormant default keeps
+    // production paths fail-closed.
+    return;
+  }
+  if (!enabled) {
+    return;
+  }
+
+  // --- 5. Open store + read current step + emit -------------------------
+  let store: EventStore;
+  try {
+    store = new EventStore(dbPath, {
+      sessionId: partitionKeys.sessionId,
+      projectId: partitionKeys.projectId,
+    });
+  } catch {
+    return;
+  }
+
+  try {
+    // Read the row-level `step` column from the most recent event. This
+    // is a single indexed query (NOT a full reduce) so the hot path
+    // stays cheap even when sessions accumulate thousands of rows.
+    const lastRow = store.lastNAny(1)[0];
+    const currentStep = lastRow?.step ?? 'idle';
+
+    const event = createStepAdvancementObserved({
+      step: currentStep,
+      toolCallId,
+      timestamp: new Date().toISOString(),
+    });
+
+    // ---------------------------------------------------------------
+    // Architectural fence — `step.advancement.observed` is audit-only.
+    //
+    // NEVER route this event through `appendEventAndUpdateState`. The
+    // reducer's `assertNever` would throw a plain `Error`, the
+    // engine's audit-on-rejection branch would NOT fire (it expects
+    // `ReducerRejectionError`), and the event would silently
+    // disappear. See `workflow/events/step-advancement.ts:30-41` and
+    // gotcha `state-db-redesign.md` §1.
+    //
+    // The TypeScript surface enforces the bypass —
+    // `StepAdvancementEvent` is intentionally NOT a member of the
+    // reducer's `Event` union — but we name the invariant here too
+    // so future hook implementers don't try to "fix" the call by
+    // widening anything.
+    //
+    // The `step` column is set at the row level (NOT only inside
+    // `data`) so `lastNAny(1)[0]?.step` returns the actual current
+    // step on subsequent reads.
+    // ---------------------------------------------------------------
+    try {
+      store.append({
+        ts: event.data.timestamp,
+        type: event.type,
+        step: currentStep,
+        data: JSON.stringify(event.data),
+        actor: 'hook',
+        sessionId,
+        idempotencyKind: 'tool-call',
+        toolCallId,
+      });
+    } catch {
+      // Best-effort — observational hooks always exit 0. Disk full,
+      // WAL lock, SQLite busy: swallow the error so the tool call
+      // succeeds.
+    }
+  } finally {
+    store.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Help
+// ---------------------------------------------------------------------------
+
+const USAGE = `Usage: gobbi workflow capture-advancement
+
+PostToolUse hook handler for the Bash tool. Reads the Claude Code hook
+payload on stdin and (when the Bash command starts with
+\`gobbi workflow transition\`) appends one \`step.advancement.observed\`
+audit-only event to the per-session event store.
+
+The emitter is gated by \`workflow.observability.advancement.enabled\`
+(default false). Flip the flag via \`gobbi config set\` to activate.
+
+Observational hook — writes no permissionDecision and always exits 0.`;
+
+export { USAGE as CAPTURE_ADVANCEMENT_USAGE };

--- a/packages/cli/src/lib/__tests__/memory-projection-diff.test.ts
+++ b/packages/cli/src/lib/__tests__/memory-projection-diff.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Tests for `lib/memory-projection-diff.ts` — the pure divergence
+ * detector consumed by PR-CFM-C's `verify-state-projections` command
+ * and (later) PR-B's `gobbi memory check`.
+ *
+ * Test surface (8) per PR-CFM-C ideation §4.5:
+ *
+ *   1. Empty divergences when memory matches events.
+ *   2. `row-missing` when start+finish events exist but no project.json row.
+ *   3. `finishedAt` when finish event committed but row finishedAt is null.
+ *   4. `task` when row task differs from workflow.start payload task.
+ *   5. `memory: null` treated as empty sessions[] (no crash).
+ *   6. `reduceFn` throwing surfaces `events.replay_threw` divergence.
+ *   7. `events.empty` info-level divergence when project.json row exists
+ *      with no event rows.
+ *   8. Mid-flight session yields zero divergences.
+ *
+ * Fixture shape mirrors `lib/__tests__/json-memory.test.ts`'s
+ * `FakeReadStore` (lines 84-122) — a pure in-memory `ReadStore` impl is
+ * the simplest way to fixture an event stream without driving the full
+ * `EventStore` partition surface or a session-by-session SQLite open.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { memoryProjectionDiff } from '../memory-projection-diff.js';
+import type {
+  MemoryDivergence,
+  MemoryProjectionDiffResult,
+} from '../memory-projection-diff.js';
+import type { ProjectJson, ProjectJsonSession } from '../json-memory.js';
+import { reduce } from '../../workflow/reducer.js';
+import type { ReadStore, CostAggregateRow } from '../../workflow/store.js';
+import type { ReduceFn, ReducerResult } from '../../workflow/types.js';
+import type { EventRow } from '../../workflow/migrations.js';
+
+// ---------------------------------------------------------------------------
+// FakeReadStore — multi-session in-memory event store. Mirrors the helper
+// in `json-memory.test.ts` (the production EventStore is partition-bound
+// to one session per open, so a multi-session diff needs a fake).
+// ---------------------------------------------------------------------------
+
+class FakeReadStore implements ReadStore {
+  private readonly rows: readonly EventRow[];
+
+  constructor(rows: readonly EventRow[]) {
+    this.rows = rows;
+  }
+
+  replayAll(): EventRow[] {
+    return [...this.rows];
+  }
+  byType(type: string): EventRow[] {
+    return this.rows.filter((r) => r.type === type);
+  }
+  byStep(step: string, type?: string): EventRow[] {
+    return this.rows.filter(
+      (r) => r.step === step && (type === undefined || r.type === type),
+    );
+  }
+  since(seq: number): EventRow[] {
+    return this.rows.filter((r) => r.seq > seq);
+  }
+  last(type: string): EventRow | null {
+    const filtered = this.rows.filter((r) => r.type === type);
+    return filtered.length === 0 ? null : (filtered[filtered.length - 1] ?? null);
+  }
+  lastN(type: string, n: number): readonly EventRow[] {
+    const filtered = this.rows.filter((r) => r.type === type);
+    return filtered.slice(-n);
+  }
+  lastNAny(n: number): readonly EventRow[] {
+    return this.rows.slice(-n);
+  }
+  eventCount(): number {
+    return this.rows.length;
+  }
+  aggregateDelegationCosts(): readonly CostAggregateRow[] {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Row + project.json fixture factories
+// ---------------------------------------------------------------------------
+
+let rowCounter = 0;
+function nextSeq(): number {
+  rowCounter += 1;
+  return rowCounter;
+}
+
+interface MakeRowArgs {
+  readonly type: string;
+  readonly sessionId: string;
+  readonly ts?: string;
+  readonly step?: string | null;
+  readonly data?: Record<string, unknown>;
+}
+
+function makeRow(args: MakeRowArgs): EventRow {
+  const seq = nextSeq();
+  return {
+    seq,
+    ts: args.ts ?? '2026-04-29T10:00:00.000Z',
+    schema_version: 7,
+    type: args.type,
+    step: args.step ?? null,
+    data: JSON.stringify(args.data ?? { sessionId: args.sessionId, timestamp: args.ts ?? '2026-04-29T10:00:00.000Z' }),
+    actor: 'orchestrator',
+    parent_seq: null,
+    idempotency_key: `key-${seq}-${args.sessionId}`,
+    session_id: args.sessionId,
+    project_id: 'gobbi',
+  };
+}
+
+/**
+ * Build the full event stream that drives a session from `idle` through
+ * every productive step to `done`, using event types and step values that
+ * the production reducer accepts. Each STEP_EXIT carries the `step` field
+ * the reducer requires (`event.data.step` must match `state.currentStep`).
+ *
+ * Sequence (eval gates default to disabled because `evalConfig` stays
+ * `null` — no `workflow.eval.decide` event in this stream — and the
+ * `evalIdeationDisabled` / `evalPlanningDisabled` / `evalMemorizationDisabled`
+ * predicates short-circuit `null?.x !== true` to `true`):
+ *
+ *   idle → ideation                    via workflow.start
+ *   ideation → planning                via step.exit (eval disabled)
+ *   planning → execution               via step.exit (eval disabled)
+ *   execution → execution_eval         via step.exit (always — no condition)
+ *   execution_eval → memorization      via decision.eval.verdict (verdict='pass')
+ *   memorization → handoff             via step.exit (eval disabled)
+ *   handoff → done                     via workflow.finish
+ */
+function buildDoneStream(sessionId: string): readonly EventRow[] {
+  return [
+    makeRow({ type: 'workflow.start', sessionId }),
+    makeRow({ type: 'workflow.step.exit', sessionId, step: 'ideation', data: { step: 'ideation' } }),
+    makeRow({ type: 'workflow.step.exit', sessionId, step: 'planning', data: { step: 'planning' } }),
+    makeRow({ type: 'workflow.step.exit', sessionId, step: 'execution', data: { step: 'execution' } }),
+    makeRow({ type: 'decision.eval.verdict', sessionId, step: 'execution_eval', data: { verdict: 'pass' } }),
+    makeRow({ type: 'workflow.step.exit', sessionId, step: 'memorization', data: { step: 'memorization' } }),
+    makeRow({ type: 'workflow.finish', sessionId, ts: '2026-04-29T11:00:00.000Z', data: {} }),
+  ];
+}
+
+function makeProjectJson(sessions: readonly ProjectJsonSession[]): ProjectJson {
+  return {
+    schemaVersion: 1,
+    projectName: 'gobbi',
+    projectId: 'gobbi',
+    sessions,
+    gotchas: [],
+    decisions: [],
+    learnings: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('memoryProjectionDiff', () => {
+  test('1 — empty divergences when memory matches events (happy path)', () => {
+    const sessionId = 'sess-happy';
+    const rows = buildDoneStream(sessionId);
+    const store = new FakeReadStore(rows);
+    const memory = makeProjectJson([
+      {
+        sessionId,
+        createdAt: '2026-04-29T10:00:00.000Z',
+        finishedAt: '2026-04-29T11:00:00.000Z',
+        task: 'demo',
+      },
+    ]);
+
+    const result: MemoryProjectionDiffResult = memoryProjectionDiff({
+      store,
+      memory,
+      reduceFn: reduce,
+    });
+
+    expect(result.divergences).toEqual([]);
+    expect(result.sessionsChecked).toBe(1);
+    expect(result.elapsedMs).toBeGreaterThanOrEqual(0);
+  });
+
+  test('2 — row-missing when start+finish events exist but no project.json row', () => {
+    const sessionId = 'sess-orphan';
+    const store = new FakeReadStore(buildDoneStream(sessionId));
+    const memory = makeProjectJson([]); // empty sessions[]
+
+    const result = memoryProjectionDiff({ store, memory, reduceFn: reduce });
+
+    expect(result.divergences).toHaveLength(1);
+    const div = result.divergences[0] as MemoryDivergence;
+    expect(div.sessionId).toBe(sessionId);
+    expect(div.field).toBe('row-missing');
+    expect(div.fromMemory).toBeNull();
+    // fromEvents carries a workflow.finish witness when the finish event
+    // is on the stream — guard against silent regression.
+    expect(div.fromEvents).toContain('workflow.finish');
+  });
+
+  test('3 — finishedAt divergence when finish event committed but row finishedAt is null', () => {
+    const sessionId = 'sess-finish-null';
+    const store = new FakeReadStore(buildDoneStream(sessionId));
+    const memory = makeProjectJson([
+      {
+        sessionId,
+        createdAt: '2026-04-29T10:00:00.000Z',
+        finishedAt: null, // ← the divergence
+        task: 'demo',
+      },
+    ]);
+
+    const result = memoryProjectionDiff({ store, memory, reduceFn: reduce });
+
+    expect(result.divergences).toHaveLength(1);
+    const div = result.divergences[0] as MemoryDivergence;
+    expect(div.field).toBe('finishedAt');
+    expect(div.sessionId).toBe(sessionId);
+    expect(div.fromEvents).toContain('workflow.finish');
+    expect(div.fromMemory).toBeNull();
+  });
+
+  test('4 — task divergence when row task differs from workflow.start payload task', () => {
+    const sessionId = 'sess-task-drift';
+    // Override the start row to embed a `task` field in its payload —
+    // the wire-format does not declare `task` today, but the diff logic
+    // surfaces drift when a fixture (or a future emitter) does carry one.
+    const baseRows = buildDoneStream(sessionId);
+    const rows: readonly EventRow[] = baseRows.map((row) =>
+      row.type === 'workflow.start'
+        ? {
+            ...row,
+            data: JSON.stringify({
+              sessionId,
+              timestamp: row.ts,
+              task: 'event-side task',
+            }),
+          }
+        : row,
+    );
+    const store = new FakeReadStore(rows);
+    const memory = makeProjectJson([
+      {
+        sessionId,
+        createdAt: '2026-04-29T10:00:00.000Z',
+        finishedAt: '2026-04-29T11:00:00.000Z',
+        task: 'memory-side task', // ← differs
+      },
+    ]);
+
+    const result = memoryProjectionDiff({ store, memory, reduceFn: reduce });
+
+    const taskDivs = result.divergences.filter((d) => d.field === 'task');
+    expect(taskDivs).toHaveLength(1);
+    const div = taskDivs[0] as MemoryDivergence;
+    expect(div.fromEvents).toBe('event-side task');
+    expect(div.fromMemory).toBe('memory-side task');
+  });
+
+  test('5 — memory: null treated as empty sessions[] (no crash)', () => {
+    const sessionId = 'sess-no-memory';
+    const store = new FakeReadStore(buildDoneStream(sessionId));
+
+    const result = memoryProjectionDiff({
+      store,
+      memory: null,
+      reduceFn: reduce,
+    });
+
+    // No memory + finished session → row-missing (the same kind we'd see
+    // when memory was present-but-empty).
+    expect(result.divergences).toHaveLength(1);
+    const div = result.divergences[0] as MemoryDivergence;
+    expect(div.field).toBe('row-missing');
+    expect(div.sessionId).toBe(sessionId);
+  });
+
+  test('6 — reduceFn throwing surfaces events.replay_threw (not a library throw)', () => {
+    const sessionId = 'sess-bad-reducer';
+    const store = new FakeReadStore(buildDoneStream(sessionId));
+    const throwingReduce: ReduceFn = (): ReducerResult => {
+      throw new Error('synthetic reducer crash');
+    };
+
+    // The library MUST NOT propagate the throw — it surfaces a divergence.
+    const result = memoryProjectionDiff({
+      store,
+      memory: null,
+      reduceFn: throwingReduce,
+    });
+
+    expect(result.divergences).toHaveLength(1);
+    const div = result.divergences[0] as MemoryDivergence;
+    expect(div.field).toBe('events.replay_threw');
+    expect(div.sessionId).toBe(sessionId);
+    expect(div.note).toContain('synthetic reducer crash');
+  });
+
+  test('7 — events.empty info-level divergence when project.json row exists with no event rows', () => {
+    const store = new FakeReadStore([]); // no events at all
+    const memory = makeProjectJson([
+      {
+        sessionId: 'sess-only-in-memory',
+        createdAt: '2026-04-29T10:00:00.000Z',
+        finishedAt: null,
+        task: 'demo',
+      },
+    ]);
+
+    const result = memoryProjectionDiff({ store, memory, reduceFn: reduce });
+
+    expect(result.divergences).toHaveLength(1);
+    const div = result.divergences[0] as MemoryDivergence;
+    expect(div.field).toBe('events.empty');
+    expect(div.sessionId).toBe('sess-only-in-memory');
+    // `note` is the field that distinguishes info-level from error-level
+    // without introducing a severity bucket.
+    expect(div.note).toContain('no events');
+  });
+
+  test('8 — mid-flight session yields zero divergences', () => {
+    // Mid-flight = workflow.start + step.exit (memorization upserted the
+    // session row mid-run) + NO workflow.finish. The §4 check matrix says
+    // this is OK — memorization legitimately upserts the row before the
+    // finish event lands.
+    const sessionId = 'sess-mid-flight';
+    const rows: readonly EventRow[] = [
+      makeRow({ type: 'workflow.start', sessionId }),
+      makeRow({ type: 'workflow.step.exit', sessionId, step: 'ideation', data: { step: 'ideation' } }),
+      makeRow({ type: 'workflow.step.exit', sessionId, step: 'planning', data: { step: 'planning' } }),
+      // currently in execution; no finish event.
+    ];
+    const store = new FakeReadStore(rows);
+    const memory = makeProjectJson([
+      {
+        sessionId,
+        createdAt: '2026-04-29T10:00:00.000Z',
+        finishedAt: null, // mid-flight; legitimately null
+        task: 'demo',
+      },
+    ]);
+
+    const result = memoryProjectionDiff({ store, memory, reduceFn: reduce });
+
+    expect(result.divergences).toEqual([]);
+    expect(result.sessionsChecked).toBe(1);
+  });
+});

--- a/packages/cli/src/lib/__tests__/settings.test.ts
+++ b/packages/cli/src/lib/__tests__/settings.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for the unified `Settings` shape — focused on
+ * `WorkflowSettings.observability.advancement` (PR-CFM-C T4).
+ *
+ * The new field gates the `step.advancement.observed` PostToolUse emitter
+ * (#197) and is wired in PR-CFM-C T5. This file pins the schema +
+ * default + cascade round-trip contract so T5 (and any future emitter
+ * gate) can rely on the field landing at every level of the cascade.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { DEFAULTS } from '../settings.js';
+import { projectSettingsPath, resolveSettings } from '../settings-io.js';
+import { validateSettings } from '../settings-validator.js';
+
+// ---------------------------------------------------------------------------
+// Scratch lifecycle — mirrors `settings-io.test.ts` fixture pattern
+// ---------------------------------------------------------------------------
+
+let scratchDir: string;
+
+beforeEach(() => {
+  scratchDir = mkdtempSync(join(tmpdir(), 'gobbi-settings-'));
+});
+
+afterEach(() => {
+  try {
+    rmSync(scratchDir, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+});
+
+function writeJson(filePath: string, value: unknown): void {
+  mkdirSync(join(filePath, '..'), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+// ---------------------------------------------------------------------------
+// workflow.observability.advancement.enabled — PR-CFM-C T4 round-trip
+// ---------------------------------------------------------------------------
+
+describe('workflow.observability.advancement.enabled (PR-CFM-C T4)', () => {
+  test('schema validates the field as a boolean; default cascade resolves to false; cascade round-trips true', () => {
+    // (1) AJV: the new field validates as a boolean at every nesting level.
+    expect(
+      validateSettings({
+        schemaVersion: 1,
+        workflow: { observability: { advancement: { enabled: true } } },
+      }),
+    ).toBe(true);
+    expect(
+      validateSettings({
+        schemaVersion: 1,
+        workflow: { observability: { advancement: { enabled: false } } },
+      }),
+    ).toBe(true);
+    // Non-boolean value rejected — confirms the leaf type is locked.
+    expect(
+      validateSettings({
+        schemaVersion: 1,
+        workflow: { observability: { advancement: { enabled: 'yes' } } },
+      }),
+    ).toBe(false);
+
+    // DEFAULTS carries the dormant default explicitly.
+    expect(DEFAULTS.workflow?.observability?.advancement?.enabled).toBe(false);
+
+    // (2) Default cascade — no fixture files written — resolves to false.
+    const defaultsResolved = resolveSettings({
+      repoRoot: scratchDir,
+      projectName: 'gobbi',
+    });
+    expect(defaultsResolved.workflow?.observability?.advancement?.enabled).toBe(false);
+
+    // (3) Project-level overlay flips the gate; cascade round-trips true.
+    writeJson(projectSettingsPath(scratchDir, 'gobbi'), {
+      schemaVersion: 1,
+      workflow: { observability: { advancement: { enabled: true } } },
+    });
+    const overrideResolved = resolveSettings({
+      repoRoot: scratchDir,
+      projectName: 'gobbi',
+    });
+    expect(overrideResolved.workflow?.observability?.advancement?.enabled).toBe(true);
+  });
+});

--- a/packages/cli/src/lib/memory-projection-diff.ts
+++ b/packages/cli/src/lib/memory-projection-diff.ts
@@ -1,0 +1,407 @@
+/**
+ * Pure divergence detector between event-derived workflow state and the
+ * `project.json` handoff projection — single source of truth shared by
+ * future PR-B `gobbi memory check` and PR-C's `verify-state-projections`
+ * maintenance command.
+ *
+ * # Contract
+ *
+ * `memoryProjectionDiff()` is synchronous and pure: it does NO I/O and
+ * NEVER throws on per-session corruption. All discovered drift is
+ * surfaced as `MemoryDivergence` rows in the result. The library
+ * throwing is reserved for "the library could not run at all" (e.g. the
+ * caller passed `undefined` where a `ReadStore` was required).
+ *
+ * The caller is responsible for I/O:
+ *
+ *   - Read `project.json` (or pass `null` for an empty memory).
+ *   - Open a `ReadStore` against the workspace `.gobbi/state.db` (or
+ *     per-session `gobbi.db`).
+ *   - Inject the production `reduce` function — the lib stays free of
+ *     the lib→workflow circular import that broke `engine.ts` apart in
+ *     Wave A.1. Mirrors `state-derivation.ts::deriveState`'s injection
+ *     pattern.
+ *
+ * # Critical type-import (Architecture eval F2)
+ *
+ * `ReduceFn` is imported from `'../workflow/types.js'`, NOT from
+ * `'../workflow/state-derivation.js'`. The latter pulls
+ * `lib/settings.js` through its `ResolvedSettings` import which would
+ * close a type-graph cycle for any `lib/`-side consumer. `types.ts` is
+ * the dedicated cycle-free home for `ReduceFn` and `ReducerResult`.
+ *
+ * # Divergence kinds (5)
+ *
+ *   - `row-missing`         — `workflow.start`+`workflow.finish` exist
+ *                             but the session has no row in
+ *                             `project.json.sessions[]`.
+ *   - `finishedAt`          — finish event committed but the row's
+ *                             `finishedAt` is `null`.
+ *   - `task`                — the row's `task` differs from
+ *                             `workflow.start.data.task` (when the
+ *                             event payload carries one).
+ *   - `events.replay_threw` — `reduceFn` threw while replaying the
+ *                             session's events (corrupt event stream).
+ *   - `events.empty`        — info-level — `project.json` has a row
+ *                             for this session but no events for it
+ *                             exist in the store. Legitimate edge
+ *                             (post-init, pre-event-append) that
+ *                             operators should still see.
+ *
+ * # Walk shape
+ *
+ * The function unions two session sources:
+ *
+ *   1. Every `sessionId` referenced by `memory.sessions[]`.
+ *   2. Every distinct `session_id` (or partition-derived id) found in
+ *      the events returned by `store.replayAll()`.
+ *
+ * For each session it then runs the §4 ground-truth check matrix from
+ * the PR-CFM-C ideation doc.
+ */
+
+import type { ReadStore } from '../workflow/store.js';
+import type { ReduceFn } from '../workflow/types.js';
+import type { EventRow } from '../workflow/migrations.js';
+import { rowToEvent, initialState } from '../workflow/state-derivation.js';
+import type { ProjectJson, ProjectJsonSession } from './json-memory.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Closed union of divergence kinds. Adding a kind extends the union (no
+ * severity bucket bookkeeping). Severity model deferred — a flat list
+ * scales; severity is a sort/filter axis the consumer command applies
+ * as policy.
+ */
+export type DivergenceField =
+  | 'row-missing'
+  | 'finishedAt'
+  | 'task'
+  | 'events.replay_threw'
+  | 'events.empty';
+
+/**
+ * One divergence row. `fromEvents` and `fromMemory` carry the human-
+ * readable witness on each side (typically a string, sometimes `null`).
+ * `note` is an optional free-text field used by info-level kinds (e.g.
+ * `events.empty`) and by `events.replay_threw` to describe the throw.
+ */
+export interface MemoryDivergence {
+  readonly sessionId: string;
+  readonly field: DivergenceField;
+  readonly fromEvents: string | null;
+  readonly fromMemory: string | null;
+  readonly note?: string;
+}
+
+export interface MemoryProjectionDiffArgs {
+  readonly store: ReadStore;
+  /** `null` is treated as an empty `sessions[]` (no crash). */
+  readonly memory: ProjectJson | null;
+  /**
+   * Injected reducer — typically `reduce` from `workflow/reducer.js`.
+   * Keeping this a parameter avoids the lib→workflow circular import
+   * (mirror `state-derivation.ts::deriveState`).
+   */
+  readonly reduceFn: ReduceFn;
+  /** Test seam for `elapsedMs`. Defaults to `Date.now`. */
+  readonly now?: () => number;
+}
+
+export interface MemoryProjectionDiffResult {
+  readonly divergences: readonly MemoryDivergence[];
+  readonly sessionsChecked: number;
+  readonly elapsedMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+const TERMINAL_STEP = 'done' as const;
+
+/**
+ * Compute drift between event-derived state and the `project.json`
+ * projection. See module docblock for contract.
+ */
+export function memoryProjectionDiff(
+  args: MemoryProjectionDiffArgs,
+): MemoryProjectionDiffResult {
+  const { store, memory, reduceFn } = args;
+  const now = args.now ?? Date.now;
+  const startMs = now();
+
+  // 1. Read every event row once. Group by sessionId.
+  const allRows = store.replayAll();
+  const rowsBySession = groupRowsBySession(allRows);
+
+  // 2. Build the union of session ids: project.json rows ∪ event sessionIds.
+  const memorySessionMap = new Map<string, ProjectJsonSession>();
+  if (memory !== null) {
+    for (const row of memory.sessions) {
+      memorySessionMap.set(row.sessionId, row);
+    }
+  }
+
+  const sessionIds = new Set<string>();
+  for (const sessionId of memorySessionMap.keys()) sessionIds.add(sessionId);
+  for (const sessionId of rowsBySession.keys()) sessionIds.add(sessionId);
+
+  // 3. Walk each session, applying the check matrix.
+  const divergences: MemoryDivergence[] = [];
+  for (const sessionId of sessionIds) {
+    const sessionRows = rowsBySession.get(sessionId) ?? [];
+    const memoryRow = memorySessionMap.get(sessionId) ?? null;
+    diffOneSession(sessionId, sessionRows, memoryRow, reduceFn, divergences);
+  }
+
+  const elapsedMs = Math.max(0, now() - startMs);
+
+  return {
+    divergences,
+    sessionsChecked: sessionIds.size,
+    elapsedMs,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-session diff
+// ---------------------------------------------------------------------------
+
+function diffOneSession(
+  sessionId: string,
+  rows: readonly EventRow[],
+  memoryRow: ProjectJsonSession | null,
+  reduceFn: ReduceFn,
+  out: MemoryDivergence[],
+): void {
+  // Edge: project.json carries this session but the store has no events.
+  // Info-level — legitimate post-init / pre-append window.
+  if (rows.length === 0 && memoryRow !== null) {
+    out.push({
+      sessionId,
+      field: 'events.empty',
+      fromEvents: null,
+      fromMemory: sessionId,
+      note: 'project.json row exists with no events',
+    });
+    return;
+  }
+
+  // Edge: no rows AND no memory row — should not happen because the
+  // sessionId would not be in the union. Defensive no-op.
+  if (rows.length === 0) return;
+
+  // Replay through the reducer. If the reducer throws on any event we
+  // surface a single `events.replay_threw` divergence and stop checking
+  // this session — downstream invariants depend on a coherent state.
+  const replay = safeReplay(sessionId, rows, reduceFn);
+  if (!replay.ok) {
+    out.push({
+      sessionId,
+      field: 'events.replay_threw',
+      fromEvents: null,
+      fromMemory: memoryRow !== null ? sessionId : null,
+      note: `reducer threw during replay: ${replay.error}`,
+    });
+    return;
+  }
+
+  const derivedStep = replay.currentStep;
+
+  // Find the workflow.finish row (if any) for `finishedAt` and
+  // `row-missing` checks.
+  const finishRow = rows.find((r) => r.type === 'workflow.finish') ?? null;
+  const startRow = rows.find((r) => r.type === 'workflow.start') ?? null;
+
+  // Check 1: terminal-step invariants.
+  if (derivedStep === TERMINAL_STEP) {
+    if (memoryRow === null) {
+      out.push({
+        sessionId,
+        field: 'row-missing',
+        fromEvents:
+          finishRow !== null
+            ? `workflow.finish at ${finishRow.ts}`
+            : 'currentStep=done',
+        fromMemory: null,
+      });
+      // Without a memory row there's nothing else to compare. Bail.
+      return;
+    }
+    if (memoryRow.finishedAt === null) {
+      out.push({
+        sessionId,
+        field: 'finishedAt',
+        fromEvents:
+          finishRow !== null
+            ? `workflow.finish at ${finishRow.ts}`
+            : 'currentStep=done',
+        fromMemory: null,
+      });
+    }
+  }
+
+  // Check 2: task-field drift. Only fires when BOTH sides carry a value.
+  // The wire-format `WorkflowStartData` does not include `task` today,
+  // so the comparison is silent for production sessions; the kind exists
+  // to surface hand-edits or memorization-writer bugs that stamp a
+  // mismatched task into the row.
+  if (memoryRow !== null && startRow !== null) {
+    const startTask = readStartTask(startRow);
+    if (startTask !== null && memoryRow.task !== startTask) {
+      out.push({
+        sessionId,
+        field: 'task',
+        fromEvents: startTask,
+        fromMemory: memoryRow.task,
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Group every row by its session id. Rows whose `session_id` column is
+ * `null` (legacy v4 rows or unpartitioned in-memory test stores) are
+ * tolerated by reading the event payload's `sessionId` field on the
+ * `workflow.start` event for the partition they belong to. When neither
+ * exists the row is dropped — there is no session to associate it with.
+ *
+ * Production stores always stamp `session_id` per
+ * `EventStore::computeIdempotencyKey`, so this fallback fires only in
+ * test fixtures using the in-memory store without explicit partition
+ * keys.
+ */
+function groupRowsBySession(
+  rows: readonly EventRow[],
+): ReadonlyMap<string, readonly EventRow[]> {
+  // First pass: prefer the row column.
+  const out = new Map<string, EventRow[]>();
+  const orphaned: EventRow[] = [];
+  for (const row of rows) {
+    const sid = row.session_id;
+    if (sid !== null && sid !== '') {
+      pushRow(out, sid, row);
+      continue;
+    }
+    orphaned.push(row);
+  }
+
+  // Second pass: when every row lacks `session_id`, attempt to recover
+  // a sessionId from a `workflow.start` payload in the orphan list.
+  if (orphaned.length > 0) {
+    const recovered = recoverSessionIdFromOrphans(orphaned);
+    if (recovered !== null) {
+      for (const row of orphaned) {
+        pushRow(out, recovered, row);
+      }
+    }
+    // If recovery fails, orphan rows are silently skipped — a session
+    // with no detectable id has nothing to compare against.
+  }
+
+  return out;
+}
+
+function pushRow(
+  acc: Map<string, EventRow[]>,
+  sessionId: string,
+  row: EventRow,
+): void {
+  const current = acc.get(sessionId);
+  if (current === undefined) {
+    acc.set(sessionId, [row]);
+  } else {
+    current.push(row);
+  }
+}
+
+function recoverSessionIdFromOrphans(
+  rows: readonly EventRow[],
+): string | null {
+  for (const row of rows) {
+    if (row.type !== 'workflow.start') continue;
+    try {
+      const parsed: unknown = JSON.parse(row.data);
+      if (parsed === null || typeof parsed !== 'object') continue;
+      const candidate = (parsed as { sessionId?: unknown }).sessionId;
+      if (typeof candidate === 'string' && candidate !== '') return candidate;
+    } catch {
+      // skip
+    }
+  }
+  return null;
+}
+
+interface ReplayOk {
+  readonly ok: true;
+  readonly currentStep: string;
+}
+interface ReplayErr {
+  readonly ok: false;
+  readonly error: string;
+}
+
+/**
+ * Replay rows through `reduceFn`, returning the final `currentStep`.
+ * Catches any throw and returns a structured error so the caller can
+ * surface a divergence instead of crashing the whole walk.
+ *
+ * Differs from `deriveState` in that we do NOT swallow reducer errors —
+ * the diff library wants to surface "the reducer threw" as a divergence
+ * row, while `deriveState` is a happy-path projection that skips bad
+ * events for resume robustness.
+ */
+function safeReplay(
+  sessionId: string,
+  rows: readonly EventRow[],
+  reduceFn: ReduceFn,
+): ReplayOk | ReplayErr {
+  try {
+    let state = initialState(sessionId);
+    for (const row of rows) {
+      const event = rowToEvent(row);
+      if (event === null) continue;
+      const result = reduceFn(state, event, row.ts);
+      if (result.ok) {
+        state = result.state;
+      }
+      // Reducer-rejected events do NOT become divergences — they are
+      // a routine outcome (engine writes `workflow.invalid_transition`
+      // audit and rolls the row back). Replay-threw is reserved for
+      // unhandled exceptions inside the reducer.
+    }
+    return { ok: true, currentStep: state.currentStep };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
+}
+
+/**
+ * Read the `task` field from a `workflow.start` row's data payload, if
+ * present. Returns `null` when absent or when the payload is not parseable
+ * — both are silent (no divergence emitted).
+ *
+ * The wire-format `WorkflowStartData` does not declare a `task` field
+ * today; this check only fires when a future emitter (or a fixture)
+ * adds one. The kind is wired now so PR-B's `gobbi memory check` can
+ * surface task-field hand-edits without another lib touch.
+ */
+function readStartTask(row: EventRow): string | null {
+  try {
+    const parsed: unknown = JSON.parse(row.data);
+    if (parsed === null || typeof parsed !== 'object') return null;
+    const candidate = (parsed as { task?: unknown }).task;
+    return typeof candidate === 'string' ? candidate : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/cli/src/lib/settings-validator.ts
+++ b/packages/cli/src/lib/settings-validator.ts
@@ -241,6 +241,26 @@ const settingsSchema: JSONSchemaType<Settings> = {
             maxIterations: { type: 'integer', nullable: true, minimum: 1 },
           },
         },
+        // PR-CFM-C T4: dormant gate for the `step.advancement.observed`
+        // PostToolUse emitter (#197). Default `false`; T5 wires the
+        // emitter to read this value via `resolveSettings()`. Schema
+        // mirrors `additionalProperties: false` discipline at every
+        // nest level — sibling memorization slot is the structural model.
+        observability: {
+          type: 'object',
+          nullable: true,
+          additionalProperties: false,
+          properties: {
+            advancement: {
+              type: 'object',
+              nullable: true,
+              additionalProperties: false,
+              properties: {
+                enabled: { type: 'boolean', nullable: true },
+              },
+            },
+          },
+        },
       },
     },
     notify: {

--- a/packages/cli/src/lib/settings.ts
+++ b/packages/cli/src/lib/settings.ts
@@ -176,6 +176,25 @@ export interface StepSettings {
 }
 
 /**
+ * Observability sub-tree for the workflow step lifecycle. Currently the
+ * only field is `advancement.enabled` — the dormant gate for the
+ * `step.advancement.observed` PostToolUse emitter (PR-CFM-C / #197).
+ *
+ * Default (`enabled: false`) keeps the emitter inert; flipping the flag
+ * to `true` activates the audit-only event path without touching the
+ * reducer. The emitter itself lives at
+ * `commands/workflow/capture-advancement.ts` and reads this gate via
+ * `resolveSettings()` at the dispatcher boundary.
+ */
+export interface WorkflowObservabilityAdvancement {
+  readonly enabled?: boolean;
+}
+
+export interface WorkflowObservability {
+  readonly advancement?: WorkflowObservabilityAdvancement;
+}
+
+/**
  * Per-step config keyed by the workflow loop's name. Settings field name
  * and state-machine literal both align on `'planning'`. Callers that pass
  * the legacy `'plan'` literal fail at compile time.
@@ -186,12 +205,15 @@ export interface StepSettings {
  * with a true orchestrator decision) the workflow init pipeline stamps
  * `memorization: true` onto the `EVAL_DECIDE` event payload and the
  * reducer lands the boolean in `state.evalConfig.memorization`.
+ *
+ * `observability` (PR-CFM-C T4) holds dormant audit-emitter gates.
  */
 export interface WorkflowSettings {
   readonly ideation?: StepSettings;
   readonly planning?: StepSettings;
   readonly execution?: StepSettings;
   readonly memorization?: StepSettings;
+  readonly observability?: WorkflowObservability;
 }
 
 /**
@@ -342,6 +364,7 @@ export const DEFAULTS: Settings = {
       evaluate: { mode: 'always', agent: { model: 'auto', effort: 'auto' } },
       maxIterations: 3,
     },
+    observability: { advancement: { enabled: false } },
   },
   notify: {
     slack: { enabled: false, events: [], triggers: [], channel: null },

--- a/plugins/gobbi/hooks/hooks.json
+++ b/plugins/gobbi/hooks/hooks.json
@@ -88,6 +88,16 @@
             "timeout": 30
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "gobbi hook post-tool-use",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PostToolUseFailure": [


### PR DESCRIPTION
## Summary

PR 2 of 5 in the multi-session "Finalize gobbi-config + gobbi-memory" campaign tracked by **#238**. Sequencing locked A → C → B → D → E.

This PR ships memory invariants & wiring:

- **#199** — Drop the misleading `stateDbPathFromStore` helper. Thread `stateDbPath: string` through `readLastPatch` and `readPatchSeqByContent` to match the dominant codebase pattern.
- **`memoryProjectionDiff()` library** — New pure function at `lib/memory-projection-diff.ts` for divergence detection between event-derived state and the `project.json` handoff projection. Single source of truth — PR-CFM-B's `gobbi memory check` will consume it.
- **#201** — New `gobbi maintenance verify-state-projections` command. Pure-core / argv-shell mirroring `migrate-state-db.ts:362`. Iterates all sessions reachable from `state.db ∪ project.json`, returns structured divergences, exits 0 (no divergence) / 1 (divergent or missing file) / 2 (parseArgs).
- **#197** — Wire `step.advancement.observed` **DORMANT**. New PostToolUse Bash matcher in `plugins/gobbi/hooks/hooks.json`, dispatcher branch in `commands/hook/post-tool-use.ts`, new emitter at `commands/workflow/capture-advancement.ts`. Gated on new setting `workflow.observability.advancement.enabled` (default `false`). The audit-only event bypasses the reducer per `events/step-advancement.ts:30-41` fence; idempotency `kind:'tool-call'` keyed on `tool_call_id`. **No Stop-hook consumer this PR** — that's a future out-of-cluster PR; the dormant period generates audit data the consumer-PR will use as test fixtures.

#122 (state-shape `schemaVersion` bump) is **NOT** in this PR — closed separately as won't-fix because PR-C does not change `WorkflowState` shape.

## Tail-risk caveat for the operator

First run of `gobbi maintenance verify-state-projections` on a workspace containing sessions that predate the JSON memory pivot may surface as `row-missing` divergences. **This is expected** — those sessions never had a `project.json` row written. The command's `--help` text repeats this caveat at the source.

## Commit shape (bisect-safe)

1. \`3be969c\` `fix(prompt): #199 thread stateDbPath through patch helpers` (+1 test)
2. \`989d99d\` `feat(lib): introduce memoryProjectionDiff library` (+8 tests)
3. \`e08e3d5\` `feat(maintenance): #201 add verify-state-projections command` (+11 tests)
4. \`6d881d0\` `feat(settings): add workflow.observability.advancement.enabled (dormant default)` (+1 test)
5. \`7731868\` `feat(hooks): #197 wire step.advancement.observed dormant emitter` (+13 tests)

Each commit independently passes \`bun run build:safe && bun test\`.

## Verification

- **Test count**: \`2151 pass / 0 fail / 9 skip / 8 todo, Ran 2168\` baseline → \`2185 pass / 0 fail / 9 skip / 8 todo, Ran 2202\` post (+34 pass; vs +31 target — T3 contributed +2 extra tests for fuller coverage of registry-and-help dispatch, T5 split the architectural-fence regression into a load-bearing static + runtime sub-test).
- **ALLOW_LIST in `jsonpivot-drift.test.ts`**: 41 → 41 (no change; no PR-touched file is in the allow-list, no entries pruned).
- **Manual smoke**: `gobbi maintenance --help | grep verify-state-projections`, `gobbi maintenance verify-state-projections --help` (USAGE includes pre-pivot caveat).

## Carry-forwards from 3-perspective Ideation eval (all applied)

- `resolveSettings({ repoRoot })` — sync, NOT async (Project F1 + Architecture F4)
- Pre-pivot caveat in command USAGE text, not just PR description (Project F2)
- Stop-hook consumer explicitly out-of-scope (Project F3)
- `import type { ReduceFn } from '../workflow/types.js'` — avoids type-graph cycle (Architecture F2)
- `AppendInput.step` row-level column set, not just inside `data` JSON (Architecture F3 — Medium-100 finding)
- Architectural fence comment at the `store.append()` call site (audit-only events bypass the reducer)

## Test plan

- [x] All 5 commits independently green at every commit (bisect-safe)
- [x] Final \`bun test\` passes 2185 / 0 fail
- [ ] Manual smoke: `gobbi maintenance verify-state-projections --json` against this repo's own session data — expect mostly clean (some pre-pivot rows may surface as `row-missing`)
- [ ] Manual smoke: flip `workflow.observability.advancement.enabled=true`, run `gobbi workflow transition` in a session, query events table for one new `step.advancement.observed` row
- [ ] CI green

Closes #199. Closes #201. Closes #197.
References #238 (campaign tracker — PR-CFM-C complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)