### PR TITLE
chore(session): dedupe duplicated 05-31 journal line

### DIFF
--- a/.gobbi/projects/gobbi/sessions/journal.md
+++ b/.gobbi/projects/gobbi/sessions/journal.md
@@ -4,4 +4,3 @@ Newest entries at the bottom.
 
 - 2026-05-30 `a30b7a6e` — principles clarity pass: removed Iron Law Index, literal rewrite of P6/P10/P11, added Principle 14 (plain language); 4 commits on chore/session-2026-05-30-a30b7a6e; dual-system eval PASS-after-remediation; next: confirm PR merge.
 - 2026-05-31 `a30b7a6e` — principle title merge: name + Iron Law folded into each heading + both tables (header→Principle) + prose rename; PR #276 merged as 2b6b885; dual-system PASS. Recorded manager mistake: asserted unverified state (fabricated SHAs + fictional defect) into a PR body; safety classifier blocked it.
-- 2026-05-31 `a30b7a6e` — principle title merge: name + Iron Law folded into each heading + both tables (header→Principle) + prose rename; PR #276 merged as 2b6b885; dual-system PASS. Recorded manager mistake: asserted unverified state (fabricated SHAs + fictional defect) into a PR body; safety classifier blocked it.


### PR DESCRIPTION
## Summary
- Remove a duplicated 2026-05-31 entry in `sessions/journal.md`. The line was written twice (a journal rebuild + an append both added it) and the earlier dedup attempt raced the #277 squash merge, so the duplicate reached develop.

## Changes
- `sessions/journal.md` — one 05-31 entry instead of two; 05-30 entry untouched.

## Test plan
- [ ] `grep -c "principle title merge" sessions/journal.md` → 1

## Linked issues
Refs: session a30b7a6e journal cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)