### PR TITLE
fix(deployment): G1 deployment hygiene — .claude/skills mirror root cause + manifest/version/install

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "gobbi",
       "description": "Structured orchestration, planning, execution, evaluation, memory, record, and handoff for Claude Code.",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "source": "./plugins/gobbi"
     }
   ]

--- a/.claude/skills/codex/task-metadata.md
+++ b/.claude/skills/codex/task-metadata.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/codex/task-metadata.md

--- a/.claude/skills/coding/SKILL.md
+++ b/.claude/skills/coding/SKILL.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/coding/SKILL.md

--- a/.claude/skills/coding/evaluation.md
+++ b/.claude/skills/coding/evaluation.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/coding/evaluation.md

--- a/.claude/skills/coding/review.md
+++ b/.claude/skills/coding/review.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/coding/review.md

--- a/.claude/skills/git/scripts/git-posture-probe.sh
+++ b/.claude/skills/git/scripts/git-posture-probe.sh
@@ -1,0 +1,1 @@
+../../../../.gobbi/projects/gobbi/skills/git/scripts/git-posture-probe.sh

--- a/.claude/skills/gobbi/hook-authoring.md
+++ b/.claude/skills/gobbi/hook-authoring.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/gobbi/hook-authoring.md

--- a/.claude/skills/memory/memory-vocabulary.json
+++ b/.claude/skills/memory/memory-vocabulary.json
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/memory/memory-vocabulary.json

--- a/.claude/skills/memory/scripts/validate-frontmatter.sh
+++ b/.claude/skills/memory/scripts/validate-frontmatter.sh
@@ -1,0 +1,1 @@
+../../../../.gobbi/projects/gobbi/skills/memory/scripts/validate-frontmatter.sh

--- a/.claude/skills/orchestration/scripts/agent-token-usage.sh
+++ b/.claude/skills/orchestration/scripts/agent-token-usage.sh
@@ -1,0 +1,1 @@
+../../../../.gobbi/projects/gobbi/skills/orchestration/scripts/agent-token-usage.sh

--- a/.claude/skills/orchestration/scripts/check-markdown-links.sh
+++ b/.claude/skills/orchestration/scripts/check-markdown-links.sh
@@ -1,0 +1,1 @@
+../../../../.gobbi/projects/gobbi/skills/orchestration/scripts/check-markdown-links.sh

--- a/.claude/skills/orchestration/scripts/check-merge-ref-integrity.sh
+++ b/.claude/skills/orchestration/scripts/check-merge-ref-integrity.sh
@@ -1,0 +1,1 @@
+../../../../.gobbi/projects/gobbi/skills/orchestration/scripts/check-merge-ref-integrity.sh

--- a/.claude/skills/orchestration/scripts/check-residual-vocab.sh
+++ b/.claude/skills/orchestration/scripts/check-residual-vocab.sh
@@ -1,0 +1,1 @@
+../../../../.gobbi/projects/gobbi/skills/orchestration/scripts/check-residual-vocab.sh

--- a/.claude/skills/orchestration/scripts/check-skill-mistakes.sh
+++ b/.claude/skills/orchestration/scripts/check-skill-mistakes.sh
@@ -1,0 +1,1 @@
+../../../../.gobbi/projects/gobbi/skills/orchestration/scripts/check-skill-mistakes.sh

--- a/.claude/skills/orchestration/scripts/check-workflow-mirror-consistency.sh
+++ b/.claude/skills/orchestration/scripts/check-workflow-mirror-consistency.sh
@@ -1,0 +1,1 @@
+../../../../.gobbi/projects/gobbi/skills/orchestration/scripts/check-workflow-mirror-consistency.sh

--- a/.claude/skills/orchestration/scripts/reconcile-session-metadata.sh
+++ b/.claude/skills/orchestration/scripts/reconcile-session-metadata.sh
@@ -1,0 +1,1 @@
+../../../../.gobbi/projects/gobbi/skills/orchestration/scripts/reconcile-session-metadata.sh

--- a/.claude/skills/orchestration/scripts/scaffold-session-dir.sh
+++ b/.claude/skills/orchestration/scripts/scaffold-session-dir.sh
@@ -1,0 +1,1 @@
+../../../../.gobbi/projects/gobbi/skills/orchestration/scripts/scaffold-session-dir.sh

--- a/.claude/skills/orchestration/scripts/validate-integration-log.sh
+++ b/.claude/skills/orchestration/scripts/validate-integration-log.sh
@@ -1,0 +1,1 @@
+../../../../.gobbi/projects/gobbi/skills/orchestration/scripts/validate-integration-log.sh

--- a/.claude/skills/record/scripts/init-record-map.sh
+++ b/.claude/skills/record/scripts/init-record-map.sh
@@ -1,0 +1,1 @@
+../../../../.gobbi/projects/gobbi/skills/record/scripts/init-record-map.sh

--- a/.claude/skills/record/scripts/verify-record-map.sh
+++ b/.claude/skills/record/scripts/verify-record-map.sh
@@ -1,0 +1,1 @@
+../../../../.gobbi/projects/gobbi/skills/record/scripts/verify-record-map.sh

--- a/.gobbi/projects/gobbi/backlogs/codex/codex-side-prompts-need-skill-load-directives.md
+++ b/.gobbi/projects/gobbi/backlogs/codex/codex-side-prompts-need-skill-load-directives.md
@@ -1,0 +1,68 @@
+---
+name: codex-side-prompts-need-skill-load-directives
+description: "Dual-system Codex proposer/evaluator prompts must carry a Codex-side Load-Directives preamble (read gobbi skills), so Codex runs the same skill-grounded procedure as its Claude counterpart."
+type: backlogs
+scope: project
+feature: null
+status: open
+created: 2026-07-01
+session: 0dc5cf75-54c5-4b52-82fa-b18750bdaade
+tags: [codex, dual-system, delegation, evaluation, process]
+author: claude
+priority: high
+---
+
+# Codex-side dual-system prompts must load gobbi skills (detailed prompts)
+
+## Design decision (USER, 2026-06-30)
+**In the gobbi system, Codex agents should get DETAILED prompts.** A Codex `codex exec` run
+in dual-system production/evaluation is a gobbi agent doing real gobbi work — it must be
+grounded in the same canonical skills/mistakes as its Claude counterpart, via a **Codex-side
+Load-Directives preamble** in the `@prompt-file`. Independence is preserved by NOT seeing the
+peer's output (the Claude draft / the other evaluator), NOT by withholding project standards.
+
+## The gap (observed, session 0dc5cf75 / G1)
+The dual-system Codex proposer + evaluator are invoked as `codex exec "@<prompt-file>"`. Codex
+is a stateless CLI with no gobbi context, so everything must be in the prompt. This session's
+Codex prompts INLINED a subset (independence stamp, output contract, the 7 perspective names,
+finding schema, verdict thresholds, scrutiny targets) but never directed Codex to **read the
+canonical gobbi skills**:
+- **Proposer prompts**: no `principles/SKILL.md`, no `mistakes/`. (Yet `codex/SKILL.md:153`
+  already sizes the proposer timeout for *"large skill reads + a complete draft"* — the design
+  EXPECTS skill reads; the prompt didn't ask for them.)
+- **Evaluator prompt**: no `evaluation/SKILL.md` (the 4-stage procedure, finding metadata,
+  producer/evaluator separation), no phase-specific `execution/evaluation.md` seed scenarios,
+  no `mistakes/` cross-check — while the parallel **Claude evaluator loaded all of them** via
+  its Load Directives. This breaks the dual-eval contract that *both systems run the same
+  7-perspective procedure*; the Codex side ran a lighter, ad-hoc version.
+
+**Impact:** worked this session (the Codex evaluator still caught 2 real High bugs on the
+inlined subset), but the asymmetry means the Codex side can apply inconsistent severity/schema
+or miss a class the full skill would catch. Latent, not yet a failure.
+
+## Fix
+Add a **Codex-side Load-Directives preamble** to the proposer/evaluator prompt patterns —
+mirroring the Claude subagent Load Directives (principles → rules → skills → mistakes),
+adapted for Codex (it READs files via absolute paths; no Skill tool):
+- **Proposer**: read `principles/SKILL.md` + the relevant domain skill(s) + `mistakes/{domain}`.
+- **Evaluator**: read `principles/SKILL.md` + `evaluation/SKILL.md` + the phase
+  `{loop}/evaluation.md` + `mistakes/{relevant}` — THEN run the 4-stage procedure.
+Then proceed to the (existing) task/independence/output-contract sections. The 1200s timeout
+already budgets for the reads.
+
+## Affected surfaces
+- `skills/codex/SKILL.md` § Dual-System Production + § Dual-System Evaluation — add the
+  mandatory Codex-side Load-Directives preamble to the worked prompt patterns (today they only
+  give the WRAPPER load directives, not Codex's).
+- `skills/orchestration/workflow/production.md` + `workflow/evaluation.md` — mandate it +
+  state that Codex runs the same skill-grounded procedure as Claude.
+- Any proposer/evaluator prompt template that encodes the `@prompt-file` shape.
+
+## Verification
+A future dual-system session's `proposer-prompt.md` / `codex-eval-prompt.md` opens with a
+"READ these SKILL.md/mistakes files first" block; the Codex evaluator's output applies the
+canonical finding metadata + shows a mistakes cross-check.
+
+## Related
+- [[dual-system-production-is-not-optional]] — same theme: don't shortcut the Codex co-work.
+- Evidence file: `sessions/2026-06-29-0dc5cf75-.../{1-ideation,3-planning,4-execution}/**/{proposer-prompt,codex-eval-prompt}.md` (the 5 as-shipped Codex prompts — none carry a skill-load preamble).

--- a/.gobbi/projects/gobbi/backlogs/evaluation/g1-eval-low-followups.md
+++ b/.gobbi/projects/gobbi/backlogs/evaluation/g1-eval-low-followups.md
@@ -1,0 +1,22 @@
+---
+name: g1-eval-low-followups
+description: "3 Low-severity doc-tightening follow-ups from the G1 dual-system Execution evaluation (non-blocking; shipped as-is)."
+type: backlogs
+scope: project
+feature: deployment-hygiene
+status: open
+created: 2026-06-30
+tags: [evaluation, deployment, docs]
+priority: low
+---
+
+# G1 Execution-eval — 3 Low follow-ups (non-blocking)
+
+From the dual-system Execution evaluation of G1 (session 0dc5cf75). All Low; G1 shipped with them open.
+
+- **F1 (assumption_risk / tooling):** `sync-plugin-package.sh agent_exposed_files()` operationalizes "exclude generated/cache" as "exclude dot-prefixed". A future NON-dot build artifact in a skill dir would be over-mirrored. No impact today (0 non-md/json/sh files). → note the dotfile assumption in the script comment, or add an extension whitelist if non-dot generated files appear.
+- **F2 (general / process):** the additive build does NOT auto-prune a stale mirror leaf when a canonical child is removed — only `--check` flags it (manual `git rm`). Matches existing `.agents`/`plugins` behavior (consistent). → optionally emit the exact `git rm` for stale leaves, or document the manual-prune in `skill-writing` P5.
+- **F3 (general / docs-sync):** `validate-plugin-hooks-fire-once.sh` header overstates auto-coverage — a future event is auto-covered for allow-listing + assert-if-present but NOT strict fire-once (the `OPERATOR_TRIGGERED_EVENTS` subset stays fixed). → tighten the comment to "auto-covered for allow-listing + assert-if-present; strict fire-once stays the operator-triggered subset".
+
+## Also surfaced (already fixed in G1, recorded for the record)
+- The fire-once validator was **non-runnable at baseline** (`printf '--- …'` crashed under `set -euo pipefail`) — a pre-existing bug the review campaign missed; fixed in commit 9c84d5ff. Lesson: a "validator" the review never RAN can hide a crash; run guards, don't just read them.

--- a/.gobbi/projects/gobbi/backlogs/process/integration-log-schema-doc-validator-drift.md
+++ b/.gobbi/projects/gobbi/backlogs/process/integration-log-schema-doc-validator-drift.md
@@ -1,0 +1,53 @@
+---
+name: integration-log-schema-doc-validator-drift
+description: "production.md Integration Log schema omits the leading `#` column the validate-integration-log.sh validator requires"
+type: backlogs
+scope: project
+feature: null
+status: open
+created: 2026-06-29
+session: 0dc5cf75-54c5-4b52-82fa-b18750bdaade
+tags: [process, docs]
+keywords: [integration-log, production, validator, schema-drift, dual-system]
+author: claude
+priority: medium
+project-scope: true
+shipped_in: null
+---
+
+# Integration Log schema drift — doc says 4 columns, validator requires 5
+
+## Context
+The dual-system production Integration Log (`working/reconciliation-iter{n}.md`) is documented in
+`orchestration/workflow/production.md` § Integration Log with a 4-field row schema —
+`delta` / `decision` / `why` / `codex_origin`. But the structural gate
+`skills/orchestration/scripts/validate-integration-log.sh` reads `decision` as awk/pipe field `$4`,
+which only holds when the table carries a LEADING `#` index column (`| # | delta | decision | why |
+codex_origin |`). A producer who follows the doc literally writes a 4-column table; the validator
+then reads `delta` at the wrong field, the header never matches, and it false-fails with "no
+Integration Log delta table found".
+
+## Why deferred
+G2-class (process / tooling hygiene), OUT of the G1 deployment-hygiene scope (C1 + C7). This slip
+just occurred in this very session — the G1 Integration Log was authored 4-column per the doc and
+the validator rejected it until a `#` column was added. It is a real doc/tool drift but belongs to
+a separate process-hygiene cluster, not G1.
+
+## When to pick up
+Any time. No prerequisite. Natural fit for a G2 (process/tooling) fix session. The fix is a doc-vs-
+tool reconciliation: either (a) update `production.md` § Integration Log to document the 5-column
+schema with the leading `#` index (recommended — the validator's column-read is the safer design,
+per its own COD-STRUCT-1 rationale), OR (b) relax the validator to locate the `decision` column by
+header name rather than fixed field `$4`. Decide one source of truth; align both.
+
+## Suggested approach
+Recommend (a): make `production.md` show the canonical 5-column header and a numbered example row,
+since the validator already documents WHY it reads a fixed column (avoiding a body-wide grep
+false-fail). Add a one-line note that the `#` column is required. Re-run
+`validate-integration-log.sh` against a doc-conformant example to confirm `VALID`.
+
+## Originating session
+`.gobbi/projects/gobbi/sessions/2026-06-29-0dc5cf75-54c5-4b52-82fa-b18750bdaade/`
+
+## Related
+- [[fix-d2-review-findings]] — sibling deployment/process fix queue from the same review campaign

--- a/.gobbi/projects/gobbi/features/deployment-hygiene/README.md
+++ b/.gobbi/projects/gobbi/features/deployment-hygiene/README.md
@@ -1,0 +1,29 @@
+---
+name: deployment-hygiene
+description: "The gobbi fix campaign's deployment-readiness cluster — plugin mirror integrity, manifest/version/install-validation hygiene (G1 done; G2/G3 pending)."
+type: features
+scope: project
+status: active
+created: 2026-06-30
+tags: [deployment, plugin, install-runtime, fix-campaign]
+---
+
+# deployment-hygiene
+
+Deployment-readiness work from the adversarial-review fix campaign. Folds under the
+`install-runtime` value-feature (the per-session runtime + plugin-package contract).
+
+## G1 — SHIPPED 2026-06-30 (PR off develop, session 0dc5cf75)
+The first fix cluster: the `.claude/skills` mirror root cause (C1) + manifest/version/install hygiene (C7).
+
+**A3 (USER-DECIDED 2026-06-29) — `.claude/skills` mirror mechanism:** per-file real dirs, **tool-owned** by `sync-plugin-package.sh`, mirroring docs AND support dirs (`scripts/`/`templates/`/`workflow/`) with the inventory **DERIVED per skill** from the canonical tree. Whole-dir symlinks rejected (Claude Code skill discovery does not resolve symlinked directories). Position S over docs-only.
+
+**A7 (USER-DECIDED 2026-06-29) — version cadence:** PATCH-only `0.5.x` on shipped-surface change (honors the standing no-v0.6.0 decision); all version-bearing files in lockstep; pre-publish gate with a derived (never hardcoded) baseline. Position P over full-semver.
+
+**What shipped (7 commits):** sync owns `.claude/skills` (derived enum + bidirectional `--check` parity; false-green killed) · skill docs corrected to script-owned · fire-once validator derives events from `hooks.json` + covers `SessionEnd` + accepts `.codex-plugin` + **fail-closed** on broken source · Codex `SessionStart` matcher wildcard dropped · new `validate-plugin-publish-readiness.sh` (strict semver) · version `0.5.0→0.5.1` lockstep.
+
+**Closed findings:** D2-015/010/030/031/032 + D6-002/003/004/006/007 + D6-007.
+
+## Remaining
+- **G2** (doc consistency: C2 links + C3 terms/counts + C6 stale CLI refs) and **G3** (structural: C4 dead-end-handoff + C5 staging-ownership) — see the fix-phase handoff plan.
+- See `backlogs/evaluation/g1-eval-low-followups.md` for the 3 Low eval follow-ups.

--- a/.gobbi/projects/gobbi/hooks/codex-hooks.json
+++ b/.gobbi/projects/gobbi/hooks/codex-hooks.json
@@ -2,7 +2,7 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "startup|resume|clear|compact|.*",
+        "matcher": "startup|resume|clear|compact",
         "hooks": [
           { "type": "command", "command": "bash \"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/hooks/session-start.sh\"" }
         ]

--- a/.gobbi/projects/gobbi/mistakes/codex/concurrent-proposer-checkout-wipes-unstaged-edits.md
+++ b/.gobbi/projects/gobbi/mistakes/codex/concurrent-proposer-checkout-wipes-unstaged-edits.md
@@ -1,0 +1,64 @@
+---
+name: concurrent-proposer-checkout-wipes-unstaged-edits
+description: A concurrent process (Codex proposer cleanup) ran git checkout in the shared worktree and wiped the producer's unstaged edits mid-run
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-06-29
+session: 2026-06-29-0dc5cf75-54c5-4b52-82fa-b18750bdaade
+tags: [process, git]
+keywords: [dual-system, codex-proposer, shared-worktree, git-checkout, unstaged-edits, edit-evaporation]
+author: claude
+domain: codex
+priority: high
+---
+
+# Concurrent proposer git-checkout wipes the producer's unstaged worktree edits
+
+## What happened
+During dual-system Execution (Claude producer + Codex proposer in parallel on the SAME
+worktree), the executor's `Edit` changes to `scripts/sync-plugin-package.sh` reported success
+and functioned across ~6 verification runs, then silently ROLLED BACK to the original committed
+file between two Bash calls. `git status` showed the script unmodified again; a harness reminder
+flagged it as "externally modified (intentional, by user or linter)". The manager identified the
+root cause: the Codex proposer's CLEANUP ran `git checkout -- scripts/sync-plugin-package.sh` in
+the shared worktree, discarding the producer's UNSTAGED edits. A partial build had already
+materialized the `.claude/skills` mirror symlinks, so they survived as orphaned untracked files —
+creating a FALSE-PASS trap where `readlink -e` checks and the OLD `--check` both passed even
+though the script no longer owned the mirror.
+
+## Why it happens (the mistaken assumption)
+The assumption is that a worktree is private to one agent. In dual-system production the producer
+and the Codex proposer share ONE worktree. A tree-level `git checkout -- <path>` / `git restore`
+/ `git stash` run by EITHER side (or its cleanup) discards ALL unstaged working-tree changes to
+that path — including the other side's in-flight edits. Unstaged edits live only in the working
+tree, so they are unprotected; the wipe is silent to the victim (no error). This is DISTINCT from
+the `edit-tool-silent-write-failure-on-worktree` trap: same symptom (edits evaporate), different
+root cause (a concurrent git op, not an Edit-tool no-op). The orphaned build artifacts then make
+the post-revert state LOOK correct to leaf-existence checks.
+
+## How to recognize
+- Dual-system production is ON (a Codex proposer runs in the same worktree as the Claude producer).
+- A file you edited reverts to its committed/original form mid-session; `git status` shows your
+  change gone; a harness reminder says the file was "externally modified".
+- Leaf-existence checks (`readlink -e`, `test -e`) pass while the SCRIPT that should own them no
+  longer contains the logic — the artifacts are orphans from a partial build.
+
+## Correct approach
+- COMMIT (or at least `git add`) edits EARLY to move them into the index/HEAD. Once committed, a
+  stray `git checkout -- <path>` restores YOUR version, not the pre-edit one — the danger is
+  neutralized. Unstaged edits are the only ones at risk.
+- Prove SCRIPT-OWNERSHIP, never orphan-existence: clear the generated artifacts (`rm -rf` the
+  mirror), THEN run the build and confirm the script RE-CREATES them from scratch, THEN `--check`.
+  A leaf-existence check alone is a false-pass when orphans survive a revert.
+- Verify the COMMITTED blob carries the logic (`git show HEAD:<path> | grep`), not just the working
+  tree — and confirm working tree == HEAD blob.
+- After any detected revert, re-apply via a robust Bash write (heredoc / `perl -i`), not `Edit`.
+- System/process fix for the manager: the Codex proposer (and its cleanup) MUST confine writes to
+  `proposals/codex/` and MUST NOT run a tree-level `git checkout`/`git restore`/`git stash` that
+  touches producer-owned paths in the shared worktree.
+
+## Related
+- [[edit-tool-silent-write-failure-on-worktree]] — same symptom (worktree edits evaporate), different root (Edit-tool no-op vs concurrent git checkout)
+- [[edit-write-tool-success-without-disk-persistence]] — sibling: tool "success" is not disk-persistence proof

--- a/.gobbi/projects/gobbi/mistakes/codex/dual-system-production-is-not-optional.md
+++ b/.gobbi/projects/gobbi/mistakes/codex/dual-system-production-is-not-optional.md
@@ -1,0 +1,42 @@
+---
+name: dual-system-production-is-not-optional
+description: "Manager downgraded dual-system PRODUCTION to single-mode for efficiency; user corrected — keep the Codex co-work at creation, not only evaluation."
+  domain: process
+type: mistakes
+status: active
+scope: project
+domain: codex
+priority: high
+feature: null
+---
+
+# Dual-system production is core, not optional ceremony
+
+**What went wrong**
+At the Ideation WORK sub-phase, the manager (auto-decide) downgraded `propose.mode`
+from the default `dual` to a single Claude-only leader run, framing the Codex
+proposer as heavyweight ceremony not worth it for a "well-specified fix whose
+design decisions the user decides anyway." The manager reserved dual-system only
+for evaluation. The user corrected: "keep the codex co-work system, not only for
+evaluation."
+
+**Why it went wrong (mistaken assumption)**
+The manager assumed the cross-family value of the Codex co-worker lives mainly at
+review time, and that at creation the user's own decision is a sufficient
+cross-check. That is wrong: dual-system PRODUCTION is a core gobbi principle —
+the anti-groupthink second generator at creation that the user trusts at review
+must also exist at creation (`orchestration/workflow/production.md` § Why
+dual-system production). Treating the proposer as optional silently strips the
+creation-time anti-groupthink signal.
+
+**How to recognize it next time**
+Any internal monologue that proposes setting `propose.mode: single`, skipping the
+Codex proposer, or "running this loop Claude-only to save effort / because the
+user decides anyway." Default is `dual` for all five productive steps; `single`
+is a deliberate, user-authorized exception, never a manager efficiency shortcut.
+
+**Corrected approach**
+Run dual-system production (Codex proposer in parallel with the Claude producer,
+then selective integration of the frozen proposal) for every productive loop by
+default. Only set `single` mode when the user explicitly authorizes it. The
+Codex co-work runs at BOTH production and evaluation.

--- a/.gobbi/projects/gobbi/notes/process/2026-06-30-g1-deployment-hygiene-handoff.md
+++ b/.gobbi/projects/gobbi/notes/process/2026-06-30-g1-deployment-hygiene-handoff.md
@@ -1,0 +1,40 @@
+---
+name: g1-deployment-hygiene-handoff
+description: "Next-session handoff: G1 fix cluster shipped (PR off develop); G2/G3 remain; dual-system production lessons promoted."
+type: notes
+scope: project
+feature: deployment-hygiene
+status: active
+created: 2026-06-30
+session: 0dc5cf75-54c5-4b52-82fa-b18750bdaade
+tags: [handoff, deployment, fix-campaign, dual-system]
+---
+
+# Handoff — G1 deployment hygiene shipped
+
+## What this session did
+First fix session of the adversarial-review FIX campaign. User restructured the 7 handoff clusters → **3 by theme** (G1 deploy hygiene = C1+C7; G2 doc consistency = C2+C3+C6; G3 structural = C4+C5). Shipped **G1** end-to-end through the full gobbi workflow (Ideation→Planning→Execution→Wrap-up, dual-system production + evaluation).
+
+**Branch** `claude-2026-06-29-0dc5cf75-…`, 7 commits off develop, PR opened `--base develop`. All gates green: `sync --check` 0, publish-readiness gate 0, validator runnable, version 0.5.1 lockstep.
+
+## Decisions locked (carry forward)
+- **A3** = per-file real-dir `.claude/skills` mirror, tool-owned, docs+support-dirs, inventory DERIVED per skill (no whole-dir symlinks). **A7** = PATCH-only 0.5.x + version-bearing-file lockstep + derived-baseline pre-publish gate.
+
+## Dual-system value this session (concrete)
+- Production caught the A3/A7 design forks → surfaced for user decision.
+- Ideation eval caught the "derive-don't-hardcode contradiction" (the draft hardcoded the mirror inventory while preaching derive — Codex's structure perspective PASSED it; Claude caught it).
+- **Execution eval: Codex caught 2 High deployment bugs the Claude evaluator rated PASS** — validator not fail-closed on a broken install; gate accepting leading-zero semver. Both fixed (commit 23d669cd). This is the anti-groupthink signal earning its cost on the exact bug-class G1 fixes.
+
+## Lessons promoted to memory
+- `mistakes/codex/dual-system-production-is-not-optional.md` — never downgrade dual PRODUCTION to single for efficiency (user correction).
+- `mistakes/codex/concurrent-proposer-checkout-wipes-unstaged-edits.md` — the Execution dual-proposer must NOT share the executor's worktree with workspace-write; a stray `git checkout` wipes unstaged edits. **System fix needed:** run the Execution Codex proposer read-only (`-o`) or in an isolated worktree; never let it run tree-level git checkout/restore/stash. (production.md / codex skill should encode this.)
+
+## Open / next
+- **G2** and **G3** clusters (separate sessions, per the fix-phase handoff plan on the 5ac6cf6e `-fixplan` branch — note that plan is NOT yet merged to develop).
+- `backlogs/process/integration-log-schema-doc-validator-drift.md` — production.md Integration-Log schema omits the `#` column its validator requires.
+- `backlogs/evaluation/g1-eval-low-followups.md` — 3 Low doc-tightening items.
+- The fire-once validator was non-runnable at baseline (printf crash) — fixed here; flags that the review campaign reads guards without running them.
+
+## Process notes
+- Teammate-continuation messaging lagged (teammates processed one instruction per wake; follow-ups needed re-triggering). Fresh report-back spawns were more reliable than continuing idle teammates.
+- Wrap-up promotion + handoff done manager-direct (not via a Wrap-up assistant) due to session length + teammate lag.

--- a/.gobbi/projects/gobbi/skills/claude-plugin/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/claude-plugin/SKILL.md
@@ -201,7 +201,7 @@ The `marketplace.json` file is NOT inside the plugin directory. Claude Code read
 
 ### Symlinked package layout
 
-The canonical sources stay under `.gobbi/projects/gobbi/{skills,agents,hooks}`. The shared package under `plugins/gobbi/` links to those canonical directories instead of copying them. The development hook paths under `.claude/hooks/` also remain symlinks to `.gobbi/projects/gobbi/hooks/`.
+The canonical sources stay under `.gobbi/projects/gobbi/{skills,agents,hooks}`. The shared package under `plugins/gobbi/` links to those canonical directories instead of copying them. The development hook paths under `.claude/hooks/` also remain symlinks to `.gobbi/projects/gobbi/hooks/`. The workspace-visible skill mirror `.claude/skills/{name}/` is likewise script-owned: `sync-plugin-package.sh` builds it as a real directory of per-file symlinks DERIVED from each canonical skill's agent-exposed children (top-level files AND support subdirs `scripts/`/`templates/`/`workflow/`), and `--check` validates it as per-skill bidirectional parity. It is per-file (not a whole-dir symlink) because Claude Code skill discovery does not resolve a symlinked directory.
 
 Historical note: verification on 2026-06-02 showed Claude marketplace install dereferenced repo-internal symlinks, while Codex install behavior around symlinked component directories needed separate smoke testing. Gobbi keeps the repo package symlinked; Codex installed-cache behavior is verified with `scripts/check-codex-plugin-smoke.sh`.
 
@@ -215,6 +215,7 @@ Run `scripts/sync-plugin-package.sh --check` before claiming the plugin package 
 | `.claude/hooks/session-start.sh` | `.gobbi/projects/gobbi/hooks/session-start.sh` |
 | `.claude/hooks/post-tool-use-agents.sh` | `.gobbi/projects/gobbi/hooks/post-tool-use-agents.sh` |
 | `.claude/hooks/session-end.sh` | `.gobbi/projects/gobbi/hooks/session-end.sh` |
+| `.claude/skills/{name}/` | real dir of per-file symlinks, DERIVED per skill from `.gobbi/projects/gobbi/skills/{name}/` (top-level files AND support subdirs); built + parity-checked by `sync-plugin-package.sh --check` |
 
 Use `scripts/sync-plugin-package.sh` after topology drift to restore the symlinks.
 

--- a/.gobbi/projects/gobbi/skills/skill-writing/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/skill-writing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-writing
-description: "Use when authoring a new gobbi skill — frontmatter schema, section skeleton, length norm, and the script-owned vs hand-owned wiring procedure."
+description: "Use when authoring a new gobbi skill — frontmatter schema, section skeleton, length norm, and the script-owned mirror wiring procedure."
 allowed-tools: Read, Grep, Glob, Bash
 ---
 
@@ -54,8 +54,8 @@ This is the highest-value discipline here: see [`mistakes.md#planning-asserted-s
 
 Authoring the `SKILL.md` body is half the job. The skill is done only when it is wired into
 both runtimes AND the wiring is verified by running the check — `sync-plugin-package.sh --check`
-exits 0, and each hand-created `.claude/skills/{name}/SKILL.md` symlink resolves under
-`readlink`. A skill on disk that no runtime loads is an unfinished skill.
+exits 0, and each `.claude/skills/{name}/SKILL.md` symlink (script-created from the canonical
+tree) resolves under `readlink`. A skill on disk that no runtime loads is an unfinished skill.
 
 ---
 
@@ -106,7 +106,7 @@ fourth is a tool-permission gate, NOT a discoverability gate.
 | **Mirror availability** | which runtimes the skill is wired into (P5) | both runtimes | a skill is intentionally one-runtime-only |
 | **`/`-visibility** | `user-invocable` frontmatter (Claude Code skill) | `true` (`/`-visible) | the skill is internal machinery the user should never invoke by slash — set `user-invocable: false` |
 | **Model auto-invocation** | `disable-model-invocation` frontmatter | `false` (model may auto-load) | the model must NEVER auto-load it (it is destructive or strictly user-triggered) — set `disable-model-invocation: true` |
-| **Tool-permission preapproval** | a `Skill()` entry in `.claude/settings.json` + `allowed-tools` | NO `Skill()` entry | zero-prompt preapproval is wanted (P5 step 6) |
+| **Tool-permission preapproval** | a `Skill()` entry in `.claude/settings.json` + `allowed-tools` | NO `Skill()` entry | zero-prompt preapproval is wanted (P5 step 5) |
 
 The defaults (`user-invocable: true`, `disable-model-invocation: false`) need no frontmatter
 key — omit both and the skill is `/`-visible and model-auto-loadable. A reference/authoring
@@ -177,57 +177,54 @@ skill-surface doc (OUT of the memory frontmatter standard — [`memory/rules.md`
 governed by its own `check-skill-mistakes.sh` guard, not by `validate-frontmatter.sh`. Wrap-up
 promotion writes it (Always-Ask routing — see [`mistake/SKILL.md`](../mistake/SKILL.md)); a brief
 that lists `skills/{name}/SKILL.md` in its Load Directives ALSO lists `skills/{name}/mistakes.md`
-as a companion path, so the trap loads in the skill's context. Wire it with the same per-file
-`.claude` symlink as `SKILL.md` (P5 step 1).
+as a companion path, so the trap loads in the skill's context. It is mirrored into
+`.claude/skills/{name}/` by the same DERIVED per-file sync as `SKILL.md` — the sync script
+enumerates every agent-exposed child, so the companion needs no separate wiring step (P5).
 
-### P5 — Wiring a new skill (SCRIPT-OWNED vs HAND-OWNED)
+### P5 — Wiring a new skill (the sync script owns every mirror)
 
-A skill has three mirror surfaces, at different granularity (verified by `readlink`):
+A skill has three mirror surfaces, at different granularity (verified by `readlink`). All
+three are SCRIPT-OWNED — `scripts/sync-plugin-package.sh` builds and validates every one:
 
 | Surface | Shape | Owner |
 |---|---|---|
-| `.claude/skills/{name}/` | a REAL directory holding one symlink PER FILE (`SKILL.md -> ../../../.gobbi/projects/gobbi/skills/{name}/SKILL.md`, plus one per companion the skill exposes — e.g. `mistakes.md`) | **HAND-CREATED** |
+| `.claude/skills/{name}/` | a REAL directory holding one symlink PER FILE — every agent-exposed child of the canonical skill, DERIVED (`SKILL.md`, any companion such as `mistakes.md`, and support subdirs `scripts/`/`templates/`/`workflow/` mirrored as real dirs of per-file symlinks) | **SCRIPT-OWNED** |
 | `.agents/skills/{name}` | ONE whole-dir symlink (`-> ../../.gobbi/projects/gobbi/skills/{name}`) | **SCRIPT-OWNED** |
 | `plugins/gobbi/skills` | ONE whole-dir symlink for ALL skills (`-> ../../.gobbi/projects/gobbi/skills`) | **SCRIPT-OWNED** |
 
 `scripts/sync-plugin-package.sh` iterates every canonical skill dir and creates/refreshes
-the `.agents/skills/{name}` per-skill symlink (its loop) plus the three plugin whole-dir
-symlinks. It does NOT touch `.claude/skills/` — that surface manages only `.claude/hooks/`.
-So the Codex mirror and the plugin mirror are produced for you by the script; only the
-Claude per-file symlink is yours to hand-create. Read the script's loop and `--check`
-mode before relying on this split.
+ALL three mirrors: the `.agents/skills/{name}` whole-dir symlink (its loop), the plugin
+whole-dir symlinks, AND the `.claude/skills/{name}` per-file mirror. The `.claude/skills`
+mirror is built from a DERIVED per-skill enumeration of agent-exposed children (no hardcoded
+file list) — per-file symlinks inside real directories, for top-level files AND support
+subdirs, at the `../` depth that matches each leaf's nesting. `--check` validates it as
+per-skill BIDIRECTIONAL parity (the mirror child set equals the canonical child set, with
+`readlink -e` per leaf), exiting non-zero on any drift. Read the script's build loop and
+`--check` mode before relying on this. No mirror surface is wired by hand.
 
 Wire a new skill in this order, each step with its verify command:
 
-1. **Hand-create the Claude per-file symlink(s).** From the worktree root:
-   ```bash
-   mkdir -p .claude/skills/{name}
-   ln -s ../../../.gobbi/projects/gobbi/skills/{name}/SKILL.md .claude/skills/{name}/SKILL.md
-   ```
-   Verify: `readlink -e .claude/skills/{name}/SKILL.md` resolves to the canonical file.
-   If the skill ships child docs, create one per-file symlink for each file the skill exposes.
-   A skill carrying a `mistakes.md` companion (the skill-owned mistakes home, hybrid model)
-   needs the SAME per-file symlink:
-   ```bash
-   ln -s ../../../.gobbi/projects/gobbi/skills/{name}/mistakes.md .claude/skills/{name}/mistakes.md
-   ```
-   Only `.claude` needs this per-file action: the `.agents/skills/{name}` and `plugins/gobbi/skills`
-   whole-dir symlinks (step 2) point at the WHOLE skill dir, so they auto-expose `mistakes.md`
-   with no extra step.
-2. **Run the sync script.** It auto-creates `.agents/skills/{name}` and refreshes the plugin
-   whole-dir symlinks:
+1. **Run the sync script — it builds every mirror.** From the worktree root:
    ```bash
    bash scripts/sync-plugin-package.sh
    ```
-3. **Confirm the mirror is intact.** The check must exit 0:
+   This creates/refreshes `.agents/skills/{name}`, the plugin whole-dir symlinks, AND the
+   `.claude/skills/{name}` per-file mirror. The `.claude/skills` mirror is DERIVED from the
+   canonical skill's agent-exposed children, so a new `SKILL.md`, a `mistakes.md` companion,
+   any child doc, and any support subdir (`scripts/`/`templates/`/`workflow/`) are mirrored
+   automatically — you name none of them and wire nothing by hand.
+2. **Confirm every mirror is intact.** The check must exit 0:
    ```bash
    bash scripts/sync-plugin-package.sh --check; echo "exit=$?"
    ```
-4. **plugin.json — NO edit.** Both `plugin.json` manifests are metadata-only; conventional
+   `--check` validates all three mirrors, including `.claude/skills/{name}` per-skill
+   bidirectional parity (a missing child OR a stale extra both fail). Spot-check a leaf:
+   `readlink -e .claude/skills/{name}/SKILL.md` resolves to the canonical file.
+3. **plugin.json — NO edit.** Both `plugin.json` manifests are metadata-only; conventional
    `skills/` directories auto-load without a manifest key (see
    [`claude-plugin/SKILL.md` § Component auto-loading](../claude-plugin/SKILL.md)). Adding a
    `skills` key has caused load failures. Do not edit `plugin.json` for a new skill.
-5. **Add a value-features prose mention in `gobbi/SKILL.md`.** A meta/authoring skill gets a
+4. **Add a value-features prose mention in `gobbi/SKILL.md`.** A meta/authoring skill gets a
    dedicated prose mention in the Product value-features section (mirror the existing
    "Install / runtime is documented, not a skill." paragraph), NOT a Loop / Cross-cutting /
    Supporting Skill-Map table row. Skill-Map placement is not uniform: some skills have a
@@ -237,7 +234,7 @@ Wire a new skill in this order, each step with its verify command:
    → 0). So a new meta skill does not need a row; this DD-5 step is the deliberate choice to
    give it a dedicated prose paragraph. Verify your mention landed:
    `grep -n '{name}' .gobbi/projects/gobbi/skills/gobbi/SKILL.md`.
-6. **`Skill()` permission — ONLY if zero-prompt preapproval is wanted.** Add a `Skill({name})`
+5. **`Skill()` permission — ONLY if zero-prompt preapproval is wanted.** Add a `Skill({name})`
    entry to `.claude/settings.json` ONLY when you want the runtime to never prompt on the
    skill's tool use. It is NOT required for the skill to load (P2). If you skip it,
    `.claude/settings.json` is UNCHANGED.
@@ -268,14 +265,15 @@ A clean run prints `ALL LINKS RESOLVE (...)` and exits 0.
 - **MUST verify every wiring claim by reading the owner** — read the script source, `readlink`
   the symlink, read `.claude/settings.json` — never assert a wiring surface exists.
 - **MUST verify loadability empirically** before declaring the skill done —
-  `sync-plugin-package.sh --check` exits 0 AND each hand-created `.claude/skills/{name}` symlink
-  resolves under `readlink`.
+  `sync-plugin-package.sh --check` exits 0 (it now validates `.claude/skills/{name}` per-skill
+  parity too) AND each `.claude/skills/{name}` per-file symlink resolves under `readlink`.
 - **NEVER edit `plugin.json`** for a new skill — conventional `skills/` auto-load; a manifest
   key has caused load failures.
 - **NEVER add a `Skill()` permission unless zero-prompt preapproval is wanted** — it is a
   permission gate, not a discoverability gate; the skill loads without it.
-- **NEVER create the `.agents/skills/{name}` or plugin symlinks by hand** — they are
-  script-owned; run `sync-plugin-package.sh` and let it create them.
+- **NEVER create the `.agents/skills/{name}`, plugin, OR `.claude/skills/{name}` symlinks by
+  hand** — all three mirrors are script-owned; run `sync-plugin-package.sh` and let it create
+  them.
 
 ## Anti-patterns
 
@@ -290,9 +288,10 @@ A clean run prints `ALL LINKS RESOLVE (...)` and exits 0.
   briefing. Verify a MECHANISM by reading its owner (script / settings / symlink), not by
   reading the end-state.
 
-- **Hand-creating the script-owned symlinks.** Manually `ln -s`-ing `.agents/skills/{name}`
-  or the plugin dir. They are produced by `sync-plugin-package.sh`; a hand-made one drifts
-  from what `--check` expects. Hand-create ONLY the `.claude/skills/{name}` per-file symlink.
+- **Hand-creating the script-owned symlinks.** Manually `ln -s`-ing `.agents/skills/{name}`,
+  the plugin dir, OR a `.claude/skills/{name}` per-file symlink. All three mirrors are produced
+  by `sync-plugin-package.sh`; a hand-made one drifts from what `--check` expects. Run the
+  script and let it build every mirror.
 
 - **Adding a Skill-Map table row for a meta skill.** Putting an authoring/reference skill in
   the Loop / Cross-cutting / Supporting table. Meta/entry skills live in value-feature prose,

--- a/plugins/gobbi/.claude-plugin/plugin.json
+++ b/plugins/gobbi/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gobbi",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Full gobbi workflow system — structured orchestration with multi-stance evaluation, adaptive planning, and git workflow isolation for Claude Code",
   "author": {
     "name": "HahyeonJeon"

--- a/plugins/gobbi/.codex-plugin/plugin.json
+++ b/plugins/gobbi/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gobbi",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Gobbi workflow skills and hooks for Codex.",
   "author": {
     "name": "HahyeonJeon",

--- a/scripts/sync-plugin-package.sh
+++ b/scripts/sync-plugin-package.sh
@@ -20,6 +20,9 @@ expected_dev_session_start='../../.gobbi/projects/gobbi/hooks/session-start.sh'
 expected_dev_post_tool_use='../../.gobbi/projects/gobbi/hooks/post-tool-use-agents.sh'
 expected_dev_session_end='../../.gobbi/projects/gobbi/hooks/session-end.sh'
 
+canonical_skills_root="$repo_root/.gobbi/projects/gobbi/skills"
+claude_skills_drift=0
+
 check_link() {
   local link_path="$1"
   local expected_target="$2"
@@ -72,6 +75,154 @@ for_each_canonical_skill() {
   done | sort
 }
 
+# Enumerate a canonical skill's agent-exposed children, recursively, as paths relative
+# to the skill dir. The set is DERIVED from the canonical tree — no skill name, file
+# name, or count is hardcoded. Dot-prefixed entries (e.g. .DS_Store, editor/cache files)
+# are the generated/metadata class and are pruned at every level; everything else
+# (.md docs, link-target data files like memory-vocabulary.json, scripts/ shell files,
+# templates/ and workflow/ children) is an agent-exposed child.
+agent_exposed_files() {
+  local dir="$canonical_skills_root/$1"
+  ( cd "$dir" && find . -mindepth 1 -name '.*' -prune -o -type f -print ) \
+    | sed 's|^\./||' | LC_ALL=C sort
+}
+
+# Enumerate the canonical skill's real subdirs (dot-pruned), relative to the skill dir.
+# Used by the --check directory-parity pass that catches an empty stale mirror subdir.
+agent_exposed_dirs() {
+  local dir="$canonical_skills_root/$1"
+  ( cd "$dir" && find . -mindepth 1 -name '.*' -prune -o -type d -print ) \
+    | sed 's|^\./||' | LC_ALL=C sort
+}
+
+# Enumerate the per-file mirror leaves under .claude/skills/{skill} (each a symlink, plus
+# any stray real file), relative to the skill dir, dot entries excluded. No -L is needed:
+# the mirror dirs are REAL and only the leaves are symlinks, so plain find lists every
+# leaf and (correctly) does NOT descend a forbidden directory symlink — which then shows
+# up as a stale dir-entry vs. the missing per-file children during the parity comparison.
+claude_skill_mirror_files() {
+  local dir="$repo_root/.claude/skills/$1"
+  [[ -d "$dir" ]] || return 0
+  ( cd "$dir" && find . -mindepth 1 -name '.*' -prune -o ! -type d -print ) \
+    | sed 's|^\./||' | LC_ALL=C sort
+}
+
+# Enumerate the mirror's REAL subdirs (no -L, so a forbidden directory symlink is excluded
+# here and instead reported by the explicit dir-symlink guard). Used for directory parity.
+claude_skill_mirror_dirs() {
+  local dir="$repo_root/.claude/skills/$1"
+  [[ -d "$dir" ]] || return 0
+  ( cd "$dir" && find . -mindepth 1 -name '.*' -prune -o -type d -print ) \
+    | sed 's|^\./||' | LC_ALL=C sort
+}
+
+# Relative symlink target for a mirror leaf. The per-file `../` depth scales with the
+# leaf's nesting level: a top-level file (.claude/skills/{skill}/{file}) needs 3, a
+# support-subdir child (.claude/skills/{skill}/scripts|templates|workflow/{file}) needs 4,
+# i.e. 3 + the number of directory segments in the relative path.
+claude_link_target() {
+  local skill="$1" rel="$2"
+  local slashes="${rel//[!\/]/}"
+  local depth=$(( 3 + ${#slashes} ))
+  local prefix="" i
+  for (( i = 0; i < depth; i++ )); do prefix+="../"; done
+  printf '%s.gobbi/projects/gobbi/skills/%s/%s' "$prefix" "$skill" "$rel"
+}
+
+# Validate per-skill BIDIRECTIONAL parity for the .claude/skills mirror: the mirror's
+# child set must equal the canonical skill's agent-exposed child set (a missing child OR a
+# stale extra both count as drift), and every canonical child must resolve through a
+# correctly-targeted symlink (find-L/readlink-e discipline). Sets a global drift flag
+# rather than fail-fast, so one run reports every drifted entry. Always returns 0.
+check_claude_skills_mirror() {
+  local skill_name="$1"
+  local mirror_dir="$repo_root/.claude/skills/$skill_name"
+  local canonical mirror missing stale rel target actual link_path
+  local canon_dirs mirror_dirs stale_dirs
+
+  canonical="$(agent_exposed_files "$skill_name")"
+
+  if [[ ! -d "$mirror_dir" ]]; then
+    printf '.claude/skills/%s is missing (no mirror directory)\n' "$skill_name" >&2
+    claude_skills_drift=1
+    return 0
+  fi
+
+  mirror="$(claude_skill_mirror_files "$skill_name")"
+
+  # comm must use the SAME collation as the LC_ALL=C sort in the producers above,
+  # else it both warns "not in sorted order" and computes the set difference wrongly.
+  missing="$(LC_ALL=C comm -23 <(printf '%s\n' "$canonical") <(printf '%s\n' "$mirror"))"
+  stale="$(LC_ALL=C comm -13 <(printf '%s\n' "$canonical") <(printf '%s\n' "$mirror"))"
+
+  if [[ -n "$missing" ]]; then
+    while IFS= read -r rel; do
+      [[ -n "$rel" ]] || continue
+      printf '.claude/skills/%s/%s is missing from the mirror\n' "$skill_name" "$rel" >&2
+      claude_skills_drift=1
+    done <<< "$missing"
+  fi
+
+  if [[ -n "$stale" ]]; then
+    while IFS= read -r rel; do
+      [[ -n "$rel" ]] || continue
+      printf '.claude/skills/%s/%s is a stale mirror entry (no canonical child)\n' "$skill_name" "$rel" >&2
+      claude_skills_drift=1
+    done <<< "$stale"
+  fi
+
+  while IFS= read -r rel; do
+    [[ -n "$rel" ]] || continue
+    link_path="$mirror_dir/$rel"
+    target="$(claude_link_target "$skill_name" "$rel")"
+    if [[ ! -L "$link_path" ]]; then
+      if [[ -e "$link_path" ]]; then
+        printf '.claude/skills/%s/%s exists and is not a symlink\n' "$skill_name" "$rel" >&2
+        claude_skills_drift=1
+      fi
+      continue
+    fi
+    actual="$(readlink "$link_path")"
+    if [[ "$actual" != "$target" ]]; then
+      printf '.claude/skills/%s/%s points to %s; expected %s\n' "$skill_name" "$rel" "$actual" "$target" >&2
+      claude_skills_drift=1
+    elif [[ ! -e "$link_path" ]]; then
+      printf '.claude/skills/%s/%s points to a missing target\n' "$skill_name" "$rel" >&2
+      claude_skills_drift=1
+    fi
+  done <<< "$canonical"
+
+  # Explicit guard for the A3 #1-forbidden case (integrated from the Codex proposal):
+  # a mirror entry that is a symlink resolving to a DIRECTORY. Claude Code skill
+  # discovery does not resolve a symlinked directory, so a dir symlink silently
+  # un-discovers the skill. The set-difference above already FAILS on this, but the
+  # explicit message names the real fix (replace with a real dir of per-file symlinks)
+  # instead of only "stale entry".
+  while IFS= read -r link_path; do
+    [[ -n "$link_path" ]] || continue
+    if [[ -L "$link_path" && -d "$link_path" ]]; then
+      printf '.claude/skills/%s/%s is a directory symlink; expected a real dir of per-file symlinks\n' "$skill_name" "${link_path#"$mirror_dir"/}" >&2
+      claude_skills_drift=1
+    fi
+  done < <(find "$mirror_dir" -type l)
+
+  # Bidirectional DIRECTORY parity (integrated from the Codex proposal). The file-only
+  # comparison cannot see an EMPTY stale subdir — it has no leaf to flag — so a stale
+  # support subdir (e.g. a renamed canonical scripts/ dir) would otherwise be invisible.
+  canon_dirs="$(agent_exposed_dirs "$skill_name")"
+  mirror_dirs="$(claude_skill_mirror_dirs "$skill_name")"
+  stale_dirs="$(LC_ALL=C comm -13 <(printf '%s\n' "$canon_dirs") <(printf '%s\n' "$mirror_dirs"))"
+  if [[ -n "$stale_dirs" ]]; then
+    while IFS= read -r rel; do
+      [[ -n "$rel" ]] || continue
+      printf '.claude/skills/%s/%s is a stale mirror subdir (no canonical dir)\n' "$skill_name" "$rel" >&2
+      claude_skills_drift=1
+    done <<< "$stale_dirs"
+  fi
+
+  return 0
+}
+
 if $check_mode; then
   while IFS= read -r skill_name; do
     check_link "$repo_root/.agents/skills/$skill_name" "../../.gobbi/projects/gobbi/skills/$skill_name"
@@ -85,7 +236,33 @@ if $check_mode; then
   check_link "$repo_root/.claude/hooks/session-end.sh" "$expected_dev_session_end"
   test -f "$package_root/.codex-plugin/plugin.json"
   test -f "$package_root/.claude-plugin/plugin.json"
-  printf 'Codex skill, plugins/gobbi, and .claude hook symlinks are intact\n'
+
+  # .claude/skills mirror — per-skill bidirectional parity, derived from the canonical
+  # tree (no hardcoded skill/file list, no magic count). Catches a missing child, a
+  # missing support-subdir file, AND a stale extra entry.
+  while IFS= read -r skill_name; do
+    check_claude_skills_mirror "$skill_name"
+  done < <(for_each_canonical_skill)
+
+  # Stale mirror directory: a .claude/skills/{name} whose canonical skill no longer
+  # exists (the dir-granularity half of the bidirectional set-equality).
+  if [[ -d "$repo_root/.claude/skills" ]]; then
+    for mirror_entry in "$repo_root"/.claude/skills/*; do
+      [[ -e "$mirror_entry" ]] || continue
+      mirror_name="${mirror_entry##*/}"
+      if [[ ! -d "$canonical_skills_root/$mirror_name" ]]; then
+        printf '.claude/skills/%s has no canonical skill (stale mirror dir)\n' "$mirror_name" >&2
+        claude_skills_drift=1
+      fi
+    done
+  fi
+
+  if [[ "$claude_skills_drift" -ne 0 ]]; then
+    printf '.claude/skills mirror is out of sync with the canonical skill tree\n' >&2
+    exit 1
+  fi
+
+  printf 'Codex skill, plugins/gobbi, .claude/skills, and .claude hook symlinks are intact\n'
   exit 0
 fi
 
@@ -100,4 +277,17 @@ ensure_link "$repo_root/.claude/hooks/session-start.sh" "$expected_dev_session_s
 ensure_link "$repo_root/.claude/hooks/post-tool-use-agents.sh" "$expected_dev_post_tool_use"
 ensure_link "$repo_root/.claude/hooks/session-end.sh" "$expected_dev_session_end"
 
-printf 'synchronized Codex skill, plugins/gobbi, and .claude hook symlinks\n'
+# .claude/skills mirror — OWN it from the DERIVED per-skill child enumeration. One
+# mechanism throughout: a per-file symlink inside a real directory, for top-level files
+# AND every support subdir (scripts/ templates/ workflow/), at the `../` depth that
+# matches the leaf's nesting. Additive + idempotent: ensure_link only creates/repairs,
+# so a re-run is a no-op and the other mirrors are untouched. Stale leaves (a removed
+# canonical child) are reported by --check, not pruned here.
+while IFS= read -r skill_name; do
+  while IFS= read -r rel; do
+    [[ -n "$rel" ]] || continue
+    ensure_link "$repo_root/.claude/skills/$skill_name/$rel" "$(claude_link_target "$skill_name" "$rel")"
+  done < <(agent_exposed_files "$skill_name")
+done < <(for_each_canonical_skill)
+
+printf 'synchronized Codex skill, plugins/gobbi, .claude/skills, and .claude hook symlinks\n'

--- a/scripts/validate-plugin-hooks-fire-once.sh
+++ b/scripts/validate-plugin-hooks-fire-once.sh
@@ -258,8 +258,15 @@ if [[ -f "$HOOKS_JSON" ]] && jq -e . "$HOOKS_JSON" >/dev/null 2>&1; then
     readarray -t REGISTERED_EVENTS < <(jq -r '.hooks | keys[]' "$HOOKS_JSON")
     printf 'Registered events (from hooks.json keys): %s\n\n' "${REGISTERED_EVENTS[*]}"
 else
-    info "installed hooks.json not found or invalid at ${HOOKS_JSON}; cannot derive registered events"
-    printf '\n'
+    # FAIL-CLOSED: REGISTERED_EVENTS is DERIVED from the installed hooks.json. If
+    # that file is missing or invalid JSON, the validator cannot read the very
+    # hook registration it exists to validate — so it must NOT continue with an
+    # empty registered set and reach "ALL ASSERTIONS PASSED" against a broken
+    # install. Treat an unreadable hooks.json as fatal and exit non-zero.
+    fail "installed hooks.json not found or invalid at ${HOOKS_JSON} — cannot read the plugin's own hook registration; refusing to validate a broken install"
+    printf '\n--- Summary ---\n'
+    printf 'Failures: %d\n' "$FAILURES"
+    exit $(( FAILURES > 0 ? 1 : 0 ))
 fi
 
 # Events the OPERATOR PROCEDURE (PHASE 4) triggers exactly once and that this

--- a/scripts/validate-plugin-hooks-fire-once.sh
+++ b/scripts/validate-plugin-hooks-fire-once.sh
@@ -3,11 +3,17 @@
 #
 # AUTONOMOUS DELIVERABLE — operator-assisted validation script.
 # This script validates, for an INSTALLED gobbi plugin, that:
-#   (i)   Each of the 3 hook registrations fires EXACTLY ONCE per event trigger.
-#         Events covered: SessionStart, PostToolUse, PostToolUseFailure.
+#   (i)   Each registered hook fires EXACTLY ONCE per event trigger.
+#         The expected event set is DERIVED from the installed hooks.json keys
+#         (currently SessionStart, PostToolUse, PostToolUseFailure, SessionEnd) —
+#         a future event added to hooks.json is auto-covered with no edit here.
+#         Operator-triggered events (SessionStart, PostToolUse, PostToolUseFailure,
+#         per PHASE 4) are asserted to fire exactly once. SessionEnd is allow-listed
+#         and asserted-if-present — it is awkward to trigger deterministically once,
+#         so its absence is informational, never a failure.
 #   (ii)  The installed-cache top level holds only the allow-set:
-#         {.claude-plugin, skills, agents, hooks}
-#         with no leaked repo/project-memory dirs.
+#         {.claude-plugin, skills, agents, hooks} (+ optional .codex-plugin when
+#         the package was installed via Codex) with no leaked repo/project-memory dirs.
 #
 # !! DO NOT RUN THIS SCRIPT BEFORE COMPLETING THE OPERATOR PROCEDURE BELOW !!
 # The marker-dir must be populated by live hook fires before the assertions run.
@@ -240,18 +246,62 @@ printf 'Cache root : %s\n' "$CACHE_ROOT"
 printf '\n'
 
 # ---------------------------------------------------------------------------
+# Derive the registered hook-event set from the installed plugin's own
+# hooks.json. The events this plugin registers ARE the top-level keys of
+# hooks/hooks.json, so deriving them (instead of hardcoding a 3-event list)
+# means a future event added to hooks.json — e.g. SessionEnd — is covered here
+# automatically, with no edit to this script.
+# ---------------------------------------------------------------------------
+HOOKS_JSON="${CACHE_ROOT}/hooks/hooks.json"
+declare -a REGISTERED_EVENTS=()
+if [[ -f "$HOOKS_JSON" ]] && jq -e . "$HOOKS_JSON" >/dev/null 2>&1; then
+    readarray -t REGISTERED_EVENTS < <(jq -r '.hooks | keys[]' "$HOOKS_JSON")
+    printf 'Registered events (from hooks.json keys): %s\n\n' "${REGISTERED_EVENTS[*]}"
+else
+    info "installed hooks.json not found or invalid at ${HOOKS_JSON}; cannot derive registered events"
+    printf '\n'
+fi
+
+# Events the OPERATOR PROCEDURE (PHASE 4) triggers exactly once and that this
+# script asserts fire-once on (a missing marker means a skipped trigger -> FAIL).
+# This is the operator-exercised subset, bound to PHASE 4 — NOT the registered
+# set. Registered events outside this subset (SessionEnd, future events) are
+# allow-listed and asserted-if-present (lenient), never required to be triggered.
+OPERATOR_TRIGGERED_EVENTS=( "SessionStart" "PostToolUse" "PostToolUseFailure" )
+
+# Membership test, robust to an empty argument list.
+in_list() {
+    local needle="$1"; shift
+    local item
+    for item in "$@"; do
+        [[ "$item" == "$needle" ]] && return 0
+    done
+    return 1
+}
+
+# ---------------------------------------------------------------------------
 # Section 1: Per-event one-marker assertion
 # Events: SessionStart, PostToolUse, PostToolUseFailure
 # ---------------------------------------------------------------------------
-printf '--- Section 1: hook fire-once markers ---\n'
+printf '%s\n' '--- Section 1: hook fire-once markers ---'
 
+# check_marker <event> [strict|lenient]
+#   strict  (default): a missing marker is a FAIL (operator-triggered event).
+#   lenient          : a missing marker is INFO, not FAIL (registered but awkward
+#                      to trigger, e.g. SessionEnd) — but a present marker is still
+#                      asserted to be exactly-once.
 check_marker() {
     local event="$1"
+    local mode="${2:-strict}"
     local marker_file="${MARKER_DIR}/${event}"
 
     if [[ ! -f "$marker_file" ]]; then
-        fail "marker file absent for event '${event}': ${marker_file}"
-        info "  Trigger missing? See PHASE 4 in the operator procedure."
+        if [[ "$mode" == "lenient" ]]; then
+            info "event '${event}' registered but not exercised this run; fires-once not asserted"
+        else
+            fail "marker file absent for event '${event}': ${marker_file}"
+            info "  Trigger missing? See PHASE 4 in the operator procedure."
+        fi
         return
     fi
 
@@ -268,9 +318,17 @@ check_marker() {
     fi
 }
 
-check_marker "SessionStart"
-check_marker "PostToolUse"
-check_marker "PostToolUseFailure"
+# 1a. Operator-triggered events: strict fire-once (a missing marker is a FAIL).
+for event in "${OPERATOR_TRIGGERED_EVENTS[@]}"; do
+    check_marker "$event" strict
+done
+
+# 1b. Registered events NOT in the operator-triggered subset (SessionEnd, and any
+#     future hooks.json event): allow-listed + asserted-if-present (lenient).
+for event in ${REGISTERED_EVENTS[@]+"${REGISTERED_EVENTS[@]}"}; do
+    in_list "$event" "${OPERATOR_TRIGGERED_EVENTS[@]}" && continue
+    check_marker "$event" lenient
+done
 
 # Also assert no unexpected marker files (extra hook events or double-fires
 # from dev .claude/settings.json registrations polluting the marker dir)
@@ -282,17 +340,19 @@ for f in "${MARKER_DIR}"/*; do
     printf '  %s: %d line(s)\n' "$basename_f" "$lines"
 done
 
+# A marker is allowed iff it names a REGISTERED event (derived from hooks.json
+# keys) or an operator-triggered event. A SessionEnd marker is therefore allowed
+# — SessionEnd is a hooks.json key — and never flagged a dev-registration leak.
 UNEXPECTED_MARKERS=0
 for f in "${MARKER_DIR}"/*; do
     [[ -f "$f" ]] || continue
     basename_f=$(basename "$f")
-    case "$basename_f" in
-        SessionStart|PostToolUse|PostToolUseFailure) ;;
-        *)
-            fail "unexpected marker file: ${basename_f} — dev registration leak?"
-            UNEXPECTED_MARKERS=$(( UNEXPECTED_MARKERS + 1 ))
-            ;;
-    esac
+    if in_list "$basename_f" "${OPERATOR_TRIGGERED_EVENTS[@]}" ${REGISTERED_EVENTS[@]+"${REGISTERED_EVENTS[@]}"}; then
+        :
+    else
+        fail "unexpected marker file: ${basename_f} — not a registered hooks.json event (dev registration leak?)"
+        UNEXPECTED_MARKERS=$(( UNEXPECTED_MARKERS + 1 ))
+    fi
 done
 if [[ "$UNEXPECTED_MARKERS" -eq 0 ]]; then
     pass "no unexpected marker files in marker dir"
@@ -308,7 +368,7 @@ printf '\n'
 #   *.md files at the top level (repo docs, README, CHANGELOG etc.)
 #   node_modules/  dist/  src/  scripts/
 # ---------------------------------------------------------------------------
-printf '--- Section 2: installed-cache allow-set ---\n'
+printf '%s\n' '--- Section 2: installed-cache allow-set ---'
 
 if [[ ! -d "$CACHE_ROOT" ]]; then
     fail "installed-cache dir not found: ${CACHE_ROOT}"
@@ -320,6 +380,11 @@ fi
 
 ALLOW_SET=( ".claude-plugin" "skills" "agents" "hooks" )
 ALLOW_SET_JOINED=$(printf '%s\n' "${ALLOW_SET[@]}")
+
+# .codex-plugin ships only when the package was installed via Codex; on a Claude
+# install it is absent. It is allow-listed (presence must NOT fail) but NOT
+# required (absence is informational, not a failure).
+OPTIONAL_ALLOW_SET=( ".codex-plugin" )
 
 # Enumerate actual top-level entries
 declare -a ACTUAL_ENTRIES=()
@@ -349,18 +414,29 @@ ALLOW_VIOLATIONS=0
 for e in "${ACTUAL_ENTRIES[@]}"; do
     if printf '%s\n' "${ALLOW_SET[@]}" | grep -qx "$e"; then
         pass "allow-set member present: ${e}"
+    elif printf '%s\n' "${OPTIONAL_ALLOW_SET[@]}" | grep -qx "$e"; then
+        pass "optional allow-set member present: ${e}"
     else
         fail "UNEXPECTED entry in installed-cache: '${e}' — not in allow-set"
         ALLOW_VIOLATIONS=$(( ALLOW_VIOLATIONS + 1 ))
     fi
 done
 
-# Check every allow-set member is actually present
+# Check every REQUIRED allow-set member is actually present
 for expected in "${ALLOW_SET[@]}"; do
     if printf '%s\n' "${ACTUAL_ENTRIES[@]}" | grep -qx "$expected"; then
         pass "required allow-set entry present: ${expected}"
     else
         fail "required allow-set entry MISSING: ${expected}"
+    fi
+done
+
+# Optional members: present -> info, absent -> info. Never a failure.
+for opt in "${OPTIONAL_ALLOW_SET[@]}"; do
+    if printf '%s\n' "${ACTUAL_ENTRIES[@]}" | grep -qx "$opt"; then
+        info "optional allow-set entry present: ${opt} (Codex-installed cache)"
+    else
+        info "optional allow-set entry absent: ${opt} (not a failure; Claude-only install)"
     fi
 done
 
@@ -388,7 +464,7 @@ printf '\n'
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
-printf '--- Summary ---\n'
+printf '%s\n' '--- Summary ---'
 if [[ "$FAILURES" -eq 0 ]]; then
     printf "${GREEN}ALL ASSERTIONS PASSED${RESET}\n"
     printf 'Hooks fire exactly once per event; installed-cache allow-set is clean.\n'

--- a/scripts/validate-plugin-publish-readiness.sh
+++ b/scripts/validate-plugin-publish-readiness.sh
@@ -54,9 +54,11 @@ info() { printf "${YELLOW}INFO${RESET}  %s\n" "$*"; }
 
 FAILURES=0
 
-# Semver core (MAJOR.MINOR.PATCH) — the form gobbi versions use. Deliberately no
+# Semver core (MAJOR.MINOR.PATCH) — the form gobbi versions use. Each numeric
+# identifier is `0` OR a non-zero-leading run, so a leading-zero version like
+# `01.0.0` is rejected as invalid (per the semver grammar). Deliberately no
 # version literal here, so the no-hardcoded-baseline guard stays satisfied.
-semver_re='^[0-9]+\.[0-9]+\.[0-9]+$'
+semver_re='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
 
 # version_gt <a> <b> — exit 0 (true) iff a > b numerically by MAJOR.MINOR.PATCH.
 # Both args must already be valid semver (callers guard with semver_re). 10# forces

--- a/scripts/validate-plugin-publish-readiness.sh
+++ b/scripts/validate-plugin-publish-readiness.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# validate-plugin-publish-readiness.sh
+#
+# Pre-publish readiness gate for the gobbi plugin package (the A7 version policy).
+# Run AFTER `scripts/sync-plugin-package.sh --check`.
+#
+# It FAILS (non-zero exit) when any of:
+#   (a) shipped-surface files changed since the baseline but the installer-visible
+#       version did NOT increase (a content change shipped without a bump, so
+#       `claude plugin update` would not deliver it),
+#   (b) the version-bearing files disagree on the version, or
+#   (c) any version-bearing value is not valid semver.
+#
+# The baseline is NEVER hardcoded — there is no version literal in this script.
+# It is derived, in priority order, from:
+#   1. an explicit `--base <ref>` argument,
+#   2. else `git merge-base HEAD develop`,
+#   3. else the latest release tag (`git describe --tags --abbrev=0`).
+#
+# Usage:
+#   bash scripts/validate-plugin-publish-readiness.sh [--base <ref>]
+#
+# Shipped surface (a change to it requires a version bump):
+#   plugins/gobbi/**
+#   .gobbi/projects/gobbi/{skills,agents,hooks}/**   (the canonical targets of the
+#                                                     plugins/gobbi/{skills,agents,
+#                                                     hooks} symlinks; git tracks
+#                                                     changes at the real paths)
+#   .claude-plugin/marketplace.json                  (the version-bearing marketplace
+#                                                     file)
+#
+# Version-bearing files (must agree + be valid semver):
+#   plugins/gobbi/.claude-plugin/plugin.json   ->  .version  (installer-visible)
+#   plugins/gobbi/.codex-plugin/plugin.json    ->  .version
+#   .claude-plugin/marketplace.json            ->  .plugins[] | select(.name=="gobbi") | .version
+#
+# NOTE: the Codex marketplace file .agents/plugins/marketplace.json carries NO
+# version field, so it is EXCLUDED from the version-bearing set until it gains one.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Colour helpers (degrade gracefully when not a tty)
+# ---------------------------------------------------------------------------
+if [[ -t 1 ]]; then
+    RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RESET='\033[0m'
+else
+    RED=''; GREEN=''; YELLOW=''; RESET=''
+fi
+
+pass() { printf "${GREEN}PASS${RESET}  %s\n" "$*"; }
+fail() { printf "${RED}FAIL${RESET}  %s\n" "$*"; FAILURES=$(( FAILURES + 1 )); }
+info() { printf "${YELLOW}INFO${RESET}  %s\n" "$*"; }
+
+FAILURES=0
+
+# Semver core (MAJOR.MINOR.PATCH) — the form gobbi versions use. Deliberately no
+# version literal here, so the no-hardcoded-baseline guard stays satisfied.
+semver_re='^[0-9]+\.[0-9]+\.[0-9]+$'
+
+# version_gt <a> <b> — exit 0 (true) iff a > b numerically by MAJOR.MINOR.PATCH.
+# Both args must already be valid semver (callers guard with semver_re). 10# forces
+# base-10 so a leading-zero component is never misread as octal.
+version_gt() {
+    local a1 a2 a3 b1 b2 b3
+    IFS=. read -r a1 a2 a3 <<<"$1"
+    IFS=. read -r b1 b2 b3 <<<"$2"
+    (( 10#$a1 > 10#$b1 )) && return 0
+    (( 10#$a1 < 10#$b1 )) && return 1
+    (( 10#$a2 > 10#$b2 )) && return 0
+    (( 10#$a2 < 10#$b2 )) && return 1
+    (( 10#$a3 > 10#$b3 )) && return 0
+    return 1
+}
+
+usage() {
+    printf 'usage: %s [--base <ref>]\n' "$0" >&2
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+base_ref=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --base)
+            [[ $# -ge 2 ]] || { printf 'ERROR: --base requires a ref argument\n' >&2; exit 2; }
+            base_ref="$2"; shift 2 ;;
+        --base=*)
+            base_ref="${1#--base=}"; shift ;;
+        -h|--help)
+            usage; exit 0 ;;
+        *)
+            printf 'ERROR: unknown argument: %s\n' "$1" >&2; usage; exit 2 ;;
+    esac
+done
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Baseline resolution (never hardcoded)
+# ---------------------------------------------------------------------------
+resolve_baseline() {
+    if [[ -n "$base_ref" ]]; then
+        printf '%s' "$base_ref"; return 0
+    fi
+    local mb
+    if mb=$(git -C "$repo_root" merge-base HEAD develop 2>/dev/null); then
+        printf '%s' "$mb"; return 0
+    fi
+    local tag
+    if tag=$(git -C "$repo_root" describe --tags --abbrev=0 2>/dev/null); then
+        printf '%s' "$tag"; return 0
+    fi
+    return 1
+}
+
+if ! baseline="$(resolve_baseline)"; then
+    printf 'ERROR: could not resolve a baseline ref.\n' >&2
+    printf '  Pass --base <ref>, or run where `git merge-base HEAD develop` or a\n' >&2
+    printf '  release tag resolves.\n' >&2
+    exit 2
+fi
+
+if ! git -C "$repo_root" rev-parse --verify --quiet "${baseline}^{commit}" >/dev/null; then
+    printf 'ERROR: baseline ref does not resolve to a commit: %s\n' "$baseline" >&2
+    exit 2
+fi
+
+printf '\n=== validate-plugin-publish-readiness.sh ===\n'
+printf 'Repo root : %s\n' "$repo_root"
+printf 'Baseline  : %s\n\n' "$baseline"
+
+# ---------------------------------------------------------------------------
+# Version-bearing files + their jq selectors
+# ---------------------------------------------------------------------------
+claude_manifest_rel='plugins/gobbi/.claude-plugin/plugin.json'
+codex_manifest_rel='plugins/gobbi/.codex-plugin/plugin.json'
+claude_market_rel='.claude-plugin/marketplace.json'
+
+read_json() {  # read_json <relpath> <jq-filter>
+    jq -r "$2" "$repo_root/$1" 2>/dev/null || true
+}
+
+v_claude=$(read_json "$claude_manifest_rel" '.version')
+v_codex=$(read_json "$codex_manifest_rel" '.version')
+v_market=$(read_json "$claude_market_rel" '.plugins[] | select(.name=="gobbi") | .version')
+
+# ---------------------------------------------------------------------------
+# (c) semver validity + (b) agreement across version-bearing files
+# ---------------------------------------------------------------------------
+printf '%s\n' '--- version-bearing files ---'
+
+vb_names=( "$claude_manifest_rel" "$codex_manifest_rel" "$claude_market_rel" )
+vb_values=( "$v_claude" "$v_codex" "$v_market" )
+
+for i in "${!vb_names[@]}"; do
+    name="${vb_names[$i]}"
+    val="${vb_values[$i]}"
+    if [[ -z "$val" || "$val" == "null" ]]; then
+        fail "version missing in ${name}"
+    elif [[ ! "$val" =~ $semver_re ]]; then
+        fail "version in ${name} is not valid semver: '${val}'"
+    else
+        pass "valid semver in ${name}: ${val}"
+    fi
+done
+
+if [[ "$v_claude" == "$v_codex" && "$v_codex" == "$v_market" ]]; then
+    pass "version-bearing files agree: ${v_claude}"
+else
+    fail "version-bearing files DISAGREE: claude='${v_claude}' codex='${v_codex}' marketplace='${v_market}'"
+fi
+
+printf '\n'
+
+# ---------------------------------------------------------------------------
+# (a) shipped-surface change since baseline must be matched by a version increase
+# ---------------------------------------------------------------------------
+printf '%s\n' '--- shipped-surface vs version bump ---'
+
+# Installer-visible baseline version: read the Claude plugin manifest AS OF the
+# baseline ref. Absent (new file) => no baseline => any valid version is an
+# increase.
+baseline_version=$(git -C "$repo_root" show "${baseline}:${claude_manifest_rel}" 2>/dev/null \
+    | jq -r '.version' 2>/dev/null || true)
+
+# git diff <baseline> -- <paths> compares the baseline to the WORKING TREE, so it
+# catches both committed and uncommitted shipped-surface changes about to ship.
+mapfile -t changed_files < <(git -C "$repo_root" diff --name-only "$baseline" -- \
+    'plugins/gobbi' \
+    '.gobbi/projects/gobbi/skills' \
+    '.gobbi/projects/gobbi/agents' \
+    '.gobbi/projects/gobbi/hooks' \
+    "$claude_market_rel" 2>/dev/null || true)
+
+if (( ${#changed_files[@]} > 0 )); then
+    info "shipped-surface files changed since ${baseline} (${#changed_files[@]}):"
+    for f in "${changed_files[@]}"; do
+        info "    ${f}"
+    done
+    if [[ -z "$baseline_version" || "$baseline_version" == "null" || ! "$baseline_version" =~ $semver_re ]]; then
+        pass "no usable baseline version at ${baseline} (new/unparseable package) — version-increase requirement satisfied"
+    elif [[ ! "$v_claude" =~ $semver_re ]]; then
+        info "current installer version is not valid semver (failed above); skipping increase comparison"
+    elif version_gt "$v_claude" "$baseline_version"; then
+        pass "shipped surface changed and installer version increased: ${baseline_version} -> ${v_claude}"
+    else
+        fail "shipped surface changed since ${baseline} but installer version did NOT increase (baseline ${baseline_version}, current ${v_claude}) — a version bump is required"
+    fi
+else
+    info "no shipped-surface change since ${baseline}; version bump not required"
+fi
+
+printf '\n'
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '%s\n' '--- Summary ---'
+if [[ "$FAILURES" -eq 0 ]]; then
+    printf "${GREEN}PUBLISH-READY${RESET}\n"
+    printf 'Version-bearing files agree, are valid semver, and any shipped-surface change carries a version increase.\n'
+    exit 0
+else
+    printf "${RED}%d CHECK(S) FAILED${RESET} — not publish-ready; review FAIL lines above.\n" "$FAILURES"
+    exit 1
+fi


### PR DESCRIPTION
## What & why
First fix cluster (**G1**) of the adversarial-review fix campaign — the deployment-readiness slice. Closes the campaign's single highest-leverage root cause (C1) plus the manifest/version/install-validation hygiene defects (C7). Makes gobbi's plugin surface trustworthy to ship.

## Changes (8 commits)
**C1 — `.claude/skills` mirror root cause**
- `sync-plugin-package.sh` now **owns** `.claude/skills` in both build and `--check`, from a **DERIVED** per-skill enumeration (no hardcoded skill/file/count). One mechanism: per-file symlinks in real dirs for docs + support subdirs. `--check` does per-skill **bidirectional** parity (files AND dirs) and exits non-zero on any drift — **the false-green is dead**. 19 missing leaves (`coding`, 4 `scripts/` dirs, `task-metadata.md`, …) materialized.
- `skill-writing` P5 + `claude-plugin` docs corrected: `.claude/skills` is script-owned, not hand-created.

**C7 — manifest / version / install hygiene**
- fire-once validator derives its expected event set from `hooks.json` keys, covers `SessionEnd`, accepts `.codex-plugin`, and is **fail-closed** on an unreadable `hooks.json` (was non-runnable at baseline — pre-existing `printf` crash, fixed).
- Codex `SessionStart` matcher: dropped the `|.*` wildcard.
- new `validate-plugin-publish-readiness.sh` — derived (never hardcoded) baseline, version-bearing-file lockstep, strict semver (rejects leading zeros), shipped-surface bump gate.
- version `0.5.0 → 0.5.1` lockstep across the 3 version-bearing files.

Closes: D2-015/010/030/031/032, D6-002/003/004/006/007.

## Decisions (user-locked)
- **A3**: per-file real-dir mirror, tool-owned, docs+support-dirs, inventory derived per skill (whole-dir symlinks rejected — Claude Code discovery doesn't resolve symlinked dirs).
- **A7**: PATCH-only `0.5.x` + lockstep + derived-baseline pre-publish gate.

## Verification
All gates green: `sync-plugin-package.sh --check` 0 · `validate-plugin-publish-readiness.sh` 0 (fails pre-bump, green post-bump) · validator `bash -n` 0 · `check-codex-plugin-smoke.sh` 0. Bidirectional parity 96/96; negative tests (missing child / stale extra / dir-symlink) all fail correctly.

## Dual-system review
Built with dual-system production + evaluation. The **Codex evaluator caught 2 High deployment bugs the Claude evaluator rated PASS** (validator not fail-closed; gate accepting `01.0.0`) — both fixed in `23d669cd`. Anti-groupthink signal on the exact bug-class this PR fixes.

## Follow-ups (non-blocking, in repo)
`backlogs/evaluation/g1-eval-low-followups.md` (3 Low doc items) · `backlogs/process/integration-log-schema-doc-validator-drift.md`. G2/G3 clusters are separate sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01YRobBQfWbgVF65MCqziQ3x