### PR TITLE
fix(install-runtime): gobbi plugin fails to load — drop redundant manifest component keys

### DIFF
--- a/.gobbi/projects/gobbi/skills/claude-plugin/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/claude-plugin/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: claude-plugin
-description: "Load when authoring, updating, or packaging a Claude Code plugin. Covers the plugin.json manifest schema, component key asymmetries (skills ADDS-to vs agents REPLACES), hooks.json structure, marketplace.json format, the install-copies-and-skips-symlinks security constraint, version cadence, and the CLI validate/install/update flow. Includes a gobbi-specific layer covering the bounded package layout, materialization via sync-plugin-package.sh, and the DD-8 dev-vs-installed hook split."
+description: "Load when authoring, updating, or packaging a Claude Code plugin. Covers the plugin.json manifest schema (metadata-only; components auto-load from conventional directories), convention-based component auto-loading (verified on CLI v2.1.159), hooks.json structure, marketplace.json format, the install-copies-and-skips-symlinks security constraint, version cadence, and the CLI validate/install/update flow. Includes a gobbi-specific layer covering the bounded package layout, materialization via sync-plugin-package.sh, and the DD-8 dev-vs-installed hook split."
 allowed-tools: Read, Grep, Glob, Bash, Write, Edit
 ---
 
@@ -18,7 +18,9 @@ A Claude Code plugin is a self-contained directory that ships skills, agents, an
 
 ### The plugin.json manifest
 
-The manifest lives at `<plugin-root>/.claude-plugin/plugin.json`. Only `name` is required. All other keys are optional but strongly recommended:
+The manifest lives at `<plugin-root>/.claude-plugin/plugin.json`. Only `name` is required. All other keys are optional but strongly recommended.
+
+**The manifest is metadata-only. Do NOT list component directories in it.** Components in the conventional directories — `skills/`, `agents/`, and `hooks/hooks.json` under the plugin root — are auto-loaded by convention (verified on CLI v2.1.159). Listing them in `plugin.json` is redundant at best and breaks loading at worst: on CLI v2.1.159, an explicit `"hooks"` key caused a `"Duplicate hooks file detected"` load failure; an explicit `"agents"` array produced `Agents (0)` instead of loading the agents. The `skills`, `agents`, and `hooks` manifest keys are only for non-conventional locations or additional files beyond the standard paths — and even then, verify the result empirically before shipping.
 
 ```json
 {
@@ -30,13 +32,7 @@ The manifest lives at `<plugin-root>/.claude-plugin/plugin.json`. Only `name` is
     "email": "you@example.com"
   },
   "license": "MIT",
-  "keywords": ["tag1", "tag2"],
-  "skills": "./skills/",
-  "agents": [
-    "./agents/manager.md",
-    "./agents/executor.md"
-  ],
-  "hooks": "./hooks/hooks.json"
+  "keywords": ["tag1", "tag2"]
 }
 ```
 
@@ -45,26 +41,29 @@ Key points about the manifest:
 - **`name`** — required, must be unique. Identifies the plugin in install commands and the marketplace.
 - **`version`** — when omitted, Claude Code uses the git SHA of the commit as the version. You MUST bump `version` explicitly in the manifest for installers to receive updates via `claude plugin update` — a SHA-only version never increments from the installer's perspective.
 - **`author`** — an OBJECT with `name` (and optionally `email`, `url`) — NOT a bare string. A bare string is not the correct schema.
-- **Component paths are relative to the plugin ROOT** (the directory that contains `.claude-plugin/`). They do NOT point inside `.claude-plugin/`. For example, `"skills": "./skills/"` means `<plugin-root>/skills/` — the `.claude-plugin/` subdirectory only holds `plugin.json`.
+- **Do NOT add `skills`, `agents`, or `hooks` keys for conventional paths.** Place skills under `<plugin-root>/skills/`, agents under `<plugin-root>/agents/`, and hooks at `<plugin-root>/hooks/hooks.json` — the CLI auto-loads all three by convention. Adding manifest keys for these paths is not needed and has caused load failures in practice (CLI v2.1.159).
 
-### Component keys — skills vs agents (ADDS-to vs REPLACES asymmetry)
+### Component auto-loading — conventional directories
 
-> **Critical footgun — read before authoring.**
+> **Use conventional directories, not manifest keys, for components.**
 
-The two main component keys have opposite default-override semantics:
+Components in conventional directories are auto-loaded by the CLI without any manifest keys (verified on CLI v2.1.159):
 
-| Key | Type | Semantic |
-|---|---|---|
-| `skills` | `string` (dir) or `string[]` (dirs) | **ADDS-TO** the default skill set. The installed plugin's skills are merged with whatever the user already has. |
-| `agents` | `string[]` (array of file paths) | **REPLACES** the default agent set. If you supply `agents`, the user's default agents are entirely replaced with the plugin's list. |
+| Directory / file | What it auto-loads |
+|---|---|
+| `<plugin-root>/skills/` | All skill subdirectories — ADDS-TO the user's existing skill set |
+| `<plugin-root>/agents/` | All `.md` agent files — makes them available alongside existing agents |
+| `<plugin-root>/hooks/hooks.json` | Hook registrations — auto-loaded by convention |
 
-**Consequence for plugin authors:** if you ship `agents`, every agent file you want available must be listed — the default agents are gone. If you only want to extend agents, you cannot: you must list all desired agents explicitly. Omitting `agents` entirely leaves the default agents intact.
+**Do NOT add `skills`, `agents`, or `hooks` keys to `plugin.json` for these conventional paths.** The auto-load behavior is the correct and verified path.
 
-An `agents` array with even one entry replaces all defaults. An `agents` array with zero entries is equivalent to removing all agents. Ship `agents` only when you intend to define the complete agent set for the user.
+**Caveat — manifest `agents` key (if used for non-conventional paths):** the documented intent of the `agents` manifest key is to REPLACE the default agent set with an explicit list. However, empirical testing on CLI v2.1.159 showed that an explicit `agents` array of 5 file paths produced `Agents (0)` — the explicit array was mis-handled and loaded nothing. The conventional `agents/` directory (no manifest key) loaded all 5 agents correctly. If you must use the `agents` key for a non-conventional location, verify empirically that agents actually load before shipping.
 
 ### hooks — hooks.json structure
 
-The `hooks` key in `plugin.json` points to a `hooks.json` file (conventionally at `<plugin-root>/hooks/hooks.json`). The hooks.json must have a top-level `"hooks"` key:
+The `hooks/hooks.json` file under the plugin root is auto-loaded by convention — do NOT add a `"hooks"` key to `plugin.json` pointing at it. On CLI v2.1.159, adding `"hooks": "./hooks/hooks.json"` to the manifest caused a `"Duplicate hooks file detected: ./hooks/hooks.json resolves to already-loaded file"` error and a `Status: failed to load` for the whole plugin. The manifest `"hooks"` key is only for additional hook files at non-conventional paths — and only if you verify the result empirically.
+
+The `hooks/hooks.json` file itself (the FILE structure, not the manifest key) must have a top-level `"hooks"` key:
 
 ```json
 {
@@ -168,7 +167,7 @@ The gobbi plugin is a bounded package under `plugins/gobbi/`. The package contai
 ```
 plugins/gobbi/
   .claude-plugin/
-    plugin.json          ← manifest (name, version, author, skills/agents/hooks keys)
+    plugin.json          ← manifest (metadata-only: name, version, author, license, keywords)
   skills/                ← 19 materialized skill dirs (real files, no symlinks)
   agents/                ← 5 materialized agent .md files
   hooks/
@@ -222,11 +221,15 @@ This is **Option C** of the dev-vs-installed hook design: two separate registrat
 
 Do not collapse the two registrations into one — the dev registration must use bare relative paths (`.claude/hooks/...`) to work from a checked-out worktree without the plugin installed.
 
-### agents REPLACES vs skills ADDS-to — applied to this package
+### Component auto-loading — applied to this package
 
-The gobbi plugin ships `agents` as an explicit array of 5 file paths (manager, leader, executor, evaluator, assistant). This REPLACES the user's default agents when the plugin is installed. Every agent the user needs must be in this list — there is no partial merge.
+The gobbi plugin uses the metadata-only manifest (no `skills`, `agents`, or `hooks` keys). All components auto-load from their conventional directories:
 
-The `skills` key uses a directory pointer (`"./skills/"`), which ADDS-TO the default skill set. The 19 gobbi skills are merged with whatever the user already has.
+- `plugins/gobbi/agents/` — 5 agent files (manager, leader, executor, evaluator, assistant) auto-loaded by convention
+- `plugins/gobbi/skills/` — 19 skill directories auto-loaded by convention; merged with the user's existing skills (ADDS-TO semantics)
+- `plugins/gobbi/hooks/hooks.json` — hook registrations (3 events) auto-loaded by convention
+
+Verified on CLI v2.1.159: `claude plugin details gobbi` reports `Skills (19), Agents (5), Hooks (3)` with no manifest component keys. Adding `skills`/`agents`/`hooks` keys to the manifest previously produced `Status: failed to load` and `Agents (0)` — those keys have been removed.
 
 ### Skills shipped by the package (19 total)
 

--- a/plugins/gobbi/.claude-plugin/plugin.json
+++ b/plugins/gobbi/.claude-plugin/plugin.json
@@ -6,14 +6,5 @@
     "name": "HahyeonJeon"
   },
   "license": "MIT",
-  "keywords": ["gobbi", "workflow", "orchestration", "evaluation", "planning", "claude-code"],
-  "skills": "./skills/",
-  "agents": [
-    "./agents/manager.md",
-    "./agents/leader.md",
-    "./agents/executor.md",
-    "./agents/evaluator.md",
-    "./agents/assistant.md"
-  ],
-  "hooks": "./hooks/hooks.json"
+  "keywords": ["gobbi", "workflow", "orchestration", "evaluation", "planning", "claude-code"]
 }


### PR DESCRIPTION
## Summary

**Bug fix:** the gobbi Claude Code plugin merged in #274 **fails to load** on Claude Code CLI v2.1.159. Root cause: the manifest declared explicit `skills` / `agents` / `hooks` keys, but components in the conventional directories (`skills/`, `agents/`, `hooks/hooks.json` under the plugin root) **auto-load by convention** — re-declaring them in `plugin.json` conflicts.

## Empirical evidence (isolated `CLAUDE_CONFIG_DIR` installs + `claude plugin list` / `details`, v2.1.159)

| manifest | status | Skills | Agents | Hooks |
|---|---|---|---|---|
| shipped (skills+agents+hooks keys) | ✘ **failed to load** | 19 | **0** | 3 |
| drop `hooks` | ✔ enabled | 19 | **0** | 3 |
| drop `hooks`+`agents` | ✔ enabled | 19 | **5** | 3 |
| **metadata-only (this PR)** | **✔ enabled** | **19** | **5** | **3** |

The `hooks` key triggered `"Duplicate hooks file detected: ./hooks/hooks.json resolves to already-loaded file ... The standard hooks/hooks.json is loaded automatically, so manifest.hooks should only reference additional hook files."` The explicit `agents` array produced `Agents (0)`.

## The fix

1. **`plugins/gobbi/.claude-plugin/plugin.json`** → metadata-only (`name`/`version`/`description`/`author`/`license`/`keywords`); the three component keys removed. `claude plugin validate --strict` passes; install → `✔ enabled` with all 19 skills / 5 agents / 3 hooks loaded.
2. **`claude-plugin` skill** → corrected. It previously taught the buggy pattern (explicit component keys + a "skills ADDS-to vs agents REPLACES" model the install behavior contradicts). Now teaches convention-based auto-loading, annotated "verified on CLI v2.1.159".

`hooks/hooks.json` itself is unchanged and correct — only the manifest key pointing at it was wrong.

## Scope

Two files. Does **not** touch the symlink-vs-materialization layout question (a separate, larger follow-up — research found the materialized `plugins/gobbi/` real copies can be replaced with within-marketplace symlinks, pending a GitHub-hosted-install verification). This PR is the surgical load-failure fix only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
