### PR TITLE
fix(plugin): metadata hook matcher missed sdk-cli — drop matcher

### DIFF
--- a/plugins/gobbi/hooks/hooks.json
+++ b/plugins/gobbi/hooks/hooks.json
@@ -2,7 +2,6 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "startup|resume|clear|compact",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Root cause (real one this time)

PR #255 restored the \`gobbi session metadata\` hook with timeout 15s. But playviz still got empty \`CLAUDE_SESSION_ID\`. Diagnosis:

- Inspected \`~/.claude/session-env/{session_id}/\` for playviz's recent sessions
- Only \`sessionstart-hook-0.sh\` from codex was present (no gobbi file)
- The metadata hook itself works perfectly when invoked directly (verified, 22ms exit 0)
- Therefore the hook is **never being spawned**

The matcher \`"startup|resume|clear|compact"\` doesn't include \`sdk-cli\`, which is the source for SessionStart events when Claude Code is launched via SDK CLI (\`claude -p ...\` and similar). The Claude Code 2.1.126 binary has 7 SessionStart source values: \`startup\`, \`resume\`, \`clear\`, \`compact\`, \`init\`, \`spawn\`, \`sdk-cli\`. The previous matcher missed 3 of them.

Codex's hook has no matcher → matches all → fires reliably.

## Fix

Drop the matcher entirely on the metadata hook. It should fire for every SessionStart event regardless of source — env-var population is needed in all session contexts. Future-proof against any new sources Anthropic adds.

## Test plan

- [x] \`grep matcher plugins/gobbi/hooks/hooks.json\` only present on the notify-session block (not the metadata block)
- [ ] After merge + tag rewrite + plugin reinstall + Claude Code restart in playviz: \`ls ~/.claude/session-env/{playviz session_id}/\` shows TWO sessionstart-hook-N.sh files (one codex, one gobbi); \`env | grep CLAUDE_SESSION_ID\` non-empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)