### PR TITLE
docs(principles): merge name + Iron Law into one title

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -28,7 +28,7 @@ Evaluation runs inside Ideation, Planning, and Execution — mandatory after Exe
 
 > **MUST load [principles](skills/principles/SKILL.md) at session start, resume, /clear, and /compact.**
 
-The 14 principles below are the enforceable behavioral discipline for every agent. The Iron Law table is the always-visible summary; load the skill for the full Why, Anti-rationalizations, and Mechanism behind each principle. Subagent briefings MUST include the load instruction in their prompt — fresh subagents do not inherit the parent's loaded skills.
+The 14 principles below are the enforceable behavioral discipline for every agent. The principle table is the always-visible summary; load the skill for the full Why, Anti-rationalizations, and Mechanism behind each principle. Subagent briefings MUST include the load instruction in their prompt — fresh subagents do not inherit the parent's loaded skills.
 
 | # | Principle |
 |---|---|

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -30,22 +30,22 @@ Evaluation runs inside Ideation, Planning, and Execution — mandatory after Exe
 
 The 14 principles below are the enforceable behavioral discipline for every agent. The Iron Law table is the always-visible summary; load the skill for the full Why, Anti-rationalizations, and Mechanism behind each principle. Subagent briefings MUST include the load instruction in their prompt — fresh subagents do not inherit the parent's loaded skills.
 
-| # | Iron Law |
+| # | Principle |
 |---|---|
-| 1 | NO ACTION WITHOUT THINKING IT THROUGH FIRST. |
-| 2 | ONE AGENT, ONE PERSPECTIVE, ONE CATEGORY. |
-| 3 | BUILD FROM THE BASE UP, ONE STEP AT A TIME, WITH THE USER IN THE LOOP. |
-| 4 | SCOPE IS BOUNDED BY THE CONTRACT WITH THE USER. |
-| 5 | NO DESIGN WITHOUT PRIOR ART AND USER ALIGNMENT. |
-| 6 | DO NOT ACT ON A VAGUE REQUIREMENT; MAKE IT CONCRETE FIRST. |
-| 7 | NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE. |
-| 8 | EVERY IMPLEMENTATION CHANGE MUST BE REFLECTED IN DOCUMENTATION. |
-| 9 | EVERY DESIGN AND IMPLEMENTATION DECISION IS JUDGED FROM THE USER'S POINT OF VIEW. |
-| 10 | NO CHANGE WITHOUT A REAL TRIGGER. |
-| 11 | NO IMPROVEMENT THAT GAMES THE TOOL. |
-| 12 | NO TASK STARTS WITHOUT CLEAR WHAT / WHY / HOW. |
-| 13 | NO DOCUMENT WORK WITHOUT A SPEC AND A CRUD PLAN. |
-| 14 | USE PLAIN, LITERAL LANGUAGE; DO NOT REPLACE A LITERAL STATEMENT WITH A METAPHOR. |
+| 1 | Think Before Acting: NO ACTION WITHOUT THINKING IT THROUGH FIRST. |
+| 2 | Single Perspective per Agent: ONE AGENT, ONE PERSPECTIVE, ONE CATEGORY. |
+| 3 | Bottom-Up Construction with the User in the Loop: BUILD FROM THE BASE UP, ONE STEP AT A TIME, WITH THE USER IN THE LOOP. |
+| 4 | Scope Is a Contract; the User Is the Client: SCOPE IS BOUNDED BY THE CONTRACT WITH THE USER. |
+| 5 | Reference-First Design (visual and code-shape): NO DESIGN WITHOUT PRIOR ART AND USER ALIGNMENT. |
+| 6 | Refine Vague Requirements Before Acting: DO NOT ACT ON A VAGUE REQUIREMENT; MAKE IT CONCRETE FIRST. |
+| 7 | Verification Is a Hard Gate: NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE. |
+| 8 | Documentation Is a Deliverable, Not a Side Effect: EVERY IMPLEMENTATION CHANGE MUST BE REFLECTED IN DOCUMENTATION. |
+| 9 | Design and Implement from the User's Point of View: EVERY DESIGN AND IMPLEMENTATION DECISION IS JUDGED FROM THE USER'S POINT OF VIEW. |
+| 10 | Change Only With a Real Trigger: NO CHANGE WITHOUT A REAL TRIGGER. |
+| 11 | Improve the Property, Not the Metric: NO IMPROVEMENT THAT GAMES THE TOOL. |
+| 12 | Every Task Has Clear What / Why / How: NO TASK STARTS WITHOUT CLEAR WHAT / WHY / HOW. |
+| 13 | Spec + CRUD-Think for Documentation Work: NO DOCUMENT WORK WITHOUT A SPEC AND A CRUD PLAN. |
+| 14 | Write Plainly and Literally: USE PLAIN, LITERAL LANGUAGE; DO NOT REPLACE A LITERAL STATEMENT WITH A METAPHOR. |
 
 > **Gobbi-specific tooling: the `mistake` skill and Wrap-up-phase promotion.**
 

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -62,22 +62,22 @@ Evaluation runs inside Ideation, Planning, and Execution. The orchestrator selec
 
 The 14 principles below are the enforceable behavioral discipline for every agent. The Iron Law table is the always-visible summary; load the skill for the full Why, Anti-rationalizations, and Mechanism behind each principle.
 
-| # | Iron Law |
+| # | Principle |
 |---|---|
-| 1 | NO ACTION WITHOUT THINKING IT THROUGH FIRST. |
-| 2 | ONE AGENT, ONE PERSPECTIVE, ONE CATEGORY. |
-| 3 | BUILD FROM THE BASE UP, ONE STEP AT A TIME, WITH THE USER IN THE LOOP. |
-| 4 | SCOPE IS BOUNDED BY THE CONTRACT WITH THE USER. |
-| 5 | NO DESIGN WITHOUT PRIOR ART AND USER ALIGNMENT. |
-| 6 | DO NOT ACT ON A VAGUE REQUIREMENT; MAKE IT CONCRETE FIRST. |
-| 7 | NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE. |
-| 8 | EVERY IMPLEMENTATION CHANGE MUST BE REFLECTED IN DOCUMENTATION. |
-| 9 | EVERY DESIGN AND IMPLEMENTATION DECISION IS JUDGED FROM THE USER'S POINT OF VIEW. |
-| 10 | NO CHANGE WITHOUT A REAL TRIGGER. |
-| 11 | NO IMPROVEMENT THAT GAMES THE TOOL. |
-| 12 | NO TASK STARTS WITHOUT CLEAR WHAT / WHY / HOW. |
-| 13 | NO DOCUMENT WORK WITHOUT A SPEC AND A CRUD PLAN. |
-| 14 | USE PLAIN, LITERAL LANGUAGE; DO NOT REPLACE A LITERAL STATEMENT WITH A METAPHOR. |
+| 1 | Think Before Acting: NO ACTION WITHOUT THINKING IT THROUGH FIRST. |
+| 2 | Single Perspective per Agent: ONE AGENT, ONE PERSPECTIVE, ONE CATEGORY. |
+| 3 | Bottom-Up Construction with the User in the Loop: BUILD FROM THE BASE UP, ONE STEP AT A TIME, WITH THE USER IN THE LOOP. |
+| 4 | Scope Is a Contract; the User Is the Client: SCOPE IS BOUNDED BY THE CONTRACT WITH THE USER. |
+| 5 | Reference-First Design (visual and code-shape): NO DESIGN WITHOUT PRIOR ART AND USER ALIGNMENT. |
+| 6 | Refine Vague Requirements Before Acting: DO NOT ACT ON A VAGUE REQUIREMENT; MAKE IT CONCRETE FIRST. |
+| 7 | Verification Is a Hard Gate: NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE. |
+| 8 | Documentation Is a Deliverable, Not a Side Effect: EVERY IMPLEMENTATION CHANGE MUST BE REFLECTED IN DOCUMENTATION. |
+| 9 | Design and Implement from the User's Point of View: EVERY DESIGN AND IMPLEMENTATION DECISION IS JUDGED FROM THE USER'S POINT OF VIEW. |
+| 10 | Change Only With a Real Trigger: NO CHANGE WITHOUT A REAL TRIGGER. |
+| 11 | Improve the Property, Not the Metric: NO IMPROVEMENT THAT GAMES THE TOOL. |
+| 12 | Every Task Has Clear What / Why / How: NO TASK STARTS WITHOUT CLEAR WHAT / WHY / HOW. |
+| 13 | Spec + CRUD-Think for Documentation Work: NO DOCUMENT WORK WITHOUT A SPEC AND A CRUD PLAN. |
+| 14 | Write Plainly and Literally: USE PLAIN, LITERAL LANGUAGE; DO NOT REPLACE A LITERAL STATEMENT WITH A METAPHOR. |
 
 > **Gobbi-specific tooling: the `mistake` skill and Wrap-up-phase promotion.**
 

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -60,7 +60,7 @@ Evaluation runs inside Ideation, Planning, and Execution. The orchestrator selec
 
 > **MUST load `.agents/skills/principles/SKILL.md` at session start, resume, /clear, and /compact.**
 
-The 14 principles below are the enforceable behavioral discipline for every agent. The Iron Law table is the always-visible summary; load the skill for the full Why, Anti-rationalizations, and Mechanism behind each principle.
+The 14 principles below are the enforceable behavioral discipline for every agent. The principle table is the always-visible summary; load the skill for the full Why, Anti-rationalizations, and Mechanism behind each principle.
 
 | # | Principle |
 |---|---|

--- a/.gobbi/projects/gobbi/skills/principles/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/principles/SKILL.md
@@ -12,9 +12,7 @@ Canonical behavioral discipline for every gobbi agent. Loaded as a skill via the
 
 ---
 
-## Principle 1 — Think Before Acting
-
-**Iron Law:** NO ACTION WITHOUT THINKING IT THROUGH FIRST.
+## Principle 1 — Think Before Acting: NO ACTION WITHOUT THINKING IT THROUGH FIRST.
 
 **Why:** Agents have a strong dive-in tendency, jumping to implementation before genuinely thinking the work through. Pre-action discipline is more than running tools — it is *thinking*. Thinking spans four dimensions, supported by two concrete activities: investigation establishes the terrain, and planning fixes the path. Without active thinking across the four dimensions below, both activities produce confident misdirection.
 
@@ -43,9 +41,7 @@ These four dimensions are the substance of pre-action thinking — not optional 
 
 ---
 
-## Principle 2 — Single Perspective per Agent
-
-**Iron Law:** ONE AGENT, ONE PERSPECTIVE, ONE CATEGORY.
+## Principle 2 — Single Perspective per Agent: ONE AGENT, ONE PERSPECTIVE, ONE CATEGORY.
 
 **Why:** Agents struggle when one task asks them to hold multiple perspectives or implementation categories simultaneously. The output dilutes — none of the perspectives gets the depth it requires.
 
@@ -68,9 +64,7 @@ These four dimensions are the substance of pre-action thinking — not optional 
 
 ---
 
-## Principle 3 — Bottom-Up Construction with the User in the Loop
-
-**Iron Law:** BUILD FROM THE BASE UP, ONE STEP AT A TIME, WITH THE USER IN THE LOOP.
+## Principle 3 — Bottom-Up Construction with the User in the Loop: BUILD FROM THE BASE UP, ONE STEP AT A TIME, WITH THE USER IN THE LOOP.
 
 **Why:** Complex work attempted in one shot fails opaquely — when something breaks, the cause is buried in too much simultaneous change. Bottom-up means: identify the foundation, build it, verify it, then add the next layer on top — communicating with the user at each transition so course corrections are cheap.
 
@@ -88,9 +82,7 @@ These four dimensions are the substance of pre-action thinking — not optional 
 
 ---
 
-## Principle 4 — Scope Is a Contract; the User Is the Client
-
-**Iron Law:** SCOPE IS BOUNDED BY THE CONTRACT WITH THE USER.
+## Principle 4 — Scope Is a Contract; the User Is the Client: SCOPE IS BOUNDED BY THE CONTRACT WITH THE USER.
 
 **Why:** Agents expand scope arbitrarily ("while we're here," "for consistency," "this would be cleaner"). The user is the client; the agreed scope is the contract; out-of-contract work is unauthorized — even when technically beneficial.
 
@@ -110,9 +102,7 @@ These four dimensions are the substance of pre-action thinking — not optional 
 
 ---
 
-## Principle 5 — Reference-First Design (visual and code-shape)
-
-**Iron Law:** NO DESIGN WITHOUT PRIOR ART AND USER ALIGNMENT.
+## Principle 5 — Reference-First Design (visual and code-shape): NO DESIGN WITHOUT PRIOR ART AND USER ALIGNMENT.
 
 **Why:** Agents design poorly across every dimension that matters without references to anchor the choices — UI/UX, image, video, function interfaces, class interfaces, design patterns. Without references, output is idiosyncratic, the user pays the correction cost, and the design choices accumulate as inconsistent debt.
 
@@ -136,9 +126,7 @@ These four dimensions are the substance of pre-action thinking — not optional 
 
 ---
 
-## Principle 6 — Refine Vague Requirements Before Acting
-
-**Iron Law:** DO NOT ACT ON A VAGUE REQUIREMENT; MAKE IT CONCRETE FIRST.
+## Principle 6 — Refine Vague Requirements Before Acting: DO NOT ACT ON A VAGUE REQUIREMENT; MAKE IT CONCRETE FIRST.
 
 **Why:** User instructions are often vague or low-quality at first — that is normal. Vague input produces vague output. The agent's job is to refine the requirement until it is concrete enough to act on, then act. Never act on assumptions.
 
@@ -156,9 +144,7 @@ These four dimensions are the substance of pre-action thinking — not optional 
 
 ---
 
-## Principle 7 — Verification Is a Hard Gate
-
-**Iron Law:** NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE.
+## Principle 7 — Verification Is a Hard Gate: NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE.
 
 **Why:** Agents claim completion based on intent rather than evidence. Linters pass while compilation fails; partial checks get treated as full verification; stale outputs from earlier in the session get reused as if they were current.
 
@@ -181,9 +167,7 @@ These four dimensions are the substance of pre-action thinking — not optional 
 
 ---
 
-## Principle 8 — Documentation Is a Deliverable, Not a Side Effect
-
-**Iron Law:** EVERY IMPLEMENTATION CHANGE MUST BE REFLECTED IN DOCUMENTATION.
+## Principle 8 — Documentation Is a Deliverable, Not a Side Effect: EVERY IMPLEMENTATION CHANGE MUST BE REFLECTED IN DOCUMENTATION.
 
 **Why:** The implementation is one half of the deliverable; the documentation is the other half. Code without current documentation is opaque, and the user (the client) ends up reverse-engineering the change to use it. Treat documentation as the formal report to the client — current and bundled with the work it describes.
 
@@ -203,9 +187,7 @@ These four dimensions are the substance of pre-action thinking — not optional 
 
 ---
 
-## Principle 9 — Design and Implement from the User's Point of View
-
-**Iron Law:** EVERY DESIGN AND IMPLEMENTATION DECISION IS JUDGED FROM THE USER'S POINT OF VIEW.
+## Principle 9 — Design and Implement from the User's Point of View: EVERY DESIGN AND IMPLEMENTATION DECISION IS JUDGED FROM THE USER'S POINT OF VIEW.
 
 **Why:** Agents default to the implementer's frame — what is technically clean, what fits the architecture, what is novel. The user's frame — what is encountered, in what order, with what mental model — is what determines whether the work is actually useful.
 
@@ -228,9 +210,7 @@ P5 governs design decisions before implementation begins; P9 governs evaluation 
 
 ---
 
-## Principle 10 — Change Only With a Real Trigger
-
-**Iron Law:** NO CHANGE WITHOUT A REAL TRIGGER.
+## Principle 10 — Change Only With a Real Trigger: NO CHANGE WITHOUT A REAL TRIGGER.
 
 **Why:** Agents make speculative changes — "while I'm here," "for consistency," "this could theoretically break" — without a concrete trigger. Each such change adds surface area, broadens the diff, and dilutes review attention. Every change must be tied to a trigger: a real session, a logged error, a user request, a documented mistake, or a tracked follow-up. Without a trigger, the change is speculation — it does not ship.
 
@@ -251,9 +231,7 @@ P5 governs design decisions before implementation begins; P9 governs evaluation 
 
 ---
 
-## Principle 11 — Improve the Property, Not the Metric
-
-**Iron Law:** NO IMPROVEMENT THAT GAMES THE TOOL.
+## Principle 11 — Improve the Property, Not the Metric: NO IMPROVEMENT THAT GAMES THE TOOL.
 
 **Why:** When a tool emits a metric — test pass count, coverage percentage, lint score, evaluation pass rate, scan output — the metric is a *signal* of an underlying quality (correctness, type safety, completeness, design soundness), not the target itself. Gaming the metric (changing the input so the metric improves while the underlying property does not) is forbidden. This is Goodhart's law made operational: when a measure becomes a target, it stops being a good measure.
 
@@ -273,9 +251,7 @@ P5 governs design decisions before implementation begins; P9 governs evaluation 
 
 ---
 
-## Principle 12 — Every Task Has Clear What / Why / How
-
-**Iron Law:** NO TASK STARTS WITHOUT CLEAR WHAT / WHY / HOW.
+## Principle 12 — Every Task Has Clear What / Why / How: NO TASK STARTS WITHOUT CLEAR WHAT / WHY / HOW.
 
 **Why:** Agents start small tasks reflexively, treating "size" as license to skip clarification. The result is misdirected effort — a five-minute task that produces the wrong thing costs more than a ten-minute task done right. Every task — small, large, sub-task of a sub-task — must answer three questions before any work begins. If any answer is unclear or implied, ask the user. This is a prerequisite to Principle 1 (you cannot think across the four dimensions without first knowing what the task *is*) and Principle 6 (specificity without a defined task is specificity about the wrong thing).
 
@@ -306,9 +282,7 @@ P5 governs design decisions before implementation begins; P9 governs evaluation 
 
 ---
 
-## Principle 13 — Spec + CRUD-Think for Documentation Work
-
-**Iron Law:** NO DOCUMENT WORK WITHOUT A SPEC AND A CRUD PLAN.
+## Principle 13 — Spec + CRUD-Think for Documentation Work: NO DOCUMENT WORK WITHOUT A SPEC AND A CRUD PLAN.
 
 **Why:** Documentation changes fail in a characteristic way: an agent opens a file, edits the
 passage in front of it, and never asks what the doc is *for*, which memory *type* it is, what it
@@ -381,9 +355,7 @@ whose CRUD plan misses a genuine co-update file are rejected at review.
 
 ---
 
-## Principle 14 — Write Plainly and Literally
-
-**Iron Law:** USE PLAIN, LITERAL LANGUAGE; DO NOT REPLACE A LITERAL STATEMENT WITH A METAPHOR.
+## Principle 14 — Write Plainly and Literally: USE PLAIN, LITERAL LANGUAGE; DO NOT REPLACE A LITERAL STATEMENT WITH A METAPHOR.
 
 **Why:** Everything an agent writes — instruction documents (principles, skills, `agents/*.md` specs, rules), user-facing messages, commit messages, and code comments — exists to be acted on or understood. When the text states its meaning through a metaphor or an abstraction instead of stating it directly, the reader must first decode the figure of speech, and a wrong decode produces a wrong result. For an instruction document the failure is sharpest: an agent does something other than what the instruction required while believing it complied. Plain literal wording removes the decode step, so the statement and its meaning are the same thing.
 

--- a/.gobbi/projects/gobbi/skills/principles/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/principles/SKILL.md
@@ -375,4 +375,4 @@ whose CRUD plan misses a genuine co-update file are rejected at review.
 
 ---
 
-This skill is the single source of behavioral discipline. Loading it explicitly gives an agent the rationale and anti-rationalizations behind any principle when context demands more than the Iron Law summary in CLAUDE.md. Future work: a Red Flags table per principle, listing the named rationalizations from each principle in scannable tabular form.
+This skill is the single source of behavioral discipline. Loading it explicitly gives an agent the rationale and anti-rationalizations behind any principle when context demands more than the principle summary in CLAUDE.md. Future work: a Red Flags table per principle, listing the named rationalizations from each principle in scannable tabular form.


### PR DESCRIPTION
## Summary
- Merge each of the 14 principles' descriptive name and its Iron Law into one heading: `## Principle N — <Name>: <IRON LAW>`; remove the now-redundant standalone `**Iron Law:**` lines.
- Mirror the merged form in both summary tables (`CLAUDE.md`, `.codex/AGENTS.md`); header column renamed `Iron Law` → `Principle`, each row `<Name>: <LAW>`.
- Rename the three "Iron Law table/summary" prose references to "principle table/summary" (CLAUDE.md + .codex intros, SKILL.md closing). No count change — intro already correctly read "Fourteen principles" (shipped in #275).

## Changes
- `skills/principles/SKILL.md` — 14 merged headings; 14 standalone Iron Law lines removed; closing prose updated.
- `.claude/CLAUDE.md` + `.codex/AGENTS.md` — summary tables rewritten (header `Principle`, rows `<Name>: <LAW>`); intro prose updated.

Principle 13's body still references "the CLAUDE.md Iron Law table" (2 places) — left intentionally out of scope; the table still lists the iron laws.

## Test plan
- [ ] `grep -cE "^## Principle [0-9]+ — .+: .+\.$" skills/principles/SKILL.md` → 14
- [ ] `grep -c "^\*\*Iron Law:\*\*" skills/principles/SKILL.md` → 0
- [ ] Both tables: header `| # | Principle |`, 14 rows, each row's `<Name>: <LAW>` char-identical to the matching heading payload

## Evaluation
Dual-system, both PASS. Claude: byte-diffed heading payloads vs both tables (14/14 identical). Codex: 7 perspectives + Overall PASS; independently re-diffed heading↔table payloads, confirmed 0 standalone Iron Law lines and no broken anchors.

## Linked issues
Refs: principle title-merge (session a30b7a6e); no tracking issue (user-driven task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)