### PR TITLE
docs(guardrails): hook-event count 31→30 + close webfetch-gap & residue backlogs

### DIFF
--- a/.gobbi/projects/gobbi/archive/backlogs/2026-06-01-hook-event-count-31-vs-29-docs-sync.md
+++ b/.gobbi/projects/gobbi/archive/backlogs/2026-06-01-hook-event-count-31-vs-29-docs-sync.md
@@ -46,7 +46,7 @@ When authoring or editing `.claude/settings.json` hook registration for PostTool
 
 - `features/guardrails/references/claude-code-posttooluse-hook-schema.md` (the reference carrying the "31" claim)
 - Provenance: the Codex Overall-perspective evaluator finding on iteration 3 of that session's guardrails Ideation evaluation
-- See also `features/guardrails/checklists/hook-event-count-31-vs-29-docs-sync.md` (checklist form of same item)
+- See also `../checklists/2026-06-01-hook-event-count-31-vs-29-docs-sync.md` (checklist form of same item; archived 2026-06-01)
 
 ## Resolution (2026-06-01)
 
@@ -54,4 +54,4 @@ The live count was independently re-verified on 2026-06-01 via Claude WebFetch, 
 
 The reference file `features/guardrails/references/claude-code-posttooluse-hook-schema.md` was corrected to 30 (commit 84521bc, session 34563fb4) — the event count, full enumeration, and all prose referring to "31" updated to "30". The README `## Open items` bullet was removed and a `## Recent activity` row added.
 
-Note on the closure gate: `grep -rn '"31 hook' features/guardrails/` will reach 0 matches only after this resolved item (and the companion checklist `checklists/hook-event-count-31-vs-29-docs-sync.md`) are archived out of `features/guardrails/` into `archive/backlogs/` at Wrap-up. The files are left in place here per the archive-template sole-writer rule; physical archive `git mv` is a Wrap-up-only operation.
+Note on the closure gate: `grep -rn '"31 hook' features/guardrails/` reaches 0 matches now that this resolved item and the companion checklist (`../checklists/2026-06-01-hook-event-count-31-vs-29-docs-sync.md`) have been archived out of `features/guardrails/` at Wrap-up (per the archive-template sole-writer rule; physical archive `git mv` is a Wrap-up-only operation).

--- a/.gobbi/projects/gobbi/archive/backlogs/2026-06-01-hook-event-count-31-vs-29-docs-sync.md
+++ b/.gobbi/projects/gobbi/archive/backlogs/2026-06-01-hook-event-count-31-vs-29-docs-sync.md
@@ -12,6 +12,8 @@ priority: low
 disposition: addressed
 project-scope: false
 shipped_in: "session 34563fb4 (commits 84521bc + iter2 remediation)"
+archived_at: 2026-06-01
+archive_reason: addressed
 ---
 
 # Hook event count claim (31) contradicts captured evidence (29)

--- a/.gobbi/projects/gobbi/archive/backlogs/2026-06-01-posttooluse-failure-webfetch-verification-gap.md
+++ b/.gobbi/projects/gobbi/archive/backlogs/2026-06-01-posttooluse-failure-webfetch-verification-gap.md
@@ -12,6 +12,8 @@ priority: medium
 disposition: addressed
 project-scope: false
 shipped_in: "session 34563fb4 (commits 84521bc + iter2 remediation)"
+archived_at: 2026-06-01
+archive_reason: addressed
 ---
 
 # Assume PostToolUseFailure verbatim quote was correctly retrieved via WebFetch

--- a/.gobbi/projects/gobbi/archive/backlogs/2026-06-01-principles-anti-rationalizations-label-residue.md
+++ b/.gobbi/projects/gobbi/archive/backlogs/2026-06-01-principles-anti-rationalizations-label-residue.md
@@ -4,13 +4,15 @@ description: "The frontmatter description field and closing paragraph of princip
 type: backlogs
 scope: feature
 feature: guardrails
-status: active
+status: addressed
 created: 2026-06-01
 session: a30b7a6e-164f-49ac-a857-ee225e831a7c
 tags: [principles, cosmetic, label-consistency]
 priority: null
-disposition: open
-shipped_in: null
+disposition: addressed
+shipped_in: "#285"
+archived_at: 2026-06-01
+archive_reason: addressed
 ---
 
 # Anti-rationalizations label residue in principles/SKILL.md
@@ -27,3 +29,7 @@ These are cosmetic inconsistencies. The normative content (the field bodies them
 - `grep -i "anti-rationalizations" .claude/skills/principles/SKILL.md` returns no results.
 - Frontmatter description and closing paragraph use "Anti-pattern" (or omit the label reference).
 - No normative content changed.
+
+## Resolution (2026-06-01)
+
+Cleared by PR #285 (commit `9bae55f`). Verified this session: `grep -i 'anti-rationalizations' .claude/skills/principles/SKILL.md` returns 0 matches. The frontmatter `description:` field residue ("Anti-rationalizations/Mechanism field-name residue") was removed in that PR. No normative content was changed.

--- a/.gobbi/projects/gobbi/archive/checklists/2026-06-01-hook-event-count-31-vs-29-docs-sync.md
+++ b/.gobbi/projects/gobbi/archive/checklists/2026-06-01-hook-event-count-31-vs-29-docs-sync.md
@@ -10,6 +10,8 @@ session: 1b26cf20-677b-498c-8c1b-7d7e971597ac
 tags: [hooks, docs-sync, event-count, checklist]
 disposition: addressed
 shipped_in: "session 34563fb4 (commits 84521bc + iter2 remediation)"
+archived_at: 2026-06-01
+archive_reason: addressed
 ---
 
 # Hook event count claim (31) contradicts captured evidence (29)

--- a/.gobbi/projects/gobbi/archive/checklists/2026-06-01-hook-event-count-31-vs-29-docs-sync.md
+++ b/.gobbi/projects/gobbi/archive/checklists/2026-06-01-hook-event-count-31-vs-29-docs-sync.md
@@ -40,7 +40,7 @@ Pending — this is a tracked docs-sync item, not yet swept. The count correctio
 
 - `features/guardrails/references/claude-code-posttooluse-hook-schema.md` (the reference carrying the claim)
 - Surfaced as an Overall-perspective evaluator finding during the guardrails Ideation evaluation (provenance in that session's evaluation artifacts).
-- See also `features/guardrails/backlogs/hook-event-count-31-vs-29-docs-sync.md` (backlog form of same item)
+- See also `../backlogs/2026-06-01-hook-event-count-31-vs-29-docs-sync.md` (backlog form of same item; archived 2026-06-01)
 
 ## Resolution (2026-06-01)
 

--- a/.gobbi/projects/gobbi/features/guardrails/README.md
+++ b/.gobbi/projects/gobbi/features/guardrails/README.md
@@ -44,11 +44,10 @@ Active. The behavioral floor (13 Iron Laws in the `principles` skill) and the mi
 |---|---|---|
 | 2026-05-26 | a10c82d6 | Feature directory created during the memory-system redesign and seeded with re-homed work-sprint artifacts |
 | 2026-05-30 | a30b7a6e | Principles clarity pass: removed Iron Law Index, literal rewrite of P6/P10/P11, added Principle 14 (plain literal language, all agent-authored text); decisions/ subdir created |
+| 2026-06-01 | 34563fb4 | Re-verified the hooks contract (both PostToolUseFailure quotes verbatim); corrected the event count 31→30 (+MessageDisplay); resolved the hook-event-count and WebFetch-verification-gap backlogs |
 
 ## Open items
 
-- Correct the "31 hook events" claim to the verified count of 29 in surviving references — see `backlogs/hook-event-count-31-vs-29-docs-sync.md`.
-- Empirically re-verify the `PostToolUseFailure` hook contract when authoring its `.claude/settings.json` registration — see `backlogs/posttooluse-failure-webfetch-verification-gap.md`.
 - Add a quality gate on `agents[]` field population if presence is ever treated as a metric — see `backlogs/goodhart-factor-when-demanded-deferred.md`.
 
 ## Related

--- a/.gobbi/projects/gobbi/features/guardrails/backlogs/hook-event-count-31-vs-29-docs-sync.md
+++ b/.gobbi/projects/gobbi/features/guardrails/backlogs/hook-event-count-31-vs-29-docs-sync.md
@@ -4,14 +4,14 @@ description: Deferred docs-sync — correct the "31 hook events" claim to "29" i
 type: backlogs
 scope: feature
 feature: guardrails
-status: active
+status: addressed
 created: 2026-05-23
 session: 1b26cf20-677b-498c-8c1b-7d7e971597ac
 tags: [hooks, docs-sync, event-count, deferred]
 priority: low
-disposition: open
+disposition: addressed
 project-scope: false
-shipped_in: null
+shipped_in: "session 34563fb4 (commits 84521bc + iter2 remediation)"
 ---
 
 # Hook event count claim (31) contradicts captured evidence (29)
@@ -45,3 +45,11 @@ When authoring or editing `.claude/settings.json` hook registration for PostTool
 - `features/guardrails/references/claude-code-posttooluse-hook-schema.md` (the reference carrying the "31" claim)
 - Provenance: the Codex Overall-perspective evaluator finding on iteration 3 of that session's guardrails Ideation evaluation
 - See also `features/guardrails/checklists/hook-event-count-31-vs-29-docs-sync.md` (checklist form of same item)
+
+## Resolution (2026-06-01)
+
+The live count was independently re-verified on 2026-06-01 via Claude WebFetch, Codex, and a raw-HTML parse (curl + Python row-count of the lifecycle table) as **30**, not 29. The "29" this item assumed was itself stale: the page gained `MessageDisplay` at position 12 (between Notification and SubagentStart) since the 2026-05-23 capture that produced the "29" figure. All 29 previously-captured names remain present; `MessageDisplay` is the single net addition.
+
+The reference file `features/guardrails/references/claude-code-posttooluse-hook-schema.md` was corrected to 30 (commit 84521bc, session 34563fb4) — the event count, full enumeration, and all prose referring to "31" updated to "30". The README `## Open items` bullet was removed and a `## Recent activity` row added.
+
+Note on the closure gate: `grep -rn '"31 hook' features/guardrails/` will reach 0 matches only after this resolved item (and the companion checklist `checklists/hook-event-count-31-vs-29-docs-sync.md`) are archived out of `features/guardrails/` into `archive/backlogs/` at Wrap-up. The files are left in place here per the archive-template sole-writer rule; physical archive `git mv` is a Wrap-up-only operation.

--- a/.gobbi/projects/gobbi/features/guardrails/backlogs/posttooluse-failure-webfetch-verification-gap.md
+++ b/.gobbi/projects/gobbi/features/guardrails/backlogs/posttooluse-failure-webfetch-verification-gap.md
@@ -4,14 +4,14 @@ description: Deferred verification gap — PostToolUseFailure verbatim quote was
 type: backlogs
 scope: feature
 feature: guardrails
-status: active
+status: addressed
 created: 2026-05-23
 session: 1b26cf20-677b-498c-8c1b-7d7e971597ac
 tags: [posttooluse-failure, webfetch, verification-gap, deferred]
 priority: medium
-disposition: open
+disposition: addressed
 project-scope: false
-shipped_in: null
+shipped_in: "session 34563fb4 (commits 84521bc + iter2 remediation)"
 ---
 
 # Assume PostToolUseFailure verbatim quote was correctly retrieved via WebFetch
@@ -47,3 +47,12 @@ When authoring `.claude/settings.json` hook registration for PostToolUseFailure.
 
 - `features/guardrails/references/claude-code-posttooluse-hook-schema.md` (the verbatim hook-contract quotes are preserved here)
 - The same gap was independently flagged by both the Project-perspective and Risk-perspective evaluators at Ideation (provenance in that session's evaluation artifacts).
+
+## Resolution (2026-06-01)
+
+On 2026-06-01 the two preserved `PostToolUseFailure` verbatim quotes were independently re-verified — confirmed byte-identical to the live page by Claude WebFetch, Codex, and a raw-HTML parse (curl extraction of the lifecycle and exit-code-behavior tables):
+
+- Lifecycle table: `| PostToolUseFailure | After a tool call fails |` — verbatim match confirmed.
+- Exit-code-behavior table: `| PostToolUseFailure | No | Shows stderr to Claude (tool already failed) |` — verbatim match confirmed across all three cells (event / Can block? = "No" / "Shows stderr to Claude (tool already failed)").
+
+`PostToolUseFailure` remains a documented hook event with `type: "command"` support. The verification gap opened at Ideation (Confidence-50 downgrade) is closed. The reference file `features/guardrails/references/claude-code-posttooluse-hook-schema.md` carries the re-verification note (line 40, session 34563fb4). Archive deferred to Wrap-up per the archive-template sole-writer rule.

--- a/.gobbi/projects/gobbi/features/guardrails/checklists/hook-event-count-31-vs-29-docs-sync.md
+++ b/.gobbi/projects/gobbi/features/guardrails/checklists/hook-event-count-31-vs-29-docs-sync.md
@@ -4,10 +4,12 @@ description: Implementation checklist — correct all "31 hook events" claims in
 type: checklists
 scope: feature
 feature: guardrails
-status: active
+status: addressed
 created: 2026-05-23
 session: 1b26cf20-677b-498c-8c1b-7d7e971597ac
 tags: [hooks, docs-sync, event-count, checklist]
+disposition: addressed
+shipped_in: "session 34563fb4 (commits 84521bc + iter2 remediation)"
 ---
 
 # Hook event count claim (31) contradicts captured evidence (29)
@@ -16,9 +18,9 @@ tags: [hooks, docs-sync, event-count, checklist]
 
 Correct all "31 hook events" claims in the guardrails docs to "29" (the verified enumerated count):
 
-- [ ] In `features/guardrails/references/claude-code-posttooluse-hook-schema.md`: if the header or body claims "31 events", update to "29" (verified enumerated count).
-- [ ] Scan all guardrails docs for other occurrences of the "31" hook event count claim and correct each.
-- [ ] After update: `grep -rn '"31 hook' features/guardrails/` returns 0 matches (all corrected to 29).
+- [x] In `features/guardrails/references/claude-code-posttooluse-hook-schema.md`: if the header or body claims "31 events", update to "29" (verified enumerated count). (corrected to **30**, not 29 — see Resolution)
+- [x] Scan all guardrails docs for other occurrences of the "31" hook event count claim and correct each. (corrected to **30**, not 29 — see Resolution)
+- [x] After update: `grep -rn '"31 hook' features/guardrails/` returns 0 matches (all corrected to 29). (corrected to **30**, not 29 — see Resolution; 0 matches in reference and README after this session; remaining matches are inside these now-resolved tracking files, which archive at Wrap-up)
 
 ## Why
 
@@ -37,3 +39,7 @@ Pending — this is a tracked docs-sync item, not yet swept. The count correctio
 - `features/guardrails/references/claude-code-posttooluse-hook-schema.md` (the reference carrying the claim)
 - Surfaced as an Overall-perspective evaluator finding during the guardrails Ideation evaluation (provenance in that session's evaluation artifacts).
 - See also `features/guardrails/backlogs/hook-event-count-31-vs-29-docs-sync.md` (backlog form of same item)
+
+## Resolution (2026-06-01)
+
+The live count was independently re-verified on 2026-06-01 via Claude WebFetch, Codex, and a raw-HTML parse (curl + Python row-count of the lifecycle table) as **30**, not 29. The "29" this checklist assumed as the correction target was itself stale: the page gained `MessageDisplay` at position 12 (between Notification and SubagentStart) since the 2026-05-23 capture. The reference file and README were corrected to 30 this session (commit 84521bc + iter2 remediation, session 34563fb4). Archive (project-level `archive/backlogs/` and `archive/checklists/`) deferred to Wrap-up per the archive-template sole-writer rule.

--- a/.gobbi/projects/gobbi/features/guardrails/references/claude-code-posttooluse-hook-schema.md
+++ b/.gobbi/projects/gobbi/features/guardrails/references/claude-code-posttooluse-hook-schema.md
@@ -32,8 +32,8 @@ The hook **also receives `transcript_path`** in every fire — meaning a hook ca
 
 - [`../../install-runtime/references/claude-code-transcript-tooluseresult-empirical.md`](../../install-runtime/references/claude-code-transcript-tooluseresult-empirical.md) (the empirical transcript-shape companion — the verbatim `toolUseResult` JSONL payload captured during the guardrails Ideation, which grounds the "verified empirically" claim in the Why-it-applies section)
 - `claude-code-hooks-12-lifecycle-events.md` (the companion reference covering the broader hook lifecycle-event landscape)
-- `checklists/hook-event-count-31-vs-29-docs-sync.md` and `backlogs/hook-event-count-31-vs-29-docs-sync.md` (the tracked docs-sync item: the "31 events" claim below is corrected to the verified count of **30**, re-verified 2026-06-01; the tracked docs-sync and verification-gap items are being resolved this session)
-- `backlogs/posttooluse-failure-webfetch-verification-gap.md` (the deferred empirical re-verification of the verbatim quotes captured here)
+- `../../../archive/checklists/2026-06-01-hook-event-count-31-vs-29-docs-sync.md` and `../../../archive/backlogs/2026-06-01-hook-event-count-31-vs-29-docs-sync.md` (the tracked docs-sync item — resolved 2026-06-01; count corrected to **30** via commit 84521bc + iter2 remediation; archived at Wrap-up)
+- `../../../archive/backlogs/2026-06-01-posttooluse-failure-webfetch-verification-gap.md` (the deferred empirical re-verification of the verbatim quotes — resolved 2026-06-01; both quotes confirmed verbatim; archived at Wrap-up)
 
 ## PostToolUseFailure — verbatim verification
 

--- a/.gobbi/projects/gobbi/features/guardrails/references/claude-code-posttooluse-hook-schema.md
+++ b/.gobbi/projects/gobbi/features/guardrails/references/claude-code-posttooluse-hook-schema.md
@@ -10,7 +10,7 @@ session: 2026-05-23-1b26cf20-677b-498c-8c1b-7d7e971597ac
 tags: [hook, posttooluse, posttooluse-failure, agent-tool, schema, telemetry]
 title: Claude Code PostToolUse + PostToolUseFailure hook — official input schema + empirical Task tool payload
 source: https://code.claude.com/docs/en/hooks
-accessed: 2026-05-23
+accessed: 2026-06-01
 ref_type: docs
 ---
 
@@ -32,12 +32,12 @@ The hook **also receives `transcript_path`** in every fire — meaning a hook ca
 
 - [`../../install-runtime/references/claude-code-transcript-tooluseresult-empirical.md`](../../install-runtime/references/claude-code-transcript-tooluseresult-empirical.md) (the empirical transcript-shape companion — the verbatim `toolUseResult` JSONL payload captured during the guardrails Ideation, which grounds the "verified empirically" claim in the Why-it-applies section)
 - `claude-code-hooks-12-lifecycle-events.md` (the companion reference covering the broader hook lifecycle-event landscape)
-- `checklists/hook-event-count-31-vs-29-docs-sync.md` and `backlogs/hook-event-count-31-vs-29-docs-sync.md` (the tracked docs-sync item: the "31 events" claim below should be corrected to the verified count of 29)
+- `checklists/hook-event-count-31-vs-29-docs-sync.md` and `backlogs/hook-event-count-31-vs-29-docs-sync.md` (the tracked docs-sync item: the "31 events" claim below is corrected to the verified count of **30**, re-verified 2026-06-01; the tracked docs-sync and verification-gap items are being resolved this session)
 - `backlogs/posttooluse-failure-webfetch-verification-gap.md` (the deferred empirical re-verification of the verbatim quotes captured here)
 
 ## PostToolUseFailure — verbatim verification
 
-WebFetched `https://code.claude.com/docs/en/hooks` on 2026-05-23. The official docs page lists `PostToolUseFailure` as one of 31 documented hook events and includes it in two tables:
+WebFetched `https://code.claude.com/docs/en/hooks` on 2026-05-23. The official docs page lists `PostToolUseFailure` as one of **30** documented hook events and includes it in two tables (re-verified 2026-06-01; both quotes below still match the live page verbatim):
 
 **Lifecycle table (verbatim):**
 
@@ -53,7 +53,7 @@ WebFetched `https://code.claude.com/docs/en/hooks` on 2026-05-23. The official d
 
 Shell-command hook support is explicitly confirmed: PostToolUseFailure supports the same `type: "command"` registration shape as PostToolUse (alongside HTTP, MCP-tool, prompt, and agent hooks). It is non-blocking — exit code 2 does not prevent the underlying tool failure but does surface the hook's stderr to Claude.
 
-All 31 documented hook events on this page (full enumeration for context):
+All **30** documented hook events on this page (full enumeration, re-verified 2026-06-01):
 
 1. `SessionStart`
 2. `Setup`
@@ -66,26 +66,27 @@ All 31 documented hook events on this page (full enumeration for context):
 9. `PostToolUseFailure`
 10. `PostToolBatch`
 11. `Notification`
-12. `SubagentStart`
-13. `SubagentStop`
-14. `TaskCreated`
-15. `TaskCompleted`
-16. `Stop`
-17. `StopFailure`
-18. `TeammateIdle`
-19. `InstructionsLoaded`
-20. `ConfigChange`
-21. `CwdChanged`
-22. `FileChanged`
-23. `WorktreeCreate`
-24. `WorktreeRemove`
-25. `PreCompact`
-26. `PostCompact`
-27. `Elicitation`
-28. `ElicitationResult`
-29. `SessionEnd`
+12. `MessageDisplay`
+13. `SubagentStart`
+14. `SubagentStop`
+15. `TaskCreated`
+16. `TaskCompleted`
+17. `Stop`
+18. `StopFailure`
+19. `TeammateIdle`
+20. `InstructionsLoaded`
+21. `ConfigChange`
+22. `CwdChanged`
+23. `FileChanged`
+24. `WorktreeCreate`
+25. `WorktreeRemove`
+26. `PreCompact`
+27. `PostCompact`
+28. `Elicitation`
+29. `ElicitationResult`
+30. `SessionEnd`
 
-(The page's table lists 31; the enumerated names above cover the explicitly captured events from the same WebFetch.)
+(The live lifecycle table lists 30 events, re-verified 2026-06-01; the enumeration above is complete. The only net change since the 2026-05-23 capture is the addition of `MessageDisplay` at position 12.)
 
 ## Why it applies
 The subagent-telemetry hook design explicitly required verifying the hook contract before committing to the mechanism. This insight is the verification answer:
@@ -115,3 +116,4 @@ This gives the design a clear path: even if `tool_result` in the hook payload is
 |---|---|---|
 | 2026-05-23 | 1b26cf20-677b-498c-8c1b-7d7e971597ac | Closed the hook-contract verification gate for the PostToolUse-based subagent telemetry design |
 | 2026-05-23 | 1b26cf20-677b-498c-8c1b-7d7e971597ac | Added the verbatim PostToolUseFailure quote to ground the dual-event hook registration in the official docs |
+| 2026-06-01 | 34563fb4-361d-4348-aa75-8bc9f1fbff05 | Re-verified the hook contract: both PostToolUseFailure quotes still match verbatim; corrected the event count 31→30 and added MessageDisplay |

--- a/.gobbi/projects/gobbi/features/guardrails/references/claude-code-posttooluse-hook-schema.md
+++ b/.gobbi/projects/gobbi/features/guardrails/references/claude-code-posttooluse-hook-schema.md
@@ -98,9 +98,8 @@ The subagent-telemetry hook design explicitly required verifying the hook contra
 This gives the design a clear path: even if `tool_result` in the hook payload is impoverished, the hook is rich enough because `transcript_path` is always provided. The design's mechanism — a hook for real-time append plus a shell-script reconstructor for repair — is fully supported, and the dual-event (success + failure) registration is officially documented.
 
 ## Source
-- https://code.claude.com/docs/en/hooks
-- https://code.claude.com/docs/en/agent-sdk/hooks
-- Both accessed 2026-05-23
+- https://code.claude.com/docs/en/hooks — accessed 2026-05-23, re-verified 2026-06-01
+- https://code.claude.com/docs/en/agent-sdk/hooks — accessed 2026-05-23
 
 ## Excerpt
 > "PostToolUse | After a tool call succeeds"

--- a/.gobbi/projects/gobbi/mistakes/codex-webfetch-undercounts-recently-added-table-row.md
+++ b/.gobbi/projects/gobbi/mistakes/codex-webfetch-undercounts-recently-added-table-row.md
@@ -1,0 +1,28 @@
+---
+name: codex-webfetch-undercounts-recently-added-table-row
+description: Codex `codex exec` web-search undercounted a documented table by one row (missed a recently-added event), disagreeing with Claude's WebFetch; raw-HTML parse was the tiebreaker.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-06-01
+session: 34563fb4-361d-4348-aa75-8bc9f1fbff05
+domain: docs-sync
+tags: [codex, webfetch, count-verification, dual-system, tiebreaker]
+priority: medium
+---
+
+# Codex web-search undercounts a recently-added table row; raw HTML is the count tiebreaker
+
+## What went wrong
+On a hook-event-count verification, the Claude leader's WebFetch returned **30** events (including `MessageDisplay` at position 12); an independent Codex `codex exec` web-search returned **29** — an identical list except it was missing the one newly-added event. Two careful LLM-mediated fetches of the same live page disagreed by exactly one row.
+
+## Why it went wrong
+Both LLM fetch paths share a summarization/caching failure mode: a web-search index or summarizer view can lag the live page when a table row was recently added, and the model reports the stale count without flagging uncertainty. Arbitrating between two LLM-summarized counts is unreliable because both can be wrong in the same direction.
+
+## How to recognize it next time
+- Any dispute about a COUNT or an exact enumeration drawn from a web page, where two LLM fetches (or an LLM fetch vs a recalled figure) disagree by a small number.
+- A WebFetch summarizer that returns a self-contradicting count in one pass (a tell that it is summarizing, not transcribing).
+
+## Corrected approach
+For count/enumeration disputes, fetch the **raw page text** (`curl -sL <url>` + parse/grep, e.g. count `<tr>` rows in the target `<table>`) and treat that as ground truth — do not arbitrate between two LLM-summarized counts. Raw HTML settled 30 here (`MessageDisplay` present in TOC + dedicated sections + a lifecycle `<tr>`). Reinforces [[claude-evaluator-step4-only-vs-codex-whole-file-grep]].

--- a/.gobbi/projects/gobbi/mistakes/docs-sync-count-fix-blast-radius-includes-colocated-dates-and-tracking-pointers.md
+++ b/.gobbi/projects/gobbi/mistakes/docs-sync-count-fix-blast-radius-includes-colocated-dates-and-tracking-pointers.md
@@ -1,0 +1,28 @@
+---
+name: docs-sync-count-fix-blast-radius-includes-colocated-dates-and-tracking-pointers
+description: A docs-sync count/date correction's CRUD blast radius missed the body `## Source` access-date and the tracking-pointer docs (README open-items, backlog, checklist) — caught by dual-system eval as REVISE.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-06-01
+session: 34563fb4-361d-4348-aa75-8bc9f1fbff05
+domain: docs-sync
+tags: [principle-13, blast-radius, crud-plan, docs-sync, provenance-date]
+priority: medium
+---
+
+# Docs-sync blast radius includes co-located dates AND tracking-pointer docs
+
+## What went wrong
+The iter1 CRUD plan for a "correct the hook-event count 31→30 + refresh provenance" change updated the frontmatter `accessed:` date but **missed the body `## Source` line** ("Both accessed 2026-05-23"), leaving the same file internally contradictory. It also deferred — without recording a ratified deferral — the live `README.md` open-item pointer and the backlog/checklist that still asserted the stale "29" target. Dual-system evaluation returned REVISE on both (Codex caught the Source date; Claude caught the README/tracking blast radius).
+
+## Why it went wrong
+A count/date correction "feels" local to the one prose claim, so the CRUD plan stopped at the obvious spot (frontmatter + the enumeration). Principle 13's blast-radius step was applied too narrowly: provenance metadata is duplicated across a doc (frontmatter date AND a body Source/accessed section AND a usage-history row), and a tracked task's "claim" is mirrored in pointer docs (a feature README's open-items list, the backlog, the checklist).
+
+## How to recognize it next time
+- Editing any count/date/version claim that also appears in a doc's frontmatter, a `## Source`/`## Provenance` section, and/or a usage-history table — they must ALL move together.
+- The change resolves a tracked backlog/checklist whose text or a README open-items bullet still states the old target.
+
+## Corrected approach
+For a docs-sync correction, the P13 blast-radius enumeration MUST include: (1) every co-located instance of the value in the same file (frontmatter + body Source/accessed + history rows); (2) every tracking-pointer doc (feature `README.md` open-items, the backlog, the checklist). Grep the value across the feature tree before editing. If any co-update is intentionally deferred to a later phase (e.g., archive move to Wrap-up), record that as a ratified deferral so it is not read as an open defect.

--- a/.gobbi/projects/gobbi/notes/2026-06-01-hook-event-count-and-residue-closure.md
+++ b/.gobbi/projects/gobbi/notes/2026-06-01-hook-event-count-and-residue-closure.md
@@ -1,0 +1,73 @@
+---
+name: hook-event-count-and-residue-closure
+description: "Resolved two guardrails backlogs: corrected the hook-event count claim (31→30, re-verified live), confirmed PostToolUseFailure verbatim quotes; archived 4 resolved tracking items; promoted 2 project mistakes; also closed the principles anti-rationalizations residue backlog (shipped in PR #285)."
+type: notes
+scope: project
+feature: null
+status: active
+created: 2026-06-01
+session: 34563fb4-361d-4348-aa75-8bc9f1fbff05
+tags: [guardrails, hooks, docs-sync, principles, archive, mistakes]
+features_touched: [guardrails]
+loops_completed: [ideation, execution, wrap-up]
+shipped: [
+  "mistakes/codex-webfetch-undercounts-recently-added-table-row.md",
+  "mistakes/docs-sync-count-fix-blast-radius-includes-colocated-dates-and-tracking-pointers.md",
+  "archive/backlogs/2026-06-01-hook-event-count-31-vs-29-docs-sync.md",
+  "archive/backlogs/2026-06-01-posttooluse-failure-webfetch-verification-gap.md",
+  "archive/backlogs/2026-06-01-principles-anti-rationalizations-label-residue.md",
+  "archive/checklists/2026-06-01-hook-event-count-31-vs-29-docs-sync.md"
+]
+---
+
+# Hook event count correction and residue closure (2026-06-01)
+
+## What happened
+
+This session was a Chat-mode docs-sync session targeting two guardrails backlogs plus one out-of-scope residue item.
+
+**Hook-event count (31→30 correction).** The guardrails reference file `features/guardrails/references/claude-code-posttooluse-hook-schema.md` carried a "31 hook events" claim. The Ideation phase ran WebFetch of `https://code.claude.com/docs/en/hooks` to re-verify the live count. The session leader's WebFetch returned 30 events — one more than the "29" the earlier backlog had assumed as the correction target. The discrepancy was traced to `MessageDisplay`, a newly-added event at position 12 (between Notification and SubagentStart), which was not present in the 2026-05-23 capture that produced the "29" baseline. A Codex `codex exec` web-search independently returned 29, disagreeing by one. The tiebreaker was a raw-HTML parse (curl + Python row-count of the lifecycle `<table>`), which confirmed 30 rows. This tie-breaking method — raw HTML over LLM-summarized counts — is now recorded as a project mistake.
+
+Execution iter1 (commit 84521bc) corrected the reference file: the "31" claim updated to "30", the full enumeration updated to include `MessageDisplay`, and the frontmatter `accessed:` date refreshed to 2026-06-01. The dual-system evaluator (Codex) caught that the body `## Source` access-date still read "Both accessed 2026-05-23" and the README open-item bullet + tracking backlog/checklist were not co-updated (Principle 13 blast-radius miss). The Claude evaluator caught the README tracking pointer issue. Both evaluators returned REVISE. Iter2 remediation (commit 5427e9d) fixed the `## Source` date, removed the README open-item bullet, added a `## Recent activity` row to the README, and updated both the backlog and checklist with Resolution sections and `status: addressed` / `disposition: addressed`.
+
+**PostToolUseFailure verbatim quote re-verification.** The session simultaneously re-verified the two preserved verbatim quotes in the same reference file (`| PostToolUseFailure | After a tool call fails |` from the lifecycle table, and `| PostToolUseFailure | No | Shows stderr to Claude (tool already failed) |` from the exit-code-behavior table). Both were confirmed byte-identical to the live page via Claude WebFetch, Codex, and raw-HTML extraction. The verification-gap backlog was resolved and its Resolution section appended in iter2.
+
+**Principles anti-rationalizations residue.** This backlog (created session a30b7a6e) tracked cosmetic label-consistency residue in `principles/SKILL.md` where "Anti-rationalizations" still appeared after the 4-field redesign renamed the field to "Anti-pattern". PR #285 (commit `9bae55f`) cleared it. Verified this session via grep (0 matches). Backlog flipped to `status: addressed` + `disposition: addressed`, Resolution section added, and archived at Wrap-up.
+
+## What shipped
+
+Execution commits:
+- `84521bc` — corrected event count 31→30, updated enumeration, refreshed access date
+- `5427e9d` — iter2 remediation: Source date, README open-item removal, README recent-activity row, backlog/checklist Resolution sections
+
+Wrap-up promotions (commit: see Wrap-up commit hash):
+- `mistakes/codex-webfetch-undercounts-recently-added-table-row.md` — new project mistake (LLM count arbitration unreliable; raw HTML is the tiebreaker)
+- `mistakes/docs-sync-count-fix-blast-radius-includes-colocated-dates-and-tracking-pointers.md` — new project mistake (P13 blast radius must include body Source dates + tracking-pointer docs)
+- `archive/backlogs/2026-06-01-hook-event-count-31-vs-29-docs-sync.md` — archived (was `features/guardrails/backlogs/`)
+- `archive/backlogs/2026-06-01-posttooluse-failure-webfetch-verification-gap.md` — archived (was `features/guardrails/backlogs/`)
+- `archive/backlogs/2026-06-01-principles-anti-rationalizations-label-residue.md` — archived (was `features/guardrails/backlogs/`)
+- `archive/checklists/2026-06-01-hook-event-count-31-vs-29-docs-sync.md` — archived (was `features/guardrails/checklists/`); `archive/checklists/` dir created
+
+Reference inbound pointers in `features/guardrails/references/claude-code-posttooluse-hook-schema.md` (lines 35-36) repointed to archive paths.
+
+## What got stuck
+
+None. Both primary backlogs and the residue item were fully resolved and archived. The `goodhart-factor-when-demanded-deferred.md` backlog and `cross-layer-drift-gate.md` checklist remain active and were not touched.
+
+The `claude-code-hooks-12-lifecycle-events.md` reference doc in `features/guardrails/references/` was not reviewed this session — it may drift similarly when the hooks page changes. Flagged as a possible future drift check (not a blocking issue).
+
+## What shifted
+
+The correction target shifted mid-session: the pre-existing backlogs assumed "29" as the correct count, but live re-verification landed on 30 (MessageDisplay was added to the official docs page after the 2026-05-23 capture). The entire correction arc was therefore 31→30, not 31→29.
+
+The dual-system REVISE verdict (both Codex and Claude flagging different aspects of the iter1 blast-radius miss) demonstrated the Principle 13 gap now recorded as a project mistake: count/date corrections must check for co-located duplicate values in the same document and for pointer docs that track the corrected claim.
+
+## Decisions to respect
+
+- Raw HTML (`curl -sL + <tr>` parse) is the authoritative tiebreaker when LLM-mediated fetch counts disagree. Do not re-arbitrate based on LLM-summarized counts.
+- Wrap-up is the sole writer to `archive/` — archive moves are not done during Execution even when the files are "obviously done". The executor correctly deferred the git mv to this Wrap-up.
+- Both new project mistakes (codex-webfetch and docs-sync-blast-radius) are load-bearing in the domain `docs-sync` — load them when working on any future docs-sync correction.
+
+## Next session
+
+No open threads from this session. The `goodhart-factor-when-demanded-deferred.md` backlog in `features/guardrails/backlogs/` remains active but was not triggered this session. The plugins-snapshot-resync backlog (out of this session's scope, deferred due to concurrent PR #282) also remains open.

--- a/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/execution/task-01/artifacts/task-record.md
+++ b/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/execution/task-01/artifacts/task-record.md
@@ -1,0 +1,41 @@
+---
+name: task-record-hook-event-count-and-webfetch-gap
+description: Slice 1 task-record — resolved the hook-event-count docs-sync (31→30) and the PostToolUseFailure WebFetch verification gap.
+type: plans
+scope: feature
+feature: guardrails
+status: addressed
+created: 2026-06-01
+session: 34563fb4-361d-4348-aa75-8bc9f1fbff05
+loop: execution
+tags: [chat-task-record, docs-sync, hooks, verification-gap]
+---
+
+# Slice 1 — hook-event-count docs-sync + WebFetch verification gap
+
+## What / Why / How
+- **What:** Correct the stale "31 hook events" claim in the guardrails reference to the verified live count, complete the enumeration, and close the two tracked items (`hook-event-count-31-vs-29-docs-sync`, `posttooluse-failure-webfetch-verification-gap`).
+- **Why:** Two tracked guardrails backlogs (docs-sync + a Confidence-50 verification gap deferred at the 2026-05-23 Ideation).
+- **How:** Research leader WebFetch → independent Codex re-fetch → raw-HTML tiebreaker → executor edits → dual-system eval → iter2 remediation.
+
+## Outcome
+- **Authoritative live count = 30** (raw-HTML parse of the lifecycle table; Claude WebFetch agreed; Codex undercounted at 29 by missing the newly-added `MessageDisplay` at position 12). Both `PostToolUseFailure` verbatim quotes confirmed byte-identical to the live page.
+- iter1 commit `84521bc`: reference count 31→30, enumeration gains `MessageDisplay`, provenance + usage-history refreshed; quotes untouched.
+- Dual-system eval (iter1) → REVISE: Codex caught the `## Source` body date still at 2026-05-23; Claude caught the README open-item + backlog/checklist blast radius. Both valid.
+- iter2 commit `5427e9d`: fixed `## Source` per-URL dates; removed the two resolved README open-item bullets (+ activity row); flipped all 3 tracking files to `status/disposition: addressed` with `## Resolution (2026-06-01)` notes. Manager re-verified PASS; user accepted.
+
+## Verdict
+PASS (iter2). iter1 REVISE remediated; targeted re-verification accepted in lieu of a fresh full dual-system pass (findings were binary + grep-confirmed).
+
+## Deferred to Wrap-up
+- Physical archive `git mv` of the 3 resolved tracking items to project-level `archive/backlogs/` (sole-writer-to-archive standard). After the move, the closure gate `grep -rn '"31 hook' features/guardrails/` reaches 0.
+- Promote the two staged mistake-candidates (codex-undercount tiebreaker; docs-sync blast-radius).
+
+## Commits
+- `84521bc` — iter1 reference fix
+- `5427e9d` — iter2 eval remediation
+
+## Artifacts
+- Research: `ideation/rawdata/hooks-docs-webfetch-verification.md`
+- Eval: `execution/task-01/evaluation/iter1/{claude,codex}/`
+- Drafts: `execution/task-01/rawdata/draft-iter1.md`, `draft-iter2.md`

--- a/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/execution/task-01/evaluation/iter1/claude/consistency.md
+++ b/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/execution/task-01/evaluation/iter1/claude/consistency.md
@@ -1,0 +1,73 @@
+---
+perspective: consistency
+system: claude
+loop: execution
+iter: 1
+verdict: REVISE
+---
+
+# Consistency perspective — Execution eval iter1 (claude)
+
+## Artifact Summary + Memory reads
+(See project.md for the full Artifact Summary + Memory reads register; not repeated.)
+
+## W/W/H gate
+What ✓ / Why ✓ / How ✓.
+
+## Locked Frame (Stage 1)
+
+**S1 — All count statements INSIDE the reference doc agree**
+- [ ] frontmatter/prose, enumeration header, reconciliation note, usage-history row all read 30 (or describe the 31→30 correction)
+- [ ] frontmatter `accessed:` matches the re-verification date claimed in prose
+
+**S2 — Enumeration internally coherent**
+- [ ] header count (30) equals the actual enumerated entry count (30)
+- [ ] reconciliation parenthetical's "30 events / MessageDisplay at 12" matches the list
+
+**S3 — Frontmatter still conforms to the references-type standard (memorization/rules.md §2.1–2.2)**
+- [ ] base keys present; `type: references`; `ref_type`, `title`, `source`, `accessed` extensions present
+- [ ] no staging-routing leak keys (S-set, §4.4)
+- [ ] slug unchanged (stable address, §1.1 rule 5)
+
+**S4 — Cross-artifact sync: everything that should change together changed together (P8/P13 blast radius)**
+- [ ] the feature README `Open items` pointer to this docs-sync item is consistent with the corrected target (30)
+- [ ] the tracking backlog + checklist are consistent with the corrected target (30) / closed
+- [ ] no OTHER guardrails doc still asserts the old count as the live truth
+
+**S5 — line-34 sibling pointer `claude-code-hooks-12-lifecycle-events.md` ("12 lifecycle events")**
+- [ ] determine whether the "12" is the same count claim (→ inconsistency this change should fix) or a different source (→ out of scope)
+
+**S6 (adversarial) — Doc passes its own internal checks but a sibling/index now contradicts it**
+- [ ] grep the feature tree for surviving "31…29" correction text that now contradicts the corrected reference
+
+## Per-scenario per-check results
+
+- **S1**: PASS. Lines 35, 40, 56, 89 all read 30 / describe the 31→30 correction; usage-history line 119 logs "31→30". `accessed: 2026-06-01` (line 13) matches the "re-verified 2026-06-01" prose. ✓✓
+- **S2**: PASS. Header "All **30**" (line 56) == 30 enumerated entries (verified `grep -c`). Reconciliation line 89 "30 events…MessageDisplay at position 12" matches list (MessageDisplay@line 69 = #12). ✓✓
+- **S3**: PASS. Frontmatter unchanged except `accessed:` 2026-05-23→2026-06-01 (a legitimate references extension field, §2.2). All base keys present; `type: references`; no S-set leak keys; slug unchanged. Conformant. ✓✓✓
+- **S4**: **FAIL on two of three checks.**
+  - `features/guardrails/README.md:50` (a LIVE feature-README, not a backlog) still reads: "Correct the '31 hook events' claim to the verified count of **29** in surviving references." The reference it points readers toward is now corrected to 30, so this Open-items line is now actively misleading on BOTH the target (29 vs 30) and the done/not-done state. ✗
+  - `backlogs/hook-event-count-31-vs-29-docs-sync.md` (description + body + suggested-approach) and `checklists/hook-event-count-31-vs-29-docs-sync.md` still state the correction target is "29" and are `status: active` / unchecked. The backlog's own acceptance gate `grep -rn '"31 hook' features/guardrails/` → 8 matches (not 0). ✗
+  - No third unrelated doc asserts the old count as live truth. ✓ (the schema reference is the only one that ever stated a live count)
+- **S5**: PASS — legitimately out of scope. The sibling `claude-code-hooks-12-lifecycle-events.md` is a DIFFERENT source (`source: https://claudefa.st/blog/...`, `ref_type: blog`, "12+ hook lifecycle events" framing) versus this doc's official-page WebFetch (30 events on code.claude.com). The "12" is a separate, blog-sourced "12+" count of a curated subset, not the same 30-event official-page claim. It carries its own `accessed: 2026-05-23` and is not named in either backlog. Updating it would be scope creep (P4). Recorded as out-of-scope, not a finding. ✓
+- **S6**: FAIL — the grep in S4 surfaces the README/backlog/checklist contradiction. ✗
+
+## Typed findings
+
+**C-1 — Stale "correct to 29" pointers survive in the live feature README + tracking backlog/checklist after the reference was corrected to 30**
+- Type: `general` · Domain: `docs-sync` · Disposition: `open` · Confidence: 100 · Severity: High
+- Evidence (grep-verified, all in `features/guardrails/`, excluding `sessions/`):
+  - `README.md:50` — "Correct the '31 hook events' claim to the verified count of **29** in surviving references" (live Open-items list; the reference it links is already corrected to 30).
+  - `backlogs/hook-event-count-31-vs-29-docs-sync.md` lines 3/21/35 — target stated as "29"; `status: active`, `shipped_in: null`.
+  - `checklists/hook-event-count-31-vs-29-docs-sync.md` lines 3/17/19/21/29 — "correct all … to '29'"; boxes unchecked.
+  - Backlog's own closure gate `grep -rn '"31 hook' features/guardrails/` → 8 matches (gate requires 0).
+- Why it matters: P8 (docs are a deliverable, ship the matching co-update) and P13 (blast radius — a doc change must enumerate every file the SAME change must co-touch). The reference doc was corrected, but the three artifacts that *point at* the correction were left asserting the wrong target (29) and the wrong done-state. A future agent reading the README "Open items" will (a) believe the task is still open and (b) re-correct the reference to the wrong value 29 — re-introducing the exact defect this change fixed. The research artifact itself (lines 19, 104–105) explicitly flagged that the backlog/checklist target is stale and "should be corrected to 31 → 30" and surfaced to the user before editing — so this co-update was a known, named blast-radius item.
+- FP-check: not pre-existing (the README/backlog were *correct-relative-to-their-own-target* before; this change made the reference disagree with them); not style; not speculative (grep-confirmed). The only mitigation is the brief's narrow scope — but the brief scoping a co-update out does not make the resulting cross-artifact contradiction disappear; it makes it a deliberate-deferral decision the user must ratify.
+- Suggested direction: either (a) in-scope follow-up that updates README line 50 to "30 (corrected 2026-06-01)", flips the backlog/checklist to closed/`shipped_in`, and re-targets their "29" text to "30"; or (b) an explicit user-ratified deferral recorded on the backlog. Manager + user decide per Principle 2 (never auto-apply).
+
+## Verdict
+
+**REVISE.** The reference doc is internally fully coherent (S1–S3 PASS) and the line-34 sibling pointer is correctly left out of scope (S5). But the change left a High-severity cross-artifact docs-sync contradiction (C-1, Confidence 100): a live feature README + the tracking backlog/checklist still assert the superseded "correct to 29" target after the reference was corrected to 30, and the backlog's own closure gate fails. Per the Stage-2 threshold (any High ≥ 50 → REVISE), Consistency is REVISE. This is a manager/user decision (in-scope fix vs ratified deferral), not an evaluator-applied fix.
+
+## Low-confidence appendix
+(none)

--- a/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/execution/task-01/evaluation/iter1/claude/overall.md
+++ b/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/execution/task-01/evaluation/iter1/claude/overall.md
@@ -1,0 +1,47 @@
+---
+perspective: overall
+system: claude
+loop: execution
+iter: 1
+verdict: REVISE
+---
+
+# Overall perspective (Stage 3) — Execution eval iter1 (claude)
+
+## Remaining standard perspectives (N/A-for-this-change, one line each)
+
+- **Structure**: N/A — no code, modules, types, deps, or tests touched; this is a count/enumeration prose edit to a single references-type memory doc. Frontmatter structure verified conformant under Consistency S3.
+- **Performance**: N/A — no runtime, IO, hot path, cost, or telemetry surface; a static doc edit has no perf dimension.
+- **Aesthetics**: N/A (no findings) — enumeration formatting, bold-30 emphasis, and the markdown table are consistent with the doc's existing style; no debug/leftover artifacts; reads cleanly.
+- **Usage**: N/A (one note) — the doc's consumer (a future hook-registration author) is well served by the corrected list + the explicit "MessageDisplay added at 12" provenance note; the only usage friction is the contradictory README pointer, which is captured as a Consistency finding rather than a Usage one.
+
+## Cross-perspective synthesis
+
+Project = PASS (the brief's reference-doc acceptance bar is tool-verified met on all four scenarios). Consistency = REVISE (a High/Confidence-100 cross-artifact docs-sync contradiction, C-1). The divergence is the whole story of this change: the *artifact in front of the editor* is correct and complete; the *blast radius around it* (P13) was left half-applied. This is the classic single-file-edit-misses-the-co-update pattern that Principle 13 exists to catch.
+
+## Cross-cutting findings (no single perspective owns)
+
+**O-1 — The two tracked backlog items are reported as "resolved by this change" but neither is closed and one (the verification-gap) has no in-doc resolution surface beyond a re-confirmation sentence**
+- Type: `general` · Domain: `process` · Disposition: `open` · Confidence: 75 · Severity: Medium · mistake-candidate: true
+- Evidence: brief states both backlogs "are being resolved by this change," yet `hook-event-count-31-vs-29-docs-sync.md` and `posttooluse-failure-webfetch-verification-gap.md` both remain `status: active`, `shipped_in: null`; the count backlog's own grep gate fails (8 matches). The verbatim-quote backlog is *substantively* satisfied (quotes re-verified byte-identical, recorded in usage history) but its lifecycle field was not advanced.
+- Why it matters: a backlog left `active` after its work is done re-surfaces as phantom open work; a backlog whose stated target (29) is now wrong actively misdirects. This recurs with the project's known docs-sync failure family.
+- Suggested direction: advance both backlogs' lifecycle (close + `shipped_in`) and correct the count-backlog's 29→30 target, OR record an explicit user-ratified deferral. Manager + user decide.
+
+## Karpathy four-failure-mode check
+
+- **Wrong assumptions**: Not present in the reference edit — the count (30) is triple-sourced (Claude WebFetch + Codex + raw-HTML row parse) in the research artifact and independently re-verified here (enumeration matches, quotes byte-identical). The only assumption gap is process-side: that editing the reference alone "resolves" the backlogs (see O-1).
+- **Overcomplexity**: Absent — minimal 7-edit diff, no added structure.
+- **Orthogonal edits**: Absent — `git show --name-only` confirms only the reference doc + the session draft note; no bundled unrelated change.
+- **Imperative-over-declarative**: Absent — the doc states the verifiable fact (30 events, named, in order) rather than prescribing a mechanism.
+
+## Preserve list (do NOT break on REVISE)
+
+1. The corrected reference doc itself — count=30 in all locations, enumeration 1–30 with MessageDisplay@12, is tool-verified correct and must be preserved as-is.
+2. The byte-identical PostToolUseFailure verbatim quotes (lines 46, 52, and the Excerpt copies) — re-verified against the live page; must NOT be reflowed or "tidied."
+3. The provenance note (line 89) explaining MessageDisplay is the single net addition since the 2026-05-23 capture — high-value zero-context-reader context (§4.1 dev-doc bar).
+4. The usage-history row + commit trigger references (P10 compliance) — keep.
+5. The narrow scope discipline (only the in-scope file edited) — a REVISE that fixes C-1 must add the README/backlog/checklist co-updates, not re-touch the already-correct reference body.
+
+## Overall verdict
+
+**REVISE.** Threshold: Consistency carries a High finding (C-1) at Confidence 100 → REVISE (any High ≥ 50 → REVISE). The reference doc is correct and complete and should be preserved exactly; the REVISE is entirely about the un-applied blast radius — a live README pointer + the tracking backlog/checklist still assert the superseded "correct to 29" target, and the backlogs are not closed. Per Principle 2, the manager discusses C-1 + O-1 with the user before any remediation; the fix path (in-scope co-update vs ratified deferral) is the user's decision, not the evaluator's.

--- a/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/execution/task-01/evaluation/iter1/claude/project.md
+++ b/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/execution/task-01/evaluation/iter1/claude/project.md
@@ -1,0 +1,83 @@
+---
+perspective: project
+system: claude
+loop: execution
+iter: 1
+verdict: PASS
+---
+
+# Project perspective — Execution eval iter1 (claude)
+
+## Artifact Summary + Memory reads
+
+**Artifact (What):** Single-commit (`84521bc`) documentation change to `features/guardrails/references/claude-code-posttooluse-hook-schema.md` plus an execution draft note. Corrects the hook-event-count claim 31→30 in three count-claim locations, inserts `MessageDisplay` at enumeration position 12, renumbers the enumeration to 1–30, refreshes `accessed:` and two prose/usage-history lines, and re-confirms two `PostToolUseFailure` verbatim quotes are byte-identical.
+
+**Why:** Two tracked guardrails backlog items — `hook-event-count-31-vs-29-docs-sync` (count claim is wrong; verified live count is 30) and `posttooluse-failure-webfetch-verification-gap` (verbatim quotes must be re-verified). Real trigger: both backlogs + the session ideation research artifact establishing the live count = 30.
+
+**How:** 7 CRUD edits on the one reference file, scoped per the draft note; verification by grep + enumeration count + byte-diff of quotes.
+
+**Scope Contract source:** No planning artifact exists in the session tree (`find` returned only `ideation/rawdata/hooks-docs-webfetch-verification.md` + `execution/task-01/rawdata/draft-iter1.md`). The scope contract is the evaluation brief's acceptance bar: count=30 in every count-claim location *in the reference doc*; enumeration complete (30, numbered 1–30, MessageDisplay at 12); quotes byte-identical; trigger referenced. README/backlog/checklist co-updates are NOT in the brief's acceptance criteria.
+
+**Downstream consumers:** future agents authoring `.claude/settings.json` PostToolUseFailure hook registration; the guardrails feature memory.
+
+### Memory reads
+- `.gobbi/projects/gobbi/rules/stub-redirect-format.md` (only project rule; not applicable to a references-type count fix)
+- `.gobbi/projects/gobbi/mistakes/claude-evaluator-step4-only-vs-codex-whole-file-grep.md` (whole-file grep discipline — applied)
+- `.gobbi/projects/gobbi/mistakes/evaluator-false-pass-without-diffing.md` (diffed pre/post for the quote-preservation check)
+- both backlog files + the checklist + the ideation research artifact
+- `features/guardrails/README.md`, `features/guardrails/references/claude-code-hooks-12-lifecycle-events.md` (consistency cross-checks)
+
+## W/W/H gate
+What ✓ / Why ✓ / How ✓ — all clear. No unevaluable finding.
+
+## Locked Frame (Stage 1)
+
+**S1 — Count claim = 30 in every count-claim location in the reference doc**
+- [ ] frontmatter / prose "one of N" claim reads 30
+- [ ] "All N documented hook events" header reads 30
+- [ ] reconciliation parenthetical reads 30
+- [ ] no surviving standalone count claim of 31 or 29 (outside the literal filename + the 31→30 history note)
+
+**S2 — Enumeration complete and well-formed**
+- [ ] exactly 30 numbered entries
+- [ ] consecutive 1–30, no gaps
+- [ ] no duplicate event names
+- [ ] `MessageDisplay` present at position 12
+
+**S3 — Enumeration matches the authoritative live list (research artifact)**
+- [ ] every name + order matches the 30-row table in `hooks-docs-webfetch-verification.md`
+
+**S4 — PostToolUseFailure verbatim quotes un-altered**
+- [ ] lifecycle row `| PostToolUseFailure | After a tool call fails |` byte-identical pre vs post
+- [ ] exit-code row `| PostToolUseFailure | No | Shows stderr to Claude (tool already failed) |` byte-identical pre vs post
+
+**S5 — Trigger referenced (P10)**
+- [ ] commit body references both backlog items + the research artifact
+
+**S6 (adversarial) — A "while I was in there" edit slips in**
+- [ ] `git show --name-only` shows only the in-scope reference + the session draft note
+- [ ] no edit to the load-bearing schema prose (Insight / Why it applies) beyond the count/enumeration/date
+
+## Per-scenario per-check results
+
+- **S1**: PASS. Line 40 "one of **30**"; line 56 "All **30**"; line 89 reconciliation "lists 30 events". `grep -nE '\b31\b'` → only line 35 (literal filename `…-31-vs-29-…`) + line 119 (history note "31→30"). `grep -nE '\b29\b'` → only the filename substring + `29. ElicitationResult` (a legitimate list index). No stale standalone count claim. ✓✓✓✓
+- **S2**: PASS. `grep -cE '^[0-9]+\. ` → 30. Lines 58–87 number 1–30 consecutively. `uniq -d` on names → empty (no dupes). `MessageDisplay` at line 69 = position 12. ✓✓✓✓
+- **S3**: PASS. Names + order match the research artifact's 30-row table exactly (SessionStart…SessionEnd, MessageDisplay at 12). ✓
+- **S4**: PASS. `diff` of the lifecycle quote line pre (`84521bc~1`) vs post → IDENTICAL. `diff` of the exit-code quote line → IDENTICAL. The Excerpt-section copies (lines 107/111) shifted +1 in line-number only due to the inserted enumeration line; text byte-identical. ✓✓
+- **S5**: PASS. Commit body: "Trigger: backlogs/hook-event-count-31-vs-29-docs-sync + backlogs/posttooluse-failure-webfetch-verification-gap" and cites the research artifact + session id. ✓
+- **S6**: PASS. `git show --name-only` → exactly the reference doc + `execution/task-01/rawdata/draft-iter1.md`. No schema-prose edits beyond count/enumeration/date/usage-history. ✓✓
+
+## Typed findings
+
+**P-1 — Backlog/checklist acceptance gate not satisfied; items not closed (in-scope-boundary judgment)**
+- Type: `general` · Domain: `docs-sync` · Disposition: `open` · Confidence: 75 · Severity: Low (Project lens)
+- Evidence: backlog `hook-event-count-31-vs-29-docs-sync.md` defines its own closure gate as "`grep -rn '"31 hook' features/guardrails/` returns 0 matches" (line 37). That grep returns 8 matches post-commit (the backlog/checklist/README still carry the "31 hook events…29" text). The backlog `status:` is still `active`, `shipped_in: null`.
+- Why it matters: the two backlog items are described in the brief as "being resolved by this change," but neither is marked closed and the backlog's own acceptance grep does not pass. From a strict Project lens the *reference-doc* acceptance bar (the brief's actual criteria) is fully met, so this is Low severity here — but it is a real gap that the Consistency perspective escalates (see consistency.md C-1). FP-check: not pre-existing (the gate became unsatisfiable-by-the-reference-edit-alone the moment the target changed 29→30); not out-of-scope per the brief, but the brief deliberately scoped these out — so this is a contract-boundary observation, not a contract violation. Confidence 75 (grep-verified).
+- Suggested direction: manager decides whether closing the backlog/checklist + fixing the README pointer is a follow-up slice or belongs in this session's scope; the research artifact (lines 19, 104) already recommended surfacing the 29→30 target correction to the user.
+
+## Verdict
+
+**PASS.** All four acceptance scenarios the brief defines for the reference doc (count=30 everywhere, enumeration 1–30 with MessageDisplay@12, quotes byte-identical, trigger referenced) are tool-verified met. The single Project finding (P-1) is Low severity at this lens because it concerns artifacts outside the brief's stated acceptance bar; it is surfaced for the manager and carried at higher weight under Consistency.
+
+## Low-confidence appendix
+(none)

--- a/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/execution/task-01/evaluation/iter1/codex/overall.md
+++ b/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/execution/task-01/evaluation/iter1/codex/overall.md
@@ -1,0 +1,20 @@
+# Codex evaluation — task-01 iter1 (hook-event count fix)
+
+**System:** codex (`codex exec --sandbox read-only --cd <worktree>`), manager-proxy written (codex exec emits no files).
+**Scope:** Project + Consistency + Overall (focused dual-system eval of commit `84521bc`).
+**Verdict:** REVISE
+
+## Project findings
+- `docs-sync | high | 100 | references/claude-code-posttooluse-hook-schema.md:13,100-103,119` — Acceptance criterion 4 (provenance consistency) not fully met: frontmatter + usage-history say re-verified/accessed 2026-06-01, but the `## Source` section still says "Both accessed 2026-05-23" — stale provenance for the same hooks URL.
+
+## Consistency findings
+- `docs-sync | med | 100 | references/...:100-103` — Count statements agree at 30 and the 1–30 enumeration is complete with MessageDisplay at position 12. The remaining contradiction is provenance (the leftover Source access-date), not count math.
+- Line-34 judgment: NO finding. `claude-code-hooks-12-lifecycle-events.md` is a sibling filename/reference, not a count claim made by this doc; out of scope for this count-correction unless the sibling doc itself was in scope.
+
+## Overall
+- `docs-sync | high | 100 | references/...:13,100-103,119` — Criteria 1–3 PASS by close reading + diff inspection (no stale active 31/29 count claim; enumeration 1–30 no gaps/dupes; protected PostToolUseFailure rows unchanged). Criterion 4 FAILS because provenance dates do not all agree.
+
+**VERDICT: REVISE**
+
+## Cross-system note (manager)
+Codex caught the `## Source:103` stale date that the Claude leg missed. The Claude leg caught the README:50 / backlog / checklist blast radius that Codex scoped out (Codex was judging only this doc). The two findings are complementary, not contradictory.

--- a/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/execution/task-01/rawdata/draft-iter1.md
+++ b/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/execution/task-01/rawdata/draft-iter1.md
@@ -1,0 +1,43 @@
+---
+type: execution-draft
+task: task-01
+session: 34563fb4-361d-4348-aa75-8bc9f1fbff05
+iteration: 1
+date: 2026-06-01
+status: complete
+---
+
+# task-01 draft — iter 1
+
+## What changed
+
+File edited: `.gobbi/projects/gobbi/features/guardrails/references/claude-code-posttooluse-hook-schema.md`
+
+### 7 CRUD edits applied
+
+1. **Frontmatter `accessed:` (line 13)** — `2026-05-23` → `2026-06-01`.
+2. **Related bullet (line 35)** — updated stale "correct to 29" pointer to state the claim is corrected to the verified count of **30** (re-verified 2026-06-01) and that tracked items are being resolved this session.
+3. **Line 40** — "one of 31 documented hook events" → "one of **30** documented hook events"; added re-verification note: re-verified 2026-06-01; both quotes below still match the live page verbatim.
+4. **Line 56** — "All 31 documented hook events on this page (full enumeration for context):" → "All **30** documented hook events on this page (full enumeration, re-verified 2026-06-01):".
+5. **Enumeration (lines 58–87)** — inserted `12. \`MessageDisplay\`` between `11. \`Notification\`` and the former `12. \`SubagentStart\``, renumbered 12–30. Final list is 30 entries, 1–30, no gaps.
+6. **Line 89 (was 88)** — replaced stale parenthetical "(The page's table lists 31; the enumerated names above cover the explicitly captured events from the same WebFetch.)" with "(The live lifecycle table lists 30 events, re-verified 2026-06-01; the enumeration above is complete. The only net change since the 2026-05-23 capture is the addition of `MessageDisplay` at position 12.)".
+7. **Usage history table** — added row: `| 2026-06-01 | 34563fb4-361d-4348-aa75-8bc9f1fbff05 | Re-verified the hook contract: both PostToolUseFailure quotes still match verbatim; corrected the event count 31→30 and added MessageDisplay |`.
+
+## Preserved (byte-identical, not touched)
+
+- Lifecycle table verbatim quote block (lines 44–46).
+- Exit-code behavior table verbatim quote block (lines 50–52).
+- `## Excerpt` block (lines 104–110).
+
+## Verification results (Principle 7)
+
+- Branch: `chore/session-2026-06-01-34563fb4` (confirmed before commit).
+- `grep -nE '\b31\b'`: 2 matches, both are the backlog/checklist *filename* `hook-event-count-31-vs-29-docs-sync.md` and the usage-history `31→30` note. No remaining hook-event-count claim of 31.
+- `grep -n 'MessageDisplay'`: present at position 12 in enumeration, parenthetical note, usage history row.
+- Enumeration: 30 entries numbered 1–30, consecutive, no gaps or dupes.
+- `grep -n 'After a tool call fails'` and `grep -n 'Shows stderr to Claude'`: both quotes present unchanged at lines 46 and 52.
+- `grep -nE '\b29\b'`: only the backlog/checklist filename substring and `29. \`ElicitationResult\`` in the numbered list. No stale "29" count claim.
+
+## Scope confirmation
+
+Only the one in-scope file was edited (plus this draft note). No README, backlogs, checklists, or other docs were touched.

--- a/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/execution/task-01/rawdata/draft-iter2.md
+++ b/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/execution/task-01/rawdata/draft-iter2.md
@@ -1,0 +1,52 @@
+# Task-01 iter2 draft note
+
+**Phase:** execution iter2 remediation
+**Session:** 34563fb4-361d-4348-aa75-8bc9f1fbff05
+**Date:** 2026-06-01
+**Trigger:** dual-system eval returned REVISE with two High findings
+
+---
+
+## Findings addressed
+
+### Codex C (High) — Source section date inconsistency
+The reference file `## Source` section still said "Both accessed 2026-05-23", contradicting the frontmatter
+(`accessed: 2026-06-01`) and the re-verification performed this session. The agent-sdk/hooks page was NOT
+re-fetched, so it retains the 2026-05-23 date; only the hooks page was re-verified on 2026-06-01.
+
+Fix applied (A1): replaced the flat "Both accessed 2026-05-23" with per-URL dated lines:
+- `https://code.claude.com/docs/en/hooks — accessed 2026-05-23, re-verified 2026-06-01`
+- `https://code.claude.com/docs/en/agent-sdk/hooks — accessed 2026-05-23`
+
+### Claude C-1 (High) — Blast radius not applied (README + 3 tracking files still show "29" / `status: active`)
+The README `## Open items` still listed both now-resolved bullets with the stale "29" claim. The three
+tracking files (2 backlogs + 1 checklist) still had `status: active`, `disposition: open`, `shipped_in: null`,
+and no Resolution section.
+
+Fixes applied:
+- A2: README — removed two open-item bullets; added 2026-06-01 activity row to `## Recent activity`.
+- B1: backlog `hook-event-count-31-vs-29-docs-sync.md` — frontmatter → addressed/addressed + shipped_in; appended Resolution.
+- B2: checklist `hook-event-count-31-vs-29-docs-sync.md` — frontmatter → addressed/addressed + shipped_in; `[ ]` → `[x]` with clarifier "(corrected to **30**, not 29)"; appended Resolution.
+- B3: backlog `posttooluse-failure-webfetch-verification-gap.md` — frontmatter → addressed/addressed + shipped_in; appended Resolution.
+
+---
+
+## Scope boundary respected
+
+- No archive `git mv` performed — deferred to Wrap-up per archive-template sole-writer rule.
+- Reference file count/enumeration/quote blocks not touched (correct from iter1).
+- Goodhart backlog not touched (stays open).
+- Residue backlog not in scope (separate task).
+
+---
+
+## Verification summary
+
+- `grep "Both accessed"` in reference → 0 matches.
+- `grep "re-verified 2026-06-01"` in reference Source → present.
+- `grep "31 hook events" README` → 0 matches.
+- Goodhart bullet still present in README.
+- Activity row 2026-06-01 present in README.
+- 3 tracking files: status/disposition = addressed, Resolution sections appended.
+- `grep -rn '"31 hook'` remaining matches: all inside the 3 resolved tracking files (archive at Wrap-up).
+- Branch = chore/session-2026-06-01-34563fb4 (verified before commit).

--- a/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/execution/task-01/staging/decisions/codex-webfetch-undercounts-recently-added-table-row.md
+++ b/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/execution/task-01/staging/decisions/codex-webfetch-undercounts-recently-added-table-row.md
@@ -1,0 +1,29 @@
+---
+name: codex-webfetch-undercounts-recently-added-table-row
+description: Codex `codex exec` web-search undercounted a documented table by one row (missed a recently-added event), disagreeing with Claude's WebFetch; raw-HTML parse was the tiebreaker.
+type: decisions
+scope: feature
+feature: guardrails
+status: active
+created: 2026-06-01
+session: 34563fb4-361d-4348-aa75-8bc9f1fbff05
+loop: execution
+mistake-candidate: true
+domain: docs-sync
+tags: [codex, webfetch, count-verification, dual-system, tiebreaker]
+---
+
+# Codex web-search undercounts a recently-added table row; raw HTML is the count tiebreaker
+
+## What went wrong
+On a hook-event-count verification, the Claude leader's WebFetch returned **30** events (including `MessageDisplay` at position 12); an independent Codex `codex exec` web-search returned **29** — an identical list except it was missing the one newly-added event. Two careful LLM-mediated fetches of the same live page disagreed by exactly one row.
+
+## Why it went wrong
+Both LLM fetch paths share a summarization/caching failure mode: a web-search index or summarizer view can lag the live page when a table row was recently added, and the model reports the stale count without flagging uncertainty. Arbitrating between two LLM-summarized counts is unreliable because both can be wrong in the same direction.
+
+## How to recognize it next time
+- Any dispute about a COUNT or an exact enumeration drawn from a web page, where two LLM fetches (or an LLM fetch vs a recalled figure) disagree by a small number.
+- A WebFetch summarizer that returns a self-contradicting count in one pass (a tell that it is summarizing, not transcribing).
+
+## Corrected approach
+For count/enumeration disputes, fetch the **raw page text** (`curl -sL <url>` + parse/grep, e.g. count `<tr>` rows in the target `<table>`) and treat that as ground truth — do not arbitrate between two LLM-summarized counts. Raw HTML settled 30 here (`MessageDisplay` present in TOC + dedicated sections + a lifecycle `<tr>`). Reinforces [[claude-evaluator-step4-only-vs-codex-whole-file-grep]].

--- a/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/execution/task-01/staging/decisions/docs-sync-count-fix-blast-radius-includes-colocated-dates-and-tracking-pointers.md
+++ b/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/execution/task-01/staging/decisions/docs-sync-count-fix-blast-radius-includes-colocated-dates-and-tracking-pointers.md
@@ -1,0 +1,29 @@
+---
+name: docs-sync-count-fix-blast-radius-includes-colocated-dates-and-tracking-pointers
+description: A docs-sync count/date correction's CRUD blast radius missed the body `## Source` access-date and the tracking-pointer docs (README open-items, backlog, checklist) — caught by dual-system eval as REVISE.
+type: decisions
+scope: feature
+feature: guardrails
+status: active
+created: 2026-06-01
+session: 34563fb4-361d-4348-aa75-8bc9f1fbff05
+loop: execution
+mistake-candidate: true
+domain: docs-sync
+tags: [principle-13, blast-radius, crud-plan, docs-sync, provenance-date]
+---
+
+# Docs-sync blast radius includes co-located dates AND tracking-pointer docs
+
+## What went wrong
+The iter1 CRUD plan for a "correct the hook-event count 31→30 + refresh provenance" change updated the frontmatter `accessed:` date but **missed the body `## Source` line** ("Both accessed 2026-05-23"), leaving the same file internally contradictory. It also deferred — without recording a ratified deferral — the live `README.md` open-item pointer and the backlog/checklist that still asserted the stale "29" target. Dual-system evaluation returned REVISE on both (Codex caught the Source date; Claude caught the README/tracking blast radius).
+
+## Why it went wrong
+A count/date correction "feels" local to the one prose claim, so the CRUD plan stopped at the obvious spot (frontmatter + the enumeration). Principle 13's blast-radius step was applied too narrowly: provenance metadata is duplicated across a doc (frontmatter date AND a body Source/accessed section AND a usage-history row), and a tracked task's "claim" is mirrored in pointer docs (a feature README's open-items list, the backlog, the checklist).
+
+## How to recognize it next time
+- Editing any count/date/version claim that also appears in a doc's frontmatter, a `## Source`/`## Provenance` section, and/or a usage-history table — they must ALL move together.
+- The change resolves a tracked backlog/checklist whose text or a README open-items bullet still states the old target.
+
+## Corrected approach
+For a docs-sync correction, the P13 blast-radius enumeration MUST include: (1) every co-located instance of the value in the same file (frontmatter + body Source/accessed + history rows); (2) every tracking-pointer doc (feature `README.md` open-items, the backlog, the checklist). Grep the value across the feature tree before editing. If any co-update is intentionally deferred to a later phase (e.g., archive move to Wrap-up), record that as a ratified deferral so it is not read as an open defect.

--- a/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/ideation/rawdata/hooks-docs-webfetch-verification.md
+++ b/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/ideation/rawdata/hooks-docs-webfetch-verification.md
@@ -1,0 +1,139 @@
+# Hooks docs WebFetch re-verification — findings
+
+**Phase:** research (iteration 1)
+**Date:** 2026-06-01
+**Source page:** https://code.claude.com/docs/en/hooks
+**Method:** two independent WebFetch passes + one corroborating WebSearch (allowed domains: code.claude.com / docs.claude.com / docs.anthropic.com)
+**Closes (evidence for):** `posttooluse-failure-webfetch-verification-gap` + `hook-event-count-31-vs-29-docs-sync`
+
+---
+
+## Headline finding — the count is now 30, NOT 29 (and not 31)
+
+The live lifecycle table on `https://code.claude.com/docs/en/hooks` enumerates **30 distinct hook events** as of 2026-06-01.
+
+- The reference file claims **31** (`claude-code-posttooluse-hook-schema.md` lines 40, 56, 88).
+- The two backlog/checklist items assume the correction target is **29**.
+- **Both are now stale.** The authoritative live count is **30**. The page has changed since the 2026-05-23 capture: it gained one new event, **`MessageDisplay`** (lifecycle row 12: "While assistant message text is displayed"). All 29 previously-captured names are still present in the same relative order; `MessageDisplay` is the single net addition.
+
+**Action for the manager:** the docs-sync target must be **30**, not 29. The backlog/checklist that say "correct 31 → 29" are themselves out of date and should be corrected to "31 → 30" before the Execution slice edits the reference. This is a material change to the tracked task's premise and should be surfaced to the user before editing.
+
+### Count-verification discipline note
+The first WebFetch summarizer returned a self-contradicting count ("31 distinct" / then "Actual count: 30 unique" with a confused MessageDisplay duplicate-listing). This is exactly the partial-view / summarizer-confusion failure mode recorded in `mistakes/claude-evaluator-step4-only-vs-codex-whole-file-grep.md`. The second WebFetch forced a row-by-row, no-dedup transcription of the single lifecycle table and returned a clean **TOTAL ROWS: 30**. The 30 figure is the transcribed-row count of the one authoritative lifecycle table, not a summarizer's arithmetic.
+
+---
+
+## Full event enumeration (live lifecycle table, verbatim, in order)
+
+| # | Event | When it fires (verbatim) |
+|---|-------|--------------------------|
+| 1 | SessionStart | When a session begins or resumes |
+| 2 | Setup | When you start Claude Code with `--init-only`, or with `--init` or `--maintenance` in `-p` mode. For one-time preparation in CI or scripts |
+| 3 | UserPromptSubmit | When you submit a prompt, before Claude processes it |
+| 4 | UserPromptExpansion | When a user-typed command expands into a prompt, before it reaches Claude. Can block the expansion |
+| 5 | PreToolUse | Before a tool call executes. Can block it |
+| 6 | PermissionRequest | When a permission dialog appears |
+| 7 | PermissionDenied | When a tool call is denied by the auto mode classifier. Return `{retry: true}` to tell the model it may retry the denied tool call |
+| 8 | PostToolUse | After a tool call succeeds |
+| 9 | PostToolUseFailure | After a tool call fails |
+| 10 | PostToolBatch | After a full batch of parallel tool calls resolves, before the next model call |
+| 11 | Notification | When Claude Code sends a notification |
+| 12 | **MessageDisplay** | While assistant message text is displayed  *(NEW vs 2026-05-23 capture)* |
+| 13 | SubagentStart | When a subagent is spawned |
+| 14 | SubagentStop | When a subagent finishes |
+| 15 | TaskCreated | When a task is being created via `TaskCreate` |
+| 16 | TaskCompleted | When a task is being marked as completed |
+| 17 | Stop | When Claude finishes responding |
+| 18 | StopFailure | When the turn ends due to an API error. Output and exit code are ignored |
+| 19 | TeammateIdle | When an agent team teammate is about to go idle |
+| 20 | InstructionsLoaded | When a CLAUDE.md or `.claude/rules/*.md` file is loaded into context. Fires at session start and when files are lazily loaded during a session |
+| 21 | ConfigChange | When a configuration file changes during a session |
+| 22 | CwdChanged | When the working directory changes, for example when Claude executes a `cd` command. Useful for reactive environment management with tools like direnv |
+| 23 | FileChanged | When a watched file changes on disk. The `matcher` field specifies which filenames to watch |
+| 24 | WorktreeCreate | When a worktree is being created via `--worktree` or `isolation: "worktree"`. Replaces default git behavior |
+| 25 | WorktreeRemove | When a worktree is being removed, either at session exit or when a subagent finishes |
+| 26 | PreCompact | Before context compaction |
+| 27 | PostCompact | After context compaction completes |
+| 28 | Elicitation | When an MCP server requests user input during a tool call |
+| 29 | ElicitationResult | After a user responds to an MCP elicitation, before the response is sent back to the server |
+| 30 | SessionEnd | When a session terminates |
+
+**TOTAL: 30 distinct events.**
+
+### Diff vs the 2026-05-23 capture (reference file lines 58–86)
+- The old capture listed 29 names. The only structural change is the insertion of **`MessageDisplay`** between `Notification` and `SubagentStart`.
+- Net: +1 event (`MessageDisplay`). No removals. No renames. Same ordering otherwise.
+- The reference's "31" claim was never supported even at capture time (it enumerated only 29). Today the live, fully-transcribed table is 30.
+
+---
+
+## Per-quote verdict (the two preserved PostToolUseFailure quotes)
+
+Both quotes were checked against the live page in both WebFetch passes; both passes agreed.
+
+### Quote 1 — lifecycle table row
+- **Preserved (reference line 46):** `| PostToolUseFailure | After a tool call fails |`
+- **Live (row 9):** `PostToolUseFailure` | `After a tool call fails`
+- **Verdict: MATCH** — verbatim identical (event name + "when it fires" cell).
+
+### Quote 2 — exit-code-behavior table row
+- **Preserved (reference line 52):** `| PostToolUseFailure | No | Shows stderr to Claude (tool already failed) |`
+- **Live:** `| PostToolUseFailure | No | Shows stderr to Claude (tool already failed) |`
+- **Verdict: MATCH** — verbatim identical across all three cells (event / Can block? = "No" / "Shows stderr to Claude (tool already failed)").
+
+---
+
+## PostToolUseFailure still a documented event supported via command hooks — CONFIRMED
+
+- `PostToolUseFailure` remains a documented hook event (lifecycle row 9; appears in the exit-code-behavior table; corroborated by independent WebSearch).
+- The page documents `type: "command"` hooks as a fully supported registration shape: command hooks "run a shell command; your script receives the event's JSON input on stdin and communicates results back through exit codes and stdout."
+- Command hooks are supported across hook events, with the page noting `SessionStart` and `Setup` restrict to `type: "command"` / `type: "mcp_tool"`. `PostToolUseFailure` carries no such restriction — `type: "command"` registration is supported for it.
+- It is non-blocking: "Can block? = No"; exit code 2 surfaces the hook's stderr to Claude but does not change the (already-failed) tool outcome.
+
+So the load-bearing claim that grounds the dual-event (PostToolUse + PostToolUseFailure) command-hook registration is still fully supported by the official docs.
+
+---
+
+## Recommended correction target
+
+In `features/guardrails/references/claude-code-posttooluse-hook-schema.md`:
+- Line 40: "one of 31 documented hook events" → **"one of 30 documented hook events"**.
+- Line 56: "All 31 documented hook events on this page" → **"All 30 documented hook events on this page"**.
+- Line 88: the parenthetical "(The page's table lists 31; the enumerated names above cover the explicitly captured events…)" is now contradicted twice over — the table lists **30** and the enumeration should be the full 30 (add `MessageDisplay` at position 12). Recommend replacing the 29-name enumeration with the 30-row table above and removing the stale "lists 31 / captured 29" reconciliation note.
+
+Because the live count (30) differs from BOTH the doc's claim (31) and the backlog's assumed target (29), the two tracked items should also be updated:
+- `backlogs/hook-event-count-31-vs-29-docs-sync.md` and `checklists/hook-event-count-31-vs-29-docs-sync.md`: the correction target is **30**, not 29. The `grep -rn '"31 hook'` verification still applies; additionally any "29" target text in these items is now stale.
+
+(These edits are Execution-slice work — flagged here, not performed. This research artifact is read-only on project files.)
+
+---
+
+## Other drift noticed
+
+1. **`MessageDisplay` is new** — the single material content change since 2026-05-23. Display-only hook; does not support matchers; fires per streamed assistant message. Not relevant to the guardrails subagent-telemetry design, but it is the reason the count moved.
+2. **Richer "when it fires" prose** — several rows now carry longer descriptions than the terse 2026-05-23 capture (e.g., `PermissionDenied` documents `{retry: true}`; `StopFailure` notes output/exit code are ignored). No impact on the load-bearing PostToolUseFailure claim.
+3. **No removals or renames** — every event the guardrails design depends on (`PostToolUse`, `PostToolUseFailure`, `SubagentStart`, `SubagentStop`, `Task*`) is still present with unchanged names.
+
+---
+
+## Sources
+
+- https://code.claude.com/docs/en/hooks (two WebFetch passes, 2026-06-01)
+- WebSearch corroboration (domains code.claude.com / docs.claude.com / docs.anthropic.com): confirms both `PostToolUseFailure` and `MessageDisplay` are live documented events on the hooks reference page.
+
+---
+
+## Cross-system adjudication (manager, 2026-06-01)
+
+After the leader's Claude WebFetch returned **30**, the manager ran an independent **Codex** (`codex exec --sandbox read-only`) re-fetch+count of the same page. Codex returned **29**, with a list **identical to the leader's except `MessageDisplay` was absent** (Codex went Notification → SubagentStart directly). Genuine cross-system divergence of exactly one event.
+
+The manager resolved it with **raw page text** (the failure mode both LLM fetches share is summarization, so raw HTML is the tiebreaker):
+
+- `curl -sL https://code.claude.com/docs/en/hooks` → 4.39 MB HTML.
+- `MessageDisplay` appears **51×** in raw HTML — TOC entry, dedicated `MessageDisplay input` / `MessageDisplay output` sections, and a lifecycle-table row `<tr><td><code>MessageDisplay</code></td>…`.
+- Python row-parse of the lifecycle `<table>` containing `PostToolUseFailure` → **exactly 30 `<tr>` event rows**, `MessageDisplay` at **position 12** (between Notification and SubagentStart) — matching the leader's enumeration exactly.
+- Raw-HTML extraction of the two `PostToolUseFailure` rows: lifecycle `['PostToolUseFailure', 'After a tool call fails']`; exit-code `['PostToolUseFailure', 'No', 'Shows stderr to Claude (tool already failed)']` — both verbatim-confirmed.
+
+**Verdict: count = 30 (definitive). The Claude leader was correct; Codex's web-search view undercounted by missing the newly-added `MessageDisplay`.** Three independent sources now agree on every name except the one Codex missed, and raw HTML settles that one.
+
+**Mistake-candidate (for MEMORIZATION):** Codex `codex exec` web-search can silently undercount a documented table when a row was recently added (its index/cache lagged the live page); for any *count* dispute, fetch raw HTML (`curl` + row-parse / grep) as the tiebreaker rather than arbitrating between two LLM-summarized counts. Reinforces `mistakes/claude-evaluator-step4-only-vs-codex-whole-file-grep.md`.

--- a/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/session.json
+++ b/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/session.json
@@ -1,0 +1,69 @@
+{
+  "schemaVersion": 1,
+  "sessionId": "34563fb4-361d-4348-aa75-8bc9f1fbff05",
+  "previousSessionId": "a30b7a6e-164f-49ac-a857-ee225e831a7c",
+  "project": "gobbi",
+  "feature": "guardrails",
+  "task": "Close principles residue backlog; resolve PostToolUseFailure WebFetch verification gap and 31-vs-29 hook-event-count docs-sync",
+  "system": "claude-code",
+  "startedAt": "2026-06-01T10:56:17Z",
+  "finishedAt": "2026-06-01T14:22:47Z",
+  "transcriptPath": "~/.claude/projects/-playinganalytics-git-gobbi/34563fb4-361d-4348-aa75-8bc9f1fbff05.jsonl",
+  "git": {
+    "repo": "HahyeonJeon/gobbi",
+    "baseBranch": "develop",
+    "branch": "chore/session-2026-06-01-34563fb4",
+    "worktreePath": "/playinganalytics/git/gobbi/.gobbi/projects/gobbi/worktrees/chore/session-2026-06-01-34563fb4",
+    "issue": null,
+    "pr": null
+  },
+  "workflow": {
+    "configuration": { "startedAt": "2026-06-01T10:56:17Z", "finishedAt": "2026-06-01T10:56:17Z" },
+    "ideation":      { "startedAt": "2026-06-01T10:58:00Z", "finishedAt": "2026-06-01T11:40:00Z", "iter": 1, "verdict": "pass" },
+    "preparation":   { "startedAt": null, "finishedAt": null, "iter": 0, "verdict": "skipped" },
+    "planning":      { "startedAt": null, "finishedAt": null, "iter": 0, "verdict": "skipped" },
+    "execution":     { "startedAt": "2026-06-01T12:40:00Z", "finishedAt": "2026-06-01T13:30:00Z", "iter": 2, "verdict": "pass" },
+    "wrap-up":        { "startedAt": "2026-06-01T13:35:00Z", "finishedAt": "2026-06-01T14:22:47Z", "iter": 1, "verdict": "pass",
+      "iterations": [ { "iter": 1, "verdict": "pass", "finishedAt": "2026-06-01T14:22:47Z", "evaluation_dir": "wrap-up/evaluation/iter1/", "note": "Codex REVISE (3 findings) remediated by manager; Claude PASS" } ] },
+    "chat": {
+      "tasks": [
+        {
+          "taskNo": "01",
+          "slug": "hook-event-count-and-webfetch-gap",
+          "startedAt": "2026-06-01T10:56:17Z",
+          "finishedAt": "2026-06-01T13:30:00Z",
+          "ideation":    { "state": "Done", "verdict": "pass", "iter": 1, "maxIterations": 3, "phase": null, "iterations": [] },
+          "preparation": { "state": "Skipped", "verdict": null, "iter": 0, "maxIterations": 3, "phase": null, "iterations": [] },
+          "planning":    { "state": "Skipped", "verdict": null, "iter": 0, "maxIterations": 3, "phase": null, "iterations": [] },
+          "execution":   { "state": "Done", "verdict": "pass", "iter": 2, "maxIterations": 3, "phase": null, "iterations": [] },
+          "taskRecord": { "path": "execution/task-01/artifacts/task-record.md", "writtenAt": "2026-06-01T13:30:00Z" }
+        }
+      ]
+    }
+  },
+  "agents": [
+    {
+      "id": "34563fb4-361d-4348-aa75-8bc9f1fbff05",
+      "name": "manager",
+      "type": "manager",
+      "step": "configuration",
+      "phase": null,
+      "iter": null,
+      "model": "claude-opus-4-8",
+      "system": "claude-code",
+      "transcriptPath": "~/.claude/projects/-playinganalytics-git-gobbi/34563fb4-361d-4348-aa75-8bc9f1fbff05.jsonl",
+      "tokensUsed": { "input": 0, "output": 0, "cacheRead": 0, "cacheCreation": 0 },
+      "startedAt": "2026-06-01T10:56:17Z",
+      "finishedAt": "2026-06-01T14:22:47Z"
+    },
+    { "id": "ada4a869b5aa16475", "name": "research-leader", "type": "leader", "step": "ideation", "phase": "RESEARCH", "iter": 1, "model": "opus", "system": "claude-code", "transcriptPath": null, "tokensUsed": { "input": 0, "output": 0, "cacheRead": 0, "cacheCreation": 0 }, "startedAt": "2026-06-01T10:58:00Z", "finishedAt": "2026-06-01T11:20:00Z" },
+    { "id": "a42dc5b2416ef744b", "name": "executor-iter1", "type": "executor", "step": "execution", "phase": "EXECUTION", "iter": 1, "model": "sonnet", "system": "claude-code", "transcriptPath": null, "tokensUsed": { "input": 0, "output": 0, "cacheRead": 0, "cacheCreation": 0 }, "startedAt": "2026-06-01T12:40:00Z", "finishedAt": "2026-06-01T12:55:00Z" },
+    { "id": "a49fd10c6e0227a5b", "name": "evaluator-claude-exec", "type": "evaluator", "step": "execution", "phase": "EVALUATION", "iter": 1, "model": "opus", "system": "claude-code", "transcriptPath": null, "tokensUsed": { "input": 0, "output": 0, "cacheRead": 0, "cacheCreation": 0 }, "startedAt": "2026-06-01T13:00:00Z", "finishedAt": "2026-06-01T13:05:00Z" },
+    { "id": "be8hmdx1i", "name": "evaluator-codex-exec", "type": "evaluator", "step": "execution", "phase": "EVALUATION", "iter": 1, "model": "codex", "system": "codex", "transcriptPath": null, "tokensUsed": { "input": 0, "output": 0, "cacheRead": 0, "cacheCreation": 0 }, "startedAt": "2026-06-01T13:00:00Z", "finishedAt": "2026-06-01T13:06:00Z" },
+    { "id": "adc7b1b31fac53694", "name": "executor-iter2", "type": "executor", "step": "execution", "phase": "EXECUTION", "iter": 2, "model": "sonnet", "system": "claude-code", "transcriptPath": null, "tokensUsed": { "input": 0, "output": 0, "cacheRead": 0, "cacheCreation": 0 }, "startedAt": "2026-06-01T13:15:00Z", "finishedAt": "2026-06-01T13:28:00Z" },
+    { "id": "a6f8de8bc5ffa331e", "name": "wrap-up-assistant", "type": "assistant", "step": "wrap-up", "phase": "WRAPUP", "iter": 1, "model": "sonnet", "system": "claude-code", "transcriptPath": null, "tokensUsed": { "input": 0, "output": 0, "cacheRead": 0, "cacheCreation": 0 }, "startedAt": "2026-06-01T13:35:00Z", "finishedAt": "2026-06-01T13:50:00Z" },
+    { "id": "a9d50792d4353bf34", "name": "evaluator-claude-wrapup", "type": "evaluator", "step": "wrap-up", "phase": "EVALUATION", "iter": 1, "model": "opus", "system": "claude-code", "transcriptPath": null, "tokensUsed": { "input": 0, "output": 0, "cacheRead": 0, "cacheCreation": 0 }, "startedAt": "2026-06-01T14:00:00Z", "finishedAt": "2026-06-01T14:05:00Z" },
+    { "id": "ba9ohdb2a", "name": "evaluator-codex-wrapup", "type": "evaluator", "step": "wrap-up", "phase": "EVALUATION", "iter": 1, "model": "codex", "system": "codex", "transcriptPath": null, "tokensUsed": { "input": 0, "output": 0, "cacheRead": 0, "cacheCreation": 0 }, "startedAt": "2026-06-01T14:00:00Z", "finishedAt": "2026-06-01T14:08:00Z" }
+  ],
+  "workflowFinish": { "emitted": true, "at": "2026-06-01T14:22:47Z", "verdict": "pass" }
+}

--- a/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/session.json
+++ b/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/session.json
@@ -15,16 +15,52 @@
     "branch": "chore/session-2026-06-01-34563fb4",
     "worktreePath": "/playinganalytics/git/gobbi/.gobbi/projects/gobbi/worktrees/chore/session-2026-06-01-34563fb4",
     "issue": null,
-    "pr": null
+    "pr": 286
   },
   "workflow": {
-    "configuration": { "startedAt": "2026-06-01T10:56:17Z", "finishedAt": "2026-06-01T10:56:17Z" },
-    "ideation":      { "startedAt": "2026-06-01T10:58:00Z", "finishedAt": "2026-06-01T11:40:00Z", "iter": 1, "verdict": "pass" },
-    "preparation":   { "startedAt": null, "finishedAt": null, "iter": 0, "verdict": "skipped" },
-    "planning":      { "startedAt": null, "finishedAt": null, "iter": 0, "verdict": "skipped" },
-    "execution":     { "startedAt": "2026-06-01T12:40:00Z", "finishedAt": "2026-06-01T13:30:00Z", "iter": 2, "verdict": "pass" },
-    "wrap-up":        { "startedAt": "2026-06-01T13:35:00Z", "finishedAt": "2026-06-01T14:22:47Z", "iter": 1, "verdict": "pass",
-      "iterations": [ { "iter": 1, "verdict": "pass", "finishedAt": "2026-06-01T14:22:47Z", "evaluation_dir": "wrap-up/evaluation/iter1/", "note": "Codex REVISE (3 findings) remediated by manager; Claude PASS" } ] },
+    "configuration": {
+      "startedAt": "2026-06-01T10:56:17Z",
+      "finishedAt": "2026-06-01T10:56:17Z"
+    },
+    "ideation": {
+      "startedAt": "2026-06-01T10:58:00Z",
+      "finishedAt": "2026-06-01T11:40:00Z",
+      "iter": 1,
+      "verdict": "pass"
+    },
+    "preparation": {
+      "startedAt": null,
+      "finishedAt": null,
+      "iter": 0,
+      "verdict": "skipped"
+    },
+    "planning": {
+      "startedAt": null,
+      "finishedAt": null,
+      "iter": 0,
+      "verdict": "skipped"
+    },
+    "execution": {
+      "startedAt": "2026-06-01T12:40:00Z",
+      "finishedAt": "2026-06-01T13:30:00Z",
+      "iter": 2,
+      "verdict": "pass"
+    },
+    "wrap-up": {
+      "startedAt": "2026-06-01T13:35:00Z",
+      "finishedAt": "2026-06-01T14:22:47Z",
+      "iter": 1,
+      "verdict": "pass",
+      "iterations": [
+        {
+          "iter": 1,
+          "verdict": "pass",
+          "finishedAt": "2026-06-01T14:22:47Z",
+          "evaluation_dir": "wrap-up/evaluation/iter1/",
+          "note": "Codex REVISE (3 findings) remediated by manager; Claude PASS"
+        }
+      ]
+    },
     "chat": {
       "tasks": [
         {
@@ -32,11 +68,42 @@
           "slug": "hook-event-count-and-webfetch-gap",
           "startedAt": "2026-06-01T10:56:17Z",
           "finishedAt": "2026-06-01T13:30:00Z",
-          "ideation":    { "state": "Done", "verdict": "pass", "iter": 1, "maxIterations": 3, "phase": null, "iterations": [] },
-          "preparation": { "state": "Skipped", "verdict": null, "iter": 0, "maxIterations": 3, "phase": null, "iterations": [] },
-          "planning":    { "state": "Skipped", "verdict": null, "iter": 0, "maxIterations": 3, "phase": null, "iterations": [] },
-          "execution":   { "state": "Done", "verdict": "pass", "iter": 2, "maxIterations": 3, "phase": null, "iterations": [] },
-          "taskRecord": { "path": "execution/task-01/artifacts/task-record.md", "writtenAt": "2026-06-01T13:30:00Z" }
+          "ideation": {
+            "state": "Done",
+            "verdict": "pass",
+            "iter": 1,
+            "maxIterations": 3,
+            "phase": null,
+            "iterations": []
+          },
+          "preparation": {
+            "state": "Skipped",
+            "verdict": null,
+            "iter": 0,
+            "maxIterations": 3,
+            "phase": null,
+            "iterations": []
+          },
+          "planning": {
+            "state": "Skipped",
+            "verdict": null,
+            "iter": 0,
+            "maxIterations": 3,
+            "phase": null,
+            "iterations": []
+          },
+          "execution": {
+            "state": "Done",
+            "verdict": "pass",
+            "iter": 2,
+            "maxIterations": 3,
+            "phase": null,
+            "iterations": []
+          },
+          "taskRecord": {
+            "path": "execution/task-01/artifacts/task-record.md",
+            "writtenAt": "2026-06-01T13:30:00Z"
+          }
         }
       ]
     }
@@ -52,18 +119,171 @@
       "model": "claude-opus-4-8",
       "system": "claude-code",
       "transcriptPath": "~/.claude/projects/-playinganalytics-git-gobbi/34563fb4-361d-4348-aa75-8bc9f1fbff05.jsonl",
-      "tokensUsed": { "input": 0, "output": 0, "cacheRead": 0, "cacheCreation": 0 },
+      "tokensUsed": {
+        "input": 0,
+        "output": 0,
+        "cacheRead": 0,
+        "cacheCreation": 0
+      },
       "startedAt": "2026-06-01T10:56:17Z",
       "finishedAt": "2026-06-01T14:22:47Z"
     },
-    { "id": "ada4a869b5aa16475", "name": "research-leader", "type": "leader", "step": "ideation", "phase": "RESEARCH", "iter": 1, "model": "opus", "system": "claude-code", "transcriptPath": null, "tokensUsed": { "input": 0, "output": 0, "cacheRead": 0, "cacheCreation": 0 }, "startedAt": "2026-06-01T10:58:00Z", "finishedAt": "2026-06-01T11:20:00Z" },
-    { "id": "a42dc5b2416ef744b", "name": "executor-iter1", "type": "executor", "step": "execution", "phase": "EXECUTION", "iter": 1, "model": "sonnet", "system": "claude-code", "transcriptPath": null, "tokensUsed": { "input": 0, "output": 0, "cacheRead": 0, "cacheCreation": 0 }, "startedAt": "2026-06-01T12:40:00Z", "finishedAt": "2026-06-01T12:55:00Z" },
-    { "id": "a49fd10c6e0227a5b", "name": "evaluator-claude-exec", "type": "evaluator", "step": "execution", "phase": "EVALUATION", "iter": 1, "model": "opus", "system": "claude-code", "transcriptPath": null, "tokensUsed": { "input": 0, "output": 0, "cacheRead": 0, "cacheCreation": 0 }, "startedAt": "2026-06-01T13:00:00Z", "finishedAt": "2026-06-01T13:05:00Z" },
-    { "id": "be8hmdx1i", "name": "evaluator-codex-exec", "type": "evaluator", "step": "execution", "phase": "EVALUATION", "iter": 1, "model": "codex", "system": "codex", "transcriptPath": null, "tokensUsed": { "input": 0, "output": 0, "cacheRead": 0, "cacheCreation": 0 }, "startedAt": "2026-06-01T13:00:00Z", "finishedAt": "2026-06-01T13:06:00Z" },
-    { "id": "adc7b1b31fac53694", "name": "executor-iter2", "type": "executor", "step": "execution", "phase": "EXECUTION", "iter": 2, "model": "sonnet", "system": "claude-code", "transcriptPath": null, "tokensUsed": { "input": 0, "output": 0, "cacheRead": 0, "cacheCreation": 0 }, "startedAt": "2026-06-01T13:15:00Z", "finishedAt": "2026-06-01T13:28:00Z" },
-    { "id": "a6f8de8bc5ffa331e", "name": "wrap-up-assistant", "type": "assistant", "step": "wrap-up", "phase": "WRAPUP", "iter": 1, "model": "sonnet", "system": "claude-code", "transcriptPath": null, "tokensUsed": { "input": 0, "output": 0, "cacheRead": 0, "cacheCreation": 0 }, "startedAt": "2026-06-01T13:35:00Z", "finishedAt": "2026-06-01T13:50:00Z" },
-    { "id": "a9d50792d4353bf34", "name": "evaluator-claude-wrapup", "type": "evaluator", "step": "wrap-up", "phase": "EVALUATION", "iter": 1, "model": "opus", "system": "claude-code", "transcriptPath": null, "tokensUsed": { "input": 0, "output": 0, "cacheRead": 0, "cacheCreation": 0 }, "startedAt": "2026-06-01T14:00:00Z", "finishedAt": "2026-06-01T14:05:00Z" },
-    { "id": "ba9ohdb2a", "name": "evaluator-codex-wrapup", "type": "evaluator", "step": "wrap-up", "phase": "EVALUATION", "iter": 1, "model": "codex", "system": "codex", "transcriptPath": null, "tokensUsed": { "input": 0, "output": 0, "cacheRead": 0, "cacheCreation": 0 }, "startedAt": "2026-06-01T14:00:00Z", "finishedAt": "2026-06-01T14:08:00Z" }
+    {
+      "id": "ada4a869b5aa16475",
+      "name": "research-leader",
+      "type": "leader",
+      "step": "ideation",
+      "phase": "RESEARCH",
+      "iter": 1,
+      "model": "opus",
+      "system": "claude-code",
+      "transcriptPath": null,
+      "tokensUsed": {
+        "input": 0,
+        "output": 0,
+        "cacheRead": 0,
+        "cacheCreation": 0
+      },
+      "startedAt": "2026-06-01T10:58:00Z",
+      "finishedAt": "2026-06-01T11:20:00Z"
+    },
+    {
+      "id": "a42dc5b2416ef744b",
+      "name": "executor-iter1",
+      "type": "executor",
+      "step": "execution",
+      "phase": "EXECUTION",
+      "iter": 1,
+      "model": "sonnet",
+      "system": "claude-code",
+      "transcriptPath": null,
+      "tokensUsed": {
+        "input": 0,
+        "output": 0,
+        "cacheRead": 0,
+        "cacheCreation": 0
+      },
+      "startedAt": "2026-06-01T12:40:00Z",
+      "finishedAt": "2026-06-01T12:55:00Z"
+    },
+    {
+      "id": "a49fd10c6e0227a5b",
+      "name": "evaluator-claude-exec",
+      "type": "evaluator",
+      "step": "execution",
+      "phase": "EVALUATION",
+      "iter": 1,
+      "model": "opus",
+      "system": "claude-code",
+      "transcriptPath": null,
+      "tokensUsed": {
+        "input": 0,
+        "output": 0,
+        "cacheRead": 0,
+        "cacheCreation": 0
+      },
+      "startedAt": "2026-06-01T13:00:00Z",
+      "finishedAt": "2026-06-01T13:05:00Z"
+    },
+    {
+      "id": "be8hmdx1i",
+      "name": "evaluator-codex-exec",
+      "type": "evaluator",
+      "step": "execution",
+      "phase": "EVALUATION",
+      "iter": 1,
+      "model": "codex",
+      "system": "codex",
+      "transcriptPath": null,
+      "tokensUsed": {
+        "input": 0,
+        "output": 0,
+        "cacheRead": 0,
+        "cacheCreation": 0
+      },
+      "startedAt": "2026-06-01T13:00:00Z",
+      "finishedAt": "2026-06-01T13:06:00Z"
+    },
+    {
+      "id": "adc7b1b31fac53694",
+      "name": "executor-iter2",
+      "type": "executor",
+      "step": "execution",
+      "phase": "EXECUTION",
+      "iter": 2,
+      "model": "sonnet",
+      "system": "claude-code",
+      "transcriptPath": null,
+      "tokensUsed": {
+        "input": 0,
+        "output": 0,
+        "cacheRead": 0,
+        "cacheCreation": 0
+      },
+      "startedAt": "2026-06-01T13:15:00Z",
+      "finishedAt": "2026-06-01T13:28:00Z"
+    },
+    {
+      "id": "a6f8de8bc5ffa331e",
+      "name": "wrap-up-assistant",
+      "type": "assistant",
+      "step": "wrap-up",
+      "phase": "WRAPUP",
+      "iter": 1,
+      "model": "sonnet",
+      "system": "claude-code",
+      "transcriptPath": null,
+      "tokensUsed": {
+        "input": 0,
+        "output": 0,
+        "cacheRead": 0,
+        "cacheCreation": 0
+      },
+      "startedAt": "2026-06-01T13:35:00Z",
+      "finishedAt": "2026-06-01T13:50:00Z"
+    },
+    {
+      "id": "a9d50792d4353bf34",
+      "name": "evaluator-claude-wrapup",
+      "type": "evaluator",
+      "step": "wrap-up",
+      "phase": "EVALUATION",
+      "iter": 1,
+      "model": "opus",
+      "system": "claude-code",
+      "transcriptPath": null,
+      "tokensUsed": {
+        "input": 0,
+        "output": 0,
+        "cacheRead": 0,
+        "cacheCreation": 0
+      },
+      "startedAt": "2026-06-01T14:00:00Z",
+      "finishedAt": "2026-06-01T14:05:00Z"
+    },
+    {
+      "id": "ba9ohdb2a",
+      "name": "evaluator-codex-wrapup",
+      "type": "evaluator",
+      "step": "wrap-up",
+      "phase": "EVALUATION",
+      "iter": 1,
+      "model": "codex",
+      "system": "codex",
+      "transcriptPath": null,
+      "tokensUsed": {
+        "input": 0,
+        "output": 0,
+        "cacheRead": 0,
+        "cacheCreation": 0
+      },
+      "startedAt": "2026-06-01T14:00:00Z",
+      "finishedAt": "2026-06-01T14:08:00Z"
+    }
   ],
-  "workflowFinish": { "emitted": true, "at": "2026-06-01T14:22:47Z", "verdict": "pass" }
+  "workflowFinish": {
+    "emitted": true,
+    "at": "2026-06-01T14:22:47Z",
+    "verdict": "pass"
+  }
 }

--- a/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/state.json
+++ b/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/state.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": 1,
+  "mode": "chat",
+  "workflow": {
+    "configuration": { "state": "Done",    "verdict": null, "iter": null, "maxIterations": null, "phase": null },
+    "ideation":      { "state": "Done",    "verdict": "pass", "iter": 1, "maxIterations": 3, "phase": null },
+    "preparation":   { "state": "Skipped", "verdict": null, "iter": 0,    "maxIterations": 3,    "phase": null },
+    "planning":      { "state": "Skipped", "verdict": null, "iter": 0,    "maxIterations": 3,    "phase": null },
+    "execution":     { "state": "Done",    "verdict": "pass", "iter": 2, "maxIterations": 3, "phase": null },
+    "wrap-up":        { "state": "Done",    "verdict": "pass", "iter": 1, "maxIterations": 1, "phase": null },
+    "chat": {
+      "tasks": [
+        {
+          "taskNo": "01",
+          "slug": "hook-event-count-and-webfetch-gap",
+          "startedAt": "2026-06-01T10:56:17Z",
+          "finishedAt": "2026-06-01T13:30:00Z",
+          "ideation":    { "state": "Done", "verdict": "pass", "iter": 1, "maxIterations": 3, "phase": null, "iterations": [] },
+          "preparation": { "state": "Skipped", "verdict": null, "iter": 0, "maxIterations": 3, "phase": null, "iterations": [] },
+          "planning":    { "state": "Skipped", "verdict": null, "iter": 0, "maxIterations": 3, "phase": null, "iterations": [] },
+          "execution":   { "state": "Done", "verdict": "pass", "iter": 2, "maxIterations": 3, "phase": null, "iterations": [] },
+          "taskRecord": { "path": "execution/task-01/artifacts/task-record.md", "writtenAt": "2026-06-01T13:30:00Z" }
+        }
+      ]
+    }
+  },
+  "activeNote": "Session COMPLETE. Slice 1 (hook-count + webfetch-gap) PASS; residue closure + Slice-1 tracking items archived at Wrap-up. Wrap-up PASS (Codex REVISE 3 findings remediated). workflow.finish emitted 2026-06-01T14:22:47Z. Pending: final self-contained commit + push + PR."
+}

--- a/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/wrap-up/artifacts/handoff.md
+++ b/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/wrap-up/artifacts/handoff.md
@@ -21,7 +21,7 @@ Chat-mode docs-sync session. Two guardrails backlogs resolved (hook-event count 
 
 **Execution commits (already on branch `chore/session-2026-06-01-34563fb4`):**
 - `84521bc` — `features/guardrails/references/claude-code-posttooluse-hook-schema.md`: event count 31→30, full enumeration updated (+MessageDisplay at pos 12), frontmatter `accessed:` refreshed to 2026-06-01
-- `5427e9d` — iter2 remediation: body `## Source` date updated, `features/guardrails/features/README.md` open-item bullet removed + recent-activity row added, `backlogs/hook-event-count-31-vs-29-docs-sync.md` and `checklists/hook-event-count-31-vs-29-docs-sync.md` got Resolution sections + `status: addressed` / `disposition: addressed`
+- `5427e9d` — iter2 remediation: body `## Source` date updated, `features/guardrails/README.md` open-item bullet removed + recent-activity row added, `backlogs/hook-event-count-31-vs-29-docs-sync.md` and `checklists/hook-event-count-31-vs-29-docs-sync.md` got Resolution sections + `status: addressed` / `disposition: addressed`
 
 **Wrap-up commit (this session's wrap-up):**
 - `mistakes/codex-webfetch-undercounts-recently-added-table-row.md` — new project mistake (path: `.gobbi/projects/gobbi/mistakes/`)
@@ -37,7 +37,7 @@ Chat-mode docs-sync session. Two guardrails backlogs resolved (hook-event count 
 
 - **`goodhart-factor-when-demanded-deferred.md`** (`features/guardrails/backlogs/`) — active, not triggered this session. Remains open.
 - **`claude-code-hooks-12-lifecycle-events.md`** (`features/guardrails/references/`) — not reviewed this session. It references "12 lifecycle events" and may drift if the hooks page changes further. Flagged as a possible future drift check.
-- **plugins-snapshot-resync backlog** — out of this session's scope; deferred due to concurrent PR #282. Remains open.
+- **plugins-snapshot-resync backlog** (`.gobbi/projects/gobbi/backlogs/plugins-snapshot-resync-after-principles-changes.md`) — out of this session's scope; deferred due to concurrent PR #282. Remains open.
 
 ## Decisions to respect
 

--- a/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/wrap-up/artifacts/handoff.md
+++ b/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/wrap-up/artifacts/handoff.md
@@ -1,0 +1,77 @@
+---
+loop: wrap-up
+iter: 1
+artifact_type: handoff
+created_at: 2026-06-01
+status: final
+supersedes: []
+related:
+  - "../rawdata/promotion-manifest.md"
+  - "../rawdata/staging-inventory.md"
+  - "../rawdata/pre-wrap-up-snapshot.txt"
+---
+
+# Handoff — session 34563fb4-361d-4348-aa75-8bc9f1fbff05
+
+## Summary
+
+Chat-mode docs-sync session. Two guardrails backlogs resolved (hook-event count 31→30 re-verified live; PostToolUseFailure verbatim quotes confirmed). One out-of-scope residue item (principles anti-rationalizations label, PR #285) also closed. 4 tracking files archived. 2 project mistakes promoted from execution staging.
+
+## Shipped
+
+**Execution commits (already on branch `chore/session-2026-06-01-34563fb4`):**
+- `84521bc` — `features/guardrails/references/claude-code-posttooluse-hook-schema.md`: event count 31→30, full enumeration updated (+MessageDisplay at pos 12), frontmatter `accessed:` refreshed to 2026-06-01
+- `5427e9d` — iter2 remediation: body `## Source` date updated, `features/guardrails/features/README.md` open-item bullet removed + recent-activity row added, `backlogs/hook-event-count-31-vs-29-docs-sync.md` and `checklists/hook-event-count-31-vs-29-docs-sync.md` got Resolution sections + `status: addressed` / `disposition: addressed`
+
+**Wrap-up commit (this session's wrap-up):**
+- `mistakes/codex-webfetch-undercounts-recently-added-table-row.md` — new project mistake (path: `.gobbi/projects/gobbi/mistakes/`)
+- `mistakes/docs-sync-count-fix-blast-radius-includes-colocated-dates-and-tracking-pointers.md` — new project mistake
+- `archive/backlogs/2026-06-01-hook-event-count-31-vs-29-docs-sync.md` — archived from `features/guardrails/backlogs/`
+- `archive/backlogs/2026-06-01-posttooluse-failure-webfetch-verification-gap.md` — archived from `features/guardrails/backlogs/`
+- `archive/backlogs/2026-06-01-principles-anti-rationalizations-label-residue.md` — archived from `features/guardrails/backlogs/`
+- `archive/checklists/2026-06-01-hook-event-count-31-vs-29-docs-sync.md` — archived from `features/guardrails/checklists/`; `archive/checklists/` directory created
+- `notes/2026-06-01-hook-event-count-and-residue-closure.md` — per-session journal entry
+- `features/guardrails/references/claude-code-posttooluse-hook-schema.md` — inbound reference lines 35-36 repointed to archive paths
+
+## Deferred / Open
+
+- **`goodhart-factor-when-demanded-deferred.md`** (`features/guardrails/backlogs/`) — active, not triggered this session. Remains open.
+- **`claude-code-hooks-12-lifecycle-events.md`** (`features/guardrails/references/`) — not reviewed this session. It references "12 lifecycle events" and may drift if the hooks page changes further. Flagged as a possible future drift check.
+- **plugins-snapshot-resync backlog** — out of this session's scope; deferred due to concurrent PR #282. Remains open.
+
+## Decisions to respect
+
+- Raw HTML (`curl -sL` + `<tr>` row-count of the lifecycle table) is the authoritative tiebreaker when two LLM-mediated fetch counts disagree. Do not re-arbitrate between LLM-summarized counts.
+- The hook-event count is **30** as of 2026-06-01. `MessageDisplay` (pos 12) was the net addition since the 2026-05-23 baseline. The full 30-event enumeration is in `features/guardrails/references/claude-code-posttooluse-hook-schema.md`.
+- Both PostToolUseFailure verbatim quotes are confirmed against the live page. The verification gap (opened 2026-05-23, Confidence-50) is closed.
+- Wrap-up is the sole writer to `archive/`. Executors must not perform git mv archive moves even when a backlog is "obviously done" — defer to Wrap-up.
+
+## Pointers
+
+| Artifact | Path |
+|----------|------|
+| Reference (corrected) | `features/guardrails/references/claude-code-posttooluse-hook-schema.md` |
+| New mistake 1 | `mistakes/codex-webfetch-undercounts-recently-added-table-row.md` |
+| New mistake 2 | `mistakes/docs-sync-count-fix-blast-radius-includes-colocated-dates-and-tracking-pointers.md` |
+| Journal entry | `notes/2026-06-01-hook-event-count-and-residue-closure.md` |
+| Archived backlog 1 | `archive/backlogs/2026-06-01-hook-event-count-31-vs-29-docs-sync.md` |
+| Archived backlog 2 | `archive/backlogs/2026-06-01-posttooluse-failure-webfetch-verification-gap.md` |
+| Archived backlog 3 | `archive/backlogs/2026-06-01-principles-anti-rationalizations-label-residue.md` |
+| Archived checklist | `archive/checklists/2026-06-01-hook-event-count-31-vs-29-docs-sync.md` |
+| Promotion manifest | `sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/wrap-up/rawdata/promotion-manifest.md` |
+
+All paths above are relative to `.gobbi/projects/gobbi/` (worktree root).
+
+## Promotion summary
+
+| Item | Type | Disposition |
+|------|------|-------------|
+| `codex-webfetch-undercounts-recently-added-table-row.md` | mistake-candidate → mistakes/ | promoted (project scope) |
+| `docs-sync-count-fix-blast-radius-includes-colocated-dates-and-tracking-pointers.md` | mistake-candidate → mistakes/ | promoted (project scope) |
+| `features/guardrails/backlogs/hook-event-count-31-vs-29-docs-sync.md` | backlog → archive/backlogs/ | archived (move-on-terminal) |
+| `features/guardrails/backlogs/posttooluse-failure-webfetch-verification-gap.md` | backlog → archive/backlogs/ | archived (move-on-terminal) |
+| `features/guardrails/backlogs/principles-anti-rationalizations-label-residue.md` | backlog → archive/backlogs/ | archived (move-on-terminal; status flipped this wrap-up) |
+| `features/guardrails/checklists/hook-event-count-31-vs-29-docs-sync.md` | checklist → archive/checklists/ | archived (move-on-terminal) |
+| journal entry | notes/ direct write | written (Step 6) |
+
+Closure gate: `grep -rn '"31 hook' .gobbi/projects/gobbi/features/guardrails/` → 0 matches (verified).

--- a/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/wrap-up/artifacts/memory-reads.md
+++ b/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/wrap-up/artifacts/memory-reads.md
@@ -1,0 +1,29 @@
+---
+loop: wrap-up
+iter: 1
+artifact_type: memory-reads
+created_at: 2026-06-01
+status: final
+---
+
+# Memory reads — inputs consumed by Wrap-up's promotion-routing pass
+
+## Session staging consumed (promoted)
+- `execution/task-01/staging/decisions/codex-webfetch-undercounts-recently-added-table-row.md` → `mistakes/`
+- `execution/task-01/staging/decisions/docs-sync-count-fix-blast-radius-includes-colocated-dates-and-tracking-pointers.md` → `mistakes/`
+
+## Prior-loop artifacts / evaluation read (for handoff + closure audit)
+- `ideation/rawdata/hooks-docs-webfetch-verification.md` (research + cross-system adjudication → count 30)
+- `execution/task-01/evaluation/iter1/claude/{project,consistency,overall}.md`
+- `execution/task-01/evaluation/iter1/codex/overall.md`
+- `execution/task-01/artifacts/task-record.md`
+- `execution/task-01/rawdata/{draft-iter1,draft-iter2}.md`
+
+## Project memory read (collision / supersession detection)
+- `.gobbi/projects/gobbi/mistakes/` (no slug collisions for the 2 new mistakes)
+- `.gobbi/projects/gobbi/archive/{backlogs,checklists}/` (no 2026-06-01 collisions)
+- `.gobbi/projects/gobbi/features/guardrails/{backlogs,checklists,references,README.md}`
+
+## Wrap-up own eval read
+- `wrap-up/evaluation/iter1/claude/{project,consistency,risk,overall}.md` (PASS)
+- `wrap-up/evaluation/iter1/codex/overall.md` (REVISE → remediated → PASS)

--- a/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/wrap-up/artifacts/resolution-log.md
+++ b/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/wrap-up/artifacts/resolution-log.md
@@ -1,0 +1,30 @@
+---
+loop: wrap-up
+iter: 1
+artifact_type: resolution-log
+created_at: 2026-06-01
+status: final
+---
+
+# Resolution log — every evaluator finding across all loops
+
+## Execution (task-01) — iter1 dual-system eval
+| Finding | System | Sev | Disposition |
+|---|---|---|---|
+| `## Source:103` body date stale ("Both accessed 2026-05-23") vs frontmatter 2026-06-01 | Codex | High | **Addressed** — iter2 commit 5427e9d split per-URL dates |
+| README:50 + backlogs + checklist still say "29" / active (blast radius) | Claude | High | **Addressed** — iter2 commit 5427e9d (README bullets removed; 3 tracking items flipped to addressed + Resolution notes) |
+| reference line 35 present-tense phrasing | Claude | Low | Accepted (cosmetic) |
+
+## Wrap-up — iter1 dual-system eval
+| Finding | System | Sev | Disposition |
+|---|---|---|---|
+| Commit 77b0a70 not self-contained (session artifacts untracked) | Codex | High | **Addressed** — final seal commit stages the full session tree |
+| handoff.md:24 cited `features/guardrails/features/README.md` (nonexistent) + plugins backlog path missing | Codex | Med | **Addressed** — handoff lines 24 + 40 corrected |
+| archived backlog/checklist cross-link each other's old active paths | Codex | Low | **Addressed** — repointed to `../{type}/2026-06-01-...` (archive/checklists:43, archive/backlogs:49 + closure-gate note) |
+| reference line 35 present-tense (carried from execution) | Claude | Low | Accepted (cosmetic) |
+| "sole writer to archive" stated as decision note not a rules/ entry | Claude | Low | Accepted (reinforcement, not a new uncodified rule) |
+
+## Aggregate
+- Execution: REVISE (iter1) → PASS (iter2).
+- Wrap-up: REVISE (iter1) → PASS after manager remediation of all 3 Codex findings + Claude PASS.
+- Divergence pattern: Codex caught substantive findings the Claude leg missed on BOTH eval rounds (count undercount aside — that was Codex's miss; the wrap-up findings were Codex's catches). Net: dual-system earned its cost three times this session.

--- a/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/wrap-up/evaluation/iter1/claude/consistency.md
+++ b/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/wrap-up/evaluation/iter1/claude/consistency.md
@@ -1,0 +1,36 @@
+# Wrap-up Evaluation — Consistency (Claude, iter1)
+
+## Artifact Summary + Memory reads
+(See project.md for the shared Artifact Summary + Memory reads register — same artifact, same reads.)
+
+## Locked Frame (Stage 1)
+
+S1 **Frontmatter-strip-on-promotion** (mistake `wrap-up-promotion-must-strip-staging-frontmatter`) — checklist: (a) promoted mistakes carry NO `mistake-candidate`/`loop`/`finding-id`/`confidence`/`severity`; (b) carry `type: mistakes` + base 9 + mistakes extensions (`priority`, `domain`); (c) `scope: project`, `feature: null`; (d) §4.5 gate clean over the full live tree post-promotion (NOT measured before promotion).
+S2 **Staging body vs promoted body fidelity** — promoted body == staging body (no content loss/fabrication); cross-checked against the diff (mistake `evaluator-false-pass-without-diffing`).
+S3 **Supersession/archival integrity** — (a) archived files keep ORIGINAL `type` (never `type: archive`); (b) `archived_at` + `archive_reason` present on all 4; (c) residue backlog `status` terminal + Resolution note + `shipped_in: "#285"`.
+S4 **Reference integrity after move** — (a) repointed `../../../archive/...` paths resolve; (b) no dangling old-path links to `features/guardrails/{backlogs,checklists}/` for moved slugs.
+S5 **Cross-artifact story coherence** — handoff ↔ manifest ↔ journal ↔ commit all tell one story (counts, paths, dispositions match).
+S6 **Mistakes match session corrections (adversarial — cherry-pick / fabrication)** — every promoted mistake is supported; no inconvenient staging artifact dropped.
+
+Adversarial: S6 cherry-pick probe + S1 gate-after-promotion (the exact prior false-PASS).
+Coverage matrix (Privacy/Licensing sync): `not-applicable: no PII or license content touched`.
+
+## Per-scenario per-check results
+
+S1: (a) YES — independent grep for `^(mistake-candidate|finding-id|confidence|severity|loop|iter|task|scenario|phase):` on both promoted mistakes returns 0. (b) YES — both carry `type: mistakes`, all 9 base keys, plus `priority: medium` + `domain: docs-sync`. (c) YES — `scope: project`, `feature: null`. (d) **YES — I ran the §4.5 archive-safe underscore-aware gate over the entire live tree post-promotion: 0 leak files.** The conditional `disposition` leak check on non-backlog live files: 0. This is the exact check the prior false-PASS skipped; it is clean.
+S2: YES — diffed the staging source vs promoted body. Bodies are byte-identical in substance; only frontmatter transformed (type decisions→mistakes, scope feature→project, feature→null, dropped loop/mistake-candidate, added priority). No content loss, no fabrication.
+S3: (a) YES — all 4 archived files keep `type: backlogs` / `type: checklists` (NOT `type: archive`) — verified by grep. (b) YES — `archived_at: 2026-06-01` + `archive_reason: addressed` on all 4. (c) YES — residue backlog: `status: addressed`, `disposition: addressed`, `shipped_in: "#285"`, `## Resolution (2026-06-01)` section present.
+S4: (a) YES — all 3 repointed relative paths resolved from `features/guardrails/references/` via filesystem check. (b) YES — grep for old-path patterns (`{backlogs,checklists}/hook-event-count-31-vs-29`, `backlogs/posttooluse-failure-webfetch`, `backlogs/principles-anti-rationalizations`) under `features/` returns 0. No dangling links.
+S5: YES — manifest, handoff "Shipped"/"Promotion summary", journal "What shipped", and the commit diff agree 1:1 on the 2 mistakes + 4 archives + 1 journal + 1 reference repoint. Counts consistent (31→30, MessageDisplay pos 12, raw-HTML tiebreaker) across all artifacts.
+S6: YES — both staging mistake-candidates promoted (none dropped). Journal narrative (research→Codex/Claude disagreement→raw-HTML tiebreak→iter1→dual REVISE→iter2) matches the mistakes' bodies. No fabricated mistake.
+
+## Typed findings
+
+None blocking. The prior false-PASS failure mode (`evaluator-false-pass-without-diffing` + `wrap-up-promotion-must-strip-staging-frontmatter`) was specifically guarded: I ran the §4.5 gate AFTER promotion and diffed bodies rather than trusting the manifest.
+
+## Verdict: PASS
+
+Rationale: Strip-on-promotion is correct and the post-promotion §4.5 gate is independently clean at 0 — the exact regression the recorded mistake warns about did not recur. Archived files keep original type with proper archive stamps; the residue backlog reached a terminal state with a real shipped_in. All repointed references resolve and no dangling old-path links remain. The handoff/manifest/journal/commit tell one coherent story verified against the diff, not asserted from reasoning.
+
+## Low-confidence appendix
+(none)

--- a/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/wrap-up/evaluation/iter1/claude/overall.md
+++ b/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/wrap-up/evaluation/iter1/claude/overall.md
@@ -1,0 +1,36 @@
+# Wrap-up Evaluation — Overall (Claude, iter1, Stage 3)
+
+## Artifact Summary
+(See project.md.) Wrap-up commit `77b0a70`: 2 mistakes promoted, 4 items archived (git mv), references repointed, journal + handoff + manifest + inventory + pre-snapshot written, goodhart backlog left active.
+
+## Perspectives covered in depth
+- **Project**: PASS — right session, complete, no phantom claims.
+- **Consistency**: PASS — strip clean (§4.5 gate = 0 post-promotion), bodies diffed, references resolve, one coherent story.
+- **Risk**: PASS — scratch preserved, moves reversible, no silent overwrite, process mistakes recorded.
+
+## Perspectives marked N/A-for-wrap-up
+- **Performance**: N/A beyond a bloat sanity check — promoted mistakes are 28 lines each, journal 73 lines, all within the 30–200 line memory-file bound; no raw transcript dumps. No bloat. (PASS, no findings.)
+- **Aesthetics**: N/A beyond handoff readability — handoff has Summary/Shipped/Deferred/Decisions/Pointers/Promotion-summary sections, no placeholders, dates stamped. (PASS, no findings.)
+- **Usage**: N/A beyond resume-viability — handoff + journal carry enough for a fresh agent to resume (count=30, raw-HTML tiebreaker rule, open goodhart item, drift-check flag); pointers are repo-root–relative with an explicit "relative to .gobbi/projects/gobbi/" note. (PASS, no findings.)
+- **Structure**: covered implicitly via Consistency routing — promoted files match directory conventions; `archive/checklists/` is a new subdir under the existing archive destination (not a new top-level schema), legitimate per move-on-terminal. (PASS, no findings.)
+
+## Cross-perspective tensions
+None. All three depth perspectives converge on PASS with only Low/25 cosmetic findings. No perspective diverges.
+
+## Karpathy failure modes
+- **Wrong assumptions**: NO — the wrap-up does not promote unvalidated memory; both mistakes are session-grounded and the residue closure cites a real PR.
+- **Overcomplexity**: NO — reuses existing memory categories; `archive/checklists/` is a directory under an existing destination, not a new schema/convention.
+- **Orthogonal edits**: NO — all promotions belong to one session's coherent docs-sync arc; nothing unrelated bundled.
+- **Imperative-over-declarative**: NO — "Decisions to respect" are stated as constraints (count is 30; raw-HTML is the tiebreaker; wrap-up is sole archive writer), not as step-by-step resume instructions.
+
+## Preserve list (do not break on any future REVISE)
+- The post-promotion §4.5 gate being clean at 0 — the recorded `wrap-up-promotion-must-strip-staging-frontmatter` regression did NOT recur; preserve the strip discipline.
+- Archived files retaining original `type` (backlogs/checklists, not `type: archive`) with `archived_at`/`archive_reason` stamps.
+- The two new project mistakes (`codex-webfetch-undercounts-...`, `docs-sync-count-fix-blast-radius-...`) — high-value, correctly stripped, correctly scoped.
+- Reference repoints that resolve + zero dangling old-path links.
+- goodhart + cross-layer-drift-gate left active (Principle 10 — no untriggered closure).
+- Session scratch preserved as audit trail.
+
+## Overall verdict: PASS
+
+No Critical or High finding at any confidence. The two highest-risk wrap-up failure modes for this project (false-PASS-without-diffing and strip-on-promotion regression) were specifically tested with independent tool runs — diff read + §4.5 gate executed post-promotion — and both are clean. Verdict computed per threshold rules: no Critical≥75, no High≥50 → PASS.

--- a/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/wrap-up/evaluation/iter1/claude/project.md
+++ b/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/wrap-up/evaluation/iter1/claude/project.md
@@ -1,0 +1,46 @@
+# Wrap-up Evaluation — Project (Claude, iter1)
+
+## Artifact Summary + Memory reads
+
+**What**: The Wrap-up Loop's WORK output (commit `77b0a70` on `chore/session-2026-06-01-34563fb4`) for a Chat-mode docs-sync session — promote 2 staged mistake-candidates to project `mistakes/`, archive-move 4 resolved tracking items to project `archive/{type}/`, repoint inbound references, write journal + handoff + manifest + inventory, leave goodhart backlog active.
+**Why**: Close the session cleanly so future sessions resume from durable memory rather than re-deriving the hook-event-count correction arc.
+**How**: git-mv archive moves (move-on-terminal), frontmatter strip-on-promotion, reference repoint, deterministic routing per `memory-map.md` / `rules.md`.
+W/W/H all clear — artifact is evaluable. No phase-mismatch (artifact is genuinely a wrap-up consolidation).
+
+**Memory reads**: `principles/SKILL.md`; `evaluation/SKILL.md`; `wrap-up/evaluation.md`; `memorization/rules.md`; `rules/stub-redirect-format.md`; mistakes `wrap-up-promotion-must-strip-staging-frontmatter.md`, `evaluator-false-pass-without-diffing.md`; commit `77b0a70` full diff; staging sources; promotion-manifest + staging-inventory + pre-wrap-up-snapshot; the 2 promoted mistakes; the 4 archived files; the journal note; the reference doc.
+
+## Locked Frame (Stage 1)
+
+S1 **Every staging file accounted for, no silent drop** — checklist: (a) every file in staging-inventory has a promotion-manifest entry; (b) `find` on staging dirs matches the inventory; (c) no decisions/checklists/scenarios staging beyond the 2 named.
+S2 **Promotion routing adherence** — (a) mistake-candidates → project `mistakes/`; (b) archives → project `archive/{type}/`; (c) no improvised destinations.
+S3 **"What was shipped" matches git** — (a) each handoff "shipped" claim has a real commit/path; (b) no phantom completion claims.
+S4 **Residue backlog (out-of-this-session origin) handled correctly** — (a) terminal status flip with Resolution + shipped_in; (b) trigger (PR #285) is real (Principle 10).
+S5 **goodhart backlog left active (adversarial — premature closure)** — (a) goodhart + cross-layer-drift-gate untouched and still active; (b) not archived without a trigger.
+S6 **Closure gate** — `grep -rn '"31 hook' features/guardrails/` → 0.
+
+Mistake-derived scenarios: `evaluator-false-pass-without-diffing` → S3 enforced by reading the diff + resolving paths, not trusting the manifest.
+Adversarial: S5 (premature closure) + S3 phantom-claim probe.
+Coverage matrix: cost/privacy/a11y/i18n — `not-applicable: docs-sync memory consolidation, no UI, no paid-API spend, no PII`.
+
+## Per-scenario per-check results
+
+S1: (a) YES — both inventory files (`codex-webfetch-...`, `docs-sync-count-fix-...`) appear in manifest as PROMOTED. (b) YES — `find` on `execution/task-01/staging/decisions/` shows exactly those 2 files; `execution/staging` + `ideation/staging` exist but are empty (inventory states ideation was rawdata-only). (c) YES — no other staging files. **No silent drops.**
+S2: (a) YES — both landed at `.gobbi/projects/gobbi/mistakes/{slug}.md`. (b) YES — 4 archives at `archive/backlogs/` (3) + `archive/checklists/` (1). (c) YES — destinations match the `memory-map.md` routing; `archive/checklists/` is a new subdir under the existing `archive/` destination, not a new top-level schema.
+S3: (a) YES — commits `84521bc`, `5427e9d`, `9bae55f` (PR #285) all exist with subject lines matching the handoff descriptions (git cat-file verified). All promoted/archived/journal paths resolve on disk. (b) YES — no phantom: every "shipped" item is a real file or commit.
+S4: (a) YES — residue backlog flipped `status: active→addressed`, `disposition: open→addressed`, `shipped_in: "#285"` added, `## Resolution (2026-06-01)` body appended. (b) YES — PR #285 / commit `9bae55f` is a real trigger.
+S5: (a) YES — `goodhart-factor-when-demanded-deferred.md` still in `features/guardrails/backlogs/`; `cross-layer-drift-gate.md` still in `features/guardrails/checklists/`; neither edited in the diff. (b) YES — not archived.
+S6: YES — closure grep returns 0 matches (exit 1, verified independently).
+
+## Typed findings
+
+None at the open/blocking level.
+
+F-PROJ-1 — Type `general` / Domain `docs-sync` / Disposition `open` / Confidence `25` / Severity `Low`
+Evidence: reference doc line 35 prose still calls the archived item "the tracked docs-sync item" present-tense, though the item is resolved. The same line also says "resolved 2026-06-01," so it is not contradictory — just slightly redundant phrasing. Why it matters: negligible; a reader is correctly routed to the archive path. Suggested direction: none required; cosmetic.
+
+## Verdict: PASS
+
+Rationale: The wrap-up consolidates the correct session's work completely. Every staging file is accounted for with no silent drop (S1), routing is adherent with no improvisation (S2), every shipped claim is backed by a real commit/path verified via git (S3), the out-of-session residue backlog was closed against a real trigger (S4), and the untriggered goodhart backlog was correctly left active per Principle 10 (S5). Closure gate independently confirmed at 0 (S6). No phantom claims.
+
+## Low-confidence appendix
+F-PROJ-1 (Confidence 25) — cosmetic present-tense phrasing in repointed reference line; non-blocking.

--- a/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/wrap-up/evaluation/iter1/claude/risk.md
+++ b/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/wrap-up/evaluation/iter1/claude/risk.md
@@ -1,0 +1,37 @@
+# Wrap-up Evaluation — Risk (Claude, iter1)
+
+## Artifact Summary + Memory reads
+(See project.md for the shared Artifact Summary + Memory reads register.)
+
+## Locked Frame (Stage 1)
+
+S1 **Session scratch preserved (audit trail)** — checklist: (a) wrap-up does not delete `sessions/.../{loop}/` dirs; (b) staging files still on disk post-promotion (move-on-terminal applies only to project memory, not session scratch).
+S2 **No dangling work without a pointer** — (a) git status shows no uncommitted project-memory scratch that should have been committed; (b) untracked session scratch is expected (not a defect).
+S3 **No silent overwrite of existing memory** — (a) the 2 new mistakes are new files (not overwriting an existing slug); (b) archive moves don't collide with existing archive slugs.
+S4 **Move-on-terminal reversibility** — (a) archive moves are `git mv` (history preserved, rename-detected); (b) reversible via git.
+S5 **Process mistakes recorded** — the dual-system REVISE process gap (P13 blast radius) is captured as a durable mistake.
+S6 **Irreversible op without safeguard (adversarial)** — (a) no `rm`/destructive op on project memory; (b) archive is a move, not a delete; original `type` retained so the record is still discoverable.
+
+Adversarial: S6 (destructive-op probe) + S3 (silent overwrite probe).
+Coverage matrix (Cost + Privacy + Process — Risk-owned): cost `not-applicable: no paid-API spend in wrap-up`; privacy `not-applicable: no PII in scratch or promoted files`; process — S5.
+
+## Per-scenario per-check results
+
+S1: (a) YES — diff shows only renames + new files; no `sessions/` dir deletions. (b) YES — both staging files still present at `execution/task-01/staging/decisions/` after promotion (promotion copies forward; scratch is the audit trail). Archive moves are git-mv of project-memory files only.
+S2: (a) YES — `git status` shows the wrap-up commit clean; remaining untracked entries are `sessions/.../{ideation,execution,session.json,state.json}` — session scratch, correctly NOT part of the wrap-up memory commit. (b) YES — untracked session scratch is the expected Risk posture (scratch stays under sessions/, is not promoted, is not deleted).
+S3: (a) YES — both mistake slugs are new (no pre-existing file at those paths; `git status` shows `new file`). (b) YES — archive destinations `2026-06-01-*` did not exist before (pre-snapshot + `ls archive/` confirm no collision; date-prefix disambiguates).
+S4: (a) YES — diff shows `rename from ... rename to ...` with similarity 75–98%, i.e. real git mv with history preserved. (b) YES — fully reversible.
+S5: YES — `docs-sync-count-fix-blast-radius-...` mistake captures the P13 process gap; `codex-webfetch-undercounts-...` captures the dual-system count-arbitration process lesson. Both promoted to project `mistakes/`.
+S6: (a) YES — no destructive op; (b) YES — archive is move-on-terminal, original `type` retained, file discoverable under `archive/{type}/`.
+
+## Typed findings
+
+F-RISK-1 — Type `assumption_risk` / Domain `process` / Disposition `open` / Confidence `25` / Severity `Low`
+Evidence: handoff "Decisions to respect" asserts "Wrap-up is the sole writer to `archive/`" as a standing rule, but this is stated in the journal/handoff, not promoted as a `rules/` entry. If it is meant to be an enforceable invariant it would live in `rules/`; as written it is a per-session decision note. Why it matters: low — the move-on-terminal model is already documented in `evaluation/SKILL.md` and `memorization/rules.md`, so this is reinforcement, not a new uncodified rule. Suggested direction: none required this session; if the team wants it enforceable, a follow-up `rules/` promotion — user decision.
+
+## Verdict: PASS
+
+Rationale: Session scratch is preserved as the audit trail (no deletions), archive moves are reversible git-mv operations with original type retained, no existing memory is silently overwritten (new slugs, date-disambiguated archive paths), and the session's process mistakes are durably recorded. No irreversible operation lacks a safeguard. The only finding is a Low/25 reinforcement-vs-rule nuance with no blast radius.
+
+## Low-confidence appendix
+F-RISK-1 (Confidence 25) — "sole writer to archive/" stated as decision note rather than rules/ entry; non-blocking.

--- a/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/wrap-up/evaluation/iter1/codex/overall.md
+++ b/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/wrap-up/evaluation/iter1/codex/overall.md
@@ -1,0 +1,17 @@
+# Codex wrap-up evaluation — iter1 (manager-proxy written)
+
+**System:** codex (`codex exec --sandbox read-only --cd <worktree>`).
+**Scope:** Project + Consistency + Risk + Overall.
+**Verdict:** REVISE (iter1) → all findings remediated by the manager; see resolution-log.
+
+## Findings (all ground-truthed by the manager as REAL)
+- **Project** — no findings.
+- **Consistency (med/100)** — `handoff.md:24` cited `features/guardrails/features/README.md` (doubled `features/`, nonexistent; real: `features/guardrails/README.md`); plugins-snapshot-resync backlog named without its real path. → **Fixed** (handoff lines 24 + 40).
+- **Consistency (low/95)** — the two archived files cross-linked each other's former `features/guardrails/...` active paths (now gone); reference doc was repointed but the intra-archive cross-links were not. → **Fixed** (archive/checklists:43, archive/backlogs:49 + closure-gate note repointed to `../{type}/2026-06-01-...`).
+- **Risk (high/100)** — wrap-up commit `77b0a70` not self-contained: session artifacts (ideation/, execution task-01 artifacts/eval/staging, wrap-up/evaluation/, session.json, state.json) untracked, absent from the commit tree. → **Fixed** in the final seal commit staging the full session tree.
+- **Overall (med/95)** — core checks pass in the worktree but commit-audit + handoff/link verifiability require revision before PASS. → addressed by the above.
+
+## Cross-system note
+The Claude leg PASSed and verified the strip-on-promotion gate + repointed reference + commit existence, but MISSED: commit self-containment of the session tree, the handoff internal path typo, and the intra-archive cross-links. Codex caught all three. Complementary, not contradictory — dual-system value confirmed (third time this session). Manager sided with Codex (findings ground-truthed real) and remediated all three.
+
+**Post-remediation verdict (manager-aggregated): PASS** — all REVISE drivers resolved + independently re-verified.

--- a/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/wrap-up/rawdata/pre-wrap-up-snapshot.txt
+++ b/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/wrap-up/rawdata/pre-wrap-up-snapshot.txt
@@ -1,0 +1,77 @@
+Pre-Wrap-up snapshot — session 34563fb4-361d-4348-aa75-8bc9f1fbff05
+Captured: 2026-06-01
+
+=== .gobbi/projects/gobbi/mistakes/ ===
+claude-evaluator-step4-only-vs-codex-whole-file-grep.md
+codex-eval-session-write-path-nested-in-worktree.md
+codex-exec-at-file-hangs-on-stdin-in-background.md
+codex-rescue-agent-fire-and-forget-without-result-capture.md
+codex-subprocess-writes-to-main-tree.md
+codex-wrapper-relative-path-wrong-session-write.md
+conformance-executor-pre-executed-prose-wave-reshape.md
+design-literal-retire-instruction-without-replacement.md
+dual-system-codex-caught-template-form-gaps-claude-missed.md
+edit-tool-refuses-symlink-paths.md
+evaluator-false-pass-without-diffing.md
+evaluator-returned-verdict-inline-no-per-perspective-files.md
+evaluator-revise-may-contradict-the-standard-manager-disputes-with-evidence.md
+executor-cwd-reset-commits-task-to-wrong-branch.md
+executor-main-tree-edit-near-miss.md
+executor-mirror-path-vs-worktree-physical-copy.md
+handoff-verdict-claim-not-matched-to-on-disk-eval.md
+leader-iter2-verification-claim-without-evidence.md
+manager-asserted-unverified-state-into-outward-artifacts.md
+manager-context-overflow-with-large-bundle.md
+manager-dispatched-subagent-on-unanswered-decision.md
+manager-iter2-brief-failed-iron-law-7-verbatim-spec-recheck.md
+manager-rm-rf-without-investigating-tracked-files.md
+manager-skipped-dual-system-eval.md
+memorization-delegation-prompts-must-load-memorization-skill.md
+naming-standard-needs-positive-guidance-not-just-blocklist.md
+proposed-deleting-model-instead-of-fixing-stale-mechanism.md
+prose-brief-light-pass-undersold-template-section-checks.md
+prose-reclassification-target-is-project-level-notes.md
+README.md
+reproducing-a-bugged-command-is-not-validation.md
+reused-session-dir-collides-task-artifacts-across-tasks.md
+section-order-is-part-of-the-contract-not-just-the-set.md
+sendmessage-continued-cwd-resets-to-main-tree.md
+session-dir-placed-outside-worktree.md
+skills-mirror-symlinks-not-copies.md
+subagent-relative-path-write-strays-to-main-tree.md
+subagent-relative-write-paths-stray-cd-doesnt-persist.md
+subagent-stray-recurred-despite-absolute-path-instruction.md
+symlink-restore-depth-wrong.md
+worktree-physical-file-missing-when-checked-out.md
+wrap-up-promotion-must-strip-staging-frontmatter.md
+
+(No codex-webfetch-undercounts-recently-added-table-row.md yet)
+(No docs-sync-count-fix-blast-radius-includes-colocated-dates-and-tracking-pointers.md yet)
+
+=== .gobbi/projects/gobbi/archive/backlogs/ ===
+2026-05-25-f-risk-01-subagent-ccsi-semantics.md
+2026-05-25-f-struct-01-jq-sh-env-passthrough.md
+2026-05-25-git-skill-stale-row-5-5-worktree-reference.md
+2026-05-25-gobbi-hook-authoring-skill.md
+2026-05-25-gobbi-mistake-promote-command-does-not-exist.md
+2026-05-25-session-lifecycle-worktree-boundaries-design-doc.md
+2026-05-25-stale-packages-cli-architecture-refs.md
+2026-05-25-workspace-to-mirror-sync-mechanism.md
+2026-05-28-auto-mode-silence-vs-always-ask.md
+2026-05-28-chat-mode-tiki-taka-redesign.md
+2026-05-28-memory-redesign-remaining-waves.md
+
+(No 2026-06-01 entries yet)
+
+=== .gobbi/projects/gobbi/archive/checklists/ ===
+(directory does not exist yet)
+
+=== .gobbi/projects/gobbi/features/guardrails/backlogs/ ===
+goodhart-factor-when-demanded-deferred.md   (active — NOT to be archived)
+hook-event-count-31-vs-29-docs-sync.md      (status: addressed — TO BE ARCHIVED)
+posttooluse-failure-webfetch-verification-gap.md  (status: addressed — TO BE ARCHIVED)
+principles-anti-rationalizations-label-residue.md  (status: active — TO BE FLIPPED then ARCHIVED)
+
+=== .gobbi/projects/gobbi/features/guardrails/checklists/ ===
+cross-layer-drift-gate.md                   (active — NOT to be archived)
+hook-event-count-31-vs-29-docs-sync.md      (status: addressed — TO BE ARCHIVED)

--- a/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/wrap-up/rawdata/promotion-manifest.md
+++ b/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/wrap-up/rawdata/promotion-manifest.md
@@ -1,0 +1,59 @@
+# Promotion Manifest — session 34563fb4-361d-4348-aa75-8bc9f1fbff05
+
+Generated: 2026-06-01
+
+## Step 2.5 — Prior-loop MEMORIZATION compliance scan
+
+| Loop | Gap category | Finding | Action |
+|------|-------------|---------|--------|
+| ideation | `directory-absent` for staging/ | ideation loop used rawdata-only; no staging was produced (rawdata/hooks-docs-webfetch-verification.md is rawdata, not staging) | OK — manager pre-confirmed this session structure; ideation produced rawdata input for execution planning, not staged findings |
+| execution/task-01 | none | Both staging files present, correct shape, correct vocabulary | Auto-pass |
+
+No judgment-required gaps; no NEEDS_CONTEXT escalations.
+
+---
+
+## Staging file disposition (execution/task-01/staging/decisions/)
+
+| Source staging file | Routing modifier | Destination | Action | Notes |
+|---------------------|-----------------|-------------|--------|-------|
+| `codex-webfetch-undercounts-recently-added-table-row.md` | `mistake-candidate: true`; user-confirmed `scope: project` | `.gobbi/projects/gobbi/mistakes/codex-webfetch-undercounts-recently-added-table-row.md` | PROMOTED | Stripped: `mistake-candidate`, `loop`, `feature`; changed `scope: feature` → `scope: project`; added `priority: medium` |
+| `docs-sync-count-fix-blast-radius-includes-colocated-dates-and-tracking-pointers.md` | `mistake-candidate: true`; user-confirmed `scope: project` | `.gobbi/projects/gobbi/mistakes/docs-sync-count-fix-blast-radius-includes-colocated-dates-and-tracking-pointers.md` | PROMOTED | Stripped: `mistake-candidate`, `loop`, `feature`; changed `scope: feature` → `scope: project`; added `priority: medium` |
+
+---
+
+## Archive moves (move-on-terminal; terminal state was `status: addressed`)
+
+| Source (pre-move) | Pre-move edits | Destination | Action |
+|-------------------|----------------|-------------|--------|
+| `features/guardrails/backlogs/hook-event-count-31-vs-29-docs-sync.md` | Added `archived_at: 2026-06-01`, `archive_reason: addressed` (already had `status: addressed`, `disposition: addressed`, `shipped_in`) | `archive/backlogs/2026-06-01-hook-event-count-31-vs-29-docs-sync.md` | git mv OK |
+| `features/guardrails/backlogs/posttooluse-failure-webfetch-verification-gap.md` | Added `archived_at: 2026-06-01`, `archive_reason: addressed` (already had `status: addressed`, `disposition: addressed`, `shipped_in`) | `archive/backlogs/2026-06-01-posttooluse-failure-webfetch-verification-gap.md` | git mv OK |
+| `features/guardrails/checklists/hook-event-count-31-vs-29-docs-sync.md` | Added `archived_at: 2026-06-01`, `archive_reason: addressed` (already had `status: addressed`, `disposition: addressed`, `shipped_in`) | `archive/checklists/2026-06-01-hook-event-count-31-vs-29-docs-sync.md` | git mv OK — `archive/checklists/` dir created (new) |
+| `features/guardrails/backlogs/principles-anti-rationalizations-label-residue.md` | Flipped `status: active`→`addressed`, `disposition: open`→`addressed`; added `shipped_in: "#285"`, `archived_at: 2026-06-01`, `archive_reason: addressed`; appended `## Resolution (2026-06-01)` body section | `archive/backlogs/2026-06-01-principles-anti-rationalizations-label-residue.md` | git mv OK |
+
+---
+
+## Inbound reference repoints
+
+| File | Lines updated | Old reference | New reference |
+|------|--------------|---------------|---------------|
+| `features/guardrails/references/claude-code-posttooluse-hook-schema.md` | lines 35-36 | `checklists/hook-event-count-31-vs-29-docs-sync.md` and `backlogs/hook-event-count-31-vs-29-docs-sync.md` | `../../../archive/checklists/2026-06-01-hook-event-count-31-vs-29-docs-sync.md` and `../../../archive/backlogs/2026-06-01-hook-event-count-31-vs-29-docs-sync.md` |
+| `features/guardrails/references/claude-code-posttooluse-hook-schema.md` | line 36 | `backlogs/posttooluse-failure-webfetch-verification-gap.md` | `../../../archive/backlogs/2026-06-01-posttooluse-failure-webfetch-verification-gap.md` |
+
+Relative paths verified to resolve correctly (ls confirmed all three archive targets exist).
+
+---
+
+## Journal note
+
+| Artifact | Location | Type |
+|----------|----------|------|
+| `2026-06-01-hook-event-count-and-residue-closure.md` | `notes/2026-06-01-hook-event-count-and-residue-closure.md` | notes (Wrap-up Step 6 direct write) |
+
+---
+
+## Closure gate
+
+- `grep -rn '"31 hook' .gobbi/projects/gobbi/features/guardrails/` → 0 matches (verified post-archive-moves)
+- `goodhart-factor-when-demanded-deferred.md` remains in `features/guardrails/backlogs/` (untouched, still active)
+- `cross-layer-drift-gate.md` remains in `features/guardrails/checklists/` (untouched, still active)

--- a/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/wrap-up/rawdata/staging-inventory.md
+++ b/.gobbi/projects/gobbi/sessions/2026-06-01-34563fb4-361d-4348-aa75-8bc9f1fbff05/wrap-up/rawdata/staging-inventory.md
@@ -1,0 +1,28 @@
+# Staging Inventory — session 34563fb4-361d-4348-aa75-8bc9f1fbff05
+
+Captured: 2026-06-01
+Loops with staging: execution/task-01/staging/decisions/
+Other loops: ideation (rawdata only, no staging); wrap-up (this loop)
+
+## execution/task-01/staging/decisions/
+
+| File | Type | mistake-candidate | domain | Action |
+|------|------|-------------------|--------|--------|
+| `codex-webfetch-undercounts-recently-added-table-row.md` | decisions | true | docs-sync | Promote to project mistakes/ |
+| `docs-sync-count-fix-blast-radius-includes-colocated-dates-and-tracking-pointers.md` | decisions | true | docs-sync | Promote to project mistakes/ |
+
+Both files have user-confirmed scope=project (pre-resolved decision in delegation prompt).
+
+## Step 2.5 Compliance Scan
+
+Both staging files present with:
+- `type: decisions` — correct vocabulary
+- `mistake-candidate: true` — routing flag set
+- `loop: execution` — staging-only field, will be stripped on promotion
+- `scope: feature` (staging); will be changed to `scope: project` on promotion (pre-resolved)
+- `feature: guardrails` — staging-only for routing; will be dropped on promotion (scope becomes project)
+
+Shape: both are per-concept {slug}.md files — compliant with one-record-one-concept rule.
+Gap category: none. Both files are well-formed for promotion.
+
+No `design_flaw` or `assumption_risk` types present — no NEEDS_CONTEXT escalation required for Step 2.5.


### PR DESCRIPTION
## Summary

Chat-mode docs-sync session closing three tracked guardrails items.

- **Hook-event count** corrected `31 → 30` in `features/guardrails/references/claude-code-posttooluse-hook-schema.md`, with the enumeration completed (`MessageDisplay` added at position 12 — the single net change since the 2026-05-23 capture). Count established by three independent sources: Claude WebFetch, Codex, and a raw-HTML parse of the live lifecycle table (the tiebreaker — Codex web-search had undercounted at 29 by missing the new event).
- **PostToolUseFailure WebFetch verification gap** closed: both preserved verbatim quotes confirmed byte-identical to the live page (Confidence-50 gap opened 2026-05-23 now resolved with hard evidence).
- **principles-anti-rationalizations-label-residue** backlog closed (already fixed by PR #285; grep verified 0 matches).

4 tracking items archived (move-on-terminal) to project-level `archive/`; 2 process mistakes promoted to project `mistakes/`. Closure gate `grep -rn '"31 hook' features/guardrails/` → 0.

## What shipped

| Commit | Change |
|---|---|
| `84521bc` | reference count 31→30 + enumeration + provenance |
| `5427e9d` | iter2 eval remediation: `## Source` per-URL dates; README open-items cleanup; 3 tracking items → `addressed` + Resolution notes |
| `77b0a70` | wrap-up: promote 2 mistakes, archive 4 resolved items, journal + handoff |
| `3aa9115` | seal: commit full session tree + remediate 3 wrap-up-eval findings (handoff path, intra-archive cross-links, commit self-containment) |

## Verification

- Reference lifecycle enumeration: exactly 30 entries, `MessageDisplay` at 12; both PostToolUseFailure quotes byte-identical.
- `grep -rn '"31 hook' features/guardrails/` → **0**.
- Promoted mistakes carry `type: mistakes` / `scope: project`; staging flags stripped.
- Archived files retain original `type`, carry `archived_at`/`archive_reason`; `goodhart` backlog left active (not triggered — Principle 10).

## Evaluation

Dual-system (Claude + Codex) at Execution and Wrap-up. Both rounds: Codex caught real findings the Claude leg missed (Execution: `## Source` stale date; Wrap-up: commit self-containment + handoff path + intra-archive links) — all ground-truthed and remediated. Full resolution log: `sessions/.../wrap-up/artifacts/resolution-log.md`.

## Deferred / open

- `goodhart-factor-when-demanded-deferred` (trigger not met) and the sibling `claude-code-hooks-12-lifecycle-events.md` ("12 lifecycle events") possible future drift check — both out of scope.
- `plugins-snapshot-resync-after-principles-changes` backlog — deferred due to concurrent PR #282.

🤖 Generated with [Claude Code](https://claude.com/claude-code)