### PR TITLE
chore(plugin): drop session metadata hook (v0.4.5)

### DIFF
--- a/plugins/gobbi/hooks/hooks.json
+++ b/plugins/gobbi/hooks/hooks.json
@@ -2,16 +2,6 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "startup|resume|clear|compact",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "gobbi session metadata",
-            "timeout": 5
-          }
-        ]
-      },
-      {
         "matcher": "startup|resume",
         "hooks": [
           {


### PR DESCRIPTION
## Summary

Removes the `gobbi session metadata` SessionStart hook entirely.

**Why:** Claude Code 2.1.x natively injects \`CLAUDE_SESSION_ID\` (and 6 other CLAUDE_* vars) into each Bash tool subprocess at spawn time. The metadata hook can only no-op (when \`\$CLAUDE_ENV_FILE\` is unset per upstream issue #15840 — the documented case on every 2.1.x release) or actively overwrite the natively-correct value with empty (when stdin payload lacks a \`session_id\` field). Net effect: dead weight at best, harmful at worst.

\`SessionStart\` after this change contains only \`gobbi notify session\`.

## Test plan

- [x] `grep "gobbi session metadata" plugins/gobbi/hooks/hooks.json` → empty
- [x] `SessionStart` JSON has only one block (`gobbi notify session`)
- [ ] After merge + tag rewrite + cache clear: fresh Claude Code restart in playviz, `env | grep CLAUDE_SESSION_ID` is non-empty without any gobbi hook firing

## Tag rewrite plan (post-merge)

Per the v0.4.5 pinning convention from #253, force-overwrite v0.4.5 to point at the merge commit. Same flow as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)