### PR TITLE
chore(plugin): restore session metadata hook with 15s timeout (revert #254)

### DIFF
--- a/plugins/gobbi/hooks/hooks.json
+++ b/plugins/gobbi/hooks/hooks.json
@@ -2,6 +2,16 @@
   "hooks": {
     "SessionStart": [
       {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "gobbi session metadata",
+            "timeout": 15
+          }
+        ]
+      },
+      {
         "matcher": "startup|resume",
         "hooks": [
           {


### PR DESCRIPTION
## Summary

Reverts the metadata-hook drop from #254 and increases its timeout 5s → 15s.

**Why the revert:** PR #254 dropped \`gobbi session metadata\` based on the hypothesis that Claude Code 2.1.x natively injects \`CLAUDE_SESSION_ID\` into Bash subprocesses. Empirical testing in playviz disproved this — a fresh 2.1.126 session has only static CLAUDE_* vars, no \`CLAUDE_SESSION_ID\`. The env_file mechanism does work on 2.1.126 when a hook actually writes to it; v0.5.0 dev's \`gobbi-dev hook session-start\` proves this in this repo. So the metadata hook was the real mechanism for v0.4.5 plugin users; dropping it removed the only path.

**Why 15s timeout:** Bun cold-start + stdin reading can exceed 5s on first invocation. The original 5s budget was too tight, leading to silent kills before the hook could write. v0.5.0 dev's session-start hook uses 15s and works reliably. Same budget here.

## Test plan

- [x] \`grep "gobbi session metadata" plugins/gobbi/hooks/hooks.json\` → present, timeout 15
- [x] SessionStart has metadata + notify-session blocks (notify still timeout 5, async)
- [ ] After merge + tag rewrite + cache clear: fresh playviz Claude Code, \`env | grep CLAUDE_SESSION_ID\` is non-empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)