### PR TITLE
docs(principles): drop lead sentence from skill description

### DIFF
--- a/.gobbi/projects/gobbi/skills/principles/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/principles/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: principles
-description: "The mandatory behavioral-discipline floor — 14 Iron Law principles every gobbi agent obeys. EVERY agent MUST load this skill at the start of its work, before any other action. You MUST read and understand every principle, and you MUST follow them without exception — they override convenience, speed, and your own judgment. Load the full skill for the rationale, anti-rationalizations, and mechanism behind each principle."
+description: "EVERY agent MUST load this skill at the start of its work, before any other action. You MUST read and understand every principle, and you MUST follow them without exception — they override convenience, speed, and your own judgment. Load the full skill for the rationale, anti-rationalizations, and mechanism behind each principle."
 allowed-tools: Read, Grep, Glob, Bash
 ---
 


### PR DESCRIPTION
## Summary
- Remove the lead sentence "The mandatory behavioral-discipline floor — 14 Iron Law principles every gobbi agent obeys." from the `principles` skill `description` so it opens directly with the load-and-obey command. The three MUST clauses are unchanged.

## Changes
- `skills/principles/SKILL.md` — `description` frontmatter only (one line).

## Test plan
- [ ] `sed -n '3p' skills/principles/SKILL.md` no longer contains "mandatory behavioral-discipline floor"
- [ ] description still has the three MUST clauses + the "load full skill" guidance
- [ ] frontmatter valid

## Linked issues
Refs: principles description trim (session a30b7a6e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)