### PR TITLE
PR-CFM-D — Centralize project-name validation (#187 + #242)

### DIFF
--- a/.gobbi/projects/gobbi/design/v050-features/orchestration/scenarios.md
+++ b/.gobbi/projects/gobbi/design/v050-features/orchestration/scenarios.md
@@ -292,7 +292,7 @@ Evidence: `specs/handoff/spec.json`, `index.json` (handoff transitions added Wav
 **When** `gobbi maintenance migrate-state-db` runs
 **Then** events are migrated into a new workspace `.gobbi/state.db` at schema v6; partition keys (`session_id`, `project_id`) are preserved on every row; per-session `gobbi.db` files are renamed `.bak` (not deleted) for one-commit reversibility; `gobbi maintenance restore-state-db` reverses the operation; replay-equivalence integration test confirms identical state derivation pre- and post-migration.
 
-Evidence: `commands/maintenance/migrate-state-db.ts`, `commands/maintenance/restore-state-db.ts`, `commands/maintenance.ts:48-59` registry, replay-equivalence test in Wave A.1.10 integration tests.
+Evidence: `commands/maintenance/migrate-state-db.ts`, `commands/maintenance/restore-state-db.ts`, `commands/maintenance.ts:48-93` registry, replay-equivalence test in Wave A.1.10 integration tests.
 
 ---
 

--- a/.gobbi/projects/gobbi/gotchas/mkdtemp-suffix-fails-name-pattern.md
+++ b/.gobbi/projects/gobbi/gotchas/mkdtemp-suffix-fails-name-pattern.md
@@ -1,0 +1,34 @@
+---
+priority: high
+tech-stack: bun, typescript, node
+enforcement: blocking
+---
+
+### `mkdtempSync` random suffix breaks NAME_PATTERN-style validators
+
+**Priority:** High
+
+**What happened:** PR-CFM-D T2 inserted a B.0 guard in `commands/workflow/init.ts` that validates `projectFlag ?? basename(repoRoot)` against `NAME_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/`. The Plan's pre-flight item 8 asserted that the 4 `mkdtempSync` test-fixture prefixes (`gobbi-init-test-`, `gobbi-config-`, `gobbi-project-create-`, `gobbi-install-repo-`) were "all conformant — verified via grep at planning time." The check confirmed the *prefix* was lowercase + hyphenated, but missed that `mkdtempSync` appends a `[a-zA-Z0-9]{6}` random suffix that frequently includes UPPERCASE letters. Result: ~30+ test files using `mkdtempSync(join(tmpdir(), 'PREFIX-'))` produce basenames like `gobbi-init-test-AbCdEf` that fail NAME_PATTERN's lowercase-only character class. ~91 tests fail downstream because `runInit` (and any future `runInstall`/`runConfigInit` with B.0 guards) exits 2 before fixturing completes.
+
+**User feedback:** Surfaced during T2 verification when 91/2275 tests failed across 15 test files despite T2's diff being scoped to 2 files (init.ts + init.test.ts).
+
+**Correct approach:** When a validator restricts to lowercase-only character classes, every test fixture that constructs a directory whose basename will flow through the validator MUST use a deterministic-lowercase suffix. The clean replacement for `mkdtempSync(join(tmpdir(), 'PREFIX-'))`:
+
+```ts
+import { randomBytes } from 'node:crypto';
+import { mkdirSync } from 'node:fs';
+
+const dir = join(tmpdir(), `PREFIX-${randomBytes(4).toString('hex')}`);
+mkdirSync(dir, { recursive: true });
+```
+
+`randomBytes(N).toString('hex')` yields `[0-9a-f]+` — guaranteed validator-conformant. This fix is mechanical (single transformation per call site) but blast-radius is wide: all 30+ `mkdtempSync` sites that flow into `runInit` / `runInstall` / `runConfigInit` / `ensureSettingsCascade`.
+
+**Why:** `mkdtempSync` is documented as appending 6 random characters, but the character set isn't fixed in stone — `[a-zA-Z0-9]` is the practical default. Validators that restrict to `[a-z0-9]` cannot trust mkdtemp's basename. The B.0 single-guard architecture (validate-resolved-expression-once) is correct; the test fixtures are wrong.
+
+**Pre-flight check that catches this:** Before locking a Plan that adds a NAME_PATTERN-style guard at any entry point (workflow init, install, config init, project create), grep `src/**/*.test.ts` for `mkdtempSync(join(tmpdir(), '...'))` and verify EITHER:
+
+1. Every site is followed by a `--project <fixed-lowercase-name>` flag in the relevant `runInit`-style call, OR
+2. Every site is replaced with the deterministic-lowercase pattern above.
+
+The pre-flight grep on PREFIX alone is INSUFFICIENT — must also verify the random suffix shape interaction.

--- a/packages/cli/src/__tests__/e2e/migration-chain.test.ts
+++ b/packages/cli/src/__tests__/e2e/migration-chain.test.ts
@@ -28,10 +28,10 @@
 import { test, describe, expect } from 'bun:test';
 import { $ } from 'bun';
 import { Database } from 'bun:sqlite';
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { existsSync, rmSync } from 'node:fs';
 import { basename, join } from 'node:path';
 
+import { makeConformingTmpRepo } from '../helpers/conforming-tmpdir.js';
 import type { EventRow } from '../../workflow/migrations.js';
 import { sessionDir as sessionDirForProject } from '../../lib/workspace-paths.js';
 
@@ -94,7 +94,7 @@ describe('migration chain e2e', () => {
   test(
     'v1 events injected directly into gobbi.db migrate to CURRENT_SCHEMA_VERSION on next CLI read',
     async () => {
-      const tmpRoot = mkdtempSync(join(tmpdir(), 'gobbi-mig-e2e-'));
+      const tmpRoot = makeConformingTmpRepo('gobbi-mig-e2e');
       const sessionId = 'migrate-e2e';
       // Same env shape as workflow-cycle.test.ts — blank CLAUDE_SESSION_ID
       // so --session-id is authoritative; CLAUDE_TRANSCRIPT_PATH defensive.

--- a/packages/cli/src/__tests__/e2e/workflow-cycle.test.ts
+++ b/packages/cli/src/__tests__/e2e/workflow-cycle.test.ts
@@ -29,10 +29,10 @@
 
 import { test, expect } from 'bun:test';
 import { $ } from 'bun';
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { existsSync, rmSync } from 'node:fs';
 import { basename, join } from 'node:path';
 
+import { makeConformingTmpRepo } from '../helpers/conforming-tmpdir.js';
 import { sessionDir as sessionDirForProject } from '../../lib/workspace-paths.js';
 
 // ---------------------------------------------------------------------------
@@ -63,7 +63,7 @@ function parseStatus(buf: Buffer): Record<string, unknown> {
 test(
   'full workflow cycle: init -> ideation -> plan -> execution -> execution_eval -> memorization -> handoff -> done',
   async () => {
-    const tmpRoot = mkdtempSync(join(tmpdir(), 'gobbi-e2e-'));
+    const tmpRoot = makeConformingTmpRepo('gobbi-e2e');
     const sessionId = 'e2e-happy-path';
     // Shared environment for every child: keep the parent's PATH (so `bun`
     // is discoverable) but blank the session-id env so the --session-id

--- a/packages/cli/src/__tests__/features/gobbi-config.test.ts
+++ b/packages/cli/src/__tests__/features/gobbi-config.test.ts
@@ -42,16 +42,15 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, tes
 import {
   existsSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
 import { execSync } from 'node:child_process';
-import { tmpdir } from 'node:os';
 import { basename, dirname, join, resolve as resolvePath } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { makeConformingTmpRepo } from '../helpers/conforming-tmpdir.js';
 import {
   projectDir as projectDirForName,
   sessionDir as sessionDirForProject,
@@ -171,7 +170,7 @@ const ORIG_ENV_PROJECT_DIR = process.env['CLAUDE_PROJECT_DIR'];
 
 beforeAll(() => {
   origCwd = process.cwd();
-  scratchRepo = mkdtempSync(join(tmpdir(), 'gobbi-cfg-feat-'));
+  scratchRepo = makeConformingTmpRepo('gobbi-cfg-feat');
   execSync('git init -q', { cwd: scratchRepo });
   process.chdir(scratchRepo);
   // Point the mocked getRepoRoot at this file's scratch dir.

--- a/packages/cli/src/__tests__/features/gobbi-memory.test.ts
+++ b/packages/cli/src/__tests__/features/gobbi-memory.test.ts
@@ -62,14 +62,14 @@ import {
   existsSync,
   lstatSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
   readlinkSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
-import { tmpdir } from 'node:os';
 import { basename, join, resolve as pathResolve } from 'node:path';
+
+import { makeConformingTmpRepo } from '../helpers/conforming-tmpdir.js';
 
 import {
   __INTERNALS__ as INSTALL_INTERNALS,
@@ -205,7 +205,14 @@ afterEach(() => {
 });
 
 function makeScratch(prefix: string): string {
-  const dir = mkdtempSync(join(tmpdir(), prefix));
+  // The prefix is passed to {@link makeConformingTmpRepo} which appends
+  // a `-<hex8>` suffix. Strip a trailing `-` from the caller's prefix
+  // so we don't end up with `gobbi-memory-repo--abcd`. Lowercase-hex
+  // suffixes guarantee the resulting basename satisfies the validator
+  // in `lib/project-name.ts` for any caller that flows the directory
+  // through `runInit` (G-MEM2-MP-04).
+  const cleanPrefix = prefix.endsWith('-') ? prefix.slice(0, -1) : prefix;
+  const dir = makeConformingTmpRepo(cleanPrefix);
   scratchDirs.push(dir);
   return dir;
 }

--- a/packages/cli/src/__tests__/features/hook.test.ts
+++ b/packages/cli/src/__tests__/features/hook.test.ts
@@ -28,14 +28,13 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import {
   existsSync,
-  mkdtempSync,
   readFileSync,
   rmSync,
 } from 'node:fs';
 import { execSync } from 'node:child_process';
-import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 
+import { makeConformingTmpRepo } from '../helpers/conforming-tmpdir.js';
 import { sessionDir as sessionDirForProject } from '../../lib/workspace-paths.js';
 
 // ---------------------------------------------------------------------------
@@ -179,7 +178,7 @@ const ORIG_ENV: Readonly<Record<string, string | undefined>> = {
 
 beforeAll(() => {
   origCwd = process.cwd();
-  scratchRepo = mkdtempSync(join(tmpdir(), 'gobbi-hook-feat-'));
+  scratchRepo = makeConformingTmpRepo('gobbi-hook-feat');
   execSync('git init -q', { cwd: scratchRepo });
   process.chdir(scratchRepo);
   setGlobalScratch(scratchRepo);

--- a/packages/cli/src/__tests__/helpers/conforming-tmpdir.ts
+++ b/packages/cli/src/__tests__/helpers/conforming-tmpdir.ts
@@ -1,0 +1,63 @@
+/**
+ * `makeConformingTmpRepo(prefix)` — create a tmpdir whose basename is
+ * guaranteed to pass the `NAME_PATTERN` validator that
+ * `lib/project-name.ts` enforces (lowercase letters, digits, hyphens
+ * only). Use instead of
+ *
+ *     mkdtempSync(join(tmpdir(), '<prefix>-'))
+ *
+ * whenever the resulting directory will be passed as `repoRoot` to a
+ * command that calls `validateProjectName` or
+ * `assertValidProjectNameOrExit` (transitively or directly).
+ *
+ * # Why not `mkdtempSync`?
+ *
+ * `fs.mkdtempSync` appends a 6-character random suffix using
+ * `[a-zA-Z0-9]` per the Node platform implementation. The capital
+ * letters are routinely sampled and immediately fail the lowercase-only
+ * `NAME_PATTERN`. A test fixture that builds `repoRoot` via
+ * `mkdtempSync(join(tmpdir(), 'gobbi-init-test-'))` may yield
+ * `gobbi-init-test-AbCdEf` — which `runInit`'s B.0 guard rejects with
+ * exit 2, leading to flaky failures that depend on the random suffix.
+ *
+ * `randomBytes(N).toString('hex')` yields `[0-9a-f]+` — guaranteed
+ * validator-conformant.
+ *
+ * # When to use this helper
+ *
+ *   1. The fixture's directory is consumed as `repoRoot` (or the
+ *      `--project` arg) by `runInit` / `runInstall` / `runConfigInit`
+ *      OR by any command that, downstream, exercises a code path that
+ *      calls `validateProjectName` / `assertValidProjectNameOrExit`.
+ *   2. The fixture does NOT pass an explicit `--project <fixed>` flag
+ *      that would override the `basename(repoRoot)` fallback.
+ *
+ * # When NOT to use this helper
+ *
+ *   1. The fixture's directory is used for unrelated I/O (e.g. a
+ *      scratch dir for testing a writer that never sees the basename).
+ *      Plain `mkdtempSync` is fine.
+ *   2. The fixture always supplies `--project <conforming-name>` —
+ *      the basename is never read.
+ *
+ * Recorded gotcha:
+ * `.gobbi/projects/gobbi/gotchas/mkdtemp-suffix-fails-name-pattern.md`.
+ *
+ * @param prefix — the basename prefix (lowercase letters, digits, and
+ *   hyphens only — DO NOT include a trailing hyphen; the helper appends
+ *   `-<hex8>`). Verified at call time by the test it lives in.
+ * @returns the absolute path of the freshly-created directory. The
+ *   caller owns cleanup (mirrors the prior `mkdtempSync` contract).
+ */
+
+import { randomBytes } from 'node:crypto';
+import { mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export function makeConformingTmpRepo(prefix: string): string {
+  const suffix = randomBytes(4).toString('hex');
+  const dir = join(tmpdir(), `${prefix}-${suffix}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}

--- a/packages/cli/src/__tests__/integration/guard-emits-spawn.test.ts
+++ b/packages/cli/src/__tests__/integration/guard-emits-spawn.test.ts
@@ -41,6 +41,7 @@ import { basename, join } from 'node:path';
 import { runInitWithOptions } from '../../commands/workflow/init.js';
 import { runGuardWithOptions } from '../../commands/workflow/guard.js';
 import { runCaptureSubagentWithOptions } from '../../commands/workflow/capture-subagent.js';
+import { makeConformingTmpRepo } from '../helpers/conforming-tmpdir.js';
 import { sessionDir as sessionDirForProject } from '../../lib/workspace-paths.js';
 import { EventStore } from '../../workflow/store.js';
 import { resolveWorkflowState } from '../../workflow/engine.js';
@@ -131,7 +132,7 @@ afterEach(() => {
 });
 
 function makeScratchRepo(): string {
-  const dir = mkdtempSync(join(tmpdir(), 'gobbi-spawn-emit-'));
+  const dir = makeConformingTmpRepo('gobbi-spawn-emit');
   scratchDirs.push(dir);
   return dir;
 }

--- a/packages/cli/src/__tests__/integration/project-name-validation-invariant.test.ts
+++ b/packages/cli/src/__tests__/integration/project-name-validation-invariant.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Project-name validation invariant (PR-CFM-D / #187 part 5).
+ *
+ * Greps every `packages/cli/src/commands/**\/*.ts` (excluding `__tests__/`)
+ * for either:
+ *
+ *   1. A direct `path.join(<…>, '.gobbi', 'projects', <…>)` token sequence, OR
+ *   2. A call to a canonical project/session-path helper:
+ *      `projectDir(`, `projectSubdir(`, `projectSettingsPath(`,
+ *      `sessionSettingsPath(`, `sessionDirForProject(`, `projectJsonPath(`,
+ *      `sessionJsonPath(`.
+ *
+ * For every matching file, the test asserts the source `import`s
+ * `validateProjectName` OR `assertValidProjectNameOrExit` from
+ * `lib/project-name`. The intent is to keep future entry-point consumers
+ * from quietly skipping the validator that PR-CFM-D wired into install /
+ * workflow init / config init.
+ *
+ * Allow-list shape mirrors `__tests__/integration/jsonpivot-drift.test.ts`
+ * (auditable file-level entries with a `rationale` field). This list is
+ * INTENTIONALLY a SECOND list, distinct from `jsonpivot-drift.test.ts`'s
+ * 41-entry allow-list — the two detectors guard different invariants.
+ *
+ * F-OVR-1 annotation form (locked at planning time): every deferred-scope
+ * entry's rationale uses the literal phrase "follow-up filed at merge time
+ * per L12". No `#TBD`, no `TODO`, no issue numbers at commit time. The
+ * orchestrator may patch the issue # in a follow-up commit AFTER PR merge.
+ *
+ * Self-validating files NOT in the allow-list (intentional): `config.ts`,
+ * `commands/install.ts`, `commands/project/create.ts`,
+ * `commands/workflow/init.ts`. Each of these imports `validateProjectName`
+ * or `assertValidProjectNameOrExit` from `lib/project-name`, so the
+ * invariant assertion passes for them with no allow-list entry. Adding an
+ * allow-list entry for a file that already satisfies the invariant would
+ * be self-contradictory (mirrors the F-OVR-1 remediation that excluded
+ * `commands/project/create.ts`). Note: `config.ts` only validates in
+ * `runInit`; the deferred `runGet/runSet/runExplain/runList/runEnv`
+ * branches are tracked by the L12 follow-up filed at PR merge time.
+ *
+ * The grep is INTENTIONALLY token-level (no AST parse) — the invariant we
+ * care about is "file imports the validator", not "every individual
+ * call-site is gated". The file-level import is the auditable hinge.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Glob } from 'bun';
+
+const THIS_DIR = dirname(fileURLToPath(import.meta.url));
+
+// `__tests__/integration/project-name-validation-invariant.test.ts` ->
+// `packages/cli/`. Walk back: `integration` → `__tests__` → `src` → `cli`
+// (3 levels). Mirrors `jsonpivot-drift.test.ts`'s walk to REPO_ROOT but
+// stops at the package root because we only scan inside `src/commands/`.
+const CLI_PKG_ROOT = resolve(THIS_DIR, '..', '..', '..');
+
+// ---------------------------------------------------------------------------
+// Predicate: which files MUST validate?
+// ---------------------------------------------------------------------------
+
+/**
+ * A file matches the validation-required predicate if it contains either
+ * (a) a `path.join(...)` call whose argument list, in textual order,
+ * names `.gobbi` adjacent-followed-by `projects`, OR (b) a call to one
+ * of the canonical helpers below.
+ *
+ * The `path.join` regex tolerates whitespace + newlines between tokens
+ * (multi-line `path.join` calls are common). It does NOT match calls
+ * that wrap the literals in variables — that is a deliberate trade-off:
+ * the invariant we enforce is at the textual entry-point, where the
+ * raw `--project` payload is most likely to land.
+ */
+const PATH_JOIN_PATTERN =
+  /path\.join\s*\([^)]*['"]\.gobbi['"][^)]*['"]projects['"][^)]*\)/s;
+
+const HELPER_PATTERNS: readonly RegExp[] = [
+  /\bprojectDir\s*\(/,
+  /\bprojectSubdir\s*\(/,
+  /\bprojectSettingsPath\s*\(/,
+  /\bsessionSettingsPath\s*\(/,
+  /\bsessionDirForProject\s*\(/,
+  /\bprojectJsonPath\s*\(/,
+  /\bsessionJsonPath\s*\(/,
+];
+
+/**
+ * The required-import predicate. A file satisfies the invariant if it
+ * imports either `validateProjectName` OR `assertValidProjectNameOrExit`
+ * from a path ending in `lib/project-name` (with optional `.js`
+ * extension to match the verbatim ESM-style imports the codebase uses).
+ */
+const VALIDATOR_IMPORT_PATTERN =
+  /import\s*\{[^}]*\b(?:validateProjectName|assertValidProjectNameOrExit)\b[^}]*\}\s*from\s*['"][^'"]*lib\/project-name(?:\.js)?['"]/s;
+
+// ---------------------------------------------------------------------------
+// Allow-list — file-level, F-OVR-1 form
+// ---------------------------------------------------------------------------
+
+interface AllowListEntry {
+  readonly path: string;
+  readonly isGlob?: boolean;
+  readonly rationale: string;
+}
+
+const ALLOW_LIST: readonly AllowListEntry[] = [
+  {
+    path: 'src/commands/maintenance/*.ts',
+    isGlob: true,
+    rationale:
+      'allow-listed: deferred (maintenance scope, follow-up filed at merge time per L12)',
+  },
+  {
+    path: 'src/commands/memory/*.ts',
+    isGlob: true,
+    rationale:
+      'allow-listed: deferred (memory scope, follow-up filed at merge time per L12)',
+  },
+  {
+    path: 'src/commands/gotcha/*.ts',
+    isGlob: true,
+    rationale:
+      'allow-listed: deferred (gotcha scope, follow-up filed at merge time per L12)',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function toForwardSlash(p: string): string {
+  return sep === '/' ? p : p.split(sep).join('/');
+}
+
+function fileMatchesPredicate(content: string): boolean {
+  if (PATH_JOIN_PATTERN.test(content)) return true;
+  for (const helper of HELPER_PATTERNS) {
+    if (helper.test(content)) return true;
+  }
+  return false;
+}
+
+function fileHasValidatorImport(content: string): boolean {
+  return VALIDATOR_IMPORT_PATTERN.test(content);
+}
+
+function isAllowListed(relPath: string): AllowListEntry | undefined {
+  const fwd = toForwardSlash(relPath);
+  for (const entry of ALLOW_LIST) {
+    if (entry.isGlob === true) {
+      const glob = new Glob(entry.path);
+      if (glob.match(fwd)) return entry;
+    } else if (entry.path === fwd) {
+      return entry;
+    }
+  }
+  return undefined;
+}
+
+function scanCommandsTree(): readonly string[] {
+  // Forward-slash path relative to `packages/cli/`. `Bun.Glob` matches
+  // forward-slash regardless of platform sep.
+  const out: string[] = [];
+  const glob = new Glob('src/commands/**/*.ts');
+  for (const match of glob.scanSync({ cwd: CLI_PKG_ROOT, onlyFiles: true })) {
+    const rel = toForwardSlash(match);
+    if (rel.includes('__tests__/')) continue;
+    out.push(rel);
+  }
+  return out.sort();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Project-name validation invariant (PR-CFM-D / #187)', () => {
+  test('every commands/** file that opens .gobbi/projects/ imports the validator', () => {
+    const violations: string[] = [];
+    for (const relPath of scanCommandsTree()) {
+      const content = readFileSync(join(CLI_PKG_ROOT, relPath), 'utf8');
+      if (!fileMatchesPredicate(content)) continue;
+      if (isAllowListed(relPath) !== undefined) continue;
+      if (fileHasValidatorImport(content)) continue;
+      violations.push(relPath);
+    }
+    if (violations.length > 0) {
+      const message = [
+        `Found ${violations.length} commands/** file(s) that touch \`.gobbi/projects/\``,
+        `(directly via path.join or via a canonical helper) but do NOT import`,
+        `\`validateProjectName\` or \`assertValidProjectNameOrExit\` from`,
+        `\`lib/project-name\`:`,
+        '',
+        ...violations.map((v) => `  - ${v}`),
+        '',
+        `Either (a) wire \`assertValidProjectNameOrExit(<name>, '<command-label>')\``,
+        `into the entry point, OR (b) add a file-level allow-list entry to this`,
+        `test with the F-OVR-1 rationale form:`,
+        `  // allow-listed: deferred (<scope>, follow-up filed at merge time per L12)`,
+      ].join('\n');
+      expect.unreachable(message);
+    }
+  });
+
+  test('every allow-list entry resolves to at least one on-disk file (no stale paths)', () => {
+    const stale: string[] = [];
+    const treeFwd = scanCommandsTree();
+    for (const entry of ALLOW_LIST) {
+      if (entry.isGlob === true) {
+        const glob = new Glob(entry.path);
+        let matched = false;
+        for (const rel of treeFwd) {
+          if (glob.match(rel)) {
+            matched = true;
+            break;
+          }
+        }
+        if (!matched) stale.push(entry.path);
+      } else if (!existsSync(join(CLI_PKG_ROOT, entry.path))) {
+        stale.push(entry.path);
+      }
+    }
+    if (stale.length > 0) {
+      expect.unreachable(
+        [
+          `Found ${stale.length} stale allow-list entr(y/ies) — the path(s)`,
+          `match no file under \`packages/cli/src/commands/\`:`,
+          ...stale.map((p) => `  - ${p}`),
+          '',
+          `Remove the entry, or update the path to match the live tree.`,
+        ].join('\n'),
+      );
+    }
+  });
+});

--- a/packages/cli/src/commands/__tests__/config.test.ts
+++ b/packages/cli/src/commands/__tests__/config.test.ts
@@ -26,9 +26,11 @@
  * (`__tests__/features/gobbi-config.test.ts`).
  */
 
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { randomBytes } from 'node:crypto';
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -36,6 +38,55 @@ import {
 import { execSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+
+// PR-CFM-D / #187 — Override `getRepoRoot` BEFORE importing anything that
+// captures it. The module-level memoization in `lib/repo.ts` caches the
+// first git rev-parse result for the entire `bun test` process, so without
+// this mock the basename-fallback regression test (below) cannot point
+// `runInit` at an INVALID basename. The `globalThis`-scoped pointer
+// pattern mirrors `__tests__/features/gobbi-config.test.ts`. When the
+// pointer is null, the mock falls through to real git rev-parse so all
+// existing tests in this file (which chdir to `scratchRepo` in beforeAll)
+// see the same behaviour as the un-mocked module.
+interface ScratchState {
+  readonly root: string | null;
+}
+const GLOBAL_KEY = '__gobbiConfigUnitScratchRoot__';
+function setGlobalScratch(root: string | null): void {
+  (globalThis as unknown as Record<string, ScratchState>)[GLOBAL_KEY] = { root };
+}
+function getGlobalScratch(): string | null {
+  const entry = (globalThis as unknown as Record<string, ScratchState | undefined>)[GLOBAL_KEY];
+  return entry?.root ?? null;
+}
+mock.module('../../lib/repo.js', () => ({
+  getRepoRoot: (): string => {
+    const override = getGlobalScratch();
+    if (override !== null) return override;
+    try {
+      return execSync('git rev-parse --show-toplevel', {
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim();
+    } catch {
+      return process.cwd();
+    }
+  },
+  getClaudeDir: (): string => {
+    const override = getGlobalScratch();
+    const root = override ?? (() => {
+      try {
+        return execSync('git rev-parse --show-toplevel', {
+          encoding: 'utf8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+        }).trim();
+      } catch {
+        return process.cwd();
+      }
+    })();
+    return join(root, '.claude');
+  },
+}));
 
 import { COMMAND_ORDER, COMMANDS_BY_NAME } from '../../cli.js';
 import { coerceValue, runConfig } from '../config.js';
@@ -584,5 +635,79 @@ describe('runConfig set argument validation', () => {
     };
     expect(parsed.notify.slack.enabled).toBe(true);
     expect(parsed.notify.slack.channel).toBeNull();
+  });
+});
+
+// ===========================================================================
+// PR-CFM-D / #187 — runInit rejects invalid --project values + invalid
+// basename(repoRoot) fallbacks before any FS write.
+// ===========================================================================
+
+describe('runConfig init — rejects invalid --project values', () => {
+  test.each(['../tmp', '../../escape', '..', 'foo/bar', 'foo\\bar'])(
+    'rejects --project=%j with exit 2 + L13 stderr template + no settings.json write',
+    async (payload) => {
+      const repo = makeScratchRepo();
+      await captureExit(async () => {
+        await runConfig([
+          'init',
+          '--level',
+          'project',
+          '--project',
+          payload,
+        ]);
+      });
+      expect(captured.exitCode).toBe(2);
+      expect(captured.stderr).toMatch(
+        /^gobbi config init: invalid --project name '/,
+      );
+      // The raw payload renders verbatim inside the single-quoted slot.
+      expect(captured.stderr).toContain(`'${payload}'`);
+      // FS-no-write assertion: the would-be settings.json resolved from
+      // join(repoRoot, '.gobbi', 'projects', payload, 'settings.json')
+      // must NOT exist — path.join collapses '..' segments, so this
+      // confirms the validation guard short-circuits BEFORE
+      // projectSettingsPath / writeSettingsAtLevel run.
+      expect(
+        existsSync(join(repo, '.gobbi', 'projects', payload, 'settings.json')),
+      ).toBe(false);
+    },
+  );
+
+  test('rejects invalid basename(repoRoot) fallback when no --project flag', async () => {
+    // Deterministic-invalid basename: capital `I` fails NAME_PATTERN's
+    // lowercase-only character class, hex suffix avoids any platform
+    // path-separator / space pitfalls (RP1). NOTE: do NOT use
+    // `makeConformingTmpRepo` here — its purpose is the OPPOSITE
+    // (produce a basename that PASSES the validator). This fixture
+    // exercises L7 (basename fallback) by deliberately constructing an
+    // INVALID basename, then redirecting `getRepoRoot()` to it via the
+    // file-level `mock.module` pointer.
+    const invalidDir = join(
+      tmpdir(),
+      `Invalid-${randomBytes(4).toString('hex')}`,
+    );
+    mkdirSync(invalidDir, { recursive: true });
+    setGlobalScratch(invalidDir);
+    try {
+      await captureExit(async () => {
+        await runConfig(['init', '--level', 'project']);
+      });
+      expect(captured.exitCode).toBe(2);
+      expect(captured.stderr).toMatch(
+        /^gobbi config init: invalid --project name '/,
+      );
+      // The basename-derived value (the mixed-case dir name) must appear
+      // in the single-quoted slot — proves the guard validated the
+      // FALLBACK, not a literal flag value.
+      expect(captured.stderr).toContain(`'${basename(invalidDir)}'`);
+    } finally {
+      setGlobalScratch(null);
+      try {
+        rmSync(invalidDir, { recursive: true, force: true });
+      } catch {
+        // best-effort cleanup; tmpdir reaper handles residue
+      }
+    }
   });
 });

--- a/packages/cli/src/commands/__tests__/install.test.ts
+++ b/packages/cli/src/commands/__tests__/install.test.ts
@@ -857,3 +857,30 @@ describe('renderPlan', () => {
     expect(out).toContain('1 collision(s)');
   });
 });
+
+// ===========================================================================
+// PR-CFM-D / #187 — --project name validation guard
+// ===========================================================================
+
+describe('runInstall — rejects invalid --project values', () => {
+  test.each(['../tmp', '../../escape', '..', 'foo/bar', 'foo\\bar'])(
+    'rejects --project=%j with exit 2 + L13 stderr template + no FS write',
+    async (payload) => {
+      const repo = makeRepo();
+      await captureExit(() =>
+        runInstallWithOptions(['--project', payload], { repoRoot: repo }),
+      );
+      expect(captured.exitCode).toBe(2);
+      expect(captured.stderr).toMatch(
+        /^gobbi install: invalid --project name '/,
+      );
+      // The raw payload renders verbatim inside the single-quoted slot.
+      expect(captured.stderr).toContain(`'${payload}'`);
+      // FS-no-write assertion: the would-be project root resolved from
+      // join(repoRoot, '.gobbi', 'projects', payload) must NOT exist —
+      // path.join collapses '..' segments, so the assertion confirms
+      // the validation guard short-circuits BEFORE any directory create.
+      expect(existsSync(join(repo, '.gobbi', 'projects', payload))).toBe(false);
+    },
+  );
+});

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -56,6 +56,7 @@ import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
 
 import { isRecord, isString } from '../lib/guards.js';
+import { assertValidProjectNameOrExit } from '../lib/project-name.js';
 import { readStdinJson } from '../lib/stdin.js';
 import { getRepoRoot } from '../lib/repo.js';
 import {
@@ -611,6 +612,12 @@ async function runInit(args: string[]): Promise<void> {
 
   const repoRoot = getRepoRoot();
   const projectName = projectFlag ?? basename(repoRoot);
+
+  // PR-CFM-D / #187 — guard before projectSettingsPath / sessionSettingsPath
+  // path-joins below. Validates the resolved name (covers both --project
+  // flag and basename(repoRoot) fallback per L7) so traversal payloads
+  // exit 2 with the L13 stderr template before any FS write.
+  assertValidProjectNameOrExit(projectName, 'gobbi config init');
 
   // Compute the on-disk path BEFORE writing so the refuse-without-force
   // gate can inspect the existing file and the WARN line / error message

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -83,6 +83,7 @@ import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
 
 import { isString } from '../lib/guards.js';
+import { assertValidProjectNameOrExit } from '../lib/project-name.js';
 import { getRepoRoot } from '../lib/repo.js';
 import {
   loadSettingsAtLevel,
@@ -207,6 +208,12 @@ export async function runInstallWithOptions(
     process.stderr.write(`${USAGE}\n`);
     process.exit(2);
   }
+
+  // PR-CFM-D / #187 — guard before .gobbi/projects/<projectName>
+  // path-join at line 228. Validates the resolved name (default 'gobbi'
+  // or --project flag override) so traversal payloads exit 2 with the
+  // L13 stderr template before any FS write.
+  assertValidProjectNameOrExit(projectName, 'gobbi install');
 
   // --- 2. Resolve repo + template roots ---------------------------------
   const repoRoot = overrides.repoRoot ?? getRepoRoot();

--- a/packages/cli/src/commands/project/__tests__/create.test.ts
+++ b/packages/cli/src/commands/project/__tests__/create.test.ts
@@ -33,7 +33,6 @@ import {
   runProjectCreateWithOptions,
   SCAFFOLD_DIRS,
   SCAFFOLD_GITIGNORED_DIRS,
-  validateProjectName,
 } from '../create.js';
 
 // ---------------------------------------------------------------------------
@@ -129,51 +128,6 @@ function readWorkspaceSettings(repo: string): unknown {
   const raw = readFileSync(join(repo, '.gobbi', 'settings.json'), 'utf8');
   return JSON.parse(raw);
 }
-
-// ===========================================================================
-// Name validation (pure function)
-// ===========================================================================
-
-describe('validateProjectName', () => {
-  test('accepts lowercase letters', () => {
-    expect(validateProjectName('gobbi').ok).toBe(true);
-  });
-  test('accepts letters + digits + hyphens', () => {
-    expect(validateProjectName('my-project-2').ok).toBe(true);
-  });
-  test('accepts single-character names', () => {
-    expect(validateProjectName('a').ok).toBe(true);
-  });
-  test('rejects empty string', () => {
-    expect(validateProjectName('').ok).toBe(false);
-  });
-  test('rejects uppercase', () => {
-    expect(validateProjectName('Foo').ok).toBe(false);
-  });
-  test('rejects underscores', () => {
-    expect(validateProjectName('foo_bar').ok).toBe(false);
-  });
-  test('rejects dots', () => {
-    expect(validateProjectName('foo.bar').ok).toBe(false);
-  });
-  test('rejects path separators', () => {
-    expect(validateProjectName('foo/bar').ok).toBe(false);
-    expect(validateProjectName('foo\\bar').ok).toBe(false);
-  });
-  test('rejects leading hyphen', () => {
-    expect(validateProjectName('-foo').ok).toBe(false);
-  });
-  test('rejects trailing hyphen', () => {
-    expect(validateProjectName('foo-').ok).toBe(false);
-  });
-  test('rejects reserved . and ..', () => {
-    expect(validateProjectName('.').ok).toBe(false);
-    expect(validateProjectName('..').ok).toBe(false);
-  });
-  test('rejects whitespace-only', () => {
-    expect(validateProjectName(' ').ok).toBe(false);
-  });
-});
 
 // ===========================================================================
 // runProjectCreate — happy path

--- a/packages/cli/src/commands/project/create.ts
+++ b/packages/cli/src/commands/project/create.ts
@@ -89,6 +89,7 @@
 import { existsSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs';
 import { parseArgs } from 'node:util';
 
+import { validateProjectName } from '../../lib/project-name.js';
 import { getRepoRoot } from '../../lib/repo.js';
 import { projectDir, projectSubdir } from '../../lib/workspace-paths.js';
 
@@ -192,52 +193,6 @@ const SCAFFOLD_GITIGNORED_DIRS: ReadonlySet<string> = new Set([
   'tmp',
   'worktrees',
 ]);
-
-// ---------------------------------------------------------------------------
-// Name validation
-// ---------------------------------------------------------------------------
-
-/**
- * Lowercase letters, digits, and hyphens only. The body-start and
- * body-end characters exclude hyphens so names like `-foo` or `foo-`
- * are rejected upstream of any directory create. One-character names
- * pass (e.g. `a`).
- */
-const NAME_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
-
-/**
- * Reserved filesystem names that must never be accepted as a project
- * name even though they pass the {@link NAME_PATTERN}. Kept small —
- * the pattern already excludes `/`, `\`, `.`, `_`, and whitespace, so
- * only the two dot-only sentinels make it this far (but the pattern
- * also excludes `.` entirely via its character class; this array is a
- * defense-in-depth belt against future pattern loosening).
- */
-const RESERVED_NAMES: ReadonlySet<string> = new Set(['', '.', '..']);
-
-export type NameValidationResult =
-  | { readonly ok: true }
-  | { readonly ok: false; readonly reason: string };
-
-/**
- * Validate a candidate project name against the rules documented on
- * the command-level JSDoc. Pure function — no I/O, no existence check
- * (that belongs to the caller, who already has the `repoRoot`).
- */
-export function validateProjectName(name: string): NameValidationResult {
-  if (RESERVED_NAMES.has(name)) {
-    return { ok: false, reason: `name cannot be "${name}"` };
-  }
-  if (!NAME_PATTERN.test(name)) {
-    return {
-      ok: false,
-      reason:
-        'name must be lowercase letters, digits, and hyphens only ' +
-        '(no leading/trailing hyphen, no path separators)',
-    };
-  }
-  return { ok: true };
-}
 
 // ---------------------------------------------------------------------------
 // Public entry points

--- a/packages/cli/src/commands/workflow/__tests__/capture-advancement.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/capture-advancement.test.ts
@@ -28,11 +28,11 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
 import { basename, join } from 'node:path';
 
 import { runInitWithOptions } from '../init.js';
+import { makeConformingTmpRepo } from '../../../__tests__/helpers/conforming-tmpdir.js';
 import { runCaptureAdvancementWithOptions } from '../capture-advancement.js';
 import { sessionDir as sessionDirForProject } from '../../../lib/workspace-paths.js';
 import {
@@ -120,7 +120,7 @@ afterEach(() => {
 });
 
 function makeScratchRepo(): string {
-  const dir = mkdtempSync(join(tmpdir(), 'gobbi-capture-advancement-'));
+  const dir = makeConformingTmpRepo('gobbi-capture-advancement');
   scratchDirs.push(dir);
   return dir;
 }

--- a/packages/cli/src/commands/workflow/__tests__/capture-planning.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/capture-planning.test.ts
@@ -15,14 +15,13 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import {
   existsSync,
-  mkdtempSync,
   readFileSync,
   rmSync,
 } from 'node:fs';
-import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 
 import { runInitWithOptions } from '../init.js';
+import { makeConformingTmpRepo } from '../../../__tests__/helpers/conforming-tmpdir.js';
 import { runCapturePlanningWithOptions } from '../capture-planning.js';
 import { sessionDir as sessionDirForProject } from '../../../lib/workspace-paths.js';
 import { WORKFLOW_COMMANDS } from '../../workflow.js';
@@ -106,7 +105,7 @@ afterEach(() => {
 });
 
 function makeScratchRepo(): string {
-  const dir = mkdtempSync(join(tmpdir(), 'gobbi-capture-planning-'));
+  const dir = makeConformingTmpRepo('gobbi-capture-planning');
   scratchDirs.push(dir);
   return dir;
 }

--- a/packages/cli/src/commands/workflow/__tests__/capture-subagent.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/capture-subagent.test.ts
@@ -33,6 +33,7 @@ import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 
 import { runInitWithOptions } from '../init.js';
+import { makeConformingTmpRepo } from '../../../__tests__/helpers/conforming-tmpdir.js';
 import { runCaptureSubagentWithOptions } from '../capture-subagent.js';
 import { sessionDir as sessionDirForProject } from '../../../lib/workspace-paths.js';
 import { WORKFLOW_COMMANDS } from '../../workflow.js';
@@ -122,7 +123,7 @@ afterEach(() => {
 });
 
 function makeScratchRepo(): string {
-  const dir = mkdtempSync(join(tmpdir(), 'gobbi-capture-sub-'));
+  const dir = makeConformingTmpRepo('gobbi-capture-sub');
   scratchDirs.push(dir);
   return dir;
 }

--- a/packages/cli/src/commands/workflow/__tests__/guard.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/guard.test.ts
@@ -24,9 +24,9 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { existsSync, rmSync } from 'node:fs';
 import { basename, join } from 'node:path';
+import { makeConformingTmpRepo } from '../../../__tests__/helpers/conforming-tmpdir.js';
 import { sessionDir as sessionDirForProject } from '../../../lib/workspace-paths.js';
 
 import { runInitWithOptions } from '../init.js';
@@ -121,7 +121,7 @@ afterEach(() => {
 });
 
 function makeScratchRepo(): string {
-  const dir = mkdtempSync(join(tmpdir(), 'gobbi-guard-test-'));
+  const dir = makeConformingTmpRepo('gobbi-guard-test');
   scratchDirs.push(dir);
   return dir;
 }

--- a/packages/cli/src/commands/workflow/__tests__/init.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/init.test.ts
@@ -24,7 +24,9 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { randomBytes } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 
 import { EventStore } from '../../../workflow/store.js';
@@ -604,5 +606,62 @@ describe('runInit — project_id stamping (#178)', () => {
     } finally {
       store.close();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR-CFM-D / #187 — B.0 single-guard rejects invalid `--project` values and
+// invalid basename(repoRoot) fallbacks before any FS write.
+// ---------------------------------------------------------------------------
+
+describe('runInit — rejects invalid --project values', () => {
+  test.each(['../tmp', '../../escape', '..', 'foo/bar', 'foo\\bar'])(
+    'rejects --project=%j with exit 2 + L13 stderr template',
+    async (payload) => {
+      const repo = makeScratchRepo();
+      await captureExit(() =>
+        runInitWithOptions(
+          ['--session-id', 'invalid-flag', '--project', payload],
+          { repoRoot: repo },
+        ),
+      );
+      expect(captured.exitCode).toBe(2);
+      expect(captured.stderr).toMatch(
+        /^gobbi workflow init: invalid --project name '/,
+      );
+      // The raw payload renders verbatim inside the single-quoted slot.
+      expect(captured.stderr).toContain(`'${payload}'`);
+    },
+  );
+
+  test('rejects invalid basename(repoRoot) fallback when no --project flag', async () => {
+    // Deterministic-invalid basename: capital `I` fails NAME_PATTERN's
+    // lowercase-only character class, hex suffix avoids any platform
+    // path-separator / space pitfalls. NOTE: do NOT use
+    // `makeConformingTmpRepo` here — its purpose is the OPPOSITE
+    // (produce a basename that PASSES the validator). This fixture
+    // exercises L7 (basename fallback) by deliberately constructing an
+    // INVALID basename.
+    const invalidDir = join(
+      tmpdir(),
+      `Invalid-${randomBytes(4).toString('hex')}`,
+    );
+    mkdirSync(invalidDir, { recursive: true });
+    scratchDirs.push(invalidDir);
+
+    await captureExit(() =>
+      runInitWithOptions(
+        ['--session-id', 'invalid-basename'],
+        { repoRoot: invalidDir },
+      ),
+    );
+    expect(captured.exitCode).toBe(2);
+    expect(captured.stderr).toMatch(
+      /^gobbi workflow init: invalid --project name '/,
+    );
+    // The basename-derived value (the mixed-case dir name) must appear in
+    // the single-quoted slot — proves the guard validated the FALLBACK,
+    // not a literal flag value.
+    expect(captured.stderr).toContain(`'${basename(invalidDir)}'`);
   });
 });

--- a/packages/cli/src/commands/workflow/__tests__/init.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/init.test.ts
@@ -24,14 +24,14 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 
 import { EventStore } from '../../../workflow/store.js';
 import { runInitWithOptions, resolveSessionId } from '../init.js';
 import { readSessionJson, sessionJsonPath } from '../../../lib/json-memory.js';
 import { sessionDir as sessionDirForProject } from '../../../lib/workspace-paths.js';
+import { makeConformingTmpRepo } from '../../../__tests__/helpers/conforming-tmpdir.js';
 
 // ---------------------------------------------------------------------------
 // stdout/stderr capture + process.exit trap
@@ -93,7 +93,7 @@ const scratchDirs: string[] = [];
 let origSessionIdEnv: string | undefined;
 
 function makeScratchRepo(): string {
-  const dir = mkdtempSync(join(tmpdir(), 'gobbi-init-test-'));
+  const dir = makeConformingTmpRepo('gobbi-init-test');
   scratchDirs.push(dir);
   return dir;
 }
@@ -572,7 +572,7 @@ describe('runInit — project_id stamping (#178)', () => {
     // The hard regression case from issue #178: a repo named gobbi-repo
     // initialised under --project=foo must stamp project_id='foo', NOT
     // 'gobbi-repo' (basename(repoRoot)).
-    const repo = mkdtempSync(join(tmpdir(), 'gobbi-repo-'));
+    const repo = makeConformingTmpRepo('gobbi-repo');
     scratchDirs.push(repo);
     expect(basename(repo).startsWith('gobbi-repo-')).toBe(true);
 

--- a/packages/cli/src/commands/workflow/__tests__/next.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/next.test.ts
@@ -16,11 +16,11 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdtempSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { rmSync } from 'node:fs';
 import { basename, join } from 'node:path';
 
 import { runInitWithOptions } from '../init.js';
+import { makeConformingTmpRepo } from '../../../__tests__/helpers/conforming-tmpdir.js';
 import { sessionDir as sessionDirForProject } from '../../../lib/workspace-paths.js';
 import {
   compileCurrentStep,
@@ -118,7 +118,7 @@ afterEach(() => {
 });
 
 function makeScratchRepo(): string {
-  const dir = mkdtempSync(join(tmpdir(), 'gobbi-next-test-'));
+  const dir = makeConformingTmpRepo('gobbi-next-test');
   scratchDirs.push(dir);
   return dir;
 }

--- a/packages/cli/src/commands/workflow/__tests__/resume.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/resume.test.ts
@@ -20,11 +20,11 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdtempSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { rmSync } from 'node:fs';
 import { basename, join } from 'node:path';
 
 import { runInitWithOptions } from '../init.js';
+import { makeConformingTmpRepo } from '../../../__tests__/helpers/conforming-tmpdir.js';
 import { runResumeWithOptions } from '../resume.js';
 import { WORKFLOW_COMMANDS } from '../../workflow.js';
 import { sessionDir as sessionDirForProject } from '../../../lib/workspace-paths.js';
@@ -118,7 +118,7 @@ afterEach(() => {
 });
 
 function makeScratchRepo(): string {
-  const dir = mkdtempSync(join(tmpdir(), 'gobbi-resume-test-'));
+  const dir = makeConformingTmpRepo('gobbi-resume-test');
   scratchDirs.push(dir);
   return dir;
 }

--- a/packages/cli/src/commands/workflow/__tests__/status.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/status.test.ts
@@ -13,11 +13,11 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdtempSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { rmSync } from 'node:fs';
 import { basename, join } from 'node:path';
 
 import { runInitWithOptions } from '../init.js';
+import { makeConformingTmpRepo } from '../../../__tests__/helpers/conforming-tmpdir.js';
 import { sessionDir as sessionDirForProject } from '../../../lib/workspace-paths.js';
 import {
   aggregateCost,
@@ -104,7 +104,7 @@ afterEach(() => {
 });
 
 function makeScratchRepo(): string {
-  const dir = mkdtempSync(join(tmpdir(), 'gobbi-status-test-'));
+  const dir = makeConformingTmpRepo('gobbi-status-test');
   scratchDirs.push(dir);
   return dir;
 }

--- a/packages/cli/src/commands/workflow/__tests__/stop.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/stop.test.ts
@@ -26,6 +26,7 @@ import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 
 import { runInitWithOptions } from '../init.js';
+import { makeConformingTmpRepo } from '../../../__tests__/helpers/conforming-tmpdir.js';
 import { runStopWithOptions, DEFAULT_SPECS_DIR } from '../stop.js';
 import { WORKFLOW_COMMANDS } from '../../workflow.js';
 import { sessionDir as sessionDirForProject } from '../../../lib/workspace-paths.js';
@@ -118,7 +119,7 @@ afterEach(() => {
 });
 
 function makeScratchRepo(): string {
-  const dir = mkdtempSync(join(tmpdir(), 'gobbi-stop-'));
+  const dir = makeConformingTmpRepo('gobbi-stop');
   scratchDirs.push(dir);
   return dir;
 }

--- a/packages/cli/src/commands/workflow/__tests__/transition.test.ts
+++ b/packages/cli/src/commands/workflow/__tests__/transition.test.ts
@@ -20,11 +20,11 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdtempSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { rmSync } from 'node:fs';
 import { basename, join } from 'node:path';
 
 import { runInitWithOptions } from '../init.js';
+import { makeConformingTmpRepo } from '../../../__tests__/helpers/conforming-tmpdir.js';
 import { sessionDir as sessionDirForProject } from '../../../lib/workspace-paths.js';
 import {
   buildEvent,
@@ -115,7 +115,7 @@ afterEach(() => {
 });
 
 function makeScratchRepo(): string {
-  const dir = mkdtempSync(join(tmpdir(), 'gobbi-transition-test-'));
+  const dir = makeConformingTmpRepo('gobbi-transition-test');
   scratchDirs.push(dir);
   return dir;
 }

--- a/packages/cli/src/commands/workflow/init.ts
+++ b/packages/cli/src/commands/workflow/init.ts
@@ -70,6 +70,7 @@ import {
   sessionJsonPath,
   writeSessionStub,
 } from '../../lib/json-memory.js';
+import { assertValidProjectNameOrExit } from '../../lib/project-name.js';
 import { readInstalledVersion } from '../../lib/version-check.js';
 import { ConfigCascadeError } from '../../lib/settings.js';
 import { EventStore } from '../../workflow/store.js';
@@ -165,6 +166,12 @@ export async function runInitWithOptions(
     typeof values.project === 'string' && values.project !== ''
       ? values.project
       : undefined;
+
+  // PR-CFM-D / #187 — guard before line 179 cascadeProjectName / line 185
+  // ensureSettingsCascade. Validates the SAME expression line 179 then
+  // assigns; covers both --project flag and basename(repoRoot) fallback (L7).
+  const _resolvedForGuard = projectFlag ?? basename(repoRoot);
+  assertValidProjectNameOrExit(_resolvedForGuard, 'gobbi workflow init');
 
   // PR-FIN-1c: project name = `--project` flag → `basename(repoRoot)`.
   // No more `projects.active` registry; the directory tree is the source

--- a/packages/cli/src/lib/__tests__/project-name.test.ts
+++ b/packages/cli/src/lib/__tests__/project-name.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Unit tests for `lib/project-name.ts` — `validateProjectName` and the
+ * argv-shell sugar `assertValidProjectNameOrExit`.
+ *
+ * Layout:
+ *   - 12 cases migrated verbatim from `commands/project/__tests__/create.test.ts`
+ *     (the original home of the validator). Behaviour is preserved
+ *     bit-for-bit; the cap and traversal cases below are net-new.
+ *   - 2 length-cap boundary cases (PR-CFM-D L10 — `≤64 characters`).
+ *   - 3 traversal regression anchors that lock the path-separator
+ *     rejection behaviour against future pattern loosening.
+ *   - 2 helper cases: valid name → returns void with no exit/no stderr;
+ *     invalid name → `process.exit(2)` + L13 stderr template.
+ *
+ * Total: 19 cases.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+import {
+  assertValidProjectNameOrExit,
+  validateProjectName,
+} from '../project-name.js';
+
+// ---------------------------------------------------------------------------
+// stdout/stderr + exit capture (lifted from
+// `commands/project/__tests__/create.test.ts:43-101`)
+// ---------------------------------------------------------------------------
+
+interface Captured {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+}
+
+class ExitCalled extends Error {
+  constructor(readonly code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+let captured: Captured;
+let origStdoutWrite: typeof process.stdout.write;
+let origStderrWrite: typeof process.stderr.write;
+let origExit: typeof process.exit;
+
+beforeEach(() => {
+  captured = { stdout: '', stderr: '', exitCode: null };
+  origStdoutWrite = process.stdout.write;
+  origStderrWrite = process.stderr.write;
+  origExit = process.exit;
+
+  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+    captured.stdout +=
+      typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+    captured.stderr +=
+      typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    return true;
+  }) as typeof process.stderr.write;
+  process.exit = ((code?: number | string | null): never => {
+    captured.exitCode = typeof code === 'number' ? code : 0;
+    throw new ExitCalled(captured.exitCode);
+  }) as typeof process.exit;
+});
+
+afterEach(() => {
+  process.stdout.write = origStdoutWrite;
+  process.stderr.write = origStderrWrite;
+  process.exit = origExit;
+});
+
+function captureExit(fn: () => void): void {
+  try {
+    fn();
+  } catch (err) {
+    if (err instanceof ExitCalled) return;
+    throw err;
+  }
+}
+
+// ===========================================================================
+// validateProjectName — 12 migrated cases
+// ===========================================================================
+
+describe('validateProjectName', () => {
+  test('accepts lowercase letters', () => {
+    expect(validateProjectName('gobbi').ok).toBe(true);
+  });
+  test('accepts letters + digits + hyphens', () => {
+    expect(validateProjectName('my-project-2').ok).toBe(true);
+  });
+  test('accepts single-character names', () => {
+    expect(validateProjectName('a').ok).toBe(true);
+  });
+  test('rejects empty string', () => {
+    expect(validateProjectName('').ok).toBe(false);
+  });
+  test('rejects uppercase', () => {
+    expect(validateProjectName('Foo').ok).toBe(false);
+  });
+  test('rejects underscores', () => {
+    expect(validateProjectName('foo_bar').ok).toBe(false);
+  });
+  test('rejects dots', () => {
+    expect(validateProjectName('foo.bar').ok).toBe(false);
+  });
+  test('rejects path separators', () => {
+    expect(validateProjectName('foo/bar').ok).toBe(false);
+    expect(validateProjectName('foo\\bar').ok).toBe(false);
+  });
+  test('rejects leading hyphen', () => {
+    expect(validateProjectName('-foo').ok).toBe(false);
+  });
+  test('rejects trailing hyphen', () => {
+    expect(validateProjectName('foo-').ok).toBe(false);
+  });
+  test('rejects reserved . and ..', () => {
+    expect(validateProjectName('.').ok).toBe(false);
+    expect(validateProjectName('..').ok).toBe(false);
+  });
+  test('rejects whitespace-only', () => {
+    expect(validateProjectName(' ').ok).toBe(false);
+  });
+});
+
+// ===========================================================================
+// validateProjectName — length cap (PR-CFM-D L10)
+// ===========================================================================
+
+describe('validateProjectName length cap', () => {
+  test('accepts exactly 64 characters', () => {
+    const name = 'a'.repeat(64);
+    expect(validateProjectName(name).ok).toBe(true);
+  });
+  test('rejects 65 characters with ≤64 reason', () => {
+    const name = 'a'.repeat(65);
+    const result = validateProjectName(name);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/≤64 characters/);
+    }
+  });
+});
+
+// ===========================================================================
+// validateProjectName — traversal regression anchors
+// ===========================================================================
+
+describe('validateProjectName traversal anchors', () => {
+  test.each([['../tmp'], ['../../escape'], ['..\\evil']])(
+    'rejects traversal payload %p',
+    (input) => {
+      const result = validateProjectName(input);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        // Pattern-rejection text — locks the diagnostic so payloads do
+        // not slip through future pattern relaxations.
+        expect(result.reason).toMatch(
+          /lowercase letters, digits, and hyphens only/,
+        );
+      }
+    },
+  );
+});
+
+// ===========================================================================
+// assertValidProjectNameOrExit — argv-shell helper
+// ===========================================================================
+
+describe('assertValidProjectNameOrExit', () => {
+  test('valid name → returns void, no exit, no stderr', () => {
+    captureExit(() => assertValidProjectNameOrExit('my-project', 'gobbi test'));
+    expect(captured.exitCode).toBeNull();
+    expect(captured.stderr).toBe('');
+  });
+  test('invalid name → process.exit(2) + L13 stderr template', () => {
+    captureExit(() => assertValidProjectNameOrExit('../tmp', 'gobbi test'));
+    expect(captured.exitCode).toBe(2);
+    expect(captured.stderr).toMatch(
+      /^gobbi test: invalid --project name '\.\.\/tmp': /,
+    );
+  });
+});

--- a/packages/cli/src/lib/project-name.ts
+++ b/packages/cli/src/lib/project-name.ts
@@ -1,0 +1,157 @@
+/**
+ * `validateProjectName` + `assertValidProjectNameOrExit` — central
+ * project-name validator lifted out of `commands/project/create.ts` so
+ * every `--project`-bearing entry point shares one rule set and one
+ * error template.
+ *
+ * # Consumers
+ *
+ *   1. `commands/install.ts` (PR-CFM-D T3) — argv-shell guard before
+ *      template seed; uses {@link assertValidProjectNameOrExit}.
+ *   2. `commands/workflow/init.ts` (PR-CFM-D T2) — single B.0 guard at
+ *      the resolved-name site; covers both `--project` flag and
+ *      `basename(repoRoot)` fallback in one call.
+ *   3. `commands/config.ts` `runInit` only (PR-CFM-D T4) — argv-shell
+ *      guard at the resolved-name site; non-init branches (`runGet`,
+ *      `runSet`, `runExplain`, `runList`, `runEnv`) deferred per L12.
+ *   4. `commands/project/create.ts` — the original home; retains its
+ *      pre-existing exit-1 callsite (see L15 below).
+ *
+ * # L9 — exit code 2 at the 3 new entry-point sites
+ *
+ * The new sites at install/workflow-init/config-init exit with code 2
+ * via {@link assertValidProjectNameOrExit}. Two reasons: (a) POSIX
+ * "incorrect command-line usage" maps cleanly to a malformed
+ * `--project` argument; (b) parity with the sibling `parseArgs`
+ * failure paths in those commands, which already exit 2 on argv shape
+ * errors. Treating an invalid `--project` value as another argv-shape
+ * error keeps the operator's mental model uniform.
+ *
+ * # L13 — stderr template
+ *
+ * `<command-label>: invalid --project name '<input>': <reason>\n`
+ *
+ * The raw input is single-quoted so traversal payloads (`../tmp`,
+ * `..\\evil`) render verbatim without shell-mangling, mirroring the
+ * surrounding diagnostic style in those commands.
+ *
+ * # L15 — `commands/project/create.ts` callsite UNCHANGED
+ *
+ * `create.ts:294-298` has a pre-existing `process.exit(1)` callsite
+ * (the `if (!validation.ok)` branch). That callsite is INTENTIONALLY
+ * preserved as-is — it imports {@link validateProjectName} (NOT the
+ * `OrExit` helper) and continues to exit 1 because `project create`'s
+ * exit-code charter (see file JSDoc on `create.ts`) reserves exit 1
+ * for "name validation failed OR project already exists" and exit 2
+ * for "argv parse error". The exit-code-vs-exit-code split between
+ * `create` (exit 1) and `install/workflow-init/config-init` (exit 2)
+ * is deliberate, not a bug — `create`'s argv shape is `<positional>`
+ * not `--project <flag>`, so the "argv-shape error" framing of L9
+ * does not apply.
+ *
+ * # Lib-level `process.exit` precedent
+ *
+ * {@link assertValidProjectNameOrExit} calls `process.exit(2)`. This
+ * is NOT the only `process.exit` in `lib/` — see
+ * `lib/version-check.ts:345,347,362,370` for the established
+ * precedent (the `runIsLatest` helper exits 0/2 depending on JSON
+ * mode and verdict). Lib-level exits are acceptable for thin
+ * argv-shell sugar — the helper is one line of decision logic plus a
+ * uniform stderr template, and inlining the same 6 lines at every
+ * caller is worse for the L13 template-drift risk than centralising
+ * the exit here. The `OrExit` suffix on the export name marks the
+ * deliberate divergence from PR-CFM-B's exit-free
+ * `lib/workspace-read-store.ts` pattern.
+ */
+
+// ---------------------------------------------------------------------------
+// Validation rules (private — verbatim lift from create.ts:206,216)
+// ---------------------------------------------------------------------------
+
+/**
+ * Lowercase letters, digits, and hyphens only. The body-start and
+ * body-end characters exclude hyphens so names like `-foo` or `foo-`
+ * are rejected upstream of any directory create. One-character names
+ * pass (e.g. `a`).
+ */
+const NAME_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+
+/**
+ * Reserved filesystem names that must never be accepted as a project
+ * name even though they pass the {@link NAME_PATTERN}. Kept small —
+ * the pattern already excludes `/`, `\`, `.`, `_`, and whitespace, so
+ * only the two dot-only sentinels make it this far (but the pattern
+ * also excludes `.` entirely via its character class; this array is a
+ * defense-in-depth belt against future pattern loosening).
+ */
+const RESERVED_NAMES: ReadonlySet<string> = new Set(['', '.', '..']);
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export type NameValidationResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly reason: string };
+
+/**
+ * Validate a candidate project name against the rules documented on
+ * `commands/project/create.ts` JSDoc. Pure function — no I/O, no
+ * existence check (that belongs to the caller, who already has the
+ * `repoRoot`).
+ *
+ * The 64-char length cap (PR-CFM-D L10) runs as the FIRST conditional
+ * so over-long names short-circuit before the reserved-name and
+ * pattern checks. The cap defends against pathological inputs (e.g.
+ * embedded path-traversal payloads padded out to defeat NAME_PATTERN
+ * fuzzers) and aligns with conservative filesystem-component limits
+ * across platforms.
+ */
+export function validateProjectName(name: string): NameValidationResult {
+  if (name.length > 64) {
+    return { ok: false, reason: 'name must be ≤64 characters' };
+  }
+  if (RESERVED_NAMES.has(name)) {
+    return { ok: false, reason: `name cannot be "${name}"` };
+  }
+  if (!NAME_PATTERN.test(name)) {
+    return {
+      ok: false,
+      reason:
+        'name must be lowercase letters, digits, and hyphens only ' +
+        '(no leading/trailing hyphen, no path separators)',
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * Convenience helper for argv-shell sites that want uniform exit-2 +
+ * stderr template (L9/L13). Call immediately after resolving the
+ * effective project name (whether from `--project` flag or
+ * `basename(repoRoot)` fallback) and before any FS write keyed on
+ * that name.
+ *
+ * The `OrExit` suffix marks the deliberate `process.exit` divergence
+ * from PR-CFM-B's exit-free `lib/workspace-read-store.ts` pattern;
+ * precedent for lib-level `process.exit` is `lib/version-check.ts`
+ * (lines 345, 347, 362, 370 — `runIsLatest`).
+ *
+ * @param name         — the resolved project name to validate.
+ * @param commandLabel — the command identity for the stderr prefix,
+ *                       e.g. `'gobbi install'`, `'gobbi workflow init'`,
+ *                       `'gobbi config init'`. Passed in rather than
+ *                       inferred so the helper is decoupled from any
+ *                       command-name convention.
+ */
+export function assertValidProjectNameOrExit(
+  name: string,
+  commandLabel: string,
+): void {
+  const v = validateProjectName(name);
+  if (v.ok) return;
+  process.stderr.write(
+    `${commandLabel}: invalid --project name '${name}': ${v.reason}\n`,
+  );
+  process.exit(2);
+}


### PR DESCRIPTION
## Campaign position

**4-of-5** in the finalize-config-memory campaign tracker (#238). Sequence: A → C → B → **D** → E. Builds on PR-CFM-B's foundation.

## What ships

| # | SHA | Subject |
|---|---|---|
| T1 | `42c2b3f` | `refactor(lib): lift validateProjectName to lib/project-name.ts (#187 part 1)` |
| T1.5 | `d1a6d03` | `test(fixtures): migrate mkdtempSync to lowercase-deterministic basename for NAME_PATTERN conformance (#187 prep)` |
| T2 | `6a4f769` | `feat(workflow/init): validate --project + basename fallback via single B.0 guard (#187 part 2)` |
| T3 | `95dbd8a` | `feat(install): validate --project (#187 part 3)` |
| T4 | `6dcc9ba` | `feat(config): validate --project + basename fallback in runInit (#187 part 4)` |
| T5 | `4cfda3c` | `chore(invariant): add project-name-validation regression test + #242 docs cross-reference` |

6 commits → 1 squash on merge.

## Validation hardening

Three previously-unprotected ` --project ` entry points now reject path-traversal payloads (`../`, `../../tmp`, `..`, `foo/bar`, `foo\bar`) before any FS write:

- ` gobbi install --project <name>`
- ` gobbi workflow init --project <name>` (single B.0 guard at line 168 — covers both flag and ` basename(repoRoot) ` fallback per L7)
- ` gobbi config init --project <name>` ( ` runInit ` only; ` runGet `/` runSet `/` runExplain `/` runList `/` runEnv ` deferred to a follow-up issue per L12)

` commands/project/create.ts ` retains its existing exit-1 callsite (preserved per L15).

The ` ../traversal ` payload also reveals a latent bug for repos with non-conforming basenames (e.g. ` /Users/me/My Repo `, ` My_Project `): previously these silently created ` .gobbi/projects/<weird-name>/ `; now they exit 2 with a clear error.

## Architectural decisions LOCKED

- ` lib/project-name.ts ` API frozen — exports ` validateProjectName(name): NameValidationResult `, ` assertValidProjectNameOrExit(name, commandLabel): void `, ` NameValidationResult ` discriminated union. Internal-only: ` NAME_PATTERN ` (regex), ` RESERVED_NAMES ` (set).
- ` validateProjectName ` lifted **verbatim** from ` commands/project/create.ts:200-240 ` plus a 1-line 64-char length cap (L10) as the first conditional.
- ` assertValidProjectNameOrExit ` is the second lib-level ` process.exit ` call site after ` lib/version-check.ts ` — the ` OrExit ` suffix marks the deliberate divergence from PR-CFM-B's exit-free ` lib/workspace-read-store.ts ` precedent. No longer novel.
- Single B.0 guard pattern at ` workflow/init.ts:173 ` — validates ` projectFlag ?? basename(repoRoot) ` once before ` cascadeProjectName ` assignment. NO dual-insertion (early-flag + resolver-interior). ` resolveProjectNameForInit ` body untouched.
- Stderr template uniform across the 3 new sites: ` <command-label>: invalid --project name '<input>': <reason>\n `. Exit code 2 (POSIX "incorrect usage" + parity with sibling parseArgs failures).
- ` __tests__/helpers/conforming-tmpdir.ts ` shared helper exports ` makeConformingTmpRepo(prefix) ` for tests that need a tmpdir whose ` basename ` passes the new validator. Migrated 16 test files away from ` mkdtempSync ` random-suffix pattern (which can include uppercase letters that fail ` NAME_PATTERN `).
- New invariant grep test at ` __tests__/integration/project-name-validation-invariant.test.ts ` mirrors ` jsonpivot-drift.test.ts ` ALLOW_LIST shape — flags any future ` commands/**/*.ts ` consumer that path-joins into ` .gobbi/projects/ ` or calls a canonical helper without importing ` validateProjectName ` or ` assertValidProjectNameOrExit `.

## Tests + ALLOW_LIST

- Pass count: **2245 → 2271** (gross +38, removed −12, net +26).
- ` jsonpivot-drift.test.ts ` ALLOW_LIST: **41 → 41** (unchanged).
- New ` project-name-validation-invariant.test.ts ` ALLOW_LIST: 3 deferred-scope glob entries (` maintenance/* `, ` memory/* `, ` gotcha/* `).
- All 6 commits are independently green on ` bun run typecheck && bun run build:safe && bun test ` (PR-CFM-B bisect-safe convention).

## Eval rounds

- **3-perspective Ideation** — Project + Architecture + Overall NEEDS-WORK initially (1 HIGH F-ARCH-2 + 4 MED + 3 LOW). All findings remediated inline before Planning.
- **3-perspective Planning** — Project NEEDS-WORK (2 MED + 1 LOW); Architecture PASS; Overall NEEDS-WORK (1 MED + 2 LOW). All MED/LOW remediated inline before Execution.
- **4-perspective Execution** — Project PASS; Architecture PASS; Performance PASS; Overall PASS. Only LOW findings (cosmetic / informational); user chose to ship as-is.

## Closes

- Closes #187 (path-traversal centralization at install/workflow init/config init).
- Closes #242 (SC-ORCH-21 evidence-list line-range correction: ` 48-59 ` → ` 48-93 `).
- For context: #139 was closed earlier this session as obsolete (function ` readWorkspaceActiveProject ` was retired in PR-FIN-1c #213).

## Follow-ups

- Will file at merge time: a ` chore: validate --project at config get/set/explain/list/env entry points (deferred from #187) ` issue. The new invariant test's ALLOW_LIST entry annotates this scope; pruning is a 1-line follow-up commit.
- The ` mkdtemp-suffix-fails-name-pattern.md ` gotcha (recorded during T1.5) should be promoted via ` gobbi gotcha promote ` post-session.

## Test plan

- [x] ` bun run typecheck && bun run build:safe && bun test ` green at every commit (verified per task).
- [x] Final pass count 2271.
- [x] ALLOW_LIST baseline 41 unchanged.
- [x] Manual smoke: ` gobbi install --project '../escape' --dry-run ` exits 2 with the L13 stderr template (covered in install.test.ts integration cases).
- [x] Manual smoke: ` gobbi workflow init --project '../foo' ` exits 2 (covered in init.test.ts).
- [x] Manual smoke: ` gobbi config init --level project --project '..' ` exits 2 (covered in config.test.ts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)