### PR TITLE
docs(orchestration): add Entry Point section + reciprocal pointers (#259)

### DIFF
--- a/.gobbi/projects/gobbi/agents/manager.md
+++ b/.gobbi/projects/gobbi/agents/manager.md
@@ -26,7 +26,7 @@ Mandatory load order at every session start, `/clear`, compaction, and resume:
 2. **All project rules** under `.gobbi/projects/{project-name}/rules/` — read every file.
 3. **`mistake` skill** — known pitfalls; check before any non-trivial decision.
 4. **`gobbi` skill** — workflow overview, session setup, full skill map.
-5. **`orchestration` skill** — workflow state machine, phase ordering, delegation contracts.
+5. **`orchestration` skill** — workflow state machine, phase ordering, delegation contracts. (Start at `## Entry Point` for the SOP that brought you here.)
 
 Load per workflow phase (one of these — never more than one at a time):
 

--- a/.gobbi/projects/gobbi/skills/gobbi/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/gobbi/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Read, Grep, Glob, Bash, Write, Edit, Agent, Task, AskUserQuestion
 
 You are the **manager** of this gobbi session. You think like the chief of a small team — you do not do the specialist work yourself; you decide what gets done, by whom, in what order, and at what quality bar. You delegate to specialist subagents (leader / executor / evaluator / assistant) for everything except trivial bookkeeping (TaskCreate / TaskUpdate, AskUserQuestion, status updates to the user). The full behavioral spec for the manager role is in [`agents/manager.md`](../../agents/manager.md).
 
-`/gobbi` is the session-bootstrap front door. It loads core skills, checks session settings, asks the user 2 setup questions if needed, and hands off to the workflow. The productive workflow runs as a 6-step state machine: **Configuration → Ideation → Preparation → Planning → Execution → Wrap-up**, with Evaluation and Memorization running as **sub-phases inside every productive loop**.
+`/gobbi` is the session-bootstrap front door. It loads core skills, checks session settings, asks the user 2 setup questions if needed, and hands off to the workflow. The productive workflow runs as a 6-step state machine: **Configuration → Ideation → Preparation → Planning → Execution → Wrap-up**, with Evaluation and Memorization running as **sub-phases inside every productive loop**. The reciprocal [`orchestration/SKILL.md § Entry Point`](../orchestration/SKILL.md#entry-point) is the workflow-governor anchor — see it for the SOP a fresh manager follows after bootstrap.
 
 ---
 

--- a/.gobbi/projects/gobbi/skills/orchestration/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/orchestration/SKILL.md
@@ -10,6 +10,27 @@ How the manager operates. This skill defines the manager role, the two orchestra
 
 ---
 
+## Entry Point
+
+`orchestration/SKILL.md` is the **workflow governor** — it defines the manager role, the two orchestration modes, and the six-step state machine that drives every session. It is the complement to `gobbi/SKILL.md`, which is the **session-bootstrap front door**. This section is a pointer, not a duplicate: the canonical bootstrap procedure lives at [`gobbi/SKILL.md § Session Bootstrap Order`](../gobbi/SKILL.md#session-bootstrap-order) and is not reproduced here.
+
+| Skill | Role | Responsibility |
+|---|---|---|
+| [`gobbi/SKILL.md § Session Bootstrap Order`](../gobbi/SKILL.md#session-bootstrap-order) | front door | Load core skills, resolve session env vars, check settings, run setup questions, project-memory check, hand off to workflow. |
+| `orchestration/SKILL.md` (this file) | workflow governor | Define manager role, modes (Chat / Auto), 6-step workflow state machine, transitions. |
+
+### When to start here
+
+A fresh manager reads this section first in three situations:
+
+- The user types `/gobbi` (SessionStart hook fires; `gobbi/SKILL.md` bootstraps and hands off here).
+- Session resume after `/clear` or `/compact` (manager re-reads bootstrap order, then re-enters the active workflow step).
+- Automated session auto-start (same hook path as `/gobbi`).
+
+After bootstrap, the manager enters `## Step 1 — Workflow Configuration` below and proceeds through the six-step state machine. The 3-tier bootstrap detection (Empty / Sparse / Mature) is defined in that step's table — see the table at the end of `## Step 1 — Workflow Configuration`.
+
+---
+
 ## You Are the Manager
 
 You are a manager who orchestrates subagents and tasks. Your job is to direct work — not to do it.

--- a/.gobbi/projects/gobbi/skills/orchestration/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/orchestration/SKILL.md
@@ -16,7 +16,7 @@ How the manager operates. This skill defines the manager role, the two orchestra
 
 | Skill | Role | Responsibility |
 |---|---|---|
-| [`gobbi/SKILL.md § Session Bootstrap Order`](../gobbi/SKILL.md#session-bootstrap-order) | front door | Load core skills, resolve session env vars, check settings, run setup questions, project-memory check, hand off to workflow. |
+| [`gobbi/SKILL.md § Session Bootstrap Order`](../gobbi/SKILL.md#session-bootstrap-order) | front door | Owns the session-start bootstrap procedure — see the linked section for the full step order. |
 | `orchestration/SKILL.md` (this file) | workflow governor | Define manager role, modes (Chat / Auto), 6-step workflow state machine, transitions. |
 
 ### When to start here
@@ -27,7 +27,7 @@ A fresh manager reads this section first in three situations:
 - Session resume after `/clear` or `/compact` (manager re-reads bootstrap order, then re-enters the active workflow step).
 - Automated session auto-start (same hook path as `/gobbi`).
 
-After bootstrap, the manager enters `## Step 1 — Workflow Configuration` below and proceeds through the six-step state machine. The 3-tier bootstrap detection (Empty / Sparse / Mature) is defined in that step's table — see the table at the end of `## Step 1 — Workflow Configuration`.
+After bootstrap, the manager enters `### Step 1 — Workflow Configuration` below and proceeds through the six-step state machine. The 3-tier bootstrap detection (Empty / Sparse / Mature) is defined in that step's table — see the table at the end of `### Step 1 — Workflow Configuration`.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #259 — adds an `## Entry Point` section to `orchestration/SKILL.md` so a
fresh manager arriving via `/gobbi` has a clear "start here" anchor, and makes
the front-door (`gobbi/SKILL.md`) ↔ workflow-governor (`orchestration/SKILL.md`)
relationship explicit with reciprocal pointers.

**Stance**: canonicalize the bootstrap procedure in `gobbi/SKILL.md`; never
duplicate the 6-step procedure in `orchestration/SKILL.md`. The new section is
a pointer + role-split table, not a re-statement.

## Changes (2 commits on this branch)

- **`fda0d07`** — `docs(orchestration): add Entry Point section + reciprocal pointers`
  - New `## Entry Point` H2 in `orchestration/SKILL.md` between the lead and
    `## You Are the Manager` — one-paragraph role split, single Markdown link
    to `gobbi/SKILL.md § Session Bootstrap Order`, "When to start here" subsection
    (3 triggers: `/gobbi`, session resume, post-`/clear`/`/compact`), and a
    role-split table.
  - One inline reciprocal sentence in `gobbi/SKILL.md:11` pointing back at the
    new section.
  - Parenthetical on `agents/manager.md` item 5 directing the fresh manager
    to the new section.
- **`5276b5e`** — `docs(orchestration): remove duplicated bootstrap enumeration, fix H3 cite (#259, iter2)`
  - Rewrites the role-split table row 1 Responsibility cell from a verbatim
    enumeration of the bootstrap procedure ("Load core skills, …, hand off to
    workflow") into a non-enumerating pointer. Closes Plan verification gate
    #6 (DD1 canonicalize-don't-duplicate) which iter1 narrowly violated.
  - Corrects two backtick-quoted `` `## Step 1` `` cites to `` `### Step 1` ``
    so the prose matches the actual H3 heading at line 86.

## Verification

```text
# DD1 gate — no verbatim duplication of bootstrap steps inside orchestration:
grep -c "Load core skills\|Session env vars\|Check for existing session settings" \
  .claude/skills/orchestration/SKILL.md
→ 0  ✓

# Reciprocal pointer in gobbi/SKILL.md:
grep -n "orchestration/SKILL.md § Entry Point" .claude/skills/gobbi/SKILL.md
→ 11:…orchestration/SKILL.md § Entry Point…  ✓

# Parenthetical in manager.md:
grep -n "Entry Point" .claude/agents/manager.md
→ 29:…Start at `## Entry Point`…  ✓

# H3 cites match actual heading level:
grep -o '`### Step 1 — Workflow Configuration`' .claude/skills/orchestration/SKILL.md | wc -l
→ 2  ✓
grep -n "^### Step 1 — Workflow Configuration" .claude/skills/orchestration/SKILL.md
→ 86:### Step 1 — Workflow Configuration  ✓

# Symlink integrity preserved (zero broken symlinks):
find .claude/skills .claude/agents -xtype l
→ (empty)  ✓
```

## Acceptance criteria (from #259)

- [x] Fresh manager reading `orchestration/SKILL.md` top-to-bottom can answer
      "where do I start when a user types `/gobbi`?" by reading the new
      `## Entry Point` section alone (the section points at the canonical
      procedure in `gobbi/SKILL.md`; it does not duplicate it).
- [x] `gobbi/SKILL.md` and `orchestration/SKILL.md` reference each other
      explicitly.
- [ ] Adversarial re-check of F-U-01 → closed. **Run `/codex:adversarial-review`
      against the merged commit on `develop` after this PR lands** to confirm
      closure. (Slash command has `disable-model-invocation: true`; the user
      drives it.)

## Test plan

- [x] Manual read-through of the new `## Entry Point` section as a "fresh
      manager" — confirmed the role split + pointer + 3 triggers + handoff
      to Step 1 are intelligible without prior context.
- [x] All verification commands above pass with literal expected values.
- [x] Dual-system iter1 evaluation: Claude REVISE → REMEDIATED in iter2;
      `codex review` PASS.
- [x] Iter2 Claude delta-focused evaluation: PASS (closure + regression + overall).
- [ ] Post-merge: re-run F-U-01 adversarial check (see acceptance criteria above).

## Notes

- This PR ships as a squash merge — the `Closes #259` keyword in the iter1
  commit body and the `Refs #259` in iter2 collapse into the PR's own closing
  keyword on merge.
- New mistake-candidates staged this session (will be promoted to
  `.gobbi/projects/gobbi/mistakes/` via `gobbi mistake promote` post-session):
  - `session-dir-naming-convention-uses-date-prefix.md` — CLI session dirs are
    UUID-only, but the documented convention is `{date}-{session-id}`. Manager
    writes to the documented path.
  - `executor-rationalized-failing-verification-gate.md` — iter1 executor
    reported `STATUS: DONE` despite a failing Plan gate (Iron Law 11). Iter2
    executor correctly surfaced its own gate divergence as
    `DONE_WITH_CONCERNS`.
  - `manager-mispec-grep-c-for-occurrence-count.md` — manager mis-specified a
    verification gate using `grep -c` (line count) when occurrence count
    (`grep -o … | wc -l`) was intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)