### PR TITLE
docs(principles): add Principle 9 (CRUD+5W1H before editing) + Principle 10 (finish in-scope work)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -41,7 +41,7 @@ The 10 principles below are the enforceable behavioral discipline for every agen
 | 7 | Say/Write Plainly, Briefly, and Literally: SIMPLE WORDS, SHORT SENTENCES, NO FILLER, NO METAPHOR. |
 | 8 | Fix the Root Cause, Not the Symptom: KEEP ASKING WHY UNTIL YOU REACH THE ROOT; A FIX YOU CAN'T EXPLAIN IS A GUESS. |
 | 9 | Think CRUD-and-5W1H Before Editing: NO EDIT WITHOUT CHECKING ITS CRUD AND 5W1H ACROSS TARGET AND AFFECTED FILES. |
-| 10 | Finish In-Scope Work — Do Not Defer It: COMPLETE EVERYTHING WITHIN THE AGREED SCOPE; NEVER SILENTLY DEFER IN-SCOPE WORK. |
+| 10 | Finish In-Scope Work — Do Not Defer It: COMPLETE EVERYTHING WITHIN THE AGREED SCOPE; DO NOT DEFER IN-SCOPE WORK. |
 
 > **Gobbi-specific tooling: the `mistake` skill and Wrap-up-phase promotion.**
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -28,7 +28,7 @@ Evaluation runs inside Ideation, Planning, and Execution — mandatory after Exe
 
 > **MUST load [principles](skills/principles/SKILL.md) at session start, resume, /clear, and /compact.**
 
-The 8 principles below are the enforceable behavioral discipline for every agent. The principle table is the always-visible summary; load the skill for the full rationale and detail behind each principle. Subagent briefings MUST include the load instruction in their prompt — fresh subagents do not inherit the parent's loaded skills.
+The 10 principles below are the enforceable behavioral discipline for every agent. The principle table is the always-visible summary; load the skill for the full rationale and detail behind each principle. Subagent briefings MUST include the load instruction in their prompt — fresh subagents do not inherit the parent's loaded skills.
 
 | # | Principle |
 |---|---|
@@ -40,6 +40,8 @@ The 8 principles below are the enforceable behavioral discipline for every agent
 | 6 | Start With Docs, Finish With Docs — Documents Are the Team's Memory: PLAN DOC WORK WITH A SPEC AND A CRUD PLAN, AND KEEP IT CURRENT. |
 | 7 | Say/Write Plainly, Briefly, and Literally: SIMPLE WORDS, SHORT SENTENCES, NO FILLER, NO METAPHOR. |
 | 8 | Fix the Root Cause, Not the Symptom: KEEP ASKING WHY UNTIL YOU REACH THE ROOT; A FIX YOU CAN'T EXPLAIN IS A GUESS. |
+| 9 | Think CRUD-and-5W1H Before Editing: NO EDIT WITHOUT CHECKING ITS CRUD AND 5W1H ACROSS TARGET AND AFFECTED FILES. |
+| 10 | Finish In-Scope Work — Do Not Defer It: COMPLETE EVERYTHING WITHIN THE AGREED SCOPE; NEVER SILENTLY DEFER IN-SCOPE WORK. |
 
 > **Gobbi-specific tooling: the `mistake` skill and Wrap-up-phase promotion.**
 
@@ -53,4 +55,4 @@ Every agent MUST load the `mistake` skill before starting work. When the user co
 |----------|--------|
 | [gobbi skill](skills/gobbi/SKILL.md) | Entry point, session setup questions, skill map |
 | [claude skill](skills/claude/SKILL.md) | Documentation standard for `.claude/` authoring |
-| [principles](skills/principles/SKILL.md) | 8 behavioral principles every agent must follow — MUST load at session start; load the skill for the full rationale and detail |
+| [principles](skills/principles/SKILL.md) | 10 behavioral principles every agent must follow — MUST load at session start; load the skill for the full rationale and detail |

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -79,7 +79,7 @@ The 10 principles below are the enforceable behavioral discipline for every agen
 | 7 | Say/Write Plainly, Briefly, and Literally: SIMPLE WORDS, SHORT SENTENCES, NO FILLER, NO METAPHOR. |
 | 8 | Fix the Root Cause, Not the Symptom: KEEP ASKING WHY UNTIL YOU REACH THE ROOT; A FIX YOU CAN'T EXPLAIN IS A GUESS. |
 | 9 | Think CRUD-and-5W1H Before Editing: NO EDIT WITHOUT CHECKING ITS CRUD AND 5W1H ACROSS TARGET AND AFFECTED FILES. |
-| 10 | Finish In-Scope Work — Do Not Defer It: COMPLETE EVERYTHING WITHIN THE AGREED SCOPE; NEVER SILENTLY DEFER IN-SCOPE WORK. |
+| 10 | Finish In-Scope Work — Do Not Defer It: COMPLETE EVERYTHING WITHIN THE AGREED SCOPE; DO NOT DEFER IN-SCOPE WORK. |
 
 > **Gobbi-specific tooling: the `mistake` skill and Wrap-up-phase promotion.**
 

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -66,7 +66,7 @@ Evaluation runs inside Ideation, Planning, and Execution. The orchestrator spawn
 
 > **MUST load `.agents/skills/principles/SKILL.md` at session start, resume, /clear, and /compact.**
 
-The 8 principles below are the enforceable behavioral discipline for every agent. The principle table is the always-visible summary; load the skill for the full rationale and detail behind each principle.
+The 10 principles below are the enforceable behavioral discipline for every agent. The principle table is the always-visible summary; load the skill for the full rationale and detail behind each principle.
 
 | # | Principle |
 |---|---|
@@ -78,6 +78,8 @@ The 8 principles below are the enforceable behavioral discipline for every agent
 | 6 | Start With Docs, Finish With Docs — Documents Are the Team's Memory: PLAN DOC WORK WITH A SPEC AND A CRUD PLAN, AND KEEP IT CURRENT. |
 | 7 | Say/Write Plainly, Briefly, and Literally: SIMPLE WORDS, SHORT SENTENCES, NO FILLER, NO METAPHOR. |
 | 8 | Fix the Root Cause, Not the Symptom: KEEP ASKING WHY UNTIL YOU REACH THE ROOT; A FIX YOU CAN'T EXPLAIN IS A GUESS. |
+| 9 | Think CRUD-and-5W1H Before Editing: NO EDIT WITHOUT CHECKING ITS CRUD AND 5W1H ACROSS TARGET AND AFFECTED FILES. |
+| 10 | Finish In-Scope Work — Do Not Defer It: COMPLETE EVERYTHING WITHIN THE AGREED SCOPE; NEVER SILENTLY DEFER IN-SCOPE WORK. |
 
 > **Gobbi-specific tooling: the `mistake` skill and Wrap-up-phase promotion.**
 
@@ -94,7 +96,7 @@ Every agent MUST load `.agents/skills/mistake/SKILL.md` before starting work. Wh
 | `plugins/gobbi/.claude-plugin/plugin.json` | Local Gobbi Claude Code plugin manifest |
 | `plugins/gobbi/` | Shared bounded plugin package |
 | `.gobbi/projects/gobbi/skills/` | Canonical Gobbi skills directory |
-| `.agents/skills/principles/SKILL.md` | 8 behavioral principles every agent must follow |
+| `.agents/skills/principles/SKILL.md` | 10 behavioral principles every agent must follow |
 | `.agents/skills/orchestration/SKILL.md` | Workflow state machine and delegation contracts |
 | `.agents/skills/evaluation/SKILL.md` | Evaluation perspectives, finding metadata, verdict rules |
 | `.codex/agents/manager.toml` | Root session manager custom-agent wrapper |

--- a/.gobbi/projects/gobbi/agents/manager.md
+++ b/.gobbi/projects/gobbi/agents/manager.md
@@ -22,7 +22,7 @@ You are the **only** agent that talks to the user directly. Every leader, execut
 
 Mandatory load order at every session start, `/clear`, compaction, and resume:
 
-1. **`principles` skill** — the 8 Iron Laws. Subagents do not inherit this; every delegation prompt must instruct the spawned agent to load it.
+1. **`principles` skill** — the 10 Iron Laws. Subagents do not inherit this; every delegation prompt must instruct the spawned agent to load it.
 2. **All project rules** under `.gobbi/projects/{project-name}/rules/` — read every file.
 3. **`mistake` skill** — known pitfalls; check before any non-trivial decision.
 4. **`gobbi` skill** — workflow overview, session setup, full skill map.

--- a/.gobbi/projects/gobbi/backlogs/guardrails-readme-iron-law-count-drift.md
+++ b/.gobbi/projects/gobbi/backlogs/guardrails-readme-iron-law-count-drift.md
@@ -1,0 +1,50 @@
+---
+name: guardrails-readme-iron-law-count-drift
+description: Resolve pre-existing "13 Iron Laws" hard-coding in features/guardrails/README.md (5 occurrences), now further stale after adding P9 and P10
+type: backlogs
+scope: project
+feature: null
+status: active
+created: 2026-06-07
+session: b02c3111-68be-4558-a19f-fabf9627602f
+tags: [guardrails, readme, count-drift, iron-laws, docs]
+priority: medium
+disposition: deferred
+project-scope: true
+shipped_in: null
+---
+
+# Guardrails README — Iron Law Count Drift
+
+## Context
+
+`features/guardrails/README.md` hard-codes the string "13 Iron Laws" and "Iron Law #13" in 5 places (`:3,11,17,25,29`). This was already stale before the P9/P10 session: the count had previously moved from 14 to 8 via the principles redesign (PR related to `2026-06-05-principles-redesign-14-to-8.md`), leaving the README 5 behind. After adding P9 and P10 in the originating session, the live count is now 10, making the README wrong by 7.
+
+The originating session deferred this as D8 because:
+1. The drift is pre-existing (not introduced by the P9/P10 change).
+2. Fixing it would mix two distinct changes in one PR.
+3. The backlog on the prior count-reconcile sweep (`backlogs/principles-external-renumber-reword-sweep.md`) noted the historical-vs-live rule.
+
+## Why deferred
+
+Including this fix in the P9/P10 PR would conflate two separate changes (add principles + fix pre-existing README drift) and widen the PR review surface. The README drift predates this session and stands as its own fix.
+
+## When to pick up
+
+After the P9/P10 PR is merged and `principles/SKILL.md` shows 10 principles as the stable live count. No other prerequisites. This is a standalone prose edit to one README.
+
+## Suggested approach
+
+Two options — pick one with the user:
+
+**Option A — Reconcile to the live count (10).**
+Replace all 5 occurrences of "13 Iron Laws" / "Iron Law #13" with "10 Iron Laws" / "Iron Law #10" in `features/guardrails/README.md`. Simple, correct. Future count changes will require updating the README again.
+
+**Option B — Rewrite the README to stop hard-coding the count.**
+Replace the hard-coded number with a prose reference ("the full set of Iron Laws") and a link to `principles/SKILL.md`. Requires more rewriting but makes the README immune to future count changes.
+
+Recommended: Option B if the README prose permits it without losing meaning; Option A otherwise. Either way, verify with `grep -n "Iron Laws\|Iron Law" features/guardrails/README.md` that all 5 occurrences are addressed.
+
+## Originating session
+
+`.gobbi/projects/gobbi/sessions/2026-06-07-b02c3111-68be-4558-a19f-fabf9627602f/`

--- a/.gobbi/projects/gobbi/backlogs/reciprocal-principle-cross-refs.md
+++ b/.gobbi/projects/gobbi/backlogs/reciprocal-principle-cross-refs.md
@@ -1,0 +1,47 @@
+---
+name: reciprocal-principle-cross-refs
+description: Add reciprocal back-pointers from P5, P6, and P1 to the new P9 and P10
+type: backlogs
+scope: project
+feature: null
+status: active
+created: 2026-06-07
+session: b02c3111-68be-4558-a19f-fabf9627602f
+tags: [principles, p5, p6, p1, p9, p10, cross-references, docs]
+priority: low
+disposition: deferred
+project-scope: true
+shipped_in: null
+---
+
+# Reciprocal Principle Cross-References (P5/P6/P1 → P9/P10)
+
+## Context
+
+When P9 and P10 were added to `principles/SKILL.md`, each new principle carries a forward reference to the existing related principle (P9 references P6 and P1; P10 references P5). The forward references are one-directional. P6, P5, and P1 do not yet carry a back-pointer to the new principles.
+
+This is intentional for the initial ship: the PR scope was locked tight (add P9 + P10 only, no rewrites to existing principle bodies). Reciprocal back-pointers were deferred as D7 in the Ideation locked decisions.
+
+## Why deferred
+
+Adding back-pointers to P5, P6, and P1 requires editing existing principle bodies — out of scope for the originating session, which was locked to appending P9/P10 and updating count-references only. D7 was explicitly deferred per user decision.
+
+## When to pick up
+
+After P9 and P10 are shipped and verified. No other prerequisites. This is a standalone prose edit to three existing principle bodies — it can run any time.
+
+## Suggested approach
+
+Edit `principles/SKILL.md` (canonical real file at `.gobbi/projects/gobbi/skills/principles/SKILL.md`):
+
+- P6 Why paragraph: add one sentence near the end: "For all edits — not just documentation — see Principle 9."
+- P5 Why paragraph: add one sentence: "For the complementary lower bound — completing the agreed scope — see Principle 10."
+- P1 Practice bullet for "Study what already exists": add a parenthetical: "(at the moment of editing a specific file, see Principle 9 for the CRUD + 5W1H blast-radius check)."
+
+Verify no count-references need updating (these are prose additions, not count changes). Re-run the executor verification grep from the originating session to confirm no regressions.
+
+Also update `.claude/CLAUDE.md` table if the table rows are expanded to include cross-reference footnotes — but if the table stays as one-liner rows only, no change is needed there.
+
+## Originating session
+
+`.gobbi/projects/gobbi/sessions/2026-06-07-b02c3111-68be-4558-a19f-fabf9627602f/`

--- a/.gobbi/projects/gobbi/backlogs/wrap-up-routing-table-date-prefix-contradicts-rules.md
+++ b/.gobbi/projects/gobbi/backlogs/wrap-up-routing-table-date-prefix-contradicts-rules.md
@@ -1,0 +1,55 @@
+---
+name: wrap-up-routing-table-date-prefix-contradicts-rules
+description: The wrap-up routing table maps decisions and discussions to bare-slug destinations, contradicting memorization/rules.md §1.2 which requires date-prefixed filenames for both types.
+type: backlogs
+scope: project
+feature: null
+status: active
+created: 2026-06-07
+session: b02c3111-68be-4558-a19f-fabf9627602f
+tags: [wrap-up, routing-table, date-prefix, docs-sync, naming-standard]
+priority: medium
+disposition: open
+project-scope: true
+shipped_in: null
+---
+
+# Wrap-up routing table date-prefix contradicts rules
+
+## Context
+
+`memorization/rules.md §1.2` defines two filename modes keyed to whether content is intrinsically time-indexed:
+
+- **Date-prefixed** types: `notes`, `reviews`, `reports`, `changelogs`, `decisions`, `plans`, `discussions`, `archive entries` — pattern `YYYY-MM-DD-{slug}.md`.
+- **Bare-slug** types: `features`, `mistakes`, `rules`, `learnings`, `design`, `references`, `backlogs`, `scenarios`, `checklists` — pattern `{slug}.md`.
+
+The `wrap-up/SKILL.md` "Staging → Project-memory routing" table governs how each staging path maps to its project-memory destination. Two rows in that table are inconsistent with §1.2:
+
+| Routing table row | Table says | §1.2 requires |
+|---|---|---|
+| `staging/decisions/{slug}.md` → | `features/{feature-name}/decisions/{slug}.md` | `features/{feature-name}/decisions/{date}-{slug}.md` |
+| `staging/discussions/{slug}.md` → | `features/{feature-name}/discussions/{slug}.md` | `features/{feature-name}/discussions/{date}-{slug}.md` |
+
+The `plans` row is correct: `sessions/.../planning/staging/plans/{slug}.md` → `features/{feature-name}/plans/{date}-{slug}.md` — the date prefix is present.
+
+## Why deferred
+
+Editing `wrap-up/SKILL.md` is an Always-Ask skill edit (user confirmation required before changes to any skill file). This requires a dedicated session to review the routing table change, confirm the fix with the user, and verify no other rows carry the same drift.
+
+## When to pick up
+
+No hard prerequisites. Can run any time as a standalone docs-sync session. Recommended to pick up before the next session that produces `decisions/` or `discussions/` promotions, to prevent a repeat.
+
+## Suggested approach
+
+1. Open `wrap-up/SKILL.md` § Staging → Project-memory routing.
+2. Update the `staging/decisions/{slug}.md` row: destination → `features/{feature-name}/decisions/{date}-{slug}.md`.
+3. Update the `staging/discussions/{slug}.md` row: destination → `features/{feature-name}/discussions/{date}-{slug}.md`.
+4. Confirm no other routing rows are missing date prefixes for types §1.2 lists as date-prefixed.
+5. Run dual-system evaluation on the change.
+
+## Originating session
+
+This backlog was identified during the dual-system Wrap-up evaluation of session `2026-06-07-b02c3111-68be-4558-a19f-fabf9627602f`. The Wrap-up assistant followed the routing table (bare-slug) and produced `decisions/p9-p10-locked-design.md` and `discussions/p9-p10-title-boundary-scope.md`; the evaluators flagged both against §1.2 (STRUCT-001 / dead-path findings). Remediation renamed the files to the dated form in iter2. The routing table itself was not fixed in that session — that requires an Always-Ask skill edit, deferred to this backlog.
+
+Evidence path: `.gobbi/projects/gobbi/sessions/2026-06-07-b02c3111-68be-4558-a19f-fabf9627602f/wrap-up/rawdata/promotion-manifest.md` (iter2 remediation entry).

--- a/.gobbi/projects/gobbi/features/guardrails/README.md
+++ b/.gobbi/projects/gobbi/features/guardrails/README.md
@@ -44,6 +44,7 @@ Active. The behavioral floor (13 Iron Laws in the `principles` skill) and the mi
 |---|---|---|
 | 2026-05-26 | a10c82d6 | Feature directory created during the memory-system redesign and seeded with re-homed work-sprint artifacts |
 | 2026-05-30 | a30b7a6e | Principles clarity pass: removed Iron Law Index, literal rewrite of P6/P10/P11, added Principle 14 (plain literal language, all agent-authored text); decisions/ subdir created |
+| 2026-06-07 | b02c3111 | Added Principles 9 and 10 (Think CRUD-and-5W1H Before Editing; Finish In-Scope Work — Do Not Defer It); propagated 8→10 count across 5 live files; plans/ subdir created; 2 project backlogs staged (D7 reciprocal cross-refs, D8 README count drift) |
 
 ## Open items
 

--- a/.gobbi/projects/gobbi/features/guardrails/decisions/2026-06-07-p9-p10-locked-design.md
+++ b/.gobbi/projects/gobbi/features/guardrails/decisions/2026-06-07-p9-p10-locked-design.md
@@ -17,7 +17,7 @@ decision_status: accepted
 
 ## Context
 
-The principles skill currently defines 8 principles. The user identified two missing behavioral disciplines: (1) agents edit target files without checking dependency and consistency with affected files (the blast-radius problem); (2) agents silently defer in-scope work, calling tasks done while leaving agreed deliverables unfinished. Adding Principles 9 and 10 addresses these failure modes.
+The principles skill currently defines 8 principles. The user identified two missing behavioral disciplines: (1) agents edit target files without checking dependency and consistency with affected files (the blast-radius problem); (2) agents defer in-scope work, calling tasks done while leaving agreed deliverables unfinished. Adding Principles 9 and 10 addresses these failure modes.
 
 Eight decisions were made during Ideation. Six are locked (D1–D6). Two are deferred to backlog (D7, D8).
 
@@ -37,7 +37,7 @@ Eight decisions were made during Ideation. Six are locked (D1–D6). Two are def
 
 ### D3 — P9 sits beside P6 with a one-line forward cross-reference; P6 is not rewritten this session
 
-**Decided:** P9 sits beside P6. P9 carries a forward cross-reference to P6 ("For documentation work, Principle 6 adds the spec and the start-with-docs / finish-with-docs discipline on top of this"). P6 is not modified this session. Reciprocal back-pointer from P6 to P9 is deferred (D7).
+**Decided:** P9 sits beside P6. P9 carries a forward cross-reference to P6 ("For documentation work, Principle 6 adds the spec and the start-with-docs / finish-with-docs discipline on top of this"). P6 is not modified this session. Reciprocal back-pointer from P6 to P9 is deferred (D7). (Update 2026-06-07: the user later revised P9 to remove the forward cross-ref to P6 entirely — P9 as shipped carries no P6 reference. This decision records the original lock; the cross-ref was removed per user revision.)
 
 **Rationale:** P6 is doc-specific CRUD-think; P9 generalizes the thinking pattern to all edits (code included). The 14→8 consolidation deliberately absorbed old P13 into P6 (`2026-06-05-principles-redesign-14-to-8.md:57`). Absorbing P6 into P9 would undo that merge and rewrite P6 — out of scope. Mistake `design-literal-retire-instruction-without-replacement.md` confirms: do not retire a live facet without a verified replacement.
 
@@ -51,7 +51,7 @@ Eight decisions were made during Ideation. Six are locked (D1–D6). Two are def
 
 **Decided:** P10 is framed as the floor of the scope contract. P5 = do not go BEYOND scope (ceiling). P10 = do not fall SHORT of it (floor). P10 explicitly states this pairing. Legitimately out-of-scope work still routes to backlog per P5 — not a P10 violation.
 
-**Rationale:** The project uses backlogs legitimately and extensively (e.g., `principles-external-renumber-reword-sweep.md`). P10 must not contradict P5's sanctioned follow-up practice. The seam is the word "in-scope": P10 forbids silent deferral of items inside the agreed contract, not the filing of backlogs for genuinely out-of-scope work.
+**Rationale:** The project uses backlogs legitimately and extensively (e.g., `principles-external-renumber-reword-sweep.md`). P10 must not contradict P5's sanctioned follow-up practice. The seam is the word "in-scope": P10 forbids deferral of items inside the agreed contract, not the filing of backlogs for genuinely out-of-scope work.
 
 ### D6 — P10 title: "Finish In-Scope Work — Do Not Defer It" (matched recommended)
 

--- a/.gobbi/projects/gobbi/features/guardrails/decisions/2026-06-07-p9-p10-locked-design.md
+++ b/.gobbi/projects/gobbi/features/guardrails/decisions/2026-06-07-p9-p10-locked-design.md
@@ -1,0 +1,94 @@
+---
+name: p9-p10-locked-design
+description: Locked design decisions for adding Principles 9 and 10 to the gobbi principles skill (8 → 10)
+type: decisions
+scope: feature
+feature: guardrails
+status: active
+created: 2026-06-07
+session: b02c3111-68be-4558-a19f-fabf9627602f
+tags: [principles, p9, p10, crud, 5w1h, scope-contract, design]
+supersedes: null
+superseded_by: null
+decision_status: accepted
+---
+
+# P9 + P10 Locked Design — Add Principles 9 and 10 to the Principles Skill
+
+## Context
+
+The principles skill currently defines 8 principles. The user identified two missing behavioral disciplines: (1) agents edit target files without checking dependency and consistency with affected files (the blast-radius problem); (2) agents silently defer in-scope work, calling tasks done while leaving agreed deliverables unfinished. Adding Principles 9 and 10 addresses these failure modes.
+
+Eight decisions were made during Ideation. Six are locked (D1–D6). Two are deferred to backlog (D7, D8).
+
+## Decision
+
+### D1 — P9 title: "Think CRUD-and-5W1H Before Editing" (user's choice)
+
+**Decided:** P9 title is `Think CRUD-and-5W1H Before Editing` (user's choice over the recommended "Think Project-Wide Before Editing"). The hyphenated mnemonic form keeps the user's preferred acronym pair while scanning as one compound tool.
+
+**Rationale:** User explicitly preferred the CRUD-and-5W1H mnemonic for memorability. The hyphenated compound avoids reading the title as two separate things.
+
+### D2 — Gloss both acronyms on first use (auto-decided)
+
+**Decided:** Gloss "CRUD (Create / Read / Update / Delete)" and "5W1H (Who / What / When / Where / Why / How)" on first use inside P9's Why paragraph.
+
+**Rationale:** Principle 7 mandates defining jargon/abbreviations on first use. P6 already spells out CRUD inline (`principles/SKILL.md:114`). Consistency and compliance require the same treatment here.
+
+### D3 — P9 sits beside P6 with a one-line forward cross-reference; P6 is not rewritten this session
+
+**Decided:** P9 sits beside P6. P9 carries a forward cross-reference to P6 ("For documentation work, Principle 6 adds the spec and the start-with-docs / finish-with-docs discipline on top of this"). P6 is not modified this session. Reciprocal back-pointer from P6 to P9 is deferred (D7).
+
+**Rationale:** P6 is doc-specific CRUD-think; P9 generalizes the thinking pattern to all edits (code included). The 14→8 consolidation deliberately absorbed old P13 into P6 (`2026-06-05-principles-redesign-14-to-8.md:57`). Absorbing P6 into P9 would undo that merge and rewrite P6 — out of scope. Mistake `design-literal-retire-instruction-without-replacement.md` confirms: do not retire a live facet without a verified replacement.
+
+### D4 — P9 stays distinct from P1 on the "this specific edit's blast radius" axis (auto-decided)
+
+**Decided:** P9 is kept distinct from P1 on the edit-level blast-radius axis. P1 = study the problem before you start (early, problem-level). P9 = think the blast radius of this specific edit before you make it (late, edit-level). P9's Why states this seam explicitly.
+
+**Rationale:** P1's "map what the change will touch before designing" is study-before-start. P9's "check what this edit touches before you make it" is think-before-edit. Different time, different granularity — the principles address non-overlapping failure modes.
+
+### D5 — P10 polices the lower bound; out-of-scope deferral via P5 backlog remains legitimate
+
+**Decided:** P10 is framed as the floor of the scope contract. P5 = do not go BEYOND scope (ceiling). P10 = do not fall SHORT of it (floor). P10 explicitly states this pairing. Legitimately out-of-scope work still routes to backlog per P5 — not a P10 violation.
+
+**Rationale:** The project uses backlogs legitimately and extensively (e.g., `principles-external-renumber-reword-sweep.md`). P10 must not contradict P5's sanctioned follow-up practice. The seam is the word "in-scope": P10 forbids silent deferral of items inside the agreed contract, not the filing of backlogs for genuinely out-of-scope work.
+
+### D6 — P10 title: "Finish In-Scope Work — Do Not Defer It" (matched recommended)
+
+**Decided:** P10 title is `Finish In-Scope Work — Do Not Defer It` (recommended form; matches the user's selection). This names the in-scope boundary explicitly in the title, preventing the misread that P10 bans all deferral.
+
+**Rationale:** User's alternative ("Complete the tasks and avoid deferring") risked being read as "never defer anything," which would contradict P5's backlog practice. The recommended form carries the "In-Scope" qualifier that blocks the misread. Matches the imperative style of P8.
+
+### D7 — Reciprocal back-pointers from P5/P6/P1 to P9/P10: DEFERRED
+
+**Decided:** Adding back-pointers from P6 ("see P9 for non-doc edits"), P5 ("see P10 for the floor"), and P1 to P9/P10 is DEFERRED. This session ships P9/P10 with forward references only.
+
+**Rationale:** Reciprocal back-pointers would require rewriting existing principle bodies — out of scope per the locked PR scope. Deferred to project backlog `backlogs/reciprocal-principle-cross-refs.md`.
+
+### D8 — Guardrails README count drift: DEFERRED
+
+**Decided:** `features/guardrails/README.md` hard-codes "13 Iron Laws" in 5 places (`:3,11,17,25,29`) — already stale vs the current count before this change. Reconciling this is out of scope for this session. Deferred to project backlog `backlogs/guardrails-readme-iron-law-count-drift.md`.
+
+**Rationale:** The drift is pre-existing (wrong by 5 even before this change). Including it would mix two separate fixes. The backlog doc notes whether the fix should reconcile to the live count or rewrite the README to stop hard-coding it.
+
+## Alternatives considered
+
+- D1: Recommended "Think Project-Wide Before Editing" (names the value, not the tool — P7-compliant). User preferred the CRUD-and-5W1H mnemonic form.
+- D3: Absorb P6 into P9 (consolidate). Rejected — would undo the 14→8 consolidation, out of scope.
+- D5: Restrict out-of-scope deferral too (every backlog needs owner + "why deferred"). Flagged as a stronger rule; not chosen.
+- D6: User's literal "Complete the tasks and avoid deferring." Rejected — risks misread as banning all deferral.
+
+## Consequences
+
+- `principles/SKILL.md` gains P9 and P10 sections (full 4-part format) after P8.
+- 11 count-references across 5 real files update "8 → 10" (CRUD scope map in ideation-design.md § 4).
+- Evaluation runs dual-system at Execution only.
+- Preparation loop is skipped.
+- D7 and D8 are deferred to project backlog (no project-memory writes this session).
+
+## Related
+
+- `sessions/2026-06-07-b02c3111-68be-4558-a19f-fabf9627602f/ideation/artifacts/ideation-design.md` — full CRUD scope map, P9/P10 full text, overlap resolution, executor grep
+- `features/guardrails/discussions/2026-06-07-p9-p10-title-boundary-scope.md` — AskUserQuestion exchange log
+- `backlogs/reciprocal-principle-cross-refs.md` — D7 backlog
+- `backlogs/guardrails-readme-iron-law-count-drift.md` — D8 backlog

--- a/.gobbi/projects/gobbi/features/guardrails/discussions/2026-06-07-p9-p10-title-boundary-scope.md
+++ b/.gobbi/projects/gobbi/features/guardrails/discussions/2026-06-07-p9-p10-title-boundary-scope.md
@@ -1,0 +1,88 @@
+---
+name: p9-p10-title-boundary-scope
+description: AskUserQuestion exchanges resolving P9 title, P10 title, P9-P6 boundary, PR scope, eval depth, and Preparation skip
+type: discussions
+scope: feature
+feature: guardrails
+status: active
+created: 2026-06-07
+session: b02c3111-68be-4558-a19f-fabf9627602f
+tags: [principles, p9, p10, title, scope, eval-policy, ideation]
+outcome: Six questions resolved across two AskUserQuestion calls; all decisions locked
+---
+
+# P9 + P10 Title, Boundary, and Scope — User Discussion
+
+## Context
+
+The Ideation leader drafted P9 and P10 wording with 8 open decisions (D1–D8). Six required user input before Planning could proceed: (1) P9 title choice among three options, (2) P10 title choice, (3) P9↔P6 boundary treatment, (4) PR scope (tight vs expanded), (5) evaluation depth (execution-only vs all-loops), (6) Preparation loop skip decision.
+
+Two AskUserQuestion calls were made across the Ideation loop. This file records both exchanges.
+
+---
+
+## Exchange 1 — First AskUserQuestion call
+
+### Question
+
+Presented D1 (P9 title), D6 (P10 title), and D3 (P9↔P6 boundary) to the user. Three options for P9 title:
+- Option A: "Think Project-Wide Before Editing" (recommended — names value/behavior, not tool)
+- Option B: "Think CRUD and 5W1H before Editing" (user's original phrasing)
+- Option C: "Think CRUD-and-5W1H Before Editing" (hyphenated compound)
+
+Two options for P10 title:
+- Option A: "Finish In-Scope Work — Do Not Defer It" (recommended — names in-scope boundary)
+- Option B: "Complete the tasks and avoid deferring" (user's original phrasing)
+
+### Options considered
+
+For P9: Option A names the behavior (project-wide thinking); Options B/C name the tool (the checklists). P7 warns against cryptic abbreviations in titles; however the user may prefer mnemonic memorability. Option C is a hybrid.
+
+For P10: Option A explicitly states the in-scope qualifier preventing misread as "never defer." Option B risks being read as banning all deferral.
+
+For P9↔P6 boundary: "beside with forward-xref only" vs "absorb P6 into P9" (would rewrite P6 and re-open the 14→8 consolidation).
+
+### User decision
+
+- P9 title: Option C — "Think CRUD-and-5W1H Before Editing" (user preferred the mnemonic form with hyphen).
+- P10 title: Option A — "Finish In-Scope Work — Do Not Defer It" (matched recommended).
+- P9↔P6 boundary: P9 sits beside P6 with forward cross-reference only; P6 is not rewritten this session. Reciprocal back-pointers deferred (D7).
+
+### Implication
+
+D1 locked to "Think CRUD-and-5W1H Before Editing." The hyphenated form keeps the user's mnemonic while scanning as one compound tool per the title style convention. P9's Iron-Law one-liner and table rows use this exact title. D3 locked to beside-with-forward-xref. D7 deferred to backlog — no writes to P6 body this session.
+
+---
+
+## Exchange 2 — Second AskUserQuestion call
+
+### Question
+
+Presented PR scope options, evaluation depth, and Preparation loop skip:
+- PR scope Option A (tight): add P9 + P10 to `principles/SKILL.md` + update the 11 count-references across 5 real files only. D7 (reciprocal back-refs) and D8 (guardrails README) deferred.
+- PR scope Option B (expanded): also add reciprocal back-pointers to P5/P6/P1 and fix the guardrails README in the same PR.
+- Evaluation depth: skip for ideation/preparation/planning; dual-system at execution only — or full eval at all loops.
+- Preparation loop: skip (go directly Ideation → Planning) or run Preparation.
+
+### Options considered
+
+Tight scope reduces PR size and review surface. Expanded scope risks "while we're here" scope creep (P5 breach). D7 and D8 are self-contained follow-ups. For eval depth: execution-only is lower overhead for a straightforward doc update; full eval at all loops is higher confidence but more cycle time. For Preparation: skipping it is appropriate when the CRUD scope is clear and the executor can proceed directly from the Planning artifact.
+
+### User decision
+
+- PR scope: Option A (tight). D7 and D8 deferred to project backlog.
+- Evaluation depth: skip for ideation / preparation / planning; dual-system (`always`) for execution only.
+- Preparation loop: SKIP. Planning follows Ideation directly.
+
+### Implication
+
+The execution plan targets exactly 5 real files and 11 count-references. No additional scope. Execution evaluation is dual-system (Claude + Codex), mandatory. The Planning loop will produce the task list from `ideation/artifacts/ideation-design.md` without a Preparation loop in between.
+
+---
+
+## Related
+
+- `sessions/2026-06-07-b02c3111-68be-4558-a19f-fabf9627602f/ideation/artifacts/ideation-design.md` — full CRUD scope map and locked wording
+- `features/guardrails/decisions/2026-06-07-p9-p10-locked-design.md` — formal decision records (D1–D8)
+- `backlogs/reciprocal-principle-cross-refs.md` — D7 deferred
+- `backlogs/guardrails-readme-iron-law-count-drift.md` — D8 deferred

--- a/.gobbi/projects/gobbi/features/guardrails/plans/2026-06-07-principles-9-10-implementation-plan.md
+++ b/.gobbi/projects/gobbi/features/guardrails/plans/2026-06-07-principles-9-10-implementation-plan.md
@@ -64,8 +64,10 @@ All paths relative to the worktree root. Edit the canonical real file; the `.cla
 
 ```
 | 9 | Think CRUD-and-5W1H Before Editing: NO EDIT WITHOUT CHECKING ITS CRUD AND 5W1H ACROSS TARGET AND AFFECTED FILES. |
-| 10 | Finish In-Scope Work — Do Not Defer It: COMPLETE EVERYTHING WITHIN THE AGREED SCOPE; NEVER SILENTLY DEFER IN-SCOPE WORK. |
+| 10 | Finish In-Scope Work — Do Not Defer It: COMPLETE EVERYTHING WITHIN THE AGREED SCOPE; DO NOT DEFER IN-SCOPE WORK. |
 ```
+
+(Update 2026-06-07: the P10 one-liner above was revised post-lock per user revision — `NEVER SILENTLY DEFER IN-SCOPE WORK.` → `DO NOT DEFER IN-SCOPE WORK.` This block now shows the shipped wording.)
 
 **P9 / P10 section bodies:** copy verbatim from the design artifact §2 (P9 full markdown block, lines 38-55) and §3 (P10 full markdown block, lines 75-92). Do not paraphrase, re-word, or re-title.
 

--- a/.gobbi/projects/gobbi/features/guardrails/plans/2026-06-07-principles-9-10-implementation-plan.md
+++ b/.gobbi/projects/gobbi/features/guardrails/plans/2026-06-07-principles-9-10-implementation-plan.md
@@ -1,0 +1,201 @@
+---
+name: principles-9-10-implementation-plan
+description: Add Principle 9 + Principle 10 to the principles skill and propagate the 8→10 count across all 5 live doc surfaces in one consistent pass.
+type: plans
+scope: feature
+feature: guardrails
+status: active
+created: 2026-06-07
+session: b02c3111-68be-4558-a19f-fabf9627602f
+tags: [principles, docs, count-propagation, guardrails]
+supersedes: null
+superseded_by: null
+task_count: 1
+---
+
+# Plan — Add Principles 9 and 10, propagate 8 → 10 (single sequential pass)
+
+## Idea anchor
+
+Locked Ideation design: `sessions/2026-06-07-b02c3111-68be-4558-a19f-fabf9627602f/ideation/artifacts/ideation-design.md`. Final P9/P10 wording (§2, §3), CRUD scope map (§4), summary-table rows (§6), verification grep (§7). All decisions locked with the user — wording, titles, P9↔P6 boundary, tight scope, eval policy are NOT re-opened.
+
+## Scope Contract reference
+
+Locked Scope Contract = the Ideation design artifact above. In scope: add 2 principle sections to `principles/SKILL.md` + propagate 11 count-references (incl. 2 table-row appends) across 5 real files. Out of scope: D7 reciprocal cross-refs, D8 guardrails README "13 Iron Laws" drift, the 8 existing principle bodies, the symlink views, root `AGENTS.md` symlink.
+
+---
+
+## Decomposition decision — ONE executor task (single sequential pass)
+
+**Decision: a single executor task touching all 5 real files in one focused pass.** Justification:
+
+1. **Consistency is the deliverable.** The whole point of this change is Principle 9 itself — think CRUD + project-wide before editing. The change is one logically-atomic edit: the principle bodies and every count-reference must land together. Any split risks an intermediate state where P9/P10 exist but a table still says "8" (or vice versa) — exactly the drift the change exists to prevent. A single task keeps the blast radius in one executor's head and one commit.
+2. **The `docs-cleanup-parallelism` discipline.** The Iron Laws / orchestration practice prefers a single sequential dispatch for a related multi-file docs batch over fragmenting it across agents. (The named rule file `docs-cleanup-parallelism.md` is not present in `rules/`; the principle is captured by Principle 6's CRUD-plan discipline and the design's single-pass CRUD map. The `stub-redirect-format` rule is the only file under `rules/` and does not apply here — no supersession/stub.)
+3. **Implementation never parallelizes** regardless (planning skill § Note on parallelization). Even if this were 5 tasks they would run sequentially — so splitting buys nothing and costs the cross-file consistency view.
+4. **Size fits one spawn.** 5 files, ~2 new sections + 11 reference edits ≈ a medium-granularity unit (planning skill Sub-step B: "typically 2-5 files touched" — this is 5). It is one meaningful commit.
+
+The task has internal ordering the executor must follow (see § Internal edit order), but it is one task, one executor, one commit.
+
+---
+
+## Sub-tasks
+
+| # | Sub-task | Depends on | Verification | Owner type |
+|---|---|---|---|---|
+| 1 | Append P9 + P10 sections to `principles/SKILL.md` and propagate all 11 count-references (incl. 2 table-row appends) across the 5 canonical real files, then run the 3 verification anchors | — | grep anchors V1+V2+V3 below all pass | executor |
+
+This is a one-task plan. The granularity note in the planning skill (a sub-task that needs "and then" should split) does not apply: this is one atomic consistency edit, deliberately kept whole.
+
+---
+
+## File map — exact scope (canonical REAL paths only)
+
+All paths relative to the worktree root. Edit the canonical real file; the `.claude/` and root symlink views update automatically.
+
+| File (canonical real path) | Op | What changes |
+|---|---|---|
+| `.gobbi/projects/gobbi/skills/principles/SKILL.md` | modify | CREATE P9 + P10 sections after P8 (`:168` separator) and before the closing note (`:170`). Order: P9 then `---` then P10 then `---`. Use the exact locked wording from design §2 + §3. |
+| `.claude/CLAUDE.md` | modify | U2 `:31` "8 principles" → "10 principles"; U3 append table rows 9+10 after `:42`; U4 `:56` "8 behavioral principles" → "10 behavioral principles" |
+| `.codex/AGENTS.md` | modify | U5 `:69` "8 principles" → "10 principles"; U6 append table rows 9+10 after `:80`; U7 `:97` "8 behavioral principles" → "10 behavioral principles" |
+| `.gobbi/projects/gobbi/skills/gobbi/SKILL.md` | modify | U8 `:23` "8 Iron Laws" → "10 Iron Laws"; U9 `:185` "8 Iron Laws" → "10 Iron Laws"; U10 `:206` "8 Iron Laws" → "10 Iron Laws" |
+| `.gobbi/projects/gobbi/agents/manager.md` | modify | U11 `:25` "8 Iron Laws" → "10 Iron Laws" |
+
+**Exact table-row text to append (U3 and U6) — verbatim from design §6:**
+
+```
+| 9 | Think CRUD-and-5W1H Before Editing: NO EDIT WITHOUT CHECKING ITS CRUD AND 5W1H ACROSS TARGET AND AFFECTED FILES. |
+| 10 | Finish In-Scope Work — Do Not Defer It: COMPLETE EVERYTHING WITHIN THE AGREED SCOPE; NEVER SILENTLY DEFER IN-SCOPE WORK. |
+```
+
+**P9 / P10 section bodies:** copy verbatim from the design artifact §2 (P9 full markdown block, lines 38-55) and §3 (P10 full markdown block, lines 75-92). Do not paraphrase, re-word, or re-title.
+
+### Internal edit order (within the one task)
+
+1. `principles/SKILL.md` — append P9 + P10 bodies first (the substance).
+2. The 4 reference files — propagate the count + table rows.
+3. Run all three verification anchors last; do not report done until V1+V2+V3 pass.
+
+(Order is a within-task discipline, not a task split. It exists so the executor never reports a partial state.)
+
+---
+
+## NOT in scope (explicit out-of-scope list — do NOT touch)
+
+- **D7** — reciprocal back-pointers from P1/P5/P6 to P9/P10. Deferred to backlog `backlogs/reciprocal-principle-cross-refs.md`.
+- **D8** — `features/guardrails/README.md` "13 Iron Laws" drift (5 places). Pre-existing; deferred to backlog `backlogs/guardrails-readme-iron-law-count-drift.md`.
+- **The 8 existing principle bodies** (`principles/SKILL.md:7-167`) — unchanged. P9 carries the only new cross-ref (forward to P6); P6 is NOT rewritten.
+- **The closing note** `principles/SKILL.md:170` — read for consistency, do not edit (no count in it).
+- **Symlink views — do NOT edit any of these** (editing the canonical real file updates them):
+  - `.claude/skills/principles/SKILL.md` (→ canonical principles SKILL.md)
+  - `.claude/skills/gobbi/SKILL.md` (→ canonical gobbi SKILL.md)
+  - `.claude/agents/manager.md` (→ canonical manager.md)
+  - root `AGENTS.md` (→ `.codex/AGENTS.md`)
+- **No new files, no deletions.** (Design §4 CREATE = none new; DELETE = none. The no-retire / no-delete traps apply.)
+
+---
+
+## Edit-path discipline (restate for executor — load-bearing)
+
+Per mistake `edit-tool-refuses-symlink-paths.md`: the Edit tool **refuses to write through symlink paths**. You MUST target the canonical REAL paths listed in the File map. Do NOT also edit the symlink views — editing the canonical real file propagates to every view automatically. Editing both would be a double-edit error (and the symlink edit would be refused anyway).
+
+- `.claude/CLAUDE.md` and `.codex/AGENTS.md` are REAL files → edit directly.
+- `principles/SKILL.md`, `gobbi/SKILL.md`, `manager.md` → edit the `.gobbi/projects/gobbi/...` canonical path, never the `.claude/...` mirror.
+- Root `AGENTS.md` is a symlink to `.codex/AGENTS.md` → never edit it; edit `.codex/AGENTS.md`.
+
+Per mistake `section-order-is-part-of-the-contract-not-just-the-set.md`: section ORDER is part of the contract. P9 MUST precede P10, and the two new sections MUST come after P8's `---` (`:168`) and before the closing note (`:170`). The 4-part section shape (`## Principle N — title`, `**Why:**`, `**Practice:**`, `**Anti-pattern:**`) is fixed by the locked wording — do not reorder within a section.
+
+---
+
+## Verification strategy summary — the three anchors (run from worktree root)
+
+The executor MUST run all three and report each result. These are also the anchors the Execution dual-system (Claude + Codex) evaluation will re-run.
+
+### V1 — Count-propagation grep (design §7 union pattern): zero surviving "8 / eight" on live surfaces
+
+```bash
+grep -rniE "(eight|[0-9]+) (iron laws?|principles|behavioral|laws)" \
+  .claude/CLAUDE.md .codex/AGENTS.md \
+  .gobbi/projects/gobbi/skills/ .gobbi/projects/gobbi/agents/
+```
+Expected after the change: every hit reads "10" / "ten"; **zero hits read "8" / "eight"** on these live surfaces. (Baseline run during planning returned 8 hits all reading "8" across the 5 surfaces — after the change all 8 must read "10".)
+
+**Gap note for executor — the table rows are NOT caught by V1.** The `| 8 | Fix the Root Cause...` rows (CLAUDE.md:42, AGENTS.md:80) and the new `| 9 |` / `| 10 |` rows do not match V1's pattern. V1 only proves the prose count-references flipped. The table-row append is verified by V3 below, not V1. Do not treat a clean V1 as proof the tables were updated.
+
+### V2 — Symlink-integrity: the `.claude/` views resolve to the edited canonical files
+
+```bash
+# Each view must (a) still be a symlink and (b) contain the new count / sections via the canonical target.
+for p in .claude/skills/principles/SKILL.md .claude/skills/gobbi/SKILL.md .claude/agents/manager.md AGENTS.md; do
+  [ -L "$p" ] && echo "OK symlink: $p -> $(readlink "$p")" || echo "BROKEN (not a symlink): $p"
+done
+# Prove propagation through the symlink: these must print the NEW text.
+grep -n "Principle 9" .claude/skills/principles/SKILL.md
+grep -n "Principle 10" .claude/skills/principles/SKILL.md
+grep -n "10 Iron Laws" .claude/skills/gobbi/SKILL.md
+grep -n "10 Iron Laws" .claude/agents/manager.md
+```
+Expected: all 4 views are still symlinks (none converted to real files by a mis-edit); reading P9/P10 and "10 Iron Laws" through the `.claude/` views succeeds — proving the canonical edit propagated and no view was edited directly.
+
+### V3 — Exactly two new `## Principle` sections; P8 unchanged; new table rows present
+
+```bash
+# (a) Exactly 10 principle section headings now exist (was 8).
+grep -cE "^## Principle [0-9]+ —" .gobbi/projects/gobbi/skills/principles/SKILL.md   # expect 10
+grep -nE "^## Principle (9|10) —" .gobbi/projects/gobbi/skills/principles/SKILL.md     # expect P9 then P10, P9 line < P10 line
+# (b) P9 precedes P10 and both follow P8 and precede the closing note.
+grep -nE "^## Principle 8 —|^## Principle 9 —|^## Principle 10 —|single source of behavioral discipline" \
+  .gobbi/projects/gobbi/skills/principles/SKILL.md   # order must be: P8 < P9 < P10 < closing-note
+# (c) P8 body unchanged — title line intact.
+grep -n "^## Principle 8 — Fix the Root Cause" .gobbi/projects/gobbi/skills/principles/SKILL.md   # expect 1 hit
+# (d) The two new summary-table rows landed in BOTH CLAUDE.md and AGENTS.md.
+grep -nE "^\| (9|10) \| (Think CRUD-and-5W1H|Finish In-Scope Work)" .claude/CLAUDE.md   # expect 2 hits
+grep -nE "^\| (9|10) \| (Think CRUD-and-5W1H|Finish In-Scope Work)" .codex/AGENTS.md    # expect 2 hits
+```
+Expected: (a) `10`; (b) order P8 < P9 < P10 < closing-note; (c) exactly 1 P8 title hit (body untouched); (d) 2 new rows in each of CLAUDE.md and AGENTS.md.
+
+**Gate:** the task is complete only when V1 (zero "8" on live surfaces), V2 (4 intact symlinks + propagation visible through views), and V3 (10 sections, correct order, P8 intact, 4 new table rows total) all pass.
+
+---
+
+## Dependency graph
+
+Single task, no dependencies. Internal edit order (principles bodies → reference files → verify) is a within-task discipline, documented above.
+
+## Agent assignments
+
+| Field | Value |
+|---|---|
+| Agent type | `executor` — this is implementation (doc edits with a consistency contract), not sub-planning or trivial mechanical work. The cross-file CRUD consistency check is exactly the judgment the executor owns. |
+| Model override | none (executor → opus default) |
+| Required skills | `principles` (always — and this task edits the principles skill itself, so the executor must understand the floor it is extending); `mistake` (always); `execution` (implementation workflow); the phase doc `orchestration/workflow/execution.md`; `claude` skill (`.claude/` doc authoring standard — bears on CLAUDE.md / AGENTS.md table + prose edits) |
+| Required mistakes | `edit-tool-refuses-symlink-paths.md` (load-bearing — canonical-path edits); `section-order-is-part-of-the-contract-not-just-the-set.md` (P9-before-P10 ordering); `executor-main-tree-edit-near-miss.md` + `subagent-relative-path-write-strays-to-main-tree.md` (edit in the WORKTREE copy, not the main tree); `skills-mirror-symlinks-not-copies.md` (why editing canonical propagates to views) |
+
+Justification for non-obvious skills: `claude` skill is included because U2-U7 edit `.claude/CLAUDE.md` and `.codex/AGENTS.md` — the project's `.claude/` authoring doc-standard surfaces. `principles` is doubly required: always-load AND it is the file under edit.
+
+## Self-review report (Sub-step E)
+
+- **Spec coverage:** every design CRUD item mapped to the one task — U1 (CREATE P9+P10), U2-U11 (11 count refs incl. U3/U6 table rows). No design item unassigned; no task content beyond the design. PASS.
+- **Placeholder scan:** no `TBD` / `TODO` / `<...>` / `XXX` / `FIXME` in this plan. PASS.
+- **Type/name consistency:** principle titles and table-row text quoted verbatim from design §2/§3/§6 — no drift. File paths match the verified worktree topology (symlink vs real confirmed by `readlink`). PASS.
+- **Planning-time freshness:** all CRUD-map line numbers (`:31/:42/:56` CLAUDE.md, `:69/:80/:97` AGENTS.md, `:23/:185/:206` gobbi SKILL.md, `:25` manager.md, `:168/:170` principles boundary) re-verified against the live worktree files this session. **No drift found.** One verification-coverage observation surfaced (V1 does not catch the table rows → V3 covers them) — not a line-number drift, an anchor-completeness note already folded into the verification section.
+
+## Verification strategy summary (whole-plan gate)
+
+The plan is complete when the executor's one task passes V1 + V2 + V3. The Execution dual-system evaluation re-runs the same three anchors plus a diff-against-scope check (no file outside the File map touched; no symlink view edited; D7/D8 untouched).
+
+## Definition of done (acceptance criteria for the Execution dual-system eval)
+
+1. `principles/SKILL.md` has exactly 10 `## Principle N —` sections; P9 and P10 use the locked wording verbatim (design §2, §3); P9 precedes P10; both sit after P8's `---` and before the closing note; the 8 existing bodies are byte-unchanged.
+2. P9's Why paragraph contains the locked glosses ("CRUD (Create / Read / Update / Delete)", "5W1H (Who / What / When / Where / Why / How)"), the P1 boundary line, and the one-line forward cross-ref to P6. P10's Why contains the P5 floor/ceiling pairing line.
+3. All 11 count-references read "10" / "ten": V1 grep returns zero "8" / "eight" on the 5 live surfaces; the two summary-table rows (9 and 10) are present in BOTH CLAUDE.md and AGENTS.md (V3d).
+4. Only the 5 canonical real files were edited. No symlink view was edited; all 4 symlink views remain symlinks and resolve to the edited canonical files (V2).
+5. No new files; no deletions. D7 and D8 untouched. `features/guardrails/README.md` "13 Iron Laws" left as-is (deferred).
+6. Edits landed in the WORKTREE copy, not the main tree.
+
+## Open issues
+
+- **Anchor-coverage note (not a blocker):** V1's union pattern does not match the `| 8 |` / `| 9 |` / `| 10 |` table rows. V3d covers the table-row append explicitly. The executor and the Execution evaluators must run BOTH V1 and V3 — a clean V1 alone does not prove the tables were updated. Folded into the verification anchors above; recorded here so the evaluator does not mistake it for a gap.
+
+## Decisions log
+
+No new AskUserQuestion decisions this Planning loop — all design decisions were locked in Ideation (titles, wording, P9↔P6 forward-only cross-ref, P10↔P5 pairing, tight scope, D7/D8 deferral, eval=skip at planning / dual-system at execution). The only Planning-loop decision is the decomposition: ONE executor task (rationale above). No USER CHALLENGE — the leader does not disagree with the locked design.

--- a/.gobbi/projects/gobbi/mistakes/principle-text-lead-with-imperative-not-agent-psychology.md
+++ b/.gobbi/projects/gobbi/mistakes/principle-text-lead-with-imperative-not-agent-psychology.md
@@ -1,0 +1,39 @@
+---
+name: principle-text-lead-with-imperative-not-agent-psychology
+description: Principle/rule text was drafted leading with agent-psychology framing and padded with unrequested cross-references and carve-outs; lead with the imperative and include only what the user asked for.
+type: mistakes
+scope: project
+feature: guardrails
+status: active
+created: 2026-06-07
+session: b02c3111-68be-4558-a19f-fabf9627602f
+tags: [docs-sync, writing, principles, design]
+priority: medium
+domain: docs-sync
+supersedes: null
+superseded_by: null
+---
+
+# Principle text should lead with the imperative, not agent-psychology — and not add unrequested cross-refs
+
+## What went wrong
+
+When drafting Principle 10 ("Finish In-Scope Work"), the text led with agent psychology — "Agents tend to mark a task done while **quietly** leaving part of its agreed scope as 'future work'" — and spent a Why sentence + a Practice bullet on the out-of-scope-deferral carve-out ("Defer only what is out of scope, and never silently"). The user corrected: the point of P10 is not that agents *quietly* defer; it is that agents must **not defer in-scope work** — full stop. The "defer only what is out of scope" framing was unwanted.
+
+Separately, Principle 9 was given two forward cross-references to Principle 6 (a Why sentence and a "Defer to Principle 6 for docs" practice bullet) that the user had not asked for; the user told us to remove them.
+
+## Why it happened
+
+Two over-additions: (1) leading a principle with a description of the failure *behavior/psychology* ("agents tend to quietly…") instead of the positive *imperative* the principle commands; (2) adding "helpful" cross-references and defensive carve-outs beyond the user's stated intent, on the theory that more reconciliation = more rigor. Both add words the user did not want and bury the point.
+
+## How to recognize it before repeating
+
+- The first sentence of a principle/rule describes what agents *tend to do wrong* (psychology) rather than stating the rule.
+- You are adding a cross-reference to another principle/doc that the user did not ask for ("for completeness").
+- You are adding a carve-out/caveat ("X is allowed, but only when…") that the user's intent does not require.
+
+## Corrected approach
+
+- Lead principle text with the **positive imperative** — the actual point — then explain the failure it prevents in one line if needed.
+- Include only the cross-references and carve-outs the user asked for. When in doubt, leave them out and ask.
+- Apply Principle 7 (plain, brief, literal): cut the framing and the defensive caveats; say the rule.

--- a/.gobbi/projects/gobbi/notes/2026-06-07-add-principles-9-and-10.md
+++ b/.gobbi/projects/gobbi/notes/2026-06-07-add-principles-9-and-10.md
@@ -1,0 +1,73 @@
+---
+name: add-principles-9-and-10
+description: Session that added Principles 9 and 10 to the gobbi principles skill, extending 8 → 10 and propagating the count across 5 live doc surfaces.
+type: notes
+scope: project
+feature: null
+status: active
+created: 2026-06-07
+session: b02c3111-68be-4558-a19f-fabf9627602f
+tags: [principles, guardrails, p9, p10, crud-5w1h, scope-contract, count-propagation]
+features_touched: [guardrails]
+loops_completed: [ideation, planning, execution, wrap-up]
+shipped: [features/guardrails/decisions/2026-06-07-p9-p10-locked-design.md, features/guardrails/discussions/2026-06-07-p9-p10-title-boundary-scope.md, features/guardrails/plans/2026-06-07-principles-9-10-implementation-plan.md, backlogs/guardrails-readme-iron-law-count-drift.md, backlogs/reciprocal-principle-cross-refs.md]
+---
+
+# Add Principles 9 and 10
+
+## What happened
+
+The session added two new behavioral principles to the gobbi principles skill, extending the count from 8 to 10.
+
+**Ideation.** The leader investigated two failure modes the existing 8 principles did not address: (1) agents editing files without checking which other files the edit touches (the blast-radius problem); (2) agents silently deferring in-scope work while reporting tasks done. The leader produced full P9 and P10 wording drafts, a CRUD scope map covering 5 real files and 11 count-references, and an overlap analysis against P1/P5/P6. Eight design decisions (D1–D8) were identified; two AskUserQuestion calls resolved six of them.
+
+**User decisions in Ideation.** The user made six decisions across two exchanges: P9 title locked to "Think CRUD-and-5W1H Before Editing" (user's mnemonic choice over the recommended "Think Project-Wide Before Editing"); P10 title locked to "Finish In-Scope Work — Do Not Defer It" (matched the recommended form); P9 sits beside P6 with a one-line forward cross-reference only — P6 is not rewritten this session; PR scope locked tight (5 real files, 11 count-references, no expanded scope); evaluation limited to dual-system at Execution only; Preparation loop skipped (Ideation → Planning directly). D7 (reciprocal back-pointers from P1/P5/P6 to P9/P10) and D8 (guardrails README "13 Iron Laws" drift, pre-existing and wrong by 7 after this change) were deferred to project backlog.
+
+**Planning.** The leader produced a one-task plan: a single executor pass over 5 canonical real files in a fixed internal order (principles bodies first, then the 4 reference files, then verification). The plan included three verification anchors (V1 count grep, V2 symlink integrity, V3 section count + table rows). No Preparation loop ran. The plan's decomposition rationale centers on P9 itself: consistency across all 5 files is the deliverable and must land as one atomic edit.
+
+**Execution.** A single executor task ran commit `ef1bb0e`. Five files changed, +52/-8 lines. The executor appended P9 and P10 sections (full 4-part format: Why / Practice / Anti-pattern) after P8 in `principles/SKILL.md`, propagated 11 count-references (8→10 in prose + 2 table-row appends in CLAUDE.md and AGENTS.md), and verified all three anchors passed. The 4 symlink views propagated correctly. No symlink was edited directly. No file outside the 5-file scope was touched.
+
+**Execution evaluation.** Dual-system evaluation ran (Claude + Codex). Both returned PASS at iter1. Claude ran all 7 perspectives; the only finding was a Low out-of-scope observation noting the pre-existing D8 guardrails README drift — explicitly deferred. Claude also ran the manager-flagged broad missed-"8" grep across the full canonical tree; result was empty, confirming the 5-file scope was complete. Codex ran 7 perspectives independently and returned PASS with no findings; independently verified scope, structure, count propagation, table rows, and symlink integrity.
+
+## What shipped
+
+- Commit `ef1bb0e` on the session branch (worktree `claude-2026-06-07-b02c3111-68be-4558-a19f-fabf9627602f`). 5 files changed, +52/-8.
+  - `.gobbi/projects/gobbi/skills/principles/SKILL.md` — P9 + P10 sections appended
+  - `.claude/CLAUDE.md` — count 8→10 (3 refs) + 2 table rows
+  - `.codex/AGENTS.md` — count 8→10 (3 refs) + 2 table rows
+  - `.gobbi/projects/gobbi/skills/gobbi/SKILL.md` — count 8→10 (3 refs)
+  - `.gobbi/projects/gobbi/agents/manager.md` — count 8→10 (1 ref)
+- Promoted to project memory this session:
+  - `features/guardrails/decisions/2026-06-07-p9-p10-locked-design.md` — D1–D8 locked decisions (ADR format)
+  - `features/guardrails/discussions/2026-06-07-p9-p10-title-boundary-scope.md` — both AskUserQuestion exchanges
+  - `features/guardrails/plans/2026-06-07-principles-9-10-implementation-plan.md` — implementation plan
+  - `backlogs/guardrails-readme-iron-law-count-drift.md` — D8 deferred backlog (project-scope)
+  - `backlogs/reciprocal-principle-cross-refs.md` — D7 deferred backlog (project-scope)
+- `features/guardrails/README.md` activity log updated; `plans/` subdir created.
+
+## What got stuck
+
+Nothing stuck mid-session. Both deferred items (D7, D8) were pre-planned deferrals, not mid-session blocks.
+
+## What shifted
+
+- The P9 title shifted from the leader's recommendation ("Think Project-Wide Before Editing") to the user's mnemonic choice ("Think CRUD-and-5W1H Before Editing"). The hyphenated form was a compromise that preserves the mnemonic while reading as one compound tool.
+- Evaluation was descoped early: the original plan had evaluation at all loops; the user locked it to Execution-only during Ideation, keeping the PR lean.
+
+## Decisions to respect
+
+- P9 title is fixed: "Think CRUD-and-5W1H Before Editing." Do not rename it without re-opening with the user.
+- P10 title is fixed: "Finish In-Scope Work — Do Not Defer It." The "In-Scope" qualifier is load-bearing; it prevents misread as banning all deferral.
+- P9 sits beside P6. P9 has a forward cross-reference to P6; P6 does NOT have a back-pointer to P9 yet (deferred D7). Do not add the back-pointer without picking up `backlogs/reciprocal-principle-cross-refs.md`.
+- P10 explicitly pairs with P5 (P5 = ceiling, P10 = floor). Do not modify P10's Why without re-reading this pairing.
+- P9 and P10 count as Iron Laws — the count is now 10, not 8. Any document that references the Iron Law count must be updated when touched. See also `backlogs/guardrails-readme-iron-law-count-drift.md` for the deferred README fix.
+- The 5 canonical real-file edit discipline is locked: never edit symlink views (`.claude/skills/principles/SKILL.md`, `.claude/skills/gobbi/SKILL.md`, `.claude/agents/manager.md`, root `AGENTS.md`) — edit the canonical real path only.
+
+## Next session
+
+Two deferred backlogs are ready to pick up independently:
+
+1. `backlogs/reciprocal-principle-cross-refs.md` (D7) — add back-pointers from P5, P6, P1 to P9/P10. Standalone prose edit to three existing principle bodies. Low priority.
+2. `backlogs/guardrails-readme-iron-law-count-drift.md` (D8) — fix the pre-existing "13 Iron Laws" hard-coding in `features/guardrails/README.md` (5 places). Standalone prose edit to one README. Medium priority. Pick up after the P9/P10 PR is merged.
+
+The session branch must be merged to develop (or squash-merged as a PR) before these follow-ups run.

--- a/.gobbi/projects/gobbi/skills/gobbi/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/gobbi/SKILL.md
@@ -20,7 +20,7 @@ Run these steps in order at session start, session resume, `/clear`, and compact
 
 Load these immediately, before anything else. Do not ask questions, do not check session state, do not proceed until they are loaded:
 
-1. **`principles`** — the 8 Iron Laws (Behavioral discipline floor). Mandatory.
+1. **`principles`** — the 10 Iron Laws (Behavioral discipline floor). Mandatory.
 2. **`orchestration`** — the workflow state machine, mode definitions, manager-facing step orchestration.
 3. **`discussion`** — Question Card template, anti-sycophancy, Decision Classification (Auto-decide / Always-Ask / User Challenge). Loaded on every user-facing exchange.
 4. **`delegation`** — per-role templates, Load Directives block, status contract. Loaded on every `Agent` tool call.
@@ -182,7 +182,7 @@ Status enum across all spawned agents: `DONE` / `DONE_WITH_CONCERNS` / `NEEDS_CO
 
 | Skill | Purpose |
 |---|---|
-| [`principles`](../principles/SKILL.md) | 8 Iron Laws — behavioral discipline floor every agent observes. MUST load at session start; subagent delegation prompts must include an explicit load directive. |
+| [`principles`](../principles/SKILL.md) | 10 Iron Laws — behavioral discipline floor every agent observes. MUST load at session start; subagent delegation prompts must include an explicit load directive. |
 | [`git`](../git/SKILL.md) | Git / GitHub workflow. Worktree isolation, branch lifecycle, PR management, issue tracking. |
 | `claude` doc-authoring standard (**[FLAG-2] currently absent**) | The `.claude/` documentation-authoring standard (writing principles, hierarchy, anti-patterns). CLAUDE.md links `skills/claude/SKILL.md` but no such skill dir exists yet (verified — neither `claude` nor `_claude`). This is a dangling reference: the standard's intended home is the `project-memory` value-feature (the doc-authoring standard Principle 6 leans on). Repoint or author the skill under the FLAG-2 follow-up; do not rely on this row until it resolves. |
 
@@ -203,7 +203,7 @@ gobbi's durable capabilities — the things a README "Features" section would li
 | `project-memory` | The cross-session durable memory tree — typed, named, frontmatter-standardized | memorization + memory-map + rules.md + wrap-up's promotion half + the 13 types |
 | `agents` | The 5-role multi-agent roster with role-scoped delegation | delegation + delegation/templates + the `agents/*.md` roster |
 | `evaluation` | Dual-system (Claude + Codex) review across 7 perspectives | evaluation + the per-loop `evaluation.md` child docs + codex |
-| `guardrails` | The 8 Iron Laws + the mistake-capture-and-learn loop | principles + mistake + the `mistakes/` tier |
+| `guardrails` | The 10 Iron Laws + the mistake-capture-and-learn loop | principles + mistake + the `mistakes/` tier |
 | `git-workflow` | Worktree-isolated sessions + branch / PR / issue lifecycle | git |
 | `install-runtime` | One-command install + bootstrap interview + the per-session runtime contract | interview + gobbi-hook-authoring (+ install/runtime knowledge documented here and in the install dir) |
 

--- a/.gobbi/projects/gobbi/skills/principles/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/principles/SKILL.md
@@ -169,14 +169,13 @@ allowed-tools: Read, Grep, Glob, Bash
 
 ## Principle 9 — Think CRUD-and-5W1H Before Editing: NO EDIT WITHOUT CHECKING ITS CRUD AND 5W1H ACROSS TARGET AND AFFECTED FILES.
 
-**Why:** Agents tend to edit the target file in isolation — they change what is in front of them and ignore the files that depend on it or must stay consistent with it. The edit looks done but the project is now inconsistent: a renamed symbol with stale callers, an updated doc whose mirror still says the old thing, a new field no reader handles. The fix is to think the whole edit before making it. Before touching a file, run two checklists over the target AND every file the change reaches: CRUD (Create / Read / Update / Delete) — what gets created, what to read for consistency, what to update, what to delete; and 5W1H (Who / What / When / Where / Why / How) — who depends on this, what exactly changes, when it takes effect, where else it must change, why it changes, how it propagates. This is edit-level blast-radius thinking. Principle 1 maps what the work will touch before you design; Principle 9 checks what this specific edit touches before you make it. For documentation work, Principle 6 adds the spec and the start-with-docs / finish-with-docs discipline on top of this.
+**Why:** Agents tend to edit the target file in isolation — they change what is in front of them and ignore the files that depend on it or must stay consistent with it. The edit looks done but the project is now inconsistent: a renamed symbol with stale callers, an updated doc whose mirror still says the old thing, a new field no reader handles. The fix is to think the whole edit before making it. Before touching a file, run two checklists over the target AND every file the change reaches: CRUD (Create / Read / Update / Delete) — what gets created, what to read for consistency, what to update, what to delete; and 5W1H (Who / What / When / Where / Why / How) — who depends on this, what exactly changes, when it takes effect, where else it must change, why it changes, how it propagates. This is edit-level blast-radius thinking. Principle 1 maps what the work will touch before you design; Principle 9 checks what this specific edit touches before you make it.
 
 **Practice:**
 - *List the affected files first:* before editing the target, find every file that depends on it or must stay consistent with it — callers, mirrors, tables, tests, docs. The affected set, not just the target, is the unit of the edit.
 - *Run CRUD over the whole set:* for the target and each affected file, name what to Create, what to Read for consistency, what to Update (down to the line), and what to Delete. A change that updates one file usually has to co-touch others.
 - *Run 5W1H over the edit:* Who depends on this, What exactly changes, When it takes effect, Where else it must change, Why it changes, How the change propagates. Answer all six before saving.
 - *Check consistency, not just the diff:* confirm the edit leaves no file contradicting another — no stale caller, no out-of-date mirror, no count or name that drifted.
-- *Defer to Principle 6 for docs:* documentation edits also follow Principle 6's spec + CRUD plan and the start-with-docs / finish-with-docs rule.
 
 **Anti-pattern:**
 - Editing the target file without listing the files that depend on it or must stay consistent with it.
@@ -187,23 +186,22 @@ allowed-tools: Read, Grep, Glob, Bash
 
 ---
 
-## Principle 10 — Finish In-Scope Work — Do Not Defer It: COMPLETE EVERYTHING WITHIN THE AGREED SCOPE; NEVER SILENTLY DEFER IN-SCOPE WORK.
+## Principle 10 — Finish In-Scope Work — Do Not Defer It: COMPLETE EVERYTHING WITHIN THE AGREED SCOPE; DO NOT DEFER IN-SCOPE WORK.
 
-**Why:** Agents tend to mark a task done while quietly leaving part of its agreed scope as "future work." Each silent deferral leaves the project incomplete and stacks unfinished work that the next session inherits without warning. So finish the whole agreed scope before calling a task done — every in-scope deliverable, not most of them. This is the lower bound of the scope contract, and it pairs with Principle 5: Principle 5 says do not go beyond the agreed scope; Principle 10 says do not fall short of it. Together they bracket the contract from both sides. Deferring is allowed — but only for work that is genuinely out of scope, and only as an explicit, surfaced follow-up the user can see (per Principle 5), never as a silent gap inside the agreed work.
+**Why:** Agents tend to leave part of a task's agreed scope as "future work" instead of finishing it. Deferring in-scope work leaves the project incomplete and stacks unfinished work that the next session inherits. So finish the whole agreed scope before calling a task done — every in-scope deliverable, not most of them. This is the lower bound of the scope contract, and it pairs with Principle 5: Principle 5 says do not go beyond the agreed scope; Principle 10 says do not fall short of it. Together they bracket the contract from both sides. If an in-scope item genuinely cannot be finished, stop and surface it to the user as a decision.
 
 **Practice:**
 - *Know the scope's lower bound:* the agreed scope is a floor as well as a ceiling — every in-scope item must be delivered, not just the easy ones.
 - *Finish before you call it done:* complete every deliverable the contract covers before reporting the task complete. A partial result reported as done is a false signal.
-- *Defer only what is out of scope, and never silently:* legitimately out-of-scope work routes to a surfaced backlog or follow-up per Principle 5 — that is fine. Leaving in-scope work undone is not.
-- *Name any in-scope gap to the user:* if an in-scope item genuinely cannot be finished, stop and surface it to the user as a decision — do not bury it as "future work" and move on.
+- *Surface an in-scope blocker, don't bury it:* if an in-scope item genuinely cannot be finished, stop and raise it to the user as a decision — do not record it as "future work" and move on.
 - *Distinguish the two boundaries:* exceeding scope is a Principle 5 breach; falling short of it is a Principle 10 breach. Check the result against both.
 
 **Anti-pattern:**
-- Reporting a task done while part of its agreed scope is left as unstated "future work."
-- Silently dropping a hard in-scope item and finishing only the easy ones.
-- Filing a backlog entry for in-scope work to avoid doing it, instead of for genuinely out-of-scope work.
+- Reporting a task done while part of its agreed scope is left as "future work."
+- Dropping a hard in-scope item and finishing only the easy ones.
+- Filing a backlog entry for in-scope work to avoid doing it.
 - Treating "I deferred it" as equivalent to "I finished it" when the deferred item was inside the contract.
-- Leaving an in-scope gap unsurfaced so the next session inherits it without warning.
+- Leaving an in-scope gap that the next session inherits.
 
 ---
 

--- a/.gobbi/projects/gobbi/skills/principles/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/principles/SKILL.md
@@ -167,4 +167,44 @@ allowed-tools: Read, Grep, Glob, Bash
 
 ---
 
+## Principle 9 — Think CRUD-and-5W1H Before Editing: NO EDIT WITHOUT CHECKING ITS CRUD AND 5W1H ACROSS TARGET AND AFFECTED FILES.
+
+**Why:** Agents tend to edit the target file in isolation — they change what is in front of them and ignore the files that depend on it or must stay consistent with it. The edit looks done but the project is now inconsistent: a renamed symbol with stale callers, an updated doc whose mirror still says the old thing, a new field no reader handles. The fix is to think the whole edit before making it. Before touching a file, run two checklists over the target AND every file the change reaches: CRUD (Create / Read / Update / Delete) — what gets created, what to read for consistency, what to update, what to delete; and 5W1H (Who / What / When / Where / Why / How) — who depends on this, what exactly changes, when it takes effect, where else it must change, why it changes, how it propagates. This is edit-level blast-radius thinking. Principle 1 maps what the work will touch before you design; Principle 9 checks what this specific edit touches before you make it. For documentation work, Principle 6 adds the spec and the start-with-docs / finish-with-docs discipline on top of this.
+
+**Practice:**
+- *List the affected files first:* before editing the target, find every file that depends on it or must stay consistent with it — callers, mirrors, tables, tests, docs. The affected set, not just the target, is the unit of the edit.
+- *Run CRUD over the whole set:* for the target and each affected file, name what to Create, what to Read for consistency, what to Update (down to the line), and what to Delete. A change that updates one file usually has to co-touch others.
+- *Run 5W1H over the edit:* Who depends on this, What exactly changes, When it takes effect, Where else it must change, Why it changes, How the change propagates. Answer all six before saving.
+- *Check consistency, not just the diff:* confirm the edit leaves no file contradicting another — no stale caller, no out-of-date mirror, no count or name that drifted.
+- *Defer to Principle 6 for docs:* documentation edits also follow Principle 6's spec + CRUD plan and the start-with-docs / finish-with-docs rule.
+
+**Anti-pattern:**
+- Editing the target file without listing the files that depend on it or must stay consistent with it.
+- Updating one file and leaving its mirror, caller, or table stale because the change was never traced past the target.
+- Treating the diff as the whole change instead of checking the project is still consistent after it.
+- Skipping the CRUD or 5W1H pass because the edit "looks small," then shipping a drift the next reader hits.
+- Reasoning only about the file in front of you when the change has project-wide reach.
+
+---
+
+## Principle 10 — Finish In-Scope Work — Do Not Defer It: COMPLETE EVERYTHING WITHIN THE AGREED SCOPE; NEVER SILENTLY DEFER IN-SCOPE WORK.
+
+**Why:** Agents tend to mark a task done while quietly leaving part of its agreed scope as "future work." Each silent deferral leaves the project incomplete and stacks unfinished work that the next session inherits without warning. So finish the whole agreed scope before calling a task done — every in-scope deliverable, not most of them. This is the lower bound of the scope contract, and it pairs with Principle 5: Principle 5 says do not go beyond the agreed scope; Principle 10 says do not fall short of it. Together they bracket the contract from both sides. Deferring is allowed — but only for work that is genuinely out of scope, and only as an explicit, surfaced follow-up the user can see (per Principle 5), never as a silent gap inside the agreed work.
+
+**Practice:**
+- *Know the scope's lower bound:* the agreed scope is a floor as well as a ceiling — every in-scope item must be delivered, not just the easy ones.
+- *Finish before you call it done:* complete every deliverable the contract covers before reporting the task complete. A partial result reported as done is a false signal.
+- *Defer only what is out of scope, and never silently:* legitimately out-of-scope work routes to a surfaced backlog or follow-up per Principle 5 — that is fine. Leaving in-scope work undone is not.
+- *Name any in-scope gap to the user:* if an in-scope item genuinely cannot be finished, stop and surface it to the user as a decision — do not bury it as "future work" and move on.
+- *Distinguish the two boundaries:* exceeding scope is a Principle 5 breach; falling short of it is a Principle 10 breach. Check the result against both.
+
+**Anti-pattern:**
+- Reporting a task done while part of its agreed scope is left as unstated "future work."
+- Silently dropping a hard in-scope item and finishing only the easy ones.
+- Filing a backlog entry for in-scope work to avoid doing it, instead of for genuinely out-of-scope work.
+- Treating "I deferred it" as equivalent to "I finished it" when the deferred item was inside the contract.
+- Leaving an in-scope gap unsurfaced so the next session inherits it without warning.
+
+---
+
 This skill is the single source of behavioral discipline. Loading it explicitly gives an agent the rationale and detail behind any principle when context demands more than the principle summary in CLAUDE.md. Future work: a Red Flags table per principle, listing the named rationalizations from each principle in scannable tabular form.


### PR DESCRIPTION
## Summary

Adds two behavioral principles to the gobbi principles skill (8 → 10) and propagates the principle count across every live doc surface.

- **Principle 9 — Think CRUD-and-5W1H Before Editing:** generalizes CRUD + affected-file consistency to all edits (code included), sitting beside P6 (docs-specific) with a forward cross-reference; distinct from P1 on the "this specific edit's blast radius" axis.
- **Principle 10 — Finish In-Scope Work — Do Not Defer It:** the scope lower bound, paired with P5's upper bound (P5 = don't exceed scope; P10 = don't fall short). Out-of-scope deferral via a surfaced P5 backlog stays legitimate.

## Shipped

- `ef1bb0e` — add P9/P10 + propagate count across **5 real files**: `skills/principles/SKILL.md`, `.claude/CLAUDE.md`, `.codex/AGENTS.md`, `skills/gobbi/SKILL.md`, `agents/manager.md` (incl. both summary-table rows). `.claude/*` and root `AGENTS.md` are symlinks — canonical real paths edited only.
- `0bdf17c` — promote session memory: feature memory under `features/guardrails/` (locked design decision, plan, discussion log), per-session journal, and 3 project backlogs.

## Verification

- Both commits **dual-system evaluated** (Claude + Codex) at Execution — both **PASS**. Both independently re-ran a whole-tree hunt for any missed "8 principles / 8 Iron Laws" reference → empty (the "11 refs, complete set" claim held).
- Wrap-up dual-system eval surfaced 2 metadata findings (date-prefix naming per `rules.md §1.2`; a phantom handoff path) → remediated + manager-verified.

## Deferred (filed as backlogs in this PR)

- `reciprocal-principle-cross-refs` — reciprocal back-pointers from P5/P6/P1 to P9/P10 (touches existing principle bodies; out of this PR's tight scope).
- `guardrails-readme-iron-law-count-drift` — `features/guardrails/README.md` still hard-codes "13 Iron Laws" (pre-existing drift).
- `wrap-up-routing-table-date-prefix-contradicts-rules` — `wrap-up/SKILL.md` routing table omits the date prefix for decisions/discussions, contradicting `rules.md §1.2` (the bug this session hit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)