### PR TITLE
docs(principles): clear stale Anti-rationalizations/Mechanism field-name residue

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -28,7 +28,7 @@ Evaluation runs inside Ideation, Planning, and Execution — mandatory after Exe
 
 > **MUST load [principles](skills/principles/SKILL.md) at session start, resume, /clear, and /compact.**
 
-The 14 principles below are the enforceable behavioral discipline for every agent. The principle table is the always-visible summary; load the skill for the full Why, Anti-rationalizations, and Mechanism behind each principle. Subagent briefings MUST include the load instruction in their prompt — fresh subagents do not inherit the parent's loaded skills.
+The 14 principles below are the enforceable behavioral discipline for every agent. The principle table is the always-visible summary; load the skill for the full rationale and detail behind each principle. Subagent briefings MUST include the load instruction in their prompt — fresh subagents do not inherit the parent's loaded skills.
 
 | # | Principle |
 |---|---|
@@ -59,4 +59,4 @@ Every agent MUST load the `mistake` skill before starting work. When the user co
 |----------|--------|
 | [gobbi skill](skills/gobbi/SKILL.md) | Entry point, session setup questions, skill map |
 | [claude skill](skills/claude/SKILL.md) | Documentation standard for `.claude/` authoring |
-| [principles](skills/principles/SKILL.md) | 14 behavioral principles every agent must follow — MUST load at session start; load the skill for the full rationale and anti-rationalizations |
+| [principles](skills/principles/SKILL.md) | 14 behavioral principles every agent must follow — MUST load at session start; load the skill for the full rationale and detail |

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -60,7 +60,7 @@ Evaluation runs inside Ideation, Planning, and Execution. The orchestrator selec
 
 > **MUST load `.agents/skills/principles/SKILL.md` at session start, resume, /clear, and /compact.**
 
-The 14 principles below are the enforceable behavioral discipline for every agent. The principle table is the always-visible summary; load the skill for the full Why, Anti-rationalizations, and Mechanism behind each principle.
+The 14 principles below are the enforceable behavioral discipline for every agent. The principle table is the always-visible summary; load the skill for the full rationale and detail behind each principle.
 
 | # | Principle |
 |---|---|

--- a/.gobbi/projects/gobbi/agents/leader.md
+++ b/.gobbi/projects/gobbi/agents/leader.md
@@ -22,7 +22,7 @@ The manager delegates to you for Ideation (refining what to do), Preparation (ve
 
 Mandatory load — every fresh subagent:
 
-1. **`principles` skill** — Iron Laws, anti-rationalizations. Not inherited; load explicitly.
+1. **`principles` skill** — Iron Laws and rationale. Not inherited; load explicitly.
 2. **All project rules** under `.gobbi/projects/{project-name}/rules/`.
 3. **`mistake` skill** — past pitfalls in this domain.
 

--- a/.gobbi/projects/gobbi/skills/principles/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/principles/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: principles
-description: "EVERY agent MUST load this skill at the start of its work, before any other action. You MUST read and understand every principle, and you MUST follow them without exception — they override convenience, speed, and your own judgment. Load the full skill for the rationale, anti-rationalizations, and mechanism behind each principle."
+description: "EVERY agent MUST load this skill at the start of its work, before any other action. You MUST read and understand every principle, and you MUST follow them without exception — they override convenience, speed, and your own judgment. Load the full skill for the rationale and detail behind each principle."
 allowed-tools: Read, Grep, Glob, Bash
 ---
 
@@ -371,4 +371,4 @@ allowed-tools: Read, Grep, Glob, Bash
 
 ---
 
-This skill is the single source of behavioral discipline. Loading it explicitly gives an agent the rationale and anti-rationalizations behind any principle when context demands more than the principle summary in CLAUDE.md. Future work: a Red Flags table per principle, listing the named rationalizations from each principle in scannable tabular form.
+This skill is the single source of behavioral discipline. Loading it explicitly gives an agent the rationale and detail behind any principle when context demands more than the principle summary in CLAUDE.md. Future work: a Red Flags table per principle, listing the named rationalizations from each principle in scannable tabular form.


### PR DESCRIPTION
## Summary
- The 4-field redesign (#283) renamed each principle's fields to Why/What/How/Anti-pattern, but several docs still named the old fields ("Anti-rationalizations", "Mechanism"). Replace those with generic wording — "the full rationale and detail behind each principle" — so the prose won't re-go-stale on a future field rename.
- Clears the backlog `principles-anti-rationalizations-label-residue` filed during the #283 wrap-up; widened per Principle 13 (blast radius) to all live co-occurrences, not just the skill file.

## Changes
- `skills/principles/SKILL.md` — frontmatter `description` + closing paragraph.
- `.claude/CLAUDE.md` — intro prose + navigate-table row.
- `.codex/AGENTS.md` — intro prose mirror.
- `agents/leader.md` — load-directive line ("Iron Laws and rationale").

## Test plan
- [ ] `rg -ni "anti-rationalization"` across live docs (excl sessions/archive/worktrees) → none
- [ ] no "Anti-rationalizations, and Mechanism" field-list remains in CLAUDE.md / AGENTS.md
- [ ] principles unaffected: 14 headings, 56 four-field labels

## Linked issues
Refs: backlog principles-anti-rationalizations-label-residue (session a30b7a6e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)