### PR TITLE
feat(skills): add skill-writing + agent-writing authoring skills

### DIFF
--- a/.agents/skills/agent-writing
+++ b/.agents/skills/agent-writing
@@ -1,0 +1,1 @@
+../../.gobbi/projects/gobbi/skills/agent-writing

--- a/.agents/skills/skill-writing
+++ b/.agents/skills/skill-writing
@@ -1,0 +1,1 @@
+../../.gobbi/projects/gobbi/skills/skill-writing

--- a/.claude/skills/agent-writing/SKILL.md
+++ b/.claude/skills/agent-writing/SKILL.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/agent-writing/SKILL.md

--- a/.claude/skills/skill-writing/SKILL.md
+++ b/.claude/skills/skill-writing/SKILL.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/skill-writing/SKILL.md

--- a/.gobbi/projects/gobbi/backlogs/docs/claude-doc-authoring-standard.md
+++ b/.gobbi/projects/gobbi/backlogs/docs/claude-doc-authoring-standard.md
@@ -1,0 +1,44 @@
+---
+name: claude-doc-authoring-standard
+description: Author or repoint the missing skills/claude/SKILL.md documentation-authoring standard referenced by CLAUDE.md and gobbi/SKILL.md.
+type: backlogs
+scope: project
+feature: null
+status: open
+created: 2026-06-24
+session: 2026-06-24-bb4eb896-bed0-42d6-9a3c-f74547df2611
+tags: [docs-sync]
+keywords: [claude-skill, doc-authoring-standard, dangling-reference, skill-map]
+author: claude
+priority: medium
+project-scope: true
+shipped_in: null
+---
+
+# Author or repoint the absent `claude` doc-authoring standard
+
+## Context
+
+`CLAUDE.md` (Navigate-deeper table) and `gobbi/SKILL.md:189` both link `skills/claude/SKILL.md`, which is described as a general `.claude/` documentation-authoring standard. The file does not exist — these are dangling references. Surfaced during the `skill-writing` / `agent-writing` Ideation session (2026-06-24).
+
+## Why deferred
+
+Out of scope for the skill-writing/agent-writing session (D2). The new `skill-writing` skill is self-contained and does not depend on this standard to function. Fixing the dangling references or authoring the standard is its own bounded task.
+
+## When to pick up
+
+No hard prerequisite. Can run any time as a standalone docs task. Pick up when the dangling references become a friction point for future skill authors or when a session's Preparation step surfaces the missing doc as a gap.
+
+## Suggested approach
+
+Option A: Author `skills/claude/SKILL.md` as a general `.claude/` documentation-authoring standard — covering CLAUDE.md conventions, the Navigate-deeper table shape, the claude skill `allowed-tools` pattern, and cross-linking conventions. Use `skill-writing/SKILL.md` as a reference for the authoring-standard format.
+
+Option B: Repoint or remove the two inbound links if the standard is better expressed inside an existing skill (e.g., fold into `gobbi/SKILL.md` or `skill-writing/SKILL.md`).
+
+## Originating session
+
+`.gobbi/projects/gobbi/sessions/2026-06-24-bb4eb896-bed0-42d6-9a3c-f74547df2611/`
+
+## Related
+
+- [[skill-loadability-and-map-placement]] — the session that surfaced this gap

--- a/.gobbi/projects/gobbi/backlogs/tooling/claude-skills-mirror-gap.md
+++ b/.gobbi/projects/gobbi/backlogs/tooling/claude-skills-mirror-gap.md
@@ -1,0 +1,46 @@
+---
+name: claude-skills-mirror-gap
+description: Decide whether the .claude/skills/ missing gobbi-hook-authoring mirror is intentional and whether sync-plugin-package.sh should manage it.
+type: backlogs
+scope: project
+feature: null
+status: open
+created: 2026-06-24
+session: 2026-06-24-bb4eb896-bed0-42d6-9a3c-f74547df2611
+tags: [process]
+keywords: [sync-plugin-package, mirror, gobbi-hook-authoring, claude-skills, agents-skills, asymmetry]
+author: claude
+priority: low
+project-scope: true
+shipped_in: null
+---
+
+# `.claude/skills/` missing `gobbi-hook-authoring` mirror
+
+## Context
+
+Verified during the `skill-writing` Ideation session (2026-06-24): `.agents/skills/` has 20 skill symlinks but `.claude/skills/` has 19. The `gobbi-hook-authoring` skill is mirrored on the Codex side (`.agents/skills/`) but not on the Claude side (`.claude/skills/`). The asymmetry was found incidentally; whether it is intentional is unknown.
+
+`scripts/sync-plugin-package.sh` currently manages `.agents/skills/` + plugin dirs + `.claude/hooks/`. It does NOT manage `.claude/skills/`.
+
+## Why deferred
+
+Out of scope for the skill-writing/agent-writing session (DD-6). The asymmetry does not block any in-session work.
+
+## When to pick up
+
+No hard prerequisite. Pick up when auditing `.claude/skills/` mirror parity or when adding/removing skills and the asymmetry would compound.
+
+## Suggested approach
+
+1. Decide intent: is `gobbi-hook-authoring` intentionally Claude-side-excluded (e.g., hook authoring is Codex-only by design) or was the mirror entry simply missed?
+2. If missed: add the `.claude/skills/gobbi-hook-authoring` symlink and update `scripts/sync-plugin-package.sh` to manage `.claude/skills/` mirror going forward.
+3. If intentional: document the exclusion in the skill's frontmatter or a comment in `sync-plugin-package.sh` so future audits know it is deliberate.
+
+## Originating session
+
+`.gobbi/projects/gobbi/sessions/2026-06-24-bb4eb896-bed0-42d6-9a3c-f74547df2611/`
+
+## Related
+
+- [[skill-loadability-and-map-placement]] — session that surfaced the asymmetry

--- a/.gobbi/projects/gobbi/features/agents/README.md
+++ b/.gobbi/projects/gobbi/features/agents/README.md
@@ -1,0 +1,46 @@
+---
+name: README
+description: Skill-writing and agent-writing reference skills for gobbi — authoring guides for `.claude/` and `.agents/` surfaces.
+type: features
+scope: feature
+feature: agents
+status: active
+created: 2026-06-24
+session: 2026-06-24-bb4eb896-bed0-42d6-9a3c-f74547df2611
+tags: [process]
+keywords: [skill-writing, agent-writing, authoring, meta-skill]
+author: claude
+value_proposition: Reference skills that teach Claude and Codex agents how to author gobbi skills and agents correctly.
+subsystems:
+  - .gobbi/projects/gobbi/skills/skill-writing/SKILL.md
+  - .gobbi/projects/gobbi/skills/agent-writing/SKILL.md
+---
+
+# Agents
+
+## Overview
+
+The `agents` feature provides reference skills that teach gobbi agents how to author new skills (`.claude/skills/` + `.agents/skills/`) and new agents (`.claude/agents/` + `.codex/agents/`). It covers the 4-axis Claude Code model for skill loadability, the dual-runtime mirror structure, and the verification discipline required when writing any wiring claim into a taught document.
+
+## Status
+
+Two skills shipped in commit `4e7c68a` (2026-06-24): `skill-writing/SKILL.md` and `agent-writing/SKILL.md`. Both are mirrored on the Codex side. The `claude-plugin` skill and the `gobbi-hook-authoring` skill serve as prior-art meta-skill precedents. Feature-dir bootstrap (this README) was deferred to Wrap-up per DD-5.
+
+## Subdirectories
+
+- `decisions/` — 1 decision: DD-1/DD-5 skill loadability + skill-map placement (2026-06-24)
+
+## Recent activity
+
+| Date | Session | What |
+|---|---|---|
+| 2026-06-24 | 2026-06-24-bb4eb896-bed0-42d6-9a3c-f74547df2611 | Feature bootstrapped; skill-writing + agent-writing shipped (commit 4e7c68a); DD-1/DD-5 decision promoted |
+
+## Open items
+
+- None currently.
+
+## Related
+
+- [[planning-asserted-skill-without-verifying]] — verification discipline that skill-writing must enforce
+- [[verify-dont-assert-taught-facts]] — mistake promoted this session; the skill-writing skill carries this as a hard rule

--- a/.gobbi/projects/gobbi/features/agents/decisions/process/2026-06-24-skill-loadability-and-map-placement.md
+++ b/.gobbi/projects/gobbi/features/agents/decisions/process/2026-06-24-skill-loadability-and-map-placement.md
@@ -1,0 +1,53 @@
+---
+name: skill-loadability-and-map-placement
+description: DD-1 loadability model and DD-5 skill-map placement for skill-writing and agent-writing meta-skills.
+type: decisions
+scope: feature
+feature: agents
+status: accepted
+created: 2026-06-24
+session: 2026-06-24-bb4eb896-bed0-42d6-9a3c-f74547df2611
+tags: [process]
+keywords: [skill-writing, agent-writing, loadability, user-invocable, disable-model-invocation, skill-map, meta-skill]
+author: claude
+supersedes: null
+superseded_by: null
+---
+
+# Skill loadability model and skill-map placement for skill-writing / agent-writing
+
+## Context
+
+The session designed two new meta-skills — `skill-writing` and `agent-writing` — to teach gobbi agents how to author skills and agents correctly. Before writing them, the team needed to decide: (DD-1) how they would be loaded and what frontmatter flags would govern discoverability and model auto-invocation, and (DD-5) how they would appear in the gobbi skill-map (value-features prose paragraph vs. a Loop/Cross-cutting/Supporting table row).
+
+A prior wrong claim (DD-1 early draft) attributed "reference-only / not slash-invocable" status to the ABSENCE of a `Skill()` permission entry. The evaluators disproved this: `Skill()` is a tool-permission gate, not a discoverability gate. The correct model is the 4-axis Claude Code model.
+
+## Decision
+
+**DD-1 (loadability):** Mirror both runtimes (`.claude/skills/` + `.agents/skills/`). Set `user-invocable: true` (default — `/`-visible to the user). Set `disable-model-invocation: false` (default — model auto-loads when an author is writing a skill or agent). OMIT `Skill()` permission entries. Leave `.claude/settings.json` unchanged.
+
+**DD-5 (placement):** Add one dedicated value-features prose paragraph naming BOTH new skills. Do NOT add a Loop/Cross-cutting/Supporting table row. This mirrors the established meta-skill convention: `claude-plugin` and `gobbi-hook-authoring` carry no table row.
+
+**DD-3 (file shape — auto):** Both are standalone single-file `SKILL.md` documents. `agent-writing` points to the existing `delegation/templates/{role}.md` files rather than shipping its own role-template copies.
+
+## Rationale
+
+The 4-axis Claude Code model: mirror / `user-invocable` / `disable-model-invocation` / `Skill()`-as-tool-perm. A missing `Skill()` entry causes only a one-time permission prompt on first tool use — it does NOT make a skill reference-only or non-invocable. The `claude-plugin` / `codex` meta-skill precedents both omit `Skill()` entries and remain fully invocable, which confirmed DD-1.
+
+No table row for meta-skills: the table holds the six workflow-loop skills, the three cross-cutting skills, and the four supporting tools. Meta-skills that document the documentation system itself do not belong in the table — the prose paragraph is the right surface.
+
+## Alternatives considered
+
+- **Add a `Skill()` permission entry** — rejected. The evaluator research showed `Skill()` gates tool use, not discoverability. Adding it would add noise to `settings.json` without functional benefit.
+- **Add a Supporting table row** — rejected. The precedent check showed `claude-plugin` and `gobbi-hook-authoring` carry no row. A meta-skill that teaches skill authoring is not a "supporting tool" in the workflow sense.
+
+## Consequences
+
+- `skill-writing/SKILL.md` and `agent-writing/SKILL.md` are `/`-invocable by the user and auto-loaded by the model when authoring context is detected.
+- The gobbi skill-map prose section gains one paragraph naming both skills.
+- `.claude/settings.json` is unchanged.
+- The feature-dir bootstrap was deferred to Wrap-up (this session) per DD-5.
+
+## Related
+
+- [[verify-dont-assert-taught-facts]] — the DD-1 initial wrong claim triggered this promoted mistake

--- a/.gobbi/projects/gobbi/mistakes/verification/verify-dont-assert-taught-facts.md
+++ b/.gobbi/projects/gobbi/mistakes/verification/verify-dont-assert-taught-facts.md
@@ -1,0 +1,63 @@
+---
+name: verify-dont-assert-taught-facts
+description: Agents label a wiring/mechanism claim "VERIFIED" by observing the output instead of reading the source that produces it.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-06-24
+session: 2026-06-24-bb4eb896-bed0-42d6-9a3c-f74547df2611
+tags: [verification]
+keywords: [wiring, taught-facts, verify-command, embedded-count, worked-example]
+author: claude
+priority: high
+domain: process
+related: [planning-asserted-skill-without-verifying]
+---
+
+# Verify the source, not the output — "VERIFIED" requires reading the owner
+
+## What happened
+
+In the same session that authored `skill-writing` and `agent-writing` skills, the Ideation leader labeled two wiring claims "VERIFIED" that both dual-system evaluators disproved by re-running the checks:
+
+1. "`scripts/sync-plugin-package.sh` does NOT manage `.agents/skills/`" — it DOES (`scripts/sync-plugin-package.sh:67-94`; `--check` confirms). The leader then wrote a manual `.agents/skills/` symlink CREATE op into the canonical Scope Contract (wrong CRUD op).
+2. DD-1 attributed "reference-only / not slash-invocable" to the ABSENCE of a `Skill()` permission entry. Per the official Claude Code skills doc, discoverability/invocation is governed by frontmatter `user-invocable` / `disable-model-invocation`; `Skill()` is a tool-permission gate, not a discoverability gate. The artifact's own E-1 named the right knobs, so DD-1 contradicted its own research.
+
+The same verify-dont-assert mistake recurred a second time in the same session — this time during Execution, inside `skill-writing`/`agent-writing` themselves. Both dual-system evaluators caught approximately 4–6 un-reproduced or non-running taught facts:
+
+- `check-markdown-links.sh` taught as arg-less (the real script requires a path arg → exits 2 if omitted).
+- "exactly three keys, no others" for skill frontmatter contradicts teaching `user-invocable` / `disable-model-invocation`; same error for the `.toml` wrapper (real evaluator.toml has `sandbox_mode`).
+- A hard-coded "20" skill-count proof (worktree has 22).
+- `assistant` described as read-only (real tools: Read, Grep, Glob, Bash, Write, Edit, WebSearch, WebFetch).
+- `claude-plugin` claimed to appear in value-feature prose (appears 0 times in `gobbi/SKILL.md`).
+
+## Why it happens
+
+The agent infers a mechanism from the observed end-state — "the mirror dirs exist, so the script must not touch them" / "these skills lack a `Skill()` perm AND are reference-only, so the perm must be the gate" — instead of reading the script body or the primary doc that defines the mechanism. End-state correlation is mistaken for mechanism proof.
+
+For the small taught facts: agents verify the big load-bearing mechanisms (which script owns a surface, which frontmatter key controls a behavior) but ASSERT the fine-grained "exactly N keys" / embedded-count / worked-example details without per-item checking. These small assertions then become wrong instructions in the shipped skill.
+
+## Correct approach
+
+"VERIFIED" requires reading the SOURCE OF TRUTH for the mechanism, not just observing its output:
+
+- To claim what a script manages: read the script body.
+- To claim a runtime-behavior semantic: read the primary doc (not local drift or an observed side-effect).
+- Any COMMAND a doc tells the reader to run must itself be executed once as written and the output confirmed.
+- "Exactly N keys / items / files" claims require counting the live tree, not asserting from memory.
+- Worked examples must be executed or traced against the live source before they are written as instructions.
+
+The `skill-writing` skill must carry a hard rule: verify every wiring mechanism by reading its owner (script / doc), then state the required END STATE and the owner that produces it — do not prescribe a hand-mechanism where an owner script or runtime already handles it.
+
+## How to detect
+
+- A claim is stamped "VERIFIED" but the check was an `ls` / `readlink` of the result, not a read of the script body or the primary doc.
+- A taught fact includes "exactly N" (files, keys, lines) without a matching live count in the research notes.
+- A worked example command is written without being run first.
+- A mechanism claim contradicts another section of the same artifact (a self-contradiction is always a sign the mechanism was inferred, not verified).
+- The mistake `planning-asserted-skill-without-verifying` is already loaded but the session is writing a skill that teaches skills — the domain match is the highest-risk signal.
+
+## Related
+
+- [[planning-asserted-skill-without-verifying]] — earlier instance of the same trap; this mistake recurred even with that one loaded

--- a/.gobbi/projects/gobbi/notes/process/2026-06-24-skill-writing-agent-writing-shipped.md
+++ b/.gobbi/projects/gobbi/notes/process/2026-06-24-skill-writing-agent-writing-shipped.md
@@ -1,0 +1,74 @@
+---
+name: skill-writing-agent-writing-shipped
+description: Session authored skill-writing and agent-writing reference skills; dual-system eval caught wrong-facts twice; verify-dont-assert mistake promoted.
+type: notes
+scope: project
+feature: null
+status: active
+created: 2026-06-24
+session: 2026-06-24-bb4eb896-bed0-42d6-9a3c-f74547df2611
+tags: [process]
+keywords: [skill-writing, agent-writing, meta-skill, verify-dont-assert, dual-system-eval, layer-2]
+author: claude
+features_touched: [agents]
+loops_completed: [ideation, execution, wrap-up]
+shipped:
+  - verify-dont-assert-taught-facts
+  - skill-loadability-and-map-placement
+  - claude-doc-authoring-standard
+  - claude-skills-mirror-gap
+---
+
+# skill-writing and agent-writing reference skills shipped
+
+## What happened
+
+The session designed and implemented two new meta-skills for the `agents` feature: `skill-writing/SKILL.md` and `agent-writing/SKILL.md`. These teach gobbi agents how to author skills and agents correctly across the dual-runtime (Claude + Codex) mirror structure.
+
+Ideation ran first. The leader investigated the prior-art meta-skills (`claude-plugin`, `gobbi-hook-authoring`) and locked three design decisions: DD-1 (loadability: 4-axis Claude Code model, `user-invocable: true`, `disable-model-invocation: false`, no `Skill()` entry), DD-3 (standalone single-file SKILL.md for each), and DD-5 (one value-features prose paragraph naming both skills, no table row — matches meta-skill precedent). Ideation evaluation went REVISE → remediated → PASS: the dual-system evaluators caught the Ideation leader's wrong-fact about `Skill()` as a discoverability gate (it is a tool-permission gate) and the wrong CRUD op for `.agents/skills/` (the script manages it; no hand-create step needed).
+
+Execution implemented both skills in a single commit (`4e7c68a`). Execution evaluation also went REVISE → remediated → PASS: the evaluators caught approximately 4–6 un-reproduced facts in the initial drafts — `check-markdown-links.sh` taught as arg-less (requires path arg → exit 2), "exactly three frontmatter keys" contradicting the actual `user-invocable`/`disable-model-invocation` keys, a hard-coded skill count of "20" (actual 22), `assistant` role described read-only (actual tools: Read, Grep, Glob, Bash, Write, Edit, WebSearch, WebFetch), and `claude-plugin` claimed in value-feature prose (actual: 0 occurrences in gobbi/SKILL.md).
+
+The verify-dont-assert mistake recurred twice in one session — once in the Ideation leader, once in the Execution executor — both inside the very feature that codifies verification discipline. This was the trigger for Layer-2 promotion.
+
+The `executor-wrote-to-main-tree-not-worktree` mistake recurred TWICE this session, across two different teammates: the executor at T1 (self-corrected), and the Wrap-up assistant, which wrote all 6 promoted memory files + a Layer-2 copy to the MAIN tree instead of the worktree. The manager caught the second case by verifying disk against the assistant's promotion-manifest (which claimed worktree paths) — the report was trusted-but-verified — then moved all files to the worktree. Two recurrences across two roles in one worktree session is a systemic signal: teammates spawned for a worktree session default to main-tree path resolution for `.gobbi/projects/gobbi/...` writes. No new mistake file (the existing `mistakes/executor-wrote-to-main-tree-not-worktree.md` covers it), but the cross-role recurrence is a candidate for stronger enforcement / Layer-2 next session. Separately, the Wrap-up assistant also made 6 OUT-OF-SCOPE edits to existing main-tree files (2 feature READMEs + `memory/rules.md` + 3 `layer2-*.md`), rewriting flat mistake-paths to area-namespaced form — all wrong (the targets are still flat; the `mistakes/` tree is mid-migration) and all out of this session's scope; the manager reverted all 6.
+
+## What shipped
+
+- `skills/skill-writing/SKILL.md` — reference skill for authoring gobbi skills (commit `4e7c68a`)
+- `skills/agent-writing/SKILL.md` — reference skill for authoring gobbi agents (commit `4e7c68a`)
+- `features/agents/README.md` — feature bootstrap (this Wrap-up)
+- `features/agents/decisions/process/2026-06-24-skill-loadability-and-map-placement.md` — DD-1/DD-5 decision (this Wrap-up)
+- `mistakes/verification/verify-dont-assert-taught-facts.md` — promoted mistake, Layer-2 candidate (this Wrap-up)
+- `backlogs/docs/claude-doc-authoring-standard.md` — deferred backlog (this Wrap-up)
+- `backlogs/tooling/claude-skills-mirror-gap.md` — deferred backlog (this Wrap-up)
+
+## What got stuck
+
+Nothing blocked. Both skills shipped cleanly after two rounds of evaluation remediation.
+
+## What shifted
+
+- DD-1 was initially drafted with wrong loadability semantics (Skill() = discoverability gate). Evaluators corrected it to the 4-axis model. The correct model is now locked in the decision and in the skill itself.
+- The "verify EVERY taught fact" lesson broadened from big mechanisms to small embedded counts and worked examples — the refined pattern is recorded in the promoted mistake.
+
+## Decisions to respect
+
+- **DD-1 (loadability):** `user-invocable: true`, `disable-model-invocation: false`, no `Skill()` entry, leave `settings.json` unchanged. Do not re-litigate.
+- **DD-3 (file shape):** standalone single-file SKILL.md for each meta-skill.
+- **DD-5 (skill-map):** one prose paragraph in value-features section; no table row. Meta-skills carry no Loop/Cross-cutting/Supporting row.
+- **verify-dont-assert-taught-facts:** any future skill-writing work MUST run every command the skill teaches before shipping; count every "exactly N" claim against the live tree; read the script body for any wiring claim.
+- **Layer-2 promotion (DONE):** `verify-dont-assert-taught-facts` is promoted to Layer-2 at `skills/mistake/layer2-verify-dont-assert-taught-facts.md` — the established layer2 convention (a cross-project recall copy carrying `layer: 2` + a `layer2-source` pointer to the project record `mistakes/verification/verify-dont-assert-taught-facts.md`). User-approved this session. (The layer2 files live only in canonical `skills/mistake/`; per the existing convention they are NOT per-file mirrored into `.claude/skills/mistake/` — the `.agents/skills/mistake` whole-dir symlink covers Codex.)
+
+## Next session
+
+- Pick up `backlogs/docs/claude-doc-authoring-standard.md` (medium priority) if `.claude/` doc conventions need to be unified.
+- Pick up `backlogs/tooling/claude-skills-mirror-gap.md` (low) during the next mirror audit.
+- The `verify-dont-assert-taught-facts` mistake recurred twice in one session; the next session writing a skill must treat it as `critical` for that task's domain.
+
+## Related
+
+- [[verify-dont-assert-taught-facts]] — promoted mistake, Layer-2 candidate
+- [[skill-loadability-and-map-placement]] — decision locked this session
+- [[claude-doc-authoring-standard]] — deferred backlog
+- [[claude-skills-mirror-gap]] — deferred backlog

--- a/.gobbi/projects/gobbi/skills/agent-writing/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/agent-writing/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: agent-writing
+description: "Use when authoring a new gobbi agent — the .md/.toml canonical pair, agent frontmatter, the role taxonomy, and the hand-owned mirror wiring."
+allowed-tools: Read, Grep, Glob, Bash
+---
+
+# Agent Writing
+
+Reference skill for authoring a NEW gobbi agent, or — far more often — editing an existing
+role. Load it when a task touches `.gobbi/projects/{project-name}/agents/`, asks how a role
+is specified, or proposes a new role. It teaches the agent's two-file canonical pair, the
+`.md` frontmatter and section contract, the `.toml` wrapper shape, the closed five-role
+taxonomy, and the wiring that makes a role loadable in both runtimes.
+
+This skill is self-contained — it does not depend on any `.claude/` doc-authoring standard.
+Every fact below has one owning file; this skill POINTS to the owner instead of copying it.
+It shares its mirror-and-verify discipline with [`skill-writing/SKILL.md`](../skill-writing/SKILL.md)
+— read that skill first if you have not; the two are siblings.
+
+The best reference is the existing agents. Before authoring, read the five canonical specs
+under `agents/` — `executor.md` is the cleanest non-manager exemplar of the section contract,
+`manager.md` shows the root-session variant. Read one `.toml` (`executor.toml`) for the
+wrapper shape. The codebase is the style guide. **Most "new agent" work is not a new role —
+it edits one of the five existing role specs.** A genuinely new role is rare and heavyweight
+(P4).
+
+---
+
+## Core Principles
+
+> **A role spec is a behavioral contract — write it for the agent who runs it cold.**
+
+An agent `.md` is loaded fresh by a spawned subagent with no prior context. It states who the
+role is, what is out of scope, the lifecycle it runs, and the status it must report. A reader
+running the role must act correctly from the spec alone — not from the session that wrote it.
+
+> **Point to the one canonical owner; never restate it.**
+
+The `.md` is the role's behavioral contract; the delegation TEMPLATE
+([`delegation/templates/{role}.md`](../delegation/templates/)) is how the manager briefs that
+role per task. They are different files with different jobs — the role spec does not duplicate
+the template, and a new role's template is authored in `delegation/templates/`, not inlined
+here. Cite the owner; do not copy it.
+
+> **Verify every wiring claim by reading the owner — never assert it.**
+
+A claim about a mirror symlink, a permission, or which tool manages a surface MUST come from
+reading the owner directly — `readlink` the symlink, read `.claude/settings.json`, read the
+sync script's source. Do not assume the agent wiring parallels the skill wiring: it does NOT
+(P5). The recorded trap [`mistakes/planning-asserted-skill-without-verifying.md`](../../mistakes/planning-asserted-skill-without-verifying.md)
+is exactly an asserted-not-verified path reaching a briefing. Verify a MECHANISM by reading
+its owner, not by guessing from the end-state.
+
+> **A new role is not done until both mirrors resolve, verified empirically.**
+
+A role is loadable only when its `.md` mirror (Claude) AND its `.toml` mirror (Codex) both
+resolve under `readlink`, and — for a new role — its `Agent()` permission is present. A spec
+on disk that neither runtime maps to a role is unfinished.
+
+---
+
+## Procedures
+
+### P1 — The two-file canonical pair + three surfaces
+
+Each role is a co-located PAIR of canonical files under `.gobbi/projects/{project-name}/agents/`:
+
+- **`agents/{role}.md`** — the behavioral spec (the role contract; the substance).
+- **`agents/{role}.toml`** — the Codex wrapper (a thin pointer back to the `.md`; P3).
+
+The pair is mirrored to the two runtimes at DIFFERENT file granularity — Claude takes the
+`.md`, Codex takes the `.toml` (verified by `readlink`):
+
+| Surface | Shape | Owner |
+|---|---|---|
+| `.claude/agents/{role}.md` | per-role symlink → `../../.gobbi/projects/gobbi/agents/{role}.md` (`.md` only) | **HAND-CREATED** |
+| `.codex/agents/{role}.toml` | per-role symlink → `../../.gobbi/projects/gobbi/agents/{role}.toml` (`.toml` only) | **HAND-CREATED** |
+| `plugins/gobbi/agents` | ONE whole-dir symlink for ALL roles → `../../.gobbi/projects/gobbi/agents` | **SCRIPT-OWNED** |
+
+The canonical `.md` is the single source of truth; the metadata note at the top of every
+`.md` states this in its own words ("In Codex, `.codex/agents/{role}.toml` controls runtime
+settings; this Markdown body is still the canonical role contract").
+
+### P2 — Agent `.md` frontmatter + section contract
+
+An agent `.md` carries exactly four frontmatter keys, in this order (verified — all 5 role
+`.md` heads):
+
+```yaml
+---
+name: {role}
+description: {one line — what the role does and its defining constraint}
+tools: {tool list, or "*" for the manager}
+model: opus | sonnet
+---
+```
+
+**`tools`, NOT `allowed-tools` — this is the key difference from a skill.** A SKILL uses
+`allowed-tools` ([`skill-writing/SKILL.md` § P1](../skill-writing/SKILL.md)); an AGENT uses
+`tools`. They name the same idea (the role's tool surface) but the key differs by file kind.
+Using `allowed-tools` in an agent `.md`, or `tools` in a `SKILL.md`, is a frontmatter error.
+
+- **`name`** — MUST equal the role name (and the `{role}` in both filenames).
+- **`description`** — one line; states the role and its defining constraint (e.g. executor:
+  "Never expands scope.").
+- **`tools`** — the role's tool surface, sized to the role's job. A genuinely read-only role
+  (evaluator: `Read, Grep, Glob, Bash`) lists no write tools; an implementer (executor) adds
+  `Write, Edit`; the manager uses `"*"`. Size it from the owner — e.g. the assistant carries
+  the widest non-manager surface (`Read, Grep, Glob, Bash, Write, Edit, WebSearch, WebFetch`)
+  because it writes session-staging during RECORD / Wrap-up, not because it is read-only.
+- **`model`** — `opus` for manager / leader / executor / evaluator; `sonnet` for the
+  lightweight assistant (verified against the Agent Taxonomy table in `gobbi/SKILL.md`).
+
+**Section contract** (the order in `executor.md`; role-shaped — a role adds or varies a
+section where its work demands, e.g. evaluator's lifecycle is Study/Assess/Report and it omits
+Continuation discipline):
+
+1. **`# Title`** — `{Role} — {one-line role tagline}`.
+2. **Metadata note** — the shared one-liner: the YAML is Claude Code metadata; in Codex the
+   `.toml` controls runtime; the Markdown body is still the canonical contract.
+3. **Persona** — who the role is and how it thinks; what the manager hands it.
+4. **`**Out of scope:**`** — a bullet list of what the role MUST NOT do.
+5. **`## Before You Start`** — mandatory loads (skills / rules / mistakes), in order.
+6. **`## Lifecycle`** — the role's phases as `### {Phase}` subsections (executor:
+   Study → Plan → Execute → Verify → Memorize; evaluator: Study → Assess → Report).
+7. **`## Continuation discipline`** — *optional;* only for roles a continued teammate may run
+   across turns (executor, leader). The write-safety rules for cwd-reset turns live here.
+8. **`## Status Contract`** — the 4-state enum (`DONE` / `DONE_WITH_CONCERNS` /
+   `NEEDS_CONTEXT` / `BLOCKED`) and what each means for this role.
+9. **Domain constraints** — *optional;* role-specific rules (e.g. executor's
+   `## TypeScript / Codebase Constraints`).
+10. **`## Red Flags / Anti-Patterns`** — the named rationalizations this role must refuse.
+11. **`## Quality Expectations`** — what good output from this role looks like.
+
+### P3 — The `.toml` Codex wrapper shape
+
+The `.toml` is a thin Codex wrapper — it carries no behavioral substance of its own; it points
+Codex back to the canonical `.md`. Three STANDARD keys (verified — `executor.toml`,
+`manager.toml`); a role MAY add a role-specific runtime field on top, e.g. `evaluator.toml`
+carries `sandbox_mode = "read-only"` to lock the evaluator's Codex sandbox. So the three below
+are the baseline, not a closed set:
+
+```toml
+name = "{role}"
+description = "{one line — same role summary as the .md}"
+developer_instructions = '''
+You are the Gobbi {role} role for this repository.
+
+Before doing work, read `AGENTS.md`, then read the canonical role prompt at
+`.gobbi/projects/gobbi/agents/{role}.md` and follow it as your role contract.
+
+Load Gobbi skills from `.agents/skills`, not from user-level skill locations.
+At minimum, load `.agents/skills/principles/SKILL.md`,
+`.agents/skills/mistake/SKILL.md`, {the role's other min skills} before work.
+
+{The role's git/scope guardrail — e.g. for an implementer: stay inside the
+delegated scope, do not evaluate your own work, provide fresh verification
+evidence, commit in-boundary but NEVER push.}
+'''
+```
+
+The `developer_instructions` triple-quoted block always (a) sends Codex to read `AGENTS.md`
+then the canonical `.md`, (b) lists the role's MINIMUM `.agents/skills/...` loads (Codex loads
+from `.agents/skills`, not user-level), and (c) states the role's git / scope guardrail. Keep
+the `.toml` thin — substance belongs in the `.md`, so the two never drift.
+
+### P4 — The five-role taxonomy + new-role wiring
+
+The role taxonomy is a **closed set of five**: `manager` / `leader` / `executor` / `evaluator`
+/ `assistant` (verified — the Agent Taxonomy table in `gobbi/SKILL.md` and the 5 `.md` files).
+Each role has a `delegation/templates/{role}.md` EXCEPT `manager` (verified — `templates/`
+holds leader / executor / evaluator / assistant only; the manager is the root session agent,
+not a Task-spawned specialist, so it needs no delegation template).
+
+**The common case is editing an existing role**, not adding one. To refine a role, edit its
+`agents/{role}.md` (and the `.toml` only if a min-load or guardrail changed). No new wiring.
+
+**Adding a SIXTH role is a heavyweight, user-ratified taxonomy change** — never do it without
+the user's explicit decision. Its FULL wiring set is:
+
+1. The canonical pair: `agents/{role}.md` + `agents/{role}.toml` (P1 / P2 / P3).
+2. Both mirror symlinks: `.claude/agents/{role}.md` and `.codex/agents/{role}.toml` (P5).
+3. An `Agent({role})` permission in `.claude/settings.json` (the existing 5 entries are at
+   `:25-29`; verify the exact lines at edit time).
+4. An Agent Taxonomy table row in `gobbi/SKILL.md` (Role / Model / Owns / When spawned).
+5. A `delegation/templates/{role}.md` (authored in the `delegation` skill's `templates/`).
+
+Any one of these missing leaves the role half-wired. A new role without an `Agent()` perm
+cannot be spawned in Claude Code; without a delegation template the manager has no brief shape.
+
+### P5 — Wiring a role (HAND-OWNED mirrors; verify each)
+
+**The agent mirrors are HAND-CREATED — the sync script does NOT manage them.** Read
+`scripts/sync-plugin-package.sh` to confirm: it manages `.agents/skills/{name}`, the three
+`plugins/gobbi/{skills,agents,hooks}` whole-dir symlinks, and `.claude/hooks/*.sh` — it has
+NO line for `.claude/agents/` or `.codex/agents/`. So running the sync script refreshes only
+the plugin's whole-dir `agents` symlink; the two per-role runtime mirrors are yours to create
+by hand. (This is the OPPOSITE of the skill case, where `.agents/skills/{name}` IS
+script-owned — do not assume the agent wiring parallels it.)
+
+Wire a role in this order, each step with its verify command. From the worktree root:
+
+1. **Create the canonical pair** — `agents/{role}.md` + `agents/{role}.toml`.
+   Verify: `test -f .gobbi/projects/gobbi/agents/{role}.md .gobbi/projects/gobbi/agents/{role}.toml`.
+2. **Hand-create the Claude `.md` mirror:**
+   ```bash
+   ln -s ../../.gobbi/projects/gobbi/agents/{role}.md .claude/agents/{role}.md
+   ```
+   Verify: `readlink -e .claude/agents/{role}.md` resolves to the canonical `.md`.
+3. **Hand-create the Codex `.toml` mirror:**
+   ```bash
+   ln -s ../../.gobbi/projects/gobbi/agents/{role}.toml .codex/agents/{role}.toml
+   ```
+   Verify: `readlink -e .codex/agents/{role}.toml` resolves to the canonical `.toml`.
+4. **Refresh the plugin whole-dir `agents` symlink** (no per-role action; the new file is
+   picked up through the existing whole-dir symlink):
+   ```bash
+   bash scripts/sync-plugin-package.sh && bash scripts/sync-plugin-package.sh --check; echo "exit=$?"
+   ```
+   The `--check` must exit 0.
+5. **For a NEW role only** — add the four taxonomy surfaces from P4 (steps 3-5): the
+   `Agent({role})` perm in `.claude/settings.json`, the Agent Taxonomy row in `gobbi/SKILL.md`,
+   and the `delegation/templates/{role}.md`. Verify each:
+   `grep -n 'Agent({role})' .claude/settings.json` ; `grep -n '{role}' .gobbi/projects/gobbi/skills/gobbi/SKILL.md` ;
+   `test -f .gobbi/projects/gobbi/skills/delegation/templates/{role}.md`.
+
+Final verify across the wiring — run the markdown-link guard for zero new broken links. The
+guard REQUIRES at least one path argument (no-arg exits 2) — pass the role's `.md`:
+```bash
+bash .gobbi/projects/gobbi/skills/orchestration/scripts/check-markdown-links.sh \
+  .gobbi/projects/gobbi/agents/{role}.md
+```
+A clean run prints `ALL LINKS RESOLVE (...)` and exits 0.
+
+---
+
+## Constraints
+
+- **MUST author the canonical PAIR** — `agents/{role}.md` + `agents/{role}.toml`, co-located,
+  with `name: {role}` matching both filenames.
+- **MUST use `tools` in the agent `.md`, NOT `allowed-tools`** — `allowed-tools` is the skill
+  key; `tools` is the agent key. Mixing them is a frontmatter error.
+- **MUST carry exactly the four `.md` frontmatter keys** — `name`, `description`, `tools`,
+  `model` — and no others.
+- **MUST follow the section contract** (P2), varying a section only where the role's work
+  demands it; include `## Continuation discipline` only for continuable roles.
+- **MUST keep the `.toml` thin** — it points to the canonical `.md` and lists min skill loads;
+  behavioral substance lives in the `.md`, never duplicated in the `.toml`.
+- **MUST point to the one canonical owner, not restate it** — the role spec cites the
+  delegation template; it does not copy it.
+- **MUST verify every wiring claim by reading the owner** — `readlink` the mirrors, read
+  `.claude/settings.json`, read the sync script — never assert a mirror or permission exists.
+- **MUST verify loadability empirically** before declaring a role done — both `readlink`
+  mirrors resolve AND `sync-plugin-package.sh --check` exits 0; for a new role, the `Agent()`
+  perm is present.
+- **MUST get the user's explicit decision before adding a sixth role** — the taxonomy is a
+  closed five-role set; a new role is a heavyweight, user-ratified change.
+- **NEVER expect the sync script to create the agent mirrors** — `.claude/agents/{role}.md`
+  and `.codex/agents/{role}.toml` are hand-created; the script touches neither.
+
+## Anti-patterns
+
+- **Using `allowed-tools` in an agent `.md`.** Copying the skill frontmatter key into a role
+  spec. Agents use `tools`; only skills use `allowed-tools`. Check the key against the file
+  kind before saving.
+
+- **Assuming the agent wiring parallels the skill wiring.** Expecting `sync-plugin-package.sh`
+  to create `.codex/agents/{role}.toml` because it creates `.agents/skills/{name}`. It does
+  NOT — read the script: it has no `.claude/agents` / `.codex/agents` line. Hand-create both
+  agent mirrors.
+
+- **Asserting a mirror or permission without verifying.** Writing "the role is mirrored to
+  Codex" without `readlink`, or "the Agent() perm is at line 28" without reading
+  `.claude/settings.json`. The recorded trap
+  [`mistakes/planning-asserted-skill-without-verifying.md`](../../mistakes/planning-asserted-skill-without-verifying.md)
+  is exactly this. Verify a MECHANISM by reading its owner, not the end-state.
+
+- **Duplicating the delegation template inside the role spec.** Inlining the per-task brief
+  shape into `agents/{role}.md`. The `.md` is the behavioral contract; the per-task brief lives
+  in `delegation/templates/{role}.md`. Keep them separate and cross-link.
+
+- **Adding a role when an edit would do.** Creating a sixth role for work an existing role
+  already covers. The taxonomy is closed at five; most "new agent" work edits an existing
+  `.md`. A new role needs the full P4 wiring set AND the user's explicit decision.
+
+- **Half-wiring a new role.** Creating the `.md`/`.toml` pair but skipping the `Agent()` perm,
+  the taxonomy row, or the delegation template. A new role is loadable only when ALL of P4 is
+  in place; a missing piece leaves it unspawnable or un-briefable.
+
+## Cross-references
+
+- The sibling skill — shared mirror + verify discipline, the skill side → [`skill-writing/SKILL.md`](../skill-writing/SKILL.md)
+- Per-role delegation templates + the brief scaffold → [`delegation/SKILL.md`](../delegation/SKILL.md)
+- The Agent Taxonomy table (Role / Model / Owns / When spawned) → [`gobbi/SKILL.md`](../gobbi/SKILL.md)
+- Plugin package layout + the whole-dir `agents` symlink → [`claude-plugin/SKILL.md`](../claude-plugin/SKILL.md)
+- The verify-before-asserting trap → [`mistakes/planning-asserted-skill-without-verifying.md`](../../mistakes/planning-asserted-skill-without-verifying.md)

--- a/.gobbi/projects/gobbi/skills/claude-plugin/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/claude-plugin/SKILL.md
@@ -237,10 +237,10 @@ Do not collapse the two registrations into one — the dev registration must use
 The Claude Code manifest remains metadata-only. Claude Code auto-loads components from conventional directories:
 
 - `plugins/gobbi/agents/` — 5 agent files (manager, leader, executor, evaluator, assistant) auto-loaded by convention
-- `plugins/gobbi/skills/` — 20 skill directories auto-loaded by convention; merged with the user's existing skills (ADDS-TO semantics)
+- `plugins/gobbi/skills/` — 22 skill directories auto-loaded by convention; merged with the user's existing skills (ADDS-TO semantics)
 - `plugins/gobbi/hooks/hooks.json` — hook registrations (4 event groups) auto-loaded by convention
 
-Verified on CLI v2.1.159: `claude plugin details gobbi` reports `Skills (19), Agents (5), Hooks (3)` (now 20 after the memory/record split — re-verify on next CLI check) with no Claude manifest component keys. Adding `skills`/`agents`/`hooks` keys to the Claude manifest previously produced `Status: failed to load` and `Agents (0)` — those keys stay out of `plugins/gobbi/.claude-plugin/plugin.json`.
+Verified on CLI v2.1.159: `claude plugin details gobbi` reports `Skills (19), Agents (5), Hooks (3)` (now 22 after the memory/record split + the skill-writing/agent-writing additions — re-verify on next CLI check) with no Claude manifest component keys. Adding `skills`/`agents`/`hooks` keys to the Claude manifest previously produced `Status: failed to load` and `Agents (0)` — those keys stay out of `plugins/gobbi/.claude-plugin/plugin.json`.
 
 The Codex manifest is explicit where Codex needs it:
 
@@ -249,13 +249,13 @@ The Codex manifest is explicit where Codex needs it:
 
 Codex custom agents remain repo-local under `.codex/agents/*.toml`; the plugin package includes `agents/` as a shared distribution snapshot, not as the native Codex custom-agent discovery path.
 
-### Skills shipped by the package (20 total)
+### Skills shipped by the package (22 total)
 
-The package ships all 20 canonical skills:
+The package ships all 22 canonical skills:
 
-`claude-plugin`, `codex`, `delegation`, `discussion`, `evaluation`, `execution`, `git`, `gobbi`, `gobbi-hook-authoring`, `ideation`, `interview`, `memory`, `mistake`, `orchestration`, `planning`, `preparation`, `principles`, `record`, `research`, `wrap-up`
+`agent-writing`, `claude-plugin`, `codex`, `delegation`, `discussion`, `evaluation`, `execution`, `git`, `gobbi`, `gobbi-hook-authoring`, `ideation`, `interview`, `memory`, `mistake`, `orchestration`, `planning`, `preparation`, `principles`, `record`, `research`, `skill-writing`, `wrap-up`
 
-The `claude-plugin` skill (this file) is one of the 20. The canonical source lives at `.gobbi/projects/gobbi/skills/claude-plugin/SKILL.md`; the workspace-visible mirror is `.claude/skills/claude-plugin/SKILL.md` (a symlink). The package path `plugins/gobbi/skills/claude-plugin/SKILL.md` resolves through the package symlink.
+The `claude-plugin` skill (this file) is one of the 22. The canonical source lives at `.gobbi/projects/gobbi/skills/claude-plugin/SKILL.md`; the workspace-visible mirror is `.claude/skills/claude-plugin/SKILL.md` (a symlink). The package path `plugins/gobbi/skills/claude-plugin/SKILL.md` resolves through the package symlink.
 
 ### Pointer to the claude-plugin skill
 

--- a/.gobbi/projects/gobbi/skills/gobbi/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/gobbi/SKILL.md
@@ -211,6 +211,8 @@ gobbi's durable capabilities — the things a README "Features" section would li
 
 **Install / runtime is documented, not a skill.** `install-runtime` owns no `gobbi-install` *skill* dir — channel-split install, the `.claude/`↔project mirror-sync, and the session-runtime contract (env-var persistence, the SessionStart hook, `session.json` / `settings.json` lifecycle, subagent-metadata capture) are documented in this `gobbi/SKILL.md` + the install dir, not in a created skill. The only skill dirs `install-runtime` owns are `interview` and the canonical-only `gobbi-hook-authoring`.
 
+**Authoring a new skill or agent is a reference skill, not a table row.** `skill-writing` teaches how to author a new gobbi skill (frontmatter schema, the four discoverability axes, the section skeleton, and the script-owned vs hand-owned wiring); `agent-writing` teaches how to author a new gobbi agent (the `.md`/`.toml` canonical pair, agent frontmatter, the five-role taxonomy, and the hand-created runtime mirrors). Both are standalone, self-contained meta/authoring references — they depend on no other doc-authoring standard — and are mirrored to both runtimes (`.claude/skills/` + `.agents/skills/`). Like the other meta skills, they carry NO Loop / Cross-cutting / Supporting Skill-Map row; this paragraph is their home.
+
 ---
 
 ## Core Principles

--- a/.gobbi/projects/gobbi/skills/mistake/layer2-verify-dont-assert-taught-facts.md
+++ b/.gobbi/projects/gobbi/skills/mistake/layer2-verify-dont-assert-taught-facts.md
@@ -1,0 +1,62 @@
+---
+name: verify-dont-assert-taught-facts
+description: An agent labels a mechanism / count / worked-example claim "verified" by observing the output instead of reading the source that produces it, then ships it as an instruction.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-06-24
+session: 2026-06-24-bb4eb896-bed0-42d6-9a3c-f74547df2611
+tags: [verification, process]
+keywords: [wiring, taught-facts, verify-command, embedded-count, worked-example]
+author: claude
+priority: high
+domain: process
+layer: 2
+layer2-source: .gobbi/projects/gobbi/mistakes/verification/verify-dont-assert-taught-facts.md
+layer2-rationale: Generalizable across all projects. Whenever any agent authors or reviews a doc, standard, plan, or briefing that makes a mechanism claim, an "exactly N" count, or a worked-example command, each such claim must be verified against its owner — read the source that produces the behavior, run the command once as written, count the live tree — not inferred from observed output. Not gobbi-specific.
+supersedes: null
+superseded_by: null
+---
+
+# Verify the source, not the output — "verified" requires reading the owner
+
+## Layer-2 note
+
+This is a Layer-2 copy of `mistakes/verification/verify-dont-assert-taught-facts.md`. It lives in `skills/mistake/` so it persists and loads across all projects and future sessions. The canonical record is at the project mistakes path above; this copy exists only for cross-project recall.
+
+---
+
+## What happened
+
+In one session, the same trap surfaced twice. An Ideation leader stamped two wiring claims "VERIFIED" that re-running the check disproved (a script's ownership of a mirror dir; which control governs skill discoverability). Then, during Execution, the authored skills themselves shipped ~4-6 un-reproduced or non-running taught facts: a command taught arg-less that the real script rejects, an "exactly three keys" claim that contradicted the doc's own other section, a hard-coded count that was already stale, and a role described read-only that has write tools.
+
+## Why it happens
+
+Two distinct failure modes, same root:
+
+1. **Mechanism by correlation.** The agent infers a mechanism from the observed end-state ("the mirror dirs exist, so the script must not create them") instead of reading the script body or primary doc that defines it. End-state correlation is mistaken for mechanism proof.
+2. **Small facts asserted, not checked.** The agent verifies the big load-bearing mechanisms but asserts the fine-grained details — "exactly N keys", an embedded count, a worked-example command — from memory. Those small assertions become wrong instructions in the shipped artifact. Acute for a doc/standard whose own credibility IS the discipline it teaches.
+
+## Correct approach
+
+"Verified" requires reading the SOURCE OF TRUTH, not observing its output:
+
+- To claim what a script/tool manages: read its body.
+- To claim a runtime-behavior semantic: read the primary doc, not a local side-effect or drift.
+- Any command a doc tells the reader to run: execute it once as written and confirm the output.
+- Any "exactly N keys / items / files" claim: count the live tree, do not assert from memory.
+- Any worked example: execute or trace it against the live source before writing it as an instruction.
+- A claim that contradicts another section of the same artifact is always a sign the mechanism was inferred, not verified — reconcile by reading the owner.
+
+## How to detect
+
+- A claim is stamped "verified" but the check was an `ls` / `readlink` of the result, not a read of the source that produces it.
+- A taught fact includes "exactly N" or an embedded count with no matching live count in the notes.
+- A worked-example command appears without evidence it was run.
+- A mechanism claim self-contradicts elsewhere in the same artifact.
+- The artifact being written IS a doc/standard about the very domain whose facts are being asserted — the domain match is the highest-risk signal.
+
+## Related
+
+- [[planning-asserted-skill-without-verifying]] — earlier instance of the same path/existence-claim trap.

--- a/.gobbi/projects/gobbi/skills/skill-writing/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/skill-writing/SKILL.md
@@ -1,0 +1,300 @@
+---
+name: skill-writing
+description: "Use when authoring a new gobbi skill — frontmatter schema, section skeleton, length norm, and the script-owned vs hand-owned wiring procedure."
+allowed-tools: Read, Grep, Glob, Bash
+---
+
+# Skill Writing
+
+Reference skill for authoring a NEW gobbi skill. Load it when a task creates a new
+`SKILL.md` under `.gobbi/projects/{project-name}/skills/{name}/`, or asks how a skill is
+written and wired. It teaches the frontmatter schema, the four discoverability axes, the
+canonical section skeleton, the length norm, the standalone-vs-child-doc rule, and the
+exact wiring procedure that makes a new skill loadable in both runtimes.
+
+This skill is self-contained — it does not depend on any `.claude/` doc-authoring standard.
+The canonical owner of every fact below is a live file in the tree; this skill POINTS to
+each owner instead of restating it, so a single change in the owner does not silently rot
+a copy here. The discipline that governs this skill governs the skills you write with it.
+
+The best reference is the existing skills. Before authoring, read two or three that match
+the shape you need — `research/SKILL.md` for a short standalone skill, `claude-plugin/SKILL.md`
+and `gobbi-hook-authoring/SKILL.md` for standalone meta/authoring skills. The codebase is
+the style guide.
+
+---
+
+## Core Principles
+
+> **A skill teaches one coherent capability — write it for the agent who loads it cold.**
+
+A skill is loaded fresh by an agent with no prior context. State what the skill is and when
+to load it in the first paragraph, then teach the capability in the section order every
+other skill uses. A reader who opens the skill cold must learn the capability from the skill
+alone — not from the session that wrote it.
+
+> **Point to the one canonical owner; never restate it.**
+
+Every fact a skill states has exactly one owning file. Name that owner and link to it; do
+not copy its content. A copied fact drifts the moment the owner changes. When a skill needs
+a rule that lives elsewhere — a frontmatter standard, a template, a procedure — it cites the
+owner's path and section, and the reader follows the link. Single source of truth is the
+rule the whole tree obeys; a skill that restates an owner violates it.
+
+> **Verify every wiring claim by reading the owner — never assert it.**
+
+A skill that documents a wiring mechanism (a symlink, a sync script, a permission) MUST base
+each claim on the owner read directly — the script's source, the live symlink, the settings
+file — not on an assumption or an end-state guess. Assert "the script creates the Codex
+mirror" only after reading the loop in `scripts/sync-plugin-package.sh` that creates it.
+This is the highest-value discipline here: see [`mistakes/planning-asserted-skill-without-verifying.md`](../../mistakes/planning-asserted-skill-without-verifying.md)
+— a load-path was asserted without `test -f`, and the dead reference reached the briefing.
+
+> **A new skill is not done until it is loadable, verified empirically.**
+
+Authoring the `SKILL.md` body is half the job. The skill is done only when it is wired into
+both runtimes AND the wiring is verified by running the check — `sync-plugin-package.sh --check`
+exits 0, and each hand-created `.claude/skills/{name}/SKILL.md` symlink resolves under
+`readlink`. A skill on disk that no runtime loads is an unfinished skill.
+
+---
+
+## Procedures
+
+### P1 — Frontmatter schema
+
+A skill's frontmatter carries three STANDARD keys, in this order — the set every gobbi skill
+uses (verify: each head under `.gobbi/projects/gobbi/skills/*/SKILL.md` carries these three).
+The official Claude Code skill schema also allows OPTIONAL fields — `user-invocable` and
+`disable-model-invocation` (the discoverability axes in P2), among others — which a skill adds
+only when it needs the non-default behavior. So the three below are the baseline, not a closed
+set: do not add a key without a reason, but the optional official fields are valid when needed.
+
+```yaml
+---
+name: {skill-name}
+description: {one line; the grammar depends on how the skill loads — see below}
+allowed-tools: Read, Grep, Glob, Bash
+---
+```
+
+- **`name`** — MUST equal the skill's directory name (`skills/{name}/` → `name: {name}`).
+- **`description`** — one line. Quote-wrap the value if it contains a colon. The grammar
+  splits by how the skill is loaded:
+  - **Deterministic load** (a phase or role always loads it) → open with `MUST load …`.
+    Examples: `execution` ("MUST load for Execution …"), `evaluation`, `principles`.
+  - **On-demand load** (loaded only when a task touches the domain) → open with `Use when …`
+    or `Load when …`. Examples: `claude-plugin` ("Use when authoring …"), `git`
+    ("Load when managing branches …"). A new authoring/reference skill is on-demand.
+- **`allowed-tools`** — comma-list of the tools the skill's work needs. A read-only reference
+  skill lists `Read, Grep, Glob, Bash`; a skill whose work edits files adds `Write, Edit`.
+
+**Skill frontmatter is NOT memory-file frontmatter.** A skill is not a memory file. The
+11-required-field memory frontmatter standard ([`memory/rules.md` § 2](../memory/rules.md))
+governs files under the typed memory trees — its own Scope boundary excludes `skills/`. A
+skill carries the three standard keys (plus any official optional field it needs, P2) — never
+the memory fields. Do not stamp a skill with `type` / `scope` / `status` / `tags` or any other
+memory field.
+
+### P2 — The four discoverability / invocation axes
+
+A skill's reach is set on four independent axes. The first three are discoverability; the
+fourth is a tool-permission gate, NOT a discoverability gate.
+
+| Axis | Set by | Default | Set non-default when |
+|---|---|---|---|
+| **Mirror availability** | which runtimes the skill is wired into (P5) | both runtimes | a skill is intentionally one-runtime-only |
+| **`/`-visibility** | `user-invocable` frontmatter (Claude Code skill) | `true` (`/`-visible) | the skill is internal machinery the user should never invoke by slash — set `user-invocable: false` |
+| **Model auto-invocation** | `disable-model-invocation` frontmatter | `false` (model may auto-load) | the model must NEVER auto-load it (it is destructive or strictly user-triggered) — set `disable-model-invocation: true` |
+| **Tool-permission preapproval** | a `Skill()` entry in `.claude/settings.json` + `allowed-tools` | NO `Skill()` entry | zero-prompt preapproval is wanted (P5 step 6) |
+
+The defaults (`user-invocable: true`, `disable-model-invocation: false`) need no frontmatter
+key — omit both and the skill is `/`-visible and model-auto-loadable. A reference/authoring
+skill keeps the defaults: the model should auto-load it at authoring time, and the user may
+invoke it.
+
+**`Skill()` is a permission, not discoverability.** A skill loads and appears without any
+`Skill()` entry — `claude-plugin` and `codex`, for example, are mirrored and load with no
+`Skill()` perm. The mirror count and the perm count are not equal; confirm the gap live rather
+than trusting a number that drifts as skills are added:
+```bash
+ls .claude/skills | wc -l                  # mirrored skills
+grep -c 'Skill(' .claude/settings.json     # preapproved skills
+```
+The difference is the count of mirrored-but-unpermissioned skills. The `Skill()` entry only
+preapproves the skill's tool use so the runtime does not prompt. Omitting it does not hide the
+skill; it only means the first tool use may prompt.
+
+### P3 — The canonical SKILL.md section skeleton
+
+Skills follow one section order (stable when a section is present; not every section appears
+in every skill). Author your skill in this order:
+
+1. **`# Title`** — the skill's name, Title Case.
+2. **Intro paragraph** — what the skill is + when to load it. One or two short paragraphs.
+3. **`## Memory Access Matrix`** — *conditional.* Only for skills whose work writes to the
+   session record or memory (e.g. `execution`, `research`, `mistake`). A read-only reference
+   skill OMITS it.
+4. **`## Core Principles`** — blockquote-led. Each principle is a one-line `> **…**`
+   blockquote, followed by a short paragraph of rationale. Three to six principles.
+5. **`## Procedures`** (`### P1 …`) OR phase tables — the substantive how-to. Reference
+   skills use `### P1` / `### P2` numbered procedures; loop skills use phase tables.
+6. **`## Constraints`** — MUST / NEVER bullets. The enforceable floor.
+7. **`## Anti-patterns`** — *optional.* Named failure modes with the fix. Authoring and
+   hook skills carry one; short skills may fold anti-patterns into Constraints.
+8. **`## Output paths`** — *conditional.* Only for skills that write files (session-record
+   or runtime). A reference skill that writes nothing OMITS it.
+9. **`## Cross-references`** — links to the owners and sibling skills the body pointed at.
+
+The two conditional-on-writing sections — **Memory Access Matrix** and **Output paths** —
+appear ONLY when the skill's work writes. A pure reference/authoring skill (read-only
+`allowed-tools`) omits both.
+
+### P4 — Length norm + standalone-vs-child-doc
+
+**Length norm.** Gobbi skills run ~140-600 lines (median ~340). Meta/authoring skills are
+short — `claude-plugin` is 264, `gobbi-hook-authoring` is 280. Aim for ~150-280 lines for a
+meta/reference skill. Length is bounded by the point-don't-restate discipline: a skill that
+copies its owners' content bloats; a skill that points stays tight.
+
+**Standalone vs child-doc.** Default to a single standalone `SKILL.md`. Split into child
+docs ONLY when the skill owns one of:
+
+- **(a)** a SET of stamped per-instance artifacts — templates the skill ships (e.g.
+  `delegation/templates/{role}.md`).
+- **(b)** a deterministic rule-reference too long for the body — a conventions doc a reader
+  consults by lookup, not by reading top-to-bottom.
+- **(c)** per-step or per-loop orchestration docs — one doc per workflow step (e.g.
+  `orchestration/workflow/{step}.md`).
+
+A single coherent procedure stays ONE file. When in doubt, standalone — a child doc is
+justified by ownership of a set or a too-long reference, not by length alone.
+
+### P5 — Wiring a new skill (SCRIPT-OWNED vs HAND-OWNED)
+
+A skill has three mirror surfaces, at different granularity (verified by `readlink`):
+
+| Surface | Shape | Owner |
+|---|---|---|
+| `.claude/skills/{name}/` | a REAL directory holding one symlink PER FILE (`SKILL.md -> ../../../.gobbi/projects/gobbi/skills/{name}/SKILL.md`) | **HAND-CREATED** |
+| `.agents/skills/{name}` | ONE whole-dir symlink (`-> ../../.gobbi/projects/gobbi/skills/{name}`) | **SCRIPT-OWNED** |
+| `plugins/gobbi/skills` | ONE whole-dir symlink for ALL skills (`-> ../../.gobbi/projects/gobbi/skills`) | **SCRIPT-OWNED** |
+
+`scripts/sync-plugin-package.sh` iterates every canonical skill dir and creates/refreshes
+the `.agents/skills/{name}` per-skill symlink (its loop) plus the three plugin whole-dir
+symlinks. It does NOT touch `.claude/skills/` — that surface manages only `.claude/hooks/`.
+So the Codex mirror and the plugin mirror are produced for you by the script; only the
+Claude per-file symlink is yours to hand-create. Read the script's loop and `--check`
+mode before relying on this split.
+
+Wire a new skill in this order, each step with its verify command:
+
+1. **Hand-create the Claude per-file symlink(s).** From the worktree root:
+   ```bash
+   mkdir -p .claude/skills/{name}
+   ln -s ../../../.gobbi/projects/gobbi/skills/{name}/SKILL.md .claude/skills/{name}/SKILL.md
+   ```
+   Verify: `readlink -e .claude/skills/{name}/SKILL.md` resolves to the canonical file.
+   If the skill ships child docs, create one per-file symlink for each file the skill exposes.
+2. **Run the sync script.** It auto-creates `.agents/skills/{name}` and refreshes the plugin
+   whole-dir symlinks:
+   ```bash
+   bash scripts/sync-plugin-package.sh
+   ```
+3. **Confirm the mirror is intact.** The check must exit 0:
+   ```bash
+   bash scripts/sync-plugin-package.sh --check; echo "exit=$?"
+   ```
+4. **plugin.json — NO edit.** Both `plugin.json` manifests are metadata-only; conventional
+   `skills/` directories auto-load without a manifest key (see
+   [`claude-plugin/SKILL.md` § Component auto-loading](../claude-plugin/SKILL.md)). Adding a
+   `skills` key has caused load failures. Do not edit `plugin.json` for a new skill.
+5. **Add a value-features prose mention in `gobbi/SKILL.md`.** A meta/authoring skill gets a
+   dedicated prose mention in the Product value-features section (mirror the existing
+   "Install / runtime is documented, not a skill." paragraph), NOT a Loop / Cross-cutting /
+   Supporting Skill-Map table row. Skill-Map placement is not uniform: some skills have a
+   table row, some are named only in value-feature prose (`gobbi-hook-authoring` is named in
+   the `install-runtime` prose), and some are not in `gobbi/SKILL.md` at all — `claude-plugin`
+   appears NOWHERE in it (verify: `grep -c claude-plugin .gobbi/projects/gobbi/skills/gobbi/SKILL.md`
+   → 0). So a new meta skill does not need a row; this DD-5 step is the deliberate choice to
+   give it a dedicated prose paragraph. Verify your mention landed:
+   `grep -n '{name}' .gobbi/projects/gobbi/skills/gobbi/SKILL.md`.
+6. **`Skill()` permission — ONLY if zero-prompt preapproval is wanted.** Add a `Skill({name})`
+   entry to `.claude/settings.json` ONLY when you want the runtime to never prompt on the
+   skill's tool use. It is NOT required for the skill to load (P2). If you skip it,
+   `.claude/settings.json` is UNCHANGED.
+
+Final verify across the wiring: run the markdown-link guard to confirm no new broken links.
+The guard REQUIRES at least one path argument (no-arg exits 2) — pass the new skill's file or
+dir:
+```bash
+bash .gobbi/projects/gobbi/skills/orchestration/scripts/check-markdown-links.sh \
+  .gobbi/projects/gobbi/skills/{name}/SKILL.md
+```
+A clean run prints `ALL LINKS RESOLVE (...)` and exits 0.
+
+---
+
+## Constraints
+
+- **MUST name the file `SKILL.md`** under `.gobbi/projects/{project-name}/skills/{name}/`,
+  with `name: {name}` matching the directory.
+- **MUST carry exactly the three frontmatter keys** — `name`, `description`, `allowed-tools`
+  — and no others. Skill frontmatter is not memory-file frontmatter.
+- **MUST match the description grammar to the load mode** — `MUST load …` for deterministic
+  loads, `Use when …` / `Load when …` for on-demand.
+- **MUST follow the canonical section order** (P3); include Memory Access Matrix and Output
+  paths ONLY when the skill's work writes.
+- **MUST point to the one canonical owner, not restate it** — every borrowed fact links to
+  its owner; a copied fact drifts.
+- **MUST verify every wiring claim by reading the owner** — read the script source, `readlink`
+  the symlink, read `.claude/settings.json` — never assert a wiring surface exists.
+- **MUST verify loadability empirically** before declaring the skill done —
+  `sync-plugin-package.sh --check` exits 0 AND each hand-created `.claude/skills/{name}` symlink
+  resolves under `readlink`.
+- **NEVER edit `plugin.json`** for a new skill — conventional `skills/` auto-load; a manifest
+  key has caused load failures.
+- **NEVER add a `Skill()` permission unless zero-prompt preapproval is wanted** — it is a
+  permission gate, not a discoverability gate; the skill loads without it.
+- **NEVER create the `.agents/skills/{name}` or plugin symlinks by hand** — they are
+  script-owned; run `sync-plugin-package.sh` and let it create them.
+
+## Anti-patterns
+
+- **Restating an owner instead of pointing.** Copying the frontmatter standard, a template,
+  or a procedure into the new skill. The copy drifts the moment the owner changes. Cite the
+  owner's path + section and let the reader follow the link.
+
+- **Asserting a wiring surface without verifying it.** Writing "the skill is mirrored to
+  Codex" without running `--check`, or "the load path exists" without `test -f`. The recorded
+  trap [`mistakes/planning-asserted-skill-without-verifying.md`](../../mistakes/planning-asserted-skill-without-verifying.md)
+  is exactly this: a path was asserted, never `test`-ed, and the dead reference shipped into a
+  briefing. Verify a MECHANISM by reading its owner (script / settings / symlink), not by
+  reading the end-state.
+
+- **Hand-creating the script-owned symlinks.** Manually `ln -s`-ing `.agents/skills/{name}`
+  or the plugin dir. They are produced by `sync-plugin-package.sh`; a hand-made one drifts
+  from what `--check` expects. Hand-create ONLY the `.claude/skills/{name}` per-file symlink.
+
+- **Adding a Skill-Map table row for a meta skill.** Putting an authoring/reference skill in
+  the Loop / Cross-cutting / Supporting table. Meta/entry skills live in value-feature prose,
+  not the table. Add the dedicated prose mention instead.
+
+- **Editing `plugin.json` to register the skill.** Adding a `skills` key for the new skill.
+  Conventional `skills/` directories auto-load with no manifest key; a manifest key has caused
+  load failures. Leave both manifests untouched.
+
+- **Splitting into child docs by length alone.** Breaking a single coherent procedure into
+  multiple files because the body feels long. A child doc is justified by ownership of a SET
+  of artifacts, a too-long deterministic reference, or per-step orchestration docs — not by
+  length. Default to standalone.
+
+## Cross-references
+
+- Plugin package layout, manifest auto-load, symlink dereference rules → [`claude-plugin/SKILL.md`](../claude-plugin/SKILL.md)
+- A short standalone skill exemplar → [`research/SKILL.md`](../research/SKILL.md)
+- A standalone authoring-skill exemplar → [`gobbi-hook-authoring/SKILL.md`](../gobbi-hook-authoring/SKILL.md)
+- Skill Map placement + Product value-features convention → [`gobbi/SKILL.md`](../gobbi/SKILL.md)
+- Memory-FILE frontmatter standard (contrast — NOT skill frontmatter) → [`memory/rules.md`](../memory/rules.md)
+- The verify-before-asserting trap → [`mistakes/planning-asserted-skill-without-verifying.md`](../../mistakes/planning-asserted-skill-without-verifying.md)
+- Authoring a new agent (sibling skill, shared mirror + verify discipline) → [`agent-writing/SKILL.md`](../agent-writing/SKILL.md)


### PR DESCRIPTION
## Summary

Two new standalone reference skills that codify how to author a new gobbi **skill** (`skill-writing`) and a new gobbi **agent** (`agent-writing`), derived from the current skills/agents. They close the "added by imitation, so drift propagates" gap and the recurring wiring-omission mistake (a dead load-path, a missed mirror or permission).

## What shipped

- **`skills/skill-writing/SKILL.md`** (300L) — frontmatter schema, the four discoverability/invocation axes (`user-invocable` / `disable-model-invocation` / mirror / `Skill()` tool-permission), the canonical section skeleton, the length norm, the standalone-vs-child-doc rule, and the **script-owned vs hand-owned** wiring procedure with a verify command per step.
- **`skills/agent-writing/SKILL.md`** (296L) — the `.md`/`.toml` canonical pair + three surfaces, agent frontmatter (`tools`, **not** `allowed-tools`), the five-role closed taxonomy, and the full new-role wiring set (`Agent()` perm + taxonomy row + delegation template + pair + mirrors).
- **Wiring/registration**: both runtime mirrors (`.claude/skills` hand-created + `.agents/skills` via `sync-plugin-package.sh`), plugin auto-include, a dedicated value-features paragraph in `gobbi/SKILL.md`, and the `claude-plugin` package skill count 20→22.
- **Memory**: a project mistake (`verify-dont-assert-taught-facts`) + a Layer-2 cross-project copy, the feature-`agents` decision (DD-1/DD-5), two project backlogs, and the per-session journal.

## Decisions (user-locked)

- **Naming**: `skill-writing` / `agent-writing` (verb "writing", unprefixed). **Scope**: these two skills only; the dangling `claude` doc-authoring standard (FLAG-2) stays out of scope (filed as a backlog).
- **DD-1 loadability**: mirror to both runtimes, `user-invocable: true`, `disable-model-invocation: false`, **no `Skill()` permission** → `.claude/settings.json` unchanged.
- **DD-3**: both standalone single-file SKILL.md. **DD-5**: one value-features prose paragraph naming both; no Loop/Cross-cutting/Supporting table row.

## Verification

- **Dual-system evaluation** (Claude + Codex) at Ideation and Execution — each went REVISE → remediated → PASS, catching real wrong-facts before they shipped (the `.agents/skills` script ownership, the DD-1 loadability model, an arg-less verify command, the `assistant` read-only mis-description, a stale skill count).
- `sync-plugin-package.sh --check` green · `check-markdown-links.sh` green (52 links) · `validate-frontmatter.sh` green on all promoted memory files · `.claude/settings.json` diff empty.

## Process notes

- The **verify-don't-assert** mistake recurred twice (Ideation leader + Execution executor, inside the very skills that codify verification) — promoted to project memory and Layer-2.
- The **main-tree-write** trap recurred across two teammates (executor + Wrap-up assistant); caught by manager disk-verification against the promotion manifest, corrected, and flagged for stronger enforcement next session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
