### PR TITLE
docs: add codex adversarial review

### DIFF
--- a/.gobbi/projects/gobbi/plans/workflow/2026-07-01-codex-conducted-adversarial-review-charter.md
+++ b/.gobbi/projects/gobbi/plans/workflow/2026-07-01-codex-conducted-adversarial-review-charter.md
@@ -1,0 +1,375 @@
+---
+name: codex-conducted-adversarial-review-charter
+description: Executable charter for a Codex-conducted general adversarial review of Gobbi, with added Codex compatibility checks
+type: plans
+scope: project
+feature: null
+status: active
+created: 2026-07-01
+session: 019f1ef9-a676-7f12-8d78-922f12cb64e9
+tags: [planning, process, codex]
+keywords: [adversarial-review, gobbi-surface, docs-design, templates, naming, codex-compatibility, review-methodology]
+author: codex
+task: Run a Codex-conducted general adversarial review of Gobbi with added Codex compatibility checks
+task_count: 8
+supersedes: adversarial-review-charter
+superseded_by: null
+---
+
+# Codex-Conducted Adversarial Review Charter for Gobbi
+
+This document is a **charter**, not the review. It is the executable spec for a
+Codex-conducted adversarial review of Gobbi's system surface. The review is general:
+workflow, agents, skills, memory, docs design, templates, naming, runtime packaging, and
+operator experience are all in scope. Codex compatibility is an added review point set, not
+the whole lens.
+
+The review must use Codex only in this session. Do not use Claude Code, Claude Code tools, or
+Claude Code runtime assumptions as required review machinery. Previous Claude Code review
+files remain source context for deduplication and regression checks; they are not overwritten.
+
+## What This Charter Gives You
+
+- Eight review dimensions, D1-D8, with concrete targets and pass/fail signals.
+- A deeper standard for docs design, templates, and naming/word choice in Gobbi skills.
+- A Codex compatibility add-on checklist that is applied where it affects the general system.
+- A concurrent Codex lane methodology with second-pass validation for Critical/High findings.
+- A body-level finding format compatible with the existing review artifact style.
+- Preservation rules for all previous `2026-06-29-*` review files.
+
+## What This Charter Is Not
+
+- It is not a fix plan.
+- It does not authorize edits to skills, agents, runtime docs, hooks, manifests, scripts, or
+  previous review artifacts.
+- It is not a claim that this Codex-only session has satisfied Gobbi's normal dual-system
+  Claude+Codex guarantee. The substitute guarantee for this session is **multi-Codex
+  independence**: separate Codex review lanes plus independent second-pass validation for each
+  Critical/High finding.
+
+## Scope Contract
+
+### In Scope
+
+- Gobbi's whole system surface: canonical skills, canonical agents, runtime wrappers,
+  workflow docs, memory docs/templates, plugin package, install/runtime docs, scripts, hooks,
+  and prior review outputs used as context.
+- The previous review corpus under `.gobbi/projects/gobbi/reviews/adversarial-review/`, read
+  for deduplication and gap detection.
+- Docs design: skill hierarchy, section order, navigation, cross-links, examples, reference
+  placement, and reader journey.
+- Templates: frontmatter, required fields, writer/reader ownership, lifecycle timing,
+  validation expectations, and usability.
+- Naming and wording: skill names, file names, role names, state names, verbs, labels,
+  enum terms, repeated concepts, and terms that make users or agents guess.
+- Codex compatibility add-on checks: `.agents/skills`, `.codex/agents`, `.codex/AGENTS.md`,
+  `plugins/gobbi/.codex-plugin/plugin.json`, Codex hook config, native Codex session identity,
+  Codex user-decision flow, Codex smoke checks, and installed-cache boundaries.
+
+### Out Of Scope
+
+- Any fix for a finding.
+- Rewriting or deleting prior `2026-06-29-*` review files.
+- Claude Code runtime installation, `.claude/skills`, `.claude-plugin`, or Claude-only hooks
+  except where shared canonical sources create a Codex-impacting or general Gobbi defect.
+- Treating Codex compatibility as the dominant review lens.
+- Exhaustive file-by-file audit of the whole memory tree. Memory content may be sampled; memory
+  mechanism docs and templates are in the core system surface.
+
+## Prior Review Dedup Rule
+
+All previous review files are retained unchanged and used only as context:
+
+- `.gobbi/projects/gobbi/reviews/adversarial-review/2026-06-29-gobbi-adversarial-review.md`
+- `.gobbi/projects/gobbi/reviews/adversarial-review/2026-06-29-gobbi-adversarial-review-d2.md`
+- `.gobbi/projects/gobbi/reviews/adversarial-review/2026-06-29-gobbi-adversarial-review-d3-d5.md`
+- `.gobbi/projects/gobbi/reviews/adversarial-review/2026-06-29-gobbi-adversarial-review-d4.md`
+- `.gobbi/projects/gobbi/reviews/adversarial-review/2026-06-29-gobbi-adversarial-review-d6.md`
+
+A new finding must be one of:
+
+- `new`: not present in the prior corpus.
+- `regression`: previously fixed or contradicted by current state.
+- `new-variant`: same class as prior finding, but with a distinct location, trigger, or runtime
+  effect.
+- `codex-impacting-shared-source`: prior Claude-only or bridge-only finding that also affects
+  native Codex through shared sources.
+
+If the prior corpus already states the same defect with the same evidence, cite it as
+`existing` and do not re-file it.
+
+## Review Dimensions
+
+### D1 - End-To-End Workflow Correctness
+
+Review Configuration -> Ideation -> Preparation -> Planning -> Execution -> Wrap-up.
+
+Check:
+- Each loop's output matches the next loop's input.
+- DISCUSSION, WORK, EVALUATION, RECORD, and ITER/EXIT are owned and reachable.
+- PASS/REVISE/FAIL paths are explicit.
+- Session state, session record, and memory promotion boundaries agree.
+- Artifact freeze points are clear before evaluation.
+- Failure recovery paths are executable.
+
+Codex add-on:
+- Native Codex uses `CODEX_THREAD_ID`, not Claude session IDs.
+- Rollout lookup failure is non-fatal.
+- Codex user decisions route through parent-thread questions or `request_user_input` when
+  available.
+
+### D2 - Agents, Skills, And Delegation Completeness
+
+Review role prompts, skill maps, load directives, custom-agent wrappers, status contracts,
+and delegation templates.
+
+Check:
+- Agents can execute their role without hidden context.
+- Required skills and companion mistakes are named as exact files.
+- Handoffs between roles and loops are explicit.
+- Evaluators remain read-only and separate from producers.
+- Spawned agents are told how to prove they loaded required skills.
+
+Codex add-on:
+- `.codex/agents/*.toml` wrappers point at canonical role prompts.
+- Codex agents do not hard-code models or effort.
+- Codex evaluator uses read-only sandboxing.
+- Codex paths load `.agents/skills`, not user-level skill locations.
+
+### D3 - Docs Design And Information Architecture
+
+Review how Gobbi explains itself to a new manager, a spawned specialist, and a maintainer
+editing the system.
+
+Check:
+- Each skill starts with its purpose, owner, inputs, outputs, and boundaries.
+- Large skills have maps, stable section order, and clear "read next" guidance.
+- Runtime-specific branches are separated from general rules.
+- Examples are close to the procedure they illustrate.
+- Cross-links resolve and point to the right abstraction level.
+- Glossary terms live in one source of truth and are not redefined differently elsewhere.
+
+Fail signals:
+- A reader must already know Gobbi to locate the next instruction.
+- A runtime-specific note interrupts a general procedure without an explicit branch.
+- A section is mostly historical explanation but sits inside an operational path.
+- The same concept appears in several places with no source-of-truth pointer.
+
+### D4 - Templates And Schema Usability
+
+Review memory templates, session templates, settings/state/session schemas, delegation
+templates, review formats, and any generated-skill or generated-agent scaffolds.
+
+Check:
+- Every template says who writes it, when, where it lives, and who reads it next.
+- Required fields are distinguishable from optional fields.
+- Frontmatter enums match the memory rules and evaluation metadata.
+- Writer permissions match lifecycle timing.
+- Templates are neither too sparse to guide agents nor so verbose they invite copy errors.
+- Validation commands or guards exist for mechanically checkable structures.
+
+Codex add-on:
+- Templates do not require Claude-only fields in native Codex paths.
+- Codex session metadata can degrade cleanly when rollout details are missing.
+- Codex plugin and hook manifests are validated with the correct Codex-specific checks.
+
+### D5 - Naming, Vocabulary, And Word Choice Clarity
+
+Review names and wording as operational design, not polish.
+
+Check:
+- The same thing has one name across skills, agents, templates, and scripts.
+- One term does not mean several things.
+- Verbs match the action: create, stage, promote, reconcile, verify, evaluate, record, wrap up.
+- Names are literal enough for spawned agents to follow without guessing.
+- Abbreviations and shorthand are defined or removed.
+- Enum values are stable and capitalized consistently.
+- File and directory names match the concept users expect to find there.
+
+Special focus terms:
+- phase, loop, sub-phase, iter, verdict, disposition, staging, promotion, sole-writer,
+  producer, proposer, evaluator, REVIEW, RECORD, Wrap-up, session record, memory, template,
+  artifact, finding, decision, backlog.
+
+Fail signals:
+- A word sounds natural locally but contradicts another skill's meaning.
+- A name encodes implementation detail where the user-facing concept matters.
+- A "temporary" or "historical" term still appears in active procedure.
+- A label makes an agent overreach, skip a step, or write to the wrong tier.
+
+### D6 - Runtime, Plugin, Install, And Packaging Readiness
+
+Review bounded plugin topology, manifests, hooks, smoke checks, sync scripts, symlinks, and
+installed-cache assumptions.
+
+Check:
+- Source package symlink topology is documented and verified.
+- Plugin manifests declare the right components for each ecosystem.
+- Smoke checks test actual packaged behavior without silently materializing symlinked dirs.
+- Hook scripts no-op safely when runtime-specific environment is absent.
+- Install docs distinguish source package behavior from installed-cache behavior.
+
+Codex add-on:
+- `plugins/gobbi/.codex-plugin/plugin.json` declares Codex skills and hooks correctly.
+- `plugins/gobbi/hooks/codex-hooks.json` uses Codex-supported events and non-overbroad
+  matchers.
+- `.agents/plugins/marketplace.json` points to the bounded package.
+- `scripts/check-codex-plugin-smoke.sh` and `scripts/check-codex-compatibility.sh` are used as
+  evidence, not confused with Claude plugin scripts.
+
+### D7 - Live-Session UX And Operator Ergonomics
+
+Review what the user and manager can see and recover during long multi-agent work.
+
+Check:
+- Active step, task, agent, artifact path, blocker, and next action are visible.
+- Pending user decisions are file-backed or otherwise recoverable.
+- Long-running operations report progress and validation targets.
+- Resume/compact/clear behavior reloads the right skills and state.
+- The user can tell whether work is planning, reviewing, executing, or recording.
+
+Codex add-on:
+- Codex progress updates work through the parent thread.
+- Codex-specific plan/task surfaces are specified or a markdown status fallback is explicit.
+- Partial Codex metadata does not block useful progress.
+
+### D8 - Reference Harness Comparison And Gap Discovery
+
+Use prior-art comparison to find design gaps, not to score Gobbi for its own sake.
+
+Check:
+- Gobbi's skill discovery, role delegation, status tracking, artifact templates, and review
+  process are compared against strong reference patterns.
+- The comparison informs concrete findings in D1-D7.
+- Prior D3 findings are cited rather than duplicated.
+- External references are refreshed only when they materially affect the current review.
+
+## Codex Compatibility Add-On Checks
+
+Apply these checks inside the relevant dimensions:
+
+- Native Codex bootstrap does not require `CLAUDE_CODE_SESSION_ID`,
+  `CLAUDE_TRANSCRIPT_PATH`, or Claude hook metadata.
+- `.agents/skills` symlink resolution is verified with `readlink` or `find -L`.
+- `.codex/agents` wrappers load canonical role prompts and do not pin model/effort.
+- Codex evaluator/read-only boundaries are explicit.
+- Codex hook config and scripts pass without Claude-only environment.
+- Codex plugin install docs distinguish source package, marketplace source, installed cache,
+  and repo-local custom agents.
+- Codex smoke checks use isolated state and do not mutate the user's real Codex home.
+- Codex completion checks validate files and content, not detached process exit status.
+- User-only slash commands are not invoked programmatically.
+
+## Docs, Templates, And Naming Review Standard
+
+D3, D4, and D5 must go deeper than finding broken links or inconsistent counts.
+
+For each relevant skill or template, ask:
+
+- Can a fresh spawned agent identify what to read first, what to do next, and where to stop?
+- Does the document separate command procedure from rationale, examples, and history?
+- Does the template prevent the common wrong write, or does it merely describe the right write?
+- Would a maintainer know whether to edit this file, a canonical source, a mirror, or a
+  generated copy?
+- Does the name/word choice reduce work for the reader, or does it encode an internal
+  implementation detail?
+- Is a term defined exactly once and reused, or locally reinterpreted?
+- Is there a smaller, clearer structure that preserves the same contract?
+
+Findings in these areas must explain **why the current wording/design causes a concrete user
+or agent failure**. Do not file a pure style preference.
+
+## Run Methodology
+
+### Pass 0 - Scope Lock And Context
+
+- Confirm review-only scope.
+- Capture commit, branch, worktree, and session id.
+- Load `AGENTS.md`, `principles`, `mistake`, `evaluation`, `research`, `coding`, and any
+  lane-specific skills.
+- Read previous review files for dedup context.
+
+### Pass 0.5 - Inventory And Relevance Map
+
+- Build the file inventory for skills, agents, templates, scripts, manifests, hooks, and
+  review artifacts.
+- Mark each file against D1-D8.
+- Use `find -L` and `readlink` for symlinked mirrors and plugin package topology.
+- State whether each count follows symlinks.
+
+### Lane Passes
+
+Run independent Codex lanes:
+
+- Lane A: D1 workflow.
+- Lane B: D2 agents/skills/delegation.
+- Lane C: D3 docs design.
+- Lane D: D4 templates/schema.
+- Lane E: D5 naming/language.
+- Lane F: D6 runtime/plugin/Codex compatibility.
+- Lane G: D7 live UX.
+- Lane H: D8 harness/gap comparison.
+
+Each lane applies Gobbi's seven evaluation perspectives: project, structure, performance,
+aesthetics, usage, consistency, and risk.
+
+### Second-Pass Validation
+
+Every Critical or High finding needs independent Codex second-pass validation before it is
+marked confirmed. If validation cannot complete, retain the finding only with
+`needs-second-pass` and explain the blocker.
+
+### Aggregation
+
+- Read lane reports directly.
+- Deduplicate by location + claim + failure mode.
+- Preserve cross-lane disagreement.
+- Produce one aggregate review file ordered by severity, then by dimension.
+
+## Finding Record Shape
+
+Use body-level findings inside review files.
+
+```markdown
+### GEN-D3-001: {short title}
+- Type: scenario_gap | checklist_gap | design_flaw | assumption_risk | general
+- Domain: security | performance | test | observability | privacy | compliance | dependency | docs-sync | cost | accessibility | i18n | unevaluable | phase-mismatch | regression | process | general
+- Severity: Critical | High | Medium | Low
+- Confidence: 0 | 25 | 50 | 75 | 100
+- Priority: critical | high | medium | low
+- Disposition: open | addressed | disputed | deferred | superseded
+- Runner: codex
+- Dimension: D1 | D2 | D3 | D4 | D5 | D6 | D7 | D8
+- Owner-surface: workflow | agent | skill | template | memory | plugin | hook | runtime | docs | unknown
+- Location: {file}:{line or #section}
+- Expected: {what should be true}
+- Observed: {what is true}
+- Evidence: {quote, command output summary, file check, or manual trace}
+- False-positive check: pre-existing | out-of-scope | style preference | linter-catchable | speculative | none
+- Proposed remediation: {directional fix, not implementation recipe}
+- Verification: {how a future session proves the fix}
+```
+
+## Verification Appendix
+
+Required evidence rules:
+
+- Use exact `rg` or `git grep` patterns for absence claims.
+- Use `readlink` or `find -L` for symlink and mirror claims.
+- State root and symlink-following mode for count claims.
+- For JSON, run `jq empty <file>` or equivalent.
+- For shell scripts used as evidence, prefer `--check`, dry-run, or isolated temp state.
+- For Codex output claims, validate expected output files and content markers. Do not trust
+  detached exit code alone.
+- For naming and wording findings, cite the term locations and the concrete wrong behavior the
+  wording invites.
+
+## Acceptance Criteria
+
+- The new charter exists and is self-contained.
+- All prior `2026-06-29-*` review files remain unchanged.
+- New lane files and aggregate review files use the `2026-07-01-codex-conducted-*` prefix.
+- Codex compatibility appears as add-on checks, not the whole review frame.
+- D3/D4/D5 receive dedicated findings on docs design, templates, naming, and word choice.
+- Critical/High findings have direct evidence and independent second-pass validation or are
+  marked `needs-second-pass`.

--- a/.gobbi/projects/gobbi/reviews/adversarial-review/2026-07-01-codex-conducted-adversarial-review-evaluation.md
+++ b/.gobbi/projects/gobbi/reviews/adversarial-review/2026-07-01-codex-conducted-adversarial-review-evaluation.md
@@ -1,0 +1,112 @@
+---
+name: codex-conducted-adversarial-review-evaluation
+description: Codex-only evaluation of the 2026-07-01 Gobbi adversarial-review artifacts
+type: reviews
+scope: project
+feature: null
+status: active
+created: 2026-07-01
+session: 019f1ef9-a676-7f12-8d78-922f12cb64e9
+tags: [evaluation, codex, verification]
+keywords: [adversarial-review, closeout, codex-only, review-result, frontmatter-normalization]
+author: codex
+review_kind: adversarial-review
+subject: "2026-07-01 Codex-conducted adversarial review artifacts"
+verdict: pass
+related: [codex-conducted-adversarial-review]
+---
+
+# Codex-Conducted Adversarial Review Evaluation
+
+## Scope
+
+This evaluates the `2026-07-01-codex-conducted-*` adversarial-review artifacts:
+the charter, eight lane reports, and the aggregate review. It is a Codex-only
+evaluation because the user explicitly excluded Claude Code from this session.
+It is not the normal Gobbi dual-system Claude+Codex evaluation gate.
+
+## Verdict
+
+PASS after metadata normalization. Aquinas
+(`019f1f40-3322-7601-a231-80c9d965e8e3`) initially returned
+`DONE_WITH_CONCERNS` / `REVISE`: the review content was usable and faithful to
+the user's corrected scope, but the ten review artifacts failed the memory
+frontmatter validator. The frontmatter-only defects were fixed, and
+`validate-frontmatter.sh` now passes on all ten target artifacts.
+
+The review result is ready to hand off as a Codex-only review artifact. It is
+not a claim that the full Gobbi Wrap-up pipeline ran.
+
+## Perspective Results
+
+| Perspective | Result | Notes |
+|---|---|---|
+| Project | PASS | The charter keeps the review general and treats Codex compatibility as an add-on. |
+| Structure | PASS | The charter, lanes, aggregate, and evaluation form a usable decomposition after frontmatter normalization. |
+| Performance | PASS | Eight bounded lanes plus focused High validation were proportional to the review task. |
+| Aesthetics | PASS | D3, D4, and D5 contain concrete docs-design, template, and naming findings, not style-only preferences. |
+| Usage | PASS | Future maintainers can start from the aggregate and follow lanes for evidence. |
+| Consistency | PASS | Raw lane counts, dedupe, and severity summaries are internally consistent after the metadata fix. |
+| Risk | PASS with limits | Codex-only evaluation, unrun plugin smoke, and non-formal Wrap-up are explicitly recorded limits. |
+| Overall | PASS with limits | Content is usable; strict dual-system validation and memory promotion remain outside this closeout. |
+
+## Findings
+
+### CLOSEOUT-CX-001: Review artifact frontmatter failed validator
+
+- Type: checklist_gap
+- Domain: docs-sync
+- Severity: High
+- Confidence: 100
+- Disposition: addressed
+- Evidence: Aquinas ran the memory validator on the charter, aggregate, and
+  eight lane files and reported `22 violation(s) across 10 file(s)`.
+- Resolution: normalized review/plan tags to each type's controlled tag pool,
+  changed the charter `supersedes` from a path to the plain slug
+  `adversarial-review-charter`, and changed Lane H `verdict` from
+  `pass-with-findings` to the allowed enum value `needs-attention`.
+- Verification: `.agents/skills/memory/scripts/validate-frontmatter.sh` now
+  reports `OK: 10 files validated` on the target artifact set.
+
+## Verification
+
+Commands rerun by the manager after Aquinas returned:
+
+```bash
+.agents/skills/memory/scripts/validate-frontmatter.sh \
+  .gobbi/projects/gobbi/plans/workflow/2026-07-01-codex-conducted-adversarial-review-charter.md \
+  .gobbi/projects/gobbi/reviews/adversarial-review/2026-07-01-codex-conducted-adversarial-review*.md
+
+bash scripts/sync-plugin-package.sh --check
+bash scripts/check-codex-compatibility.sh
+find -L .agents/skills -maxdepth 2 -name SKILL.md | sort | wc -l
+jq empty plugins/gobbi/.codex-plugin/plugin.json \
+  plugins/gobbi/.claude-plugin/plugin.json \
+  .agents/plugins/marketplace.json \
+  .claude-plugin/marketplace.json
+```
+
+Results:
+
+- Frontmatter validator: `OK: 10 files validated`.
+- Symlink topology check: passed.
+- Codex compatibility check: passed.
+- Skill count: `22`.
+- JSON manifest check: passed.
+- Raw lane finding count: 39 findings; 0 Critical, 10 High, 26 Medium, 3 Low.
+- Aggregate count: 38 unique findings; 0 Critical, 9 High, 26 Medium, 3 Low.
+- Prior `2026-06-29-*` review files: no diff.
+
+Not run:
+
+- `scripts/check-codex-plugin-smoke.sh`, because it performs a plugin install
+  into an isolated Codex home. The aggregate records this as a limit.
+- Claude Code evaluation or any Claude Code tool, by user instruction.
+
+## Closeout Notes
+
+- The review artifacts are complete and evaluated in a Codex-only sense.
+- The strict Gobbi dual-system Wrap-up evaluation did not run.
+- No source fixes were applied for any review finding.
+- No durable memory promotion, session metadata reconciliation, commit, push, or
+  pull request was performed in this closeout.

--- a/.gobbi/projects/gobbi/reviews/adversarial-review/2026-07-01-codex-conducted-adversarial-review-lane-agents-skills.md
+++ b/.gobbi/projects/gobbi/reviews/adversarial-review/2026-07-01-codex-conducted-adversarial-review-lane-agents-skills.md
@@ -1,0 +1,130 @@
+---
+name: codex-conducted-adversarial-review-lane-agents-skills
+description: Lane B review for D2 agents, skills, and delegation completeness
+type: reviews
+scope: project
+feature: null
+status: active
+created: 2026-07-01
+session: 019f1ef9-a676-7f12-8d78-922f12cb64e9
+tags: [evaluation, codex, process]
+keywords: [d2, agents, skills, delegation, codex-conducted]
+author: codex
+review_kind: adversarial-review
+subject: "Gobbi general surface — D2 agents, skills, and delegation completeness"
+verdict: needs-attention
+---
+
+# Lane B — D2 Agents, Skills, And Delegation Completeness
+
+This lane reviews role prompts, skill maps, load directives, custom-agent wrappers, and delegation contracts.
+
+## Method
+
+Lane B reviewed role prompts, skill maps, load directives, companion mistakes, custom-agent
+wrappers, status contracts, and delegation templates. It verified basic Codex add-on surfaces:
+`.agents/skills` resolves 22 skill symlinks; `.codex/agents` has all five wrapper symlinks;
+`.codex/agents/evaluator.toml` is read-only; Codex wrappers do not pin model or effort.
+
+Commands and checks used included:
+
+- `test -d .gobbi/projects/gobbi/rules`
+- `find -L .agents/skills -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort`
+- `find .agents/skills -mindepth 1 -maxdepth 1 -printf '%f -> %l\n' | sort`
+- `find .codex/agents -mindepth 1 -maxdepth 1 -printf '%f -> %l\n' | sort`
+- `rg -n "SKILLS LOADED" .gobbi/projects/gobbi/agents/*.md`
+- `rg -n "SKILLS LOADED" .gobbi/projects/gobbi/skills/delegation/SKILL.md .gobbi/projects/gobbi/skills/delegation/templates/*.md`
+- targeted line reads of `AGENTS.md`, `.codex/AGENTS.md`, role prompts, delegation templates, and prior D2 review artifacts
+
+## Findings
+
+### GEN-D2-001: Canonical role prompts send spawned agents to an absent rules directory
+- Type: design_flaw
+- Domain: process
+- Severity: High
+- Confidence: 100
+- Priority: high
+- Disposition: open
+- Runner: codex
+- Dimension: D2
+- Owner-surface: agent
+- Location: `.gobbi/projects/gobbi/agents/manager.md:27-31`; `.gobbi/projects/gobbi/agents/leader.md:27-30`; `.gobbi/projects/gobbi/agents/executor.md:29-33`; `.gobbi/projects/gobbi/agents/evaluator.md:34-37`; `.gobbi/projects/gobbi/agents/assistant.md:39-42`
+- Expected: Canonical role prompts should direct every fresh agent to an existing rules source, or use the same no-`rules/` fallback that the delegation templates use.
+- Observed: Every canonical role prompt tells agents to read all project rules under `.gobbi/projects/{project-name}/rules/`, but `test -d .gobbi/projects/gobbi/rules` returned `rules_dir_exists_exit=1`. The templates already include the safer fallback: read `skills/memory/rules.md` when `rules/` is absent.
+- Evidence: The project's delegation mistake records this trap for delegation prompts at `.gobbi/projects/gobbi/skills/delegation/mistakes.md:12-19`. This is not a duplicate of prior D2-023; the current evidence is the canonical role-prompt/bootstrap variant, and `.codex/agents/*.toml` wrappers tell Codex agents to read these canonical prompts first.
+- False-positive check: If a manager always uses fixed delegation templates, the fallback is present. The defect remains for direct role-prompt use, custom-agent bootstrap, or incomplete parent prompts that rely on the canonical role prompt as the contract.
+- Proposed remediation: Update all five role prompts to either name the existing rules source or explicitly say: read all files under `rules/` if it exists; otherwise read `.gobbi/projects/{project-name}/skills/memory/rules.md`. Require a non-empty read or explicit absence note.
+- Verification: Re-run `test -d .gobbi/projects/gobbi/rules` and `rg -n "All project rules" .gobbi/projects/gobbi/agents/*.md`; each prompt should have the same fallback as the templates.
+- Second-pass: validated by Godel (`019f1f2d-20a4-71f0-a5e5-0ef5512dd3dc`). Severity remains High.
+
+### GEN-D2-002: Delegation templates bypass the official native Codex `.agents/skills` load path
+- Type: design_flaw
+- Domain: docs-sync
+- Severity: Medium
+- Confidence: 100
+- Priority: medium
+- Disposition: open
+- Runner: codex
+- Dimension: D2
+- Owner-surface: template
+- Location: `AGENTS.md:5-13`; `.agents/skills/codex/SKILL.md:41-42`; `.agents/skills/codex/SKILL.md:458-459`; `.gobbi/projects/gobbi/skills/delegation/templates/leader.md:31-42`; `.gobbi/projects/gobbi/skills/delegation/templates/executor.md:32-43`; `.gobbi/projects/gobbi/skills/delegation/templates/evaluator.md:59-67`; `.gobbi/projects/gobbi/skills/delegation/templates/assistant.md:40-50`
+- Expected: Native Codex load directives should use `.agents/skills/<skill>/SKILL.md`, matching the repo-local Codex entry point.
+- Observed: The root instructions and Codex skill require `.agents/skills`, and the Codex wrappers follow that path, but all delegation templates hard-code `.gobbi/projects/<<project-name>>/skills/...` for skill loads.
+- Evidence: `find -L .agents/skills -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort` showed the expected 22 Codex skill directories, and `find .agents/skills ...` showed each is a symlink to the canonical skill. The templates still emit canonical paths instead of the Codex entry point.
+- False-positive check: The canonical paths exist, so the subagent can read the skill content. The failure is a Codex-contract failure: a `SKILLS LOADED` checklist using canonical paths does not prove that the native Codex `.agents/skills` entry point works.
+- Proposed remediation: Parameterize the template skill root by runtime. For native Codex, emit `.agents/skills/...`; for canonical or Claude bridge contexts, emit the intended canonical path explicitly.
+- Verification: Render one Codex leader/executor/evaluator/assistant delegation prompt and confirm tier-1/tier-3 skill paths start with `.agents/skills/`, while project memory/mistake paths remain explicit.
+
+### GEN-D2-003: Codex bootstrap and delegation taxonomy still understate where Evaluation runs
+- Type: checklist_gap
+- Domain: process
+- Severity: Medium
+- Confidence: 100
+- Priority: medium
+- Disposition: open
+- Runner: codex
+- Dimension: D2
+- Owner-surface: docs
+- Location: `AGENTS.md:57-69`; `.codex/AGENTS.md:57-69`; `.agents/skills/gobbi/SKILL.md:141`; `.agents/skills/delegation/SKILL.md:420-429`
+- Expected: Evaluation routing should agree across bootstrap docs and delegation taxonomy: every productive step has an Evaluation sub-phase, with Evaluation mandatory after Execution and Wrap-up and optional after Ideation, Preparation, and Planning when policy allows.
+- Observed: `AGENTS.md:69` and `.codex/AGENTS.md:69` say Evaluation runs inside only Ideation, Planning, and Execution. `.agents/skills/delegation/SKILL.md:429` says evaluator use is mandatory after Execution and optional after Ideation/Planning, omitting Preparation and Wrap-up. This contradicts `.agents/skills/gobbi/SKILL.md:141` and `.agents/skills/delegation/SKILL.md:420`, which says phase-list drift is a bug.
+- Evidence: Prior D2-019 already found this class on other surfaces. This current finding is the Codex bootstrap and delegation-taxonomy variant: `.codex/AGENTS.md` and `.agents/skills/delegation/SKILL.md:429` are current evidence not covered by the older location list.
+- False-positive check: The same docs also say Wrap-up has mandatory evaluation at `.codex/AGENTS.md:65`, so a careful human may recover the correct rule. A fresh spawned or bootstrap agent reading the later summary line can still under-spawn evaluators for Preparation and Wrap-up.
+- Proposed remediation: Replace the short Evaluation sentence and evaluator taxonomy row with the canonical rule from `gobbi/SKILL.md:141`.
+- Verification: `rg -n "Evaluation runs inside|mandatory after Execution|Evaluation sub-phase" AGENTS.md .codex/AGENTS.md .agents/skills/delegation/SKILL.md .agents/skills/gobbi/SKILL.md` should return one consistent lifecycle rule.
+
+### GEN-D2-004: Canonical role status contracts do not require `SKILLS LOADED`
+- Type: checklist_gap
+- Domain: process
+- Severity: Medium
+- Confidence: 100
+- Priority: medium
+- Disposition: open
+- Runner: codex
+- Dimension: D2
+- Owner-surface: agent
+- Location: `.gobbi/projects/gobbi/agents/leader.md:124-132`; `.gobbi/projects/gobbi/agents/executor.md:114-122`; `.gobbi/projects/gobbi/agents/evaluator.md:98-106`; `.gobbi/projects/gobbi/agents/assistant.md:114-122`; `.gobbi/projects/gobbi/skills/delegation/SKILL.md:190-202`
+- Expected: Spawned agents should always be told how to prove required skill loads, per the charter and delegation wire format.
+- Observed: The delegation skill and templates require `SKILLS LOADED`, but canonical role prompt status contracts only require status/artifact/verdict-style reporting. `rg -n "SKILLS LOADED" .gobbi/projects/gobbi/agents/*.md` returned no matches.
+- Evidence: `.gobbi/projects/gobbi/skills/delegation/SKILL.md:198-202` makes `SKILLS LOADED` mandatory and transcript-verifiable; `.gobbi/projects/gobbi/skills/delegation/SKILL.md:323` calls skill named without a path an anti-pattern. The role prompts are the files Codex wrappers load first.
+- False-positive check: Delegation templates do include `SKILLS LOADED`. The gap is direct role-prompt/custom-agent invocation or any parent prompt that does not paste the full template.
+- Proposed remediation: Add the same minimal wire-format requirement to each spawned role prompt, or explicitly state role prompts are incomplete without a delegation template and must reject bare dispatches that lack `SKILLS LOADED`.
+- Verification: Re-run `rg -n "SKILLS LOADED" .gobbi/projects/gobbi/agents/*.md` and confirm each spawned role prompt contains the mandatory checklist and exact-path proof requirement.
+
+### GEN-D2-005: Codex role table labels canonical TOML files as the Codex wrappers
+- Type: general
+- Domain: docs-sync
+- Severity: Low
+- Confidence: 100
+- Priority: low
+- Disposition: open
+- Runner: codex
+- Dimension: D2
+- Owner-surface: docs
+- Location: `AGENTS.md:33-43`; `.codex/AGENTS.md:33-43`; `AGENTS.md:106-110`; `.codex/AGENTS.md:106-110`
+- Expected: The "Codex wrapper" column should point to `.codex/agents/<role>.toml`, matching the official Codex entry point and the later Navigate Deeper table.
+- Observed: The role-prompt table's "Codex wrapper" column points to `.gobbi/projects/gobbi/agents/<role>.toml`, while the same document elsewhere says custom agents live at `.codex/agents/<role>.toml`.
+- Evidence: `find .codex/agents -mindepth 1 -maxdepth 1 -printf '%f -> %l\n' | sort` showed the actual wrapper symlinks under `.codex/agents`, pointing to canonical TOML files. The table swaps the wrapper path with the canonical target path.
+- False-positive check: The symlink targets exist, so this is not a runtime dead-end. It is still a fresh-agent/operator confusion bug on the custom-agent wrapper surface.
+- Proposed remediation: Change the table column to `.codex/agents/{role}.toml` and, if useful, add a separate canonical TOML target column or prose note that those wrappers symlink to `.gobbi/projects/gobbi/agents/{role}.toml`.
+- Verification: Re-run the `find .codex/agents ...` command and compare table entries against actual wrapper paths.

--- a/.gobbi/projects/gobbi/reviews/adversarial-review/2026-07-01-codex-conducted-adversarial-review-lane-docs-design.md
+++ b/.gobbi/projects/gobbi/reviews/adversarial-review/2026-07-01-codex-conducted-adversarial-review-lane-docs-design.md
@@ -1,0 +1,133 @@
+---
+name: codex-conducted-adversarial-review-lane-docs-design
+description: Lane C review for D3 docs design and information architecture
+type: reviews
+scope: project
+feature: null
+status: active
+created: 2026-07-01
+session: 019f1ef9-a676-7f12-8d78-922f12cb64e9
+tags: [evaluation, docs-sync, design]
+keywords: [d3, docs-design, information-architecture, skills, codex-conducted]
+author: codex
+review_kind: adversarial-review
+subject: "Gobbi general surface — D3 docs design and information architecture"
+verdict: needs-attention
+---
+
+# Lane C — D3 Docs Design And Information Architecture
+
+This lane reviews how Gobbi skills and docs guide new managers, spawned agents, and maintainers.
+
+## Method
+
+Lane C reviewed skill/document information architecture, reader journeys, runtime-specific
+branching, section placement, and how new managers or spawned agents find the next instruction.
+It treated the 2026-06-29 review corpus as dedupe context and did not re-file generic
+doc-density, known D5 centralization/compact candidates, the `coding` skill-map gap, the
+missing Glossary `Stage` entry, or the known `rules/docs-cleanup-parallelism.md` broken link as
+standalone findings.
+
+Commands and checks used included:
+
+- required load reads for `AGENTS.md`, evaluator role prompt, principles, mistake, evaluation,
+  research, coding, and this charter
+- prior-review reads for D2, D3/D5, D4, D6, and D1/D7 artifacts
+- `find -L .agents/skills -type f -name 'evaluation.md' -print | sort`
+- `rg --files .gobbi/projects/gobbi/rules`
+- targeted `nl -ba` reads of `gobbi`, `orchestration`, mode docs, workflow child docs,
+  `evaluation`, `memory`, `ideation`, evaluator role prompt, and `memory-map`
+
+## Findings
+
+### GEN-D3-001: Bootstrap entry path bypasses the selected mode doc
+- Type: design_flaw
+- Domain: process
+- Severity: High
+- Confidence: 100
+- Priority: high
+- Disposition: open
+- Runner: codex
+- Dimension: D3
+- Owner-surface: workflow
+- Location: `.agents/skills/gobbi/SKILL.md:102`; `.agents/skills/gobbi/SKILL.md:104`; `.agents/skills/orchestration/SKILL.md:76`; `.agents/skills/orchestration/SKILL.md:78`; `.agents/skills/orchestration/SKILL.md:81`; `.agents/skills/orchestration/SKILL.md:84`; `.agents/skills/orchestration/auto-mode.md:44`; `.agents/skills/orchestration/auto-mode.md:51`; `.agents/skills/orchestration/chat-mode.md:61`; `.agents/skills/orchestration/chat-mode.md:63`
+- Expected: After Configuration selects `settings.mode`, the new manager should be sent to the selected mode document first; the mode document should then dispatch Ideation / Preparation / Planning / Execution / Wrap-up.
+- Observed: `gobbi/SKILL.md` Step 6 tells the reader that the first productive step is Ideation and to load `ideation` directly. The orchestration skill instead says the manager reads `settings.mode` and delegates Steps 2-6 to `auto-mode.md` or `chat-mode.md`. Auto and Chat docs both declare themselves the canonical per-mode SOP.
+- Evidence: `nl -ba .agents/skills/gobbi/SKILL.md | sed -n '88,108p'` shows Step 6 sending the reader to Ideation. `nl -ba .agents/skills/orchestration/SKILL.md | sed -n '72,92p'` shows the mode-doc routing. `nl -ba .agents/skills/orchestration/auto-mode.md | sed -n '40,84p'` and `nl -ba .agents/skills/orchestration/chat-mode.md | sed -n '56,68p'` show the two mode docs are intended workflow homes.
+- False-positive check: none. This is not the prior successor-handoff class; it is the initial reader journey immediately after bootstrap.
+- Proposed remediation: Make `gobbi/SKILL.md` Step 6 route through `orchestration/SKILL.md` / the selected mode doc, and let the mode row load Ideation.
+- Verification: A fresh manager starting from `gobbi/SKILL.md` can answer "Auto or Chat next?" without already knowing the orchestration docs.
+- Second-pass: validated by Godel (`019f1f2d-20a4-71f0-a5e5-0ef5512dd3dc`). Severity remains High.
+
+### GEN-D3-002: Mode workflow tables point spawned agents at manager-only orchestration docs
+- Type: design_flaw
+- Domain: process
+- Severity: High
+- Confidence: 100
+- Priority: high
+- Disposition: open
+- Runner: codex
+- Dimension: D3
+- Owner-surface: workflow
+- Location: `.agents/skills/orchestration/auto-mode.md:76`; `.agents/skills/orchestration/auto-mode.md:79`; `.agents/skills/orchestration/auto-mode.md:80`; `.agents/skills/orchestration/auto-mode.md:81`; `.agents/skills/orchestration/chat-mode.md:148`; `.agents/skills/orchestration/chat-mode.md:151`; `.agents/skills/orchestration/chat-mode.md:152`; `.agents/skills/orchestration/chat-mode.md:153`; `.agents/skills/orchestration/workflow/ideation.md:1`; `.agents/skills/orchestration/workflow/ideation.md:3`; `.agents/skills/orchestration/workflow/evaluation.md:1`; `.agents/skills/orchestration/workflow/evaluation.md:3`; `.agents/skills/orchestration/workflow/record.md:1`; `.agents/skills/orchestration/workflow/record.md:3`
+- Expected: In a table with `Refs` and `Agent`, the reference for a spawned `leader`, `evaluator`, or `assistant` should be the exact document that agent needs to load, or the table should label the reference as manager-only.
+- Observed: Auto and Chat rows list `leader` / `evaluator` / `assistant` as the actor while linking `workflow/ideation.md`, `workflow/evaluation.md`, and `workflow/record.md`. Those files immediately state they are manager orchestration docs and that specialists load `ideation/SKILL.md`, `evaluation/SKILL.md`, `record/SKILL.md`, and `memory/memory-map.md` instead.
+- Evidence: `nl -ba .agents/skills/orchestration/auto-mode.md | sed -n '40,84p;92,120p;128,156p'` shows specialist-agent rows whose refs are `workflow/*.md`. `nl -ba .agents/skills/orchestration/chat-mode.md | sed -n '144,156p;176,204p;228,240p'` shows the same pattern. `nl -ba .agents/skills/orchestration/workflow/{ideation,evaluation,record}.md` shows those linked files are manager-facing.
+- False-positive check: none. Links resolve; the defect is wrong abstraction level and ambiguous load guidance, not link rot.
+- Proposed remediation: Split the table into manager orchestration refs and spawned-agent load directives, or change specialist rows to point at specialist skill docs directly.
+- Verification: A manager can copy a row's load refs into a delegation prompt without accidentally giving a specialist a manager-only doc.
+- Second-pass: validated by Godel (`019f1f2d-20a4-71f0-a5e5-0ef5512dd3dc`). Severity remains High.
+
+### GEN-D3-003: Evaluation child docs are hidden behind a same-basename manager doc
+- Type: design_flaw
+- Domain: process
+- Severity: Medium
+- Confidence: 100
+- Priority: medium
+- Disposition: open
+- Runner: codex
+- Dimension: D3
+- Owner-surface: workflow
+- Location: `.agents/skills/orchestration/auto-mode.md:80`; `.agents/skills/orchestration/auto-mode.md:98`; `.agents/skills/orchestration/auto-mode.md:116`; `.agents/skills/orchestration/auto-mode.md:134`; `.agents/skills/orchestration/auto-mode.md:152`; `.agents/skills/orchestration/workflow/evaluation.md:36`; `.agents/skills/orchestration/workflow/evaluation.md:47`; `.agents/skills/evaluation/SKILL.md:126`; `.agents/skills/evaluation/SKILL.md:141`; `.agents/skills/evaluation/SKILL.md:542`
+- Expected: The evaluator spawn site should make the phase-specific evaluation child doc discoverable at the point where the evaluator is spawned.
+- Observed: Every EVALUATION row links only to `workflow/evaluation.md`, a manager doc. That doc says the evaluator loads `ideation/evaluation.md`, `preparation/evaluation.md`, `planning/evaluation.md`, `execution/evaluation.md`, or `wrap-up/evaluation.md` at Stage 0. The executable child docs all share the basename `evaluation.md`, so a fresh manager has to infer which `evaluation.md` belongs in the delegation prompt.
+- Evidence: `find -L .agents/skills -type f -name 'evaluation.md' -print | sort` returns seven files: `coding/evaluation.md`, five phase child docs, and `orchestration/workflow/evaluation.md`. `nl -ba .agents/skills/evaluation/SKILL.md | sed -n '120,180p;536,552p'` shows Stage 0 and the phase-child table.
+- False-positive check: new-variant. Prior D2-003 covers the `coding/evaluation.md` dead-end from Execution EVALUATION; this finding covers general phase-child discoverability at mode spawn rows.
+- Proposed remediation: Put the exact phase child doc in each EVALUATION row or delegation template, and consider renaming/labeling the manager doc so `workflow/evaluation.md` is not confused with evaluator child docs.
+- Verification: Each EVALUATION delegation prompt generated from the mode table contains `evaluation/SKILL.md` plus the exact phase child doc path.
+
+### GEN-D3-004: Memory read guidance is fragmented and the memory entry point points only to mistakes
+- Type: design_flaw
+- Domain: docs-sync
+- Severity: Medium
+- Confidence: 100
+- Priority: medium
+- Disposition: open
+- Runner: codex
+- Dimension: D3
+- Owner-surface: memory
+- Location: `.agents/skills/memory/SKILL.md:28`; `.agents/skills/memory/SKILL.md:34`; `.agents/skills/memory/SKILL.md:40`; `.agents/skills/gobbi/SKILL.md:95`; `.agents/skills/gobbi/SKILL.md:97`; `.agents/skills/ideation/SKILL.md:103`; `.agents/skills/evaluation/SKILL.md:142`
+- Expected: The memory entry point should tell a new manager or spawned agent where to find the durable-memory read contract across memory types, or point to one canonical read map.
+- Observed: `memory/SKILL.md` describes staging, promotion, and read-back, then says building a read procedure is not its job and points only to `mistake/SKILL.md § P1`. `gobbi/SKILL.md` checks only whether memory looks sparse. Concrete non-mistake reads are scattered in phase docs such as Ideation and Evaluation.
+- Evidence: `nl -ba .agents/skills/memory/SKILL.md | sed -n '1,48p'` shows the read beat and the mistakes-only pointer. `nl -ba .agents/skills/gobbi/SKILL.md | sed -n '88,108p'` shows the bootstrap memory check. `nl -ba .agents/skills/ideation/SKILL.md | sed -n '96,118p'` and `nl -ba .agents/skills/evaluation/SKILL.md | sed -n '120,180p'` show phase-local read tables that are not discoverable from the memory entry point.
+- False-positive check: none. Prior D3 memory findings focus on semantic retrieval / staleness; this is the docs information-architecture path for basic read instructions.
+- Proposed remediation: Add a durable-memory read map keyed by role and phase, then have `memory/SKILL.md`, `gobbi/SKILL.md`, and phase docs point to it.
+- Verification: Starting from `memory/SKILL.md`, a new evaluator or leader can find required reads for mistakes, rules, design, notes, backlogs, decisions, and feature-scoped memory without searching the whole skill tree.
+
+### GEN-D3-005: Required project-rules reads have no empty-state contract
+- Type: scenario_gap
+- Domain: process
+- Severity: Medium
+- Confidence: 100
+- Priority: medium
+- Disposition: open
+- Runner: codex
+- Dimension: D3
+- Owner-surface: memory
+- Location: `.gobbi/projects/gobbi/agents/evaluator.md:34`; `.gobbi/projects/gobbi/agents/evaluator.md:35`; `.agents/skills/ideation/SKILL.md:103`; `.agents/skills/ideation/SKILL.md:110`; `.agents/skills/evaluation/SKILL.md:142`; `.agents/skills/memory/memory-map.md:132`; `.agents/skills/memory/memory-map.md:139`
+- Expected: If evaluator and phase docs require recursive reads from `.gobbi/projects/{project-name}/rules/`, the project should either contain that directory or state that an absent directory is a valid "no rules" state and how to record it.
+- Observed: The evaluator prompt mandates loading all project rules, Ideation and Evaluation require recursive `rules/` reads, and the memory map lists `rules/{area}/{slug}.md`. In this worktree, `.gobbi/projects/gobbi/rules` does not exist; a read command errors instead of producing an explicit empty rules set.
+- Evidence: `nl -ba .gobbi/projects/gobbi/agents/evaluator.md | sed -n '26,42p'` shows the mandatory evaluator load. `nl -ba .agents/skills/ideation/SKILL.md | sed -n '96,118p'` and `nl -ba .agents/skills/evaluation/SKILL.md | sed -n '120,180p'` show required phase reads. `rg --files .gobbi/projects/gobbi/rules` returns `No such file or directory (os error 2)`.
+- False-positive check: new-variant. Prior D2-023 covers a specific broken link into `rules/docs-cleanup-parallelism.md`; this covers a broader required-read empty-state failure across evaluator and phase docs.
+- Proposed remediation: Define absent-directory behavior in the memory read contract, or ship an empty `rules/` skeleton / README that makes "no current project rules" mechanically readable.
+- Verification: Required rules-read paths either resolve successfully or the reading agent records an explicit `project rules: none / directory absent by contract` entry without treating it as missing context.

--- a/.gobbi/projects/gobbi/reviews/adversarial-review/2026-07-01-codex-conducted-adversarial-review-lane-harness-gap.md
+++ b/.gobbi/projects/gobbi/reviews/adversarial-review/2026-07-01-codex-conducted-adversarial-review-lane-harness-gap.md
@@ -1,0 +1,126 @@
+---
+name: codex-conducted-adversarial-review-lane-harness-gap
+description: Lane H review for D8 reference harness comparison and gap discovery
+type: reviews
+scope: project
+feature: null
+status: active
+created: 2026-07-01
+session: 019f1ef9-a676-7f12-8d78-922f12cb64e9
+tags: [evaluation, codex, process]
+keywords: [d8, reference-harness, gap-discovery, codex-conducted]
+author: codex
+review_kind: adversarial-review
+subject: "Gobbi general surface — D8 reference harness comparison and gap discovery"
+verdict: needs-attention
+---
+
+# Lane H — D8 Reference Harness Comparison And Gap Discovery
+
+This lane reviews reference-harness gaps that materially affect Gobbi design.
+
+## Method
+
+Lane H compared Gobbi's review method and skill/package design against current primary or
+current-source references where those references materially affected the comparison: Codex skill
+invocation policy, OpenAI eval dataset/grader practice, OpenAI Agents tracing, Claude Code subagent
+isolation, and LangGraph persistence/interrupts.
+
+The lane remained read-only and did not edit files. It also deduped against the 2026-06-29 review
+corpus. A potential pending-decision finding was dropped as a duplicate of prior D7-R1.
+
+Local commands and checks used included:
+
+- required load reads for `AGENTS.md`, evaluator role prompt, principles, mistake, evaluation,
+  research, coding, and the 2026-07-01 charter
+- `find .gobbi/projects/gobbi/rules -type f -name '*.md' -print | sort`, which failed because
+  `.gobbi/projects/gobbi/rules` is absent in the worktree
+- recursive mistake reads
+- targeted `rg -n` checks over prior review files, reference templates, memory references,
+  skill-writing docs, plugin manifests, and evaluation docs
+- symlink-aware checks with `find -L` and `readlink`
+- `jq empty plugins/gobbi/.codex-plugin/plugin.json`
+- `git rev-parse --show-toplevel`, `git rev-parse --abbrev-ref HEAD`, `git rev-parse HEAD`, and
+  `git status --short`
+
+External primary sources checked by the lane: Codex skills documentation for `agents/openai.yaml`
+and implicit invocation policy; OpenAI evals documentation for datasets, ground truth, and graders;
+OpenAI Agents SDK tracing documentation; Claude Code subagent documentation; and LangGraph
+persistence/interrupt documentation.
+
+Lane concern: `.gobbi/projects/gobbi/rules` does not exist in this worktree, so the evaluator role's
+project-rules load directive had no files to read.
+
+## Findings
+
+### GEN-D8-001: Reference records cannot preserve the dated harness-refresh matrix D3 said future work needs
+- Type: design_flaw
+- Domain: compliance
+- Severity: Medium
+- Confidence: 100
+- Priority: medium
+- Disposition: open
+- Runner: codex
+- Dimension: D8
+- Owner-surface: template
+- Location: `.gobbi/projects/gobbi/skills/memory/templates/references.md:28`
+- Expected: Reference-harness inputs record stable source identity, source authority, license/reuse posture, and freshness/materiality so D8 comparisons can be rerun without re-inferring provenance.
+- Observed: The reference template requires only `title`, `source`, `accessed`, and `ref_type`; author/date/version are optional body text, and no field captures license, reuse mode, source authority, immutable pin, or refresh materiality.
+- Evidence: `references.md:28` defines the complete reference extension set; `references.md:57-59` makes author/date/version optional body content. Prior D3 says a later refresh should produce `mechanism / source URL / license / copy-adapt-ignore` before implementation at `2026-06-29-gobbi-adversarial-review-d3-d5.md:83`. Current reference records use moving repo roots such as `source: https://github.com/eyaltoledano/claude-task-master` and body `docs/tutorial.md` with no commit/sha at `claude-task-master-dependency-tasks.md:14,28-29`. The lane's exact `rg -n "license|copy-adapt|source_authority|immutable|commit|sha|last_verified"` check found no schema support beyond the research skill's generic target mention.
+- False-positive check: new variant. Prior D3-014 asks for a future refresh matrix; this finding is the current schema gap that prevents storing that matrix as durable memory.
+- Proposed remediation: Add structured reference provenance fields or a dedicated harness-comparison template for `source_authority`, `stable_anchor`, `version_or_commit`, `license`, `reuse_policy`, `last_checked`, and `refresh_materiality`.
+- Verification: A future D8 refresh can fill those fields for all four prior harness references and any newly refreshed official sources without prose-only side notes.
+
+### GEN-D8-002: Codex skill invocation policy is not modeled in Gobbi skill authoring
+- Type: design_flaw
+- Domain: docs-sync
+- Severity: Medium
+- Confidence: 100
+- Priority: medium
+- Disposition: open
+- Runner: codex
+- Dimension: D8
+- Owner-surface: skill
+- Location: `.gobbi/projects/gobbi/skills/skill-writing/SKILL.md:99`
+- Expected: Gobbi's skill-authoring guidance describes both Claude and Codex invocation controls for packaged skills and requires trigger checks when descriptions become invocation interfaces.
+- Observed: `skill-writing` models slash visibility and model auto-invocation through Claude-specific frontmatter only: `user-invocable` and `disable-model-invocation`. The repo has no `agents/openai.yaml` files, and the Codex plugin manifest exposes package-level default prompts only.
+- Evidence: `skill-writing/SKILL.md:104-109` defines discoverability axes without Codex `agents/openai.yaml`; `plugins/gobbi/.codex-plugin/plugin.json:18-34` packages skills and default prompts but no per-skill invocation policy. `find .agents/skills plugins/gobbi/skills .gobbi/projects/gobbi/skills -name openai.yaml -print` returned no files. Current Codex docs say `agents/openai.yaml` can set `allow_implicit_invocation`, defaulting to true, and recommend testing prompts against descriptions for trigger behavior.
+- False-positive check: none. This is not the older D3-001 manual-discovery gap; it is a current Codex policy surface missing from the authoring standard.
+- Proposed remediation: Extend `skill-writing` with a Codex invocation-policy subsection and a trigger-test checklist. Decide which Gobbi skills should allow implicit Codex invocation and which should require explicit `$skill` use.
+- Verification: `rg -n "openai.yaml|allow_implicit_invocation|trigger behavior|test prompts" .gobbi/projects/gobbi/skills/skill-writing/SKILL.md plugins/gobbi/skills` shows Codex policy guidance and at least one checked example.
+
+### GEN-D8-003: Review methodology has no executable regression corpus for prior adversarial findings
+- Type: scenario_gap
+- Domain: test
+- Severity: Medium
+- Confidence: 75
+- Priority: medium
+- Disposition: open
+- Runner: codex
+- Dimension: D8
+- Owner-surface: docs
+- Location: `.gobbi/projects/gobbi/skills/evaluation/SKILL.md:558`
+- Expected: A reference-grade review harness converts recurring review failures into rerunnable cases with inputs, expected finding class, and grader/check criteria.
+- Observed: Gobbi evaluation writes prose per-perspective Markdown files only. The charter requires lane reports and aggregation, but no fixture/dataset/run format exists for replaying known defects such as stale reference anchors, missing second-pass validation, or bad skill-load directives.
+- Evidence: `evaluation/SKILL.md:562-565` defines only per-perspective and overall Markdown outputs. `find . -maxdepth 5 \( -iname '*eval*.jsonl' -o -iname '*eval*.yaml' -o -iname '*fixture*' -o -path './evals/*' -o -path './tests/evals/*' \) -print` returned no files. OpenAI eval guidance treats representative test data, ground truth, and testing criteria/graders as first-class parts of an eval run, with JSONL test data carrying inputs and labels.
+- False-positive check: none. Prior D3 confirms Gobbi is ahead on dual-system anti-groupthink; this finding preserves that differentiator and adds a small regression harness for review methodology.
+- Proposed remediation: Add a read-only review regression corpus format under reviews or tests: minimal bad artifact, expected finding metadata, expected evidence pattern, and checker command. Seed it from prior D1/D2/D4 mistakes.
+- Verification: A future session can run a documented command over the corpus and prove that Gobbi's evaluators still surface the expected finding class and evidence anchors.
+
+### GEN-D8-004: Critical/High second-pass validation is required but not part of the finding schema
+- Type: checklist_gap
+- Domain: process
+- Severity: Medium
+- Confidence: 100
+- Priority: medium
+- Disposition: open
+- Runner: codex
+- Dimension: D8
+- Owner-surface: template
+- Location: `.gobbi/projects/gobbi/plans/workflow/2026-07-01-codex-conducted-adversarial-review-charter.md:316`
+- Expected: The body-level finding shape carries structured second-pass state for every Critical/High finding: validator, status, evidence, and blocker or `needs-second-pass`.
+- Observed: The charter requires independent second-pass validation before marking Critical/High findings confirmed, but the finding record shape has no field for second-pass status. Aggregators must infer it from free text.
+- Evidence: `2026-07-01-codex-conducted-adversarial-review-charter.md:316-320` requires second-pass validation or `needs-second-pass`; the template at lines `333-350` includes metadata, evidence, false-positive check, remediation, and future verification, but no validation-status field. This conflicts with the charter's own aggregation rule to order and deduplicate lane reports at lines `322-327`.
+- False-positive check: none.
+- Proposed remediation: Add structured fields such as `Second-pass: confirmed | needs-second-pass | not-required`, `Second-pass-runner`, `Second-pass-evidence`, and `Second-pass-blocker`.
+- Verification: A synthetic High finding without the field fails a schema check; a Medium finding may set `Second-pass: not-required`.

--- a/.gobbi/projects/gobbi/reviews/adversarial-review/2026-07-01-codex-conducted-adversarial-review-lane-live-ux.md
+++ b/.gobbi/projects/gobbi/reviews/adversarial-review/2026-07-01-codex-conducted-adversarial-review-lane-live-ux.md
@@ -1,0 +1,137 @@
+---
+name: codex-conducted-adversarial-review-lane-live-ux
+description: Lane G review for D7 live-session UX and operator ergonomics
+type: reviews
+scope: project
+feature: null
+status: active
+created: 2026-07-01
+session: 019f1ef9-a676-7f12-8d78-922f12cb64e9
+tags: [evaluation, codex, process]
+keywords: [d7, live-session, ux, operator-ergonomics, codex-conducted]
+author: codex
+review_kind: adversarial-review
+subject: "Gobbi general surface — D7 live-session UX and operator ergonomics"
+verdict: needs-attention
+---
+
+# Lane G — D7 Live-Session UX And Operator Ergonomics
+
+This lane reviews progress visibility, task state, blockers, artifact paths, and long-running work.
+
+## Method
+
+Lane G reviewed the live-session user and operator path: startup/resume, progress state,
+task records, pending blockers, status rendering, transcript availability, and long-running
+workflow recoverability.
+
+The lane checked prior D7 findings before filing. It did not re-file the earlier pending-decision
+and progress-display findings where the current evidence was only a duplicate. It did file current
+variants where the state path or operator contract remains distinct.
+
+Commands and checks used included:
+
+- required load reads for `AGENTS.md`, evaluator role prompt, principles, mistake, evaluation,
+  research, coding, and the 2026-07-01 charter
+- targeted reads of `.agents/skills/gobbi/SKILL.md`
+- targeted reads of `.agents/skills/orchestration/{SKILL.md,chat-mode.md,templates/*.json}`
+- targeted reads of `.agents/skills/record/record-map.md`, record initialization scripts, and
+  scaffold scripts
+- `rg -n` checks for `currentIndex`, `InProgress`, `task-record`, `transcriptPath`, and prior D7
+  duplicates
+- `git rev-parse --show-toplevel`, `git rev-parse --abbrev-ref HEAD`, `git rev-parse HEAD`, and
+  `git status --short`
+
+## Findings
+
+### GEN-D7-001: Resume path can reset active state to Ideation
+- Type: design_flaw
+- Domain: process
+- Severity: High
+- Confidence: 100
+- Priority: high
+- Disposition: open
+- Runner: codex
+- Dimension: D7
+- Owner-surface: workflow
+- Location: `.agents/skills/gobbi/SKILL.md:72`; `.agents/skills/gobbi/SKILL.md:102`; `.agents/skills/orchestration/SKILL.md:104`; `.agents/skills/orchestration/SKILL.md:237`
+- Expected: Resume reads the persisted `state.json` and continues the active loop/phase without clobbering the active position.
+- Observed: The Gobbi entry path detects an existing `settings.json`, then still hands off to the first productive step, Ideation. Configuration row 4 stamps `state.json` with Configuration `Done` and Ideation `Active`, while the same orchestration doc says `state.json` is the recovery source after resume, clear, and compact.
+- Evidence: `.agents/skills/gobbi/SKILL.md:72-80` says existing settings means resume/clear/compact; `.agents/skills/gobbi/SKILL.md:102-104` enters Ideation as the first productive step. `.agents/skills/orchestration/SKILL.md:104-108` says the mode docs run after Configuration; `.agents/skills/orchestration/SKILL.md:237-247` stamps Ideation active. The state-persistence section says `state.json` recovers position after resume/clear/compact.
+- False-positive check: not a duplicate of prior D7-R8. That earlier item concerns operator visibility; this finding concerns state overwrite on resume.
+- Proposed remediation: Split fresh initialization from resume rehydration. On resume, read `state.json`, validate it, render the active state, and continue from that state without re-running row 4's Ideation-active stamp.
+- Verification: A future dry-run starts from a session whose `state.json` marks Planning or Execution active, resumes it, and proves no Configuration path rewrites it to Ideation.
+- Second-pass: validated by Godel (`019f1f2d-20a4-71f0-a5e5-0ef5512dd3dc`). Severity remains High.
+
+### GEN-D7-002: Codex missing rollout path is both allowed and treated as Critical
+- Type: design_flaw
+- Domain: process
+- Severity: High
+- Confidence: 100
+- Priority: high
+- Disposition: open
+- Runner: codex
+- Dimension: D7
+- Owner-surface: workflow
+- Location: `.agents/skills/codex/SKILL.md:50`; `.agents/skills/gobbi/SKILL.md:55`; `.agents/skills/record/SKILL.md:181`
+- Expected: Codex sessions with unavailable rollout metadata degrade cleanly and remain operable, with a visible warning and a lower-severity audit limitation.
+- Observed: The Codex runtime docs permit `session.json.transcriptPath` to be `null` when rollout lookup fails. RECORD then treats an absent `session.json.transcriptPath` as a Critical `general` finding with Domain `unevaluable` every time transcript copy runs.
+- Evidence: `.agents/skills/codex/SKILL.md:50-59` allows a null transcript path; `.agents/skills/gobbi/SKILL.md:55-62` says lookup failure should not block the workflow; `.agents/skills/record/SKILL.md:181-193` records a Critical unevaluable finding if the path is absent.
+- False-positive check: not a generic transcript concern. This is the native Codex degraded-metadata contract colliding with the runtime-neutral RECORD rule.
+- Proposed remediation: Add a Codex-aware degraded transcript state: expected-missing rollout metadata should warn and mark audit coverage degraded; unexpected missing paths in runtimes that guarantee transcripts can remain Critical.
+- Verification: A future Codex session with `CODEX_THREAD_ID` and no rollout row completes RECORD without a Critical finding, while a Claude session missing `CLAUDE_TRANSCRIPT_PATH` still fails loudly.
+- Second-pass: validated by Godel (`019f1f2d-20a4-71f0-a5e5-0ef5512dd3dc`). Severity remains High.
+
+### GEN-D7-003: Agent metadata collapses actionable statuses into `ok|failed`
+- Type: checklist_gap
+- Domain: observability
+- Severity: Medium
+- Confidence: 100
+- Priority: medium
+- Disposition: open
+- Runner: codex
+- Dimension: D7
+- Owner-surface: template
+- Location: `.agents/skills/delegation/SKILL.md:192`; `.agents/skills/orchestration/SKILL.md:353`; `.agents/skills/orchestration/templates/session.template.json:29`
+- Expected: Durable per-agent metadata preserves the actual terminal status and any blocker or pending user-question state needed by the manager and future operators.
+- Observed: Delegation defines actionable statuses `DONE`, `DONE_WITH_CONCERNS`, `NEEDS_CONTEXT`, and `BLOCKED`, but the session metadata lifecycle status has only `ok|failed`.
+- Evidence: `.agents/skills/delegation/SKILL.md:192-199` and `:267-286` define the four-status dispatch contract. `.agents/skills/orchestration/SKILL.md:353` and `.agents/skills/orchestration/templates/session.template.json:29-55` model agent metadata with a collapsed status.
+- False-positive check: none. The display can show active state, but the durable agent record loses the distinction between concerns, context needs, and hard blocks.
+- Proposed remediation: Extend `agents[]` records with the delegation status enum, a lifecycle field if needed, and optional `needs_context` / `blocker` data.
+- Verification: A synthetic `NEEDS_CONTEXT` subagent result persists as `NEEDS_CONTEXT` in `session.json`, not as `failed` or omitted data.
+
+### GEN-D7-004: Chat task-record path is outside the canonical session tree and scaffold
+- Type: design_flaw
+- Domain: docs-sync
+- Severity: Medium
+- Confidence: 100
+- Priority: medium
+- Disposition: open
+- Runner: codex
+- Dimension: D7
+- Owner-surface: workflow
+- Location: `.agents/skills/orchestration/chat-mode.md:216`; `.agents/skills/orchestration/chat-mode.md:343`; `.agents/skills/record/record-map.md:15`; `.agents/skills/record/scripts/init-record-map.sh:76`
+- Expected: Any path backing Chat status, review gates, or Wrap-up mining is part of the canonical session map and created by initialization or scaffold scripts.
+- Observed: Chat requires `sessions/{date}-{session-id}/chat/tasks/{NN}-{slug}/task-record.md`, but the record map, initialization script, and scaffold scripts do not create or name that path.
+- Evidence: Chat mode references the path at `chat-mode.md:216`, `:343-367`, and `:422-428`. The record map and initialization logic cover the fixed `1-ideation` through `5-wrap-up` loop tree, not a `chat/tasks` subtree.
+- False-positive check: none. This is not a preference for one layout; the path is consumed by status/review flow but is not in the tree contract.
+- Proposed remediation: Either add the Chat task-record tree to `record-map.md`, initialization, and scaffold validation, or move task records under the existing canonical loop/task tree.
+- Verification: `init-record-map.sh <session-root> chat` creates the task-record parent path or the Chat docs stop referencing it.
+
+### GEN-D7-005: Chat status renderer references missing `currentIndex` and non-canonical `InProgress`
+- Type: checklist_gap
+- Domain: docs-sync
+- Severity: Medium
+- Confidence: 100
+- Priority: medium
+- Disposition: open
+- Runner: codex
+- Dimension: D7
+- Owner-surface: workflow
+- Location: `.agents/skills/orchestration/chat-mode.md:467`; `.agents/skills/orchestration/chat-mode.md:511`; `.agents/skills/orchestration/SKILL.md:245`; `.agents/skills/orchestration/templates/state.template.json:11`
+- Expected: Chat status examples and render rules reference fields and enums that exist in `state.json` / `session.json`.
+- Observed: Chat status rendering uses `state.workflow.chat.currentIndex` and status `InProgress`, but templates and field references do not define `currentIndex`, and canonical state values use `Active` for active work.
+- Evidence: `.agents/skills/orchestration/chat-mode.md:467-469` and `:511-529` reference these names. `.agents/skills/orchestration/SKILL.md:245-247`, `:352`, `templates/state.template.json:11`, and `templates/session.template.json:27` do not define the same field/enum pair.
+- False-positive check: none. The task array exists, but the index and enum names used by the renderer drift from the persisted schema.
+- Proposed remediation: Add `currentIndex` and the exact enum to the schema/templates, or rewrite the renderer to derive the active task from existing canonical fields.
+- Verification: A JSON schema or fixture for Chat mode validates the status-render example with no undefined fields or enum drift.

--- a/.gobbi/projects/gobbi/reviews/adversarial-review/2026-07-01-codex-conducted-adversarial-review-lane-naming-language.md
+++ b/.gobbi/projects/gobbi/reviews/adversarial-review/2026-07-01-codex-conducted-adversarial-review-lane-naming-language.md
@@ -1,0 +1,146 @@
+---
+name: codex-conducted-adversarial-review-lane-naming-language
+description: Lane E review for D5 naming, vocabulary, and word-choice clarity
+type: reviews
+scope: project
+feature: null
+status: active
+created: 2026-07-01
+session: 019f1ef9-a676-7f12-8d78-922f12cb64e9
+tags: [evaluation, docs-sync, design]
+keywords: [d5, naming, vocabulary, wording, clarity, codex-conducted]
+author: codex
+review_kind: adversarial-review
+subject: "Gobbi general surface — D5 naming, vocabulary, and word-choice clarity"
+verdict: needs-attention
+---
+
+# Lane E — D5 Naming, Vocabulary, And Word-Choice Clarity
+
+This lane reviews operational naming and wording that can cause users or agents to misread instructions.
+
+## Method
+
+Lane E reviewed operational naming and wording: schema names, state labels, task identity
+terms, retired vocabulary, and terms that can make users or agents misread instructions.
+
+Commands and checks used included:
+
+- required load reads for AGENTS, evaluator role prompt, principles, mistake, evaluation,
+  research, coding, and this charter
+- `rg --files .gobbi/projects/gobbi/reviews/adversarial-review`
+- targeted dedupe search for `wrapUp`, `taskRecord: written`, `workflow.execution.tasks`,
+  `task-id`, `Rawdata draft`, `two producers`, and lower-case verdict enum variants
+- targeted `nl -ba` reads of chat mode, orchestration field references, execution RECORD,
+  record procedure, state/session templates, production workflow, gobbi glossary, delegation,
+  evaluator prompt, and prior review files
+
+## Findings
+
+### GEN-D5-001: Chat task boundary names schema fields as pseudo-states
+- Type: design_flaw
+- Domain: process
+- Severity: Medium
+- Confidence: 100
+- Priority: medium
+- Disposition: open
+- Runner: codex
+- Dimension: D5
+- Owner-surface: workflow
+- Location: `.agents/skills/orchestration/chat-mode.md:526-529`; `.agents/skills/orchestration/SKILL.md:246,352`; `.agents/skills/orchestration/templates/state.template.json:10`; `.agents/skills/orchestration/templates/session.template.json:26`
+- Expected: State-transition labels should use canonical schema keys and shapes: workflow step key `wrap-up`, and chat task metadata `taskRecord: { path, writtenAt }`.
+- Observed: Chat mode uses `taskRecord: written` as a transition state and sends "Wrap up the session" to `wrapUp.state: InProgress`, while the canonical workflow key is `wrap-up` and `taskRecord` is an object, not a state/string.
+- Evidence: `chat-mode.md:526-529` has `taskRecord: written` and `wrapUp.state: InProgress`; `orchestration/SKILL.md:246` says workflow keys include `wrap-up`; `orchestration/SKILL.md:352` defines `taskRecord: { path, writtenAt }`; templates seed `"wrap-up"` at `state.template.json:10` and `session.template.json:26`.
+- False-positive check: new-variant. Prior D4-008 covers neighboring invalid state tokens such as `InProgress`, `MEMO`, and `WRAPUP`, but not the camelCase key or `taskRecord` payload-shape mismatch.
+- Proposed remediation: Replace pseudo-state labels with canonical state/metadata wording, e.g. "current task's `taskRecord.path`/`writtenAt` present" and `workflow["wrap-up"].state`.
+- Verification: `rg -n 'wrapUp|taskRecord: written' .agents/skills/orchestration` returns no active procedure hits, and chat task examples still show a recoverable task-record path.
+
+### GEN-D5-002: Execution RECORD invents `{task-id}` and `workflow.execution.tasks`
+- Type: design_flaw
+- Domain: process
+- Severity: Medium
+- Confidence: 100
+- Priority: medium
+- Disposition: open
+- Runner: codex
+- Dimension: D5
+- Owner-surface: skill
+- Location: `.agents/skills/execution/SKILL.md:222,231,236,242,251,263`; `.agents/skills/orchestration/SKILL.md:351`; `.agents/skills/record/SKILL.md:192,214`
+- Expected: Execution task telemetry should use canonical `taskNo` + `slug` identity and write per-task value telemetry under `workflow.execution.integration.tasks[]`.
+- Observed: The execution RECORD section repeatedly names `{task-id}` and writes/checks `workflow.execution.iterations[]` keyed by `{task-id, iter}` plus `workflow.execution.tasks[{task-id}]`, neither of which is the canonical per-task telemetry shape.
+- Evidence: `execution/SKILL.md:222` says `workflow.execution.iterations[]` keyed by `{task-id, iter}`; `:236` says `workflow.execution.tasks[{task-id}].finishedAt`; `:251` checks `session.json.workflow.execution.tasks[{task-id}]`; `:263` defines `{task-id}`. By contrast, `orchestration/SKILL.md:351` and `record/SKILL.md:192,214` define execution per-task telemetry as `{ taskNo, slug, iter, ...counts }` in `workflow.execution.integration.tasks[]`.
+- False-positive check: none. Prior D4/D5 dedupe search for `task-id|workflow.execution.tasks|taskNo` did not surface a prior finding with this claim.
+- Proposed remediation: Use one task identity vocabulary in Execution RECORD: `taskNo` + `slug` for telemetry, and only documented `workflow.execution.integration.tasks[]` for the per-task array unless a separate task-status array is formally added.
+- Verification: `rg -n 'task-id|workflow\\.execution\\.tasks' .agents/skills/execution/SKILL.md` has no hits, and `rg -n 'workflow\\.execution\\.integration\\.tasks|taskNo' .agents/skills/execution/SKILL.md` shows the corrected path.
+
+### GEN-D5-003: `workflow.{step}.verdict` enum is lower-case and includes `skipped`
+- Type: design_flaw
+- Domain: process
+- Severity: Medium
+- Confidence: 100
+- Priority: medium
+- Disposition: open
+- Runner: codex
+- Dimension: D5
+- Owner-surface: workflow
+- Location: `.agents/skills/orchestration/SKILL.md:118,141,148,350`; `.agents/skills/record/SKILL.md:197`
+- Expected: Verdict vocabulary should be stable: when a verdict exists it is `PASS` / `REVISE` / `FAIL`; skipped is a state/no-verdict condition, not a verdict value.
+- Observed: The workflow metadata field reference defines `workflow.{step}.verdict` as lower-case `pass | fail | skipped`, while the glossary, status display, and RECORD write path use uppercase verdicts and state that skipped leaves the Verdict column as `—`.
+- Evidence: `gobbi/SKILL.md:118` defines Verdict as `PASS / REVISE / FAIL`; `orchestration/SKILL.md:141` says skipped keeps Verdict `—`; `orchestration/SKILL.md:148` says Verdict displays `PASS / REVISE / FAIL`; `orchestration/SKILL.md:350` says `verdict` is `pass | fail | skipped`; `record/SKILL.md:197` sets `workflow.{loop}.verdict: PASS`.
+- False-positive check: new. Prior D4-010 covers Ideation omitting `FAIL`, but not lower-case session metadata or `skipped` being named as a verdict.
+- Proposed remediation: Align the field reference to the canonical enum and specify skipped as `state: "Skipped"` with `verdict: null` or absent.
+- Verification: `rg -n '\`pass\` \\| \`fail\` \\| \`skipped\`|verdict.*skipped' .agents/skills/orchestration .agents/skills/record` returns no active schema-contract hits.
+
+### GEN-D5-004: RECORD resurrects retired `Rawdata` wording for the canonical draft source
+- Type: design_flaw
+- Domain: docs-sync
+- Severity: Medium
+- Confidence: 100
+- Priority: medium
+- Disposition: open
+- Runner: codex
+- Dimension: D5
+- Owner-surface: skill
+- Location: `.agents/skills/record/SKILL.md:17,179,194`; `.agents/skills/orchestration/workflow/production.md:27,122`; `.gobbi/projects/gobbi/reviews/adversarial-review/2026-06-29-gobbi-adversarial-review-d2.md:680-682`
+- Expected: The canonical work artifact source is `working/draft-iter{n}.md`; retired `rawdata` wording should not appear in active loop RECORD procedure.
+- Observed: RECORD Step 5 names its source as "Rawdata draft," even though the same skill's input list and production workflow identify `working/draft-iter{n}.md`.
+- Evidence: `record/SKILL.md:17` lists drafts at `working/draft-iter{n}.md`; `record/SKILL.md:179` names the current WORK output path as `working/draft-iter{n}.md`; `record/SKILL.md:194` says `Rawdata draft`; `production.md:27,122` confirm the canonical artifact lives at `working/draft-iter{n}.md`. Prior D2-038 explicitly says every loop renamed `rawdata` to `working` and treats residual `rawdata` as retired vocabulary.
+- False-positive check: new-variant. Prior D2-038 covered `interview/SKILL.md`; it did not cover `record/SKILL.md:194`, and that prior review called interview the only residual carrier.
+- Proposed remediation: Rename this source cell to "WORK draft" or the literal `working/draft-iter{n}.md`.
+- Verification: `rg -n '\\brawdata\\b|Rawdata|raw data|raw-data' .agents/skills/record .agents/skills/orchestration` has zero hits outside historical/prior-review files.
+
+### GEN-D5-005: Production calls the Codex proposer a "producer"
+- Type: assumption_risk
+- Domain: process
+- Severity: Low
+- Confidence: 75
+- Priority: low
+- Disposition: open
+- Runner: codex
+- Dimension: D5
+- Owner-surface: workflow
+- Location: `.agents/skills/orchestration/workflow/production.md:3,5,21,23,25,28`; `.agents/skills/gobbi/SKILL.md:122-123`; `.gobbi/projects/gobbi/agents/evaluator.md:25`; `.agents/skills/evaluation/SKILL.md:55-57`
+- Expected: The actor that writes the canonical artifact should be called the producer; the Codex actor should consistently be called the proposer, because evaluator independence is defined around not evaluating one's own producer work and around Codex proposer/evaluator separation.
+- Observed: `production.md` says the manager spawns "exactly two producers — the Claude producer and the Codex proposer" and has a "Spawning the Producers" table whose second row is `Codex proposer`. This makes `producer` mean both the canonical author/integrator and any independent generator.
+- Evidence: `gobbi/SKILL.md:122` defines Proposer as the Codex generator that never writes the canonical artifact; `gobbi/SKILL.md:123` says dual-system production is a Claude producer and a Codex proposer; `production.md:5` says exactly two producers; `production.md:21-28` labels the section/table as producers while row 2 is `Codex proposer`; evaluator and evaluation docs distinguish producer work from proposer/evaluator separation.
+- False-positive check: style preference avoided. The failure mode is not that "producer" sounds bad; it can make a Codex evaluator or manager over-apply producer/evaluator separation to the Codex proposal instead of the canonical artifact.
+- Proposed remediation: Reserve `producer` for the canonical author/integrator; use "two generators" or "producer + proposer" for the pair.
+- Verification: `rg -n 'two producers|Spawning the Producers|Producer \\| Who' .agents/skills/orchestration/workflow/production.md .agents/skills/delegation/SKILL.md` no longer labels the Codex proposer as a producer.
+
+### GEN-D5-006: Chat display uses `task-record` and `taskRecord` for the same boundary object
+- Type: design_flaw
+- Domain: observability
+- Severity: Low
+- Confidence: 100
+- Priority: low
+- Disposition: open
+- Runner: codex
+- Dimension: D5
+- Owner-surface: workflow
+- Location: `.agents/skills/orchestration/chat-mode.md:497,526-529`; `.agents/skills/orchestration/SKILL.md:352`
+- Expected: The visible label and schema field should make clear that the same thing is an artifact file plus a metadata object: `task-record.md` on disk and `taskRecord: { path, writtenAt }` in state/session JSON.
+- Observed: The status table displays a row named `task-record`, but the transition table uses `taskRecord: written` as if it were a state. The schema then defines `taskRecord` as an object. That three-way wording invites an implementation to store a string flag or miss the `path`/`writtenAt` metadata Wrap-up needs.
+- Evidence: `chat-mode.md:497` renders `task-record` with `{written|pending}`; `chat-mode.md:526-529` uses `taskRecord: written`; `orchestration/SKILL.md:352` defines `taskRecord: { path, writtenAt }`.
+- False-positive check: new-variant. This overlaps the same chat-mode region as D4-008, but the prior defect was non-Glossary state tokens; this is a file-label/schema-field collision with a concrete metadata-loss path.
+- Proposed remediation: Keep `task-record.md` for the file and `taskRecord.path` / `taskRecord.writtenAt` for metadata; avoid using either as a state label.
+- Verification: The chat status example and transition table mention `taskRecord.path` or equivalent object fields, and no active procedure contains `taskRecord: written`.

--- a/.gobbi/projects/gobbi/reviews/adversarial-review/2026-07-01-codex-conducted-adversarial-review-lane-runtime-plugin-codex.md
+++ b/.gobbi/projects/gobbi/reviews/adversarial-review/2026-07-01-codex-conducted-adversarial-review-lane-runtime-plugin-codex.md
@@ -1,0 +1,145 @@
+---
+name: codex-conducted-adversarial-review-lane-runtime-plugin-codex
+description: Lane F review for D6 runtime, plugin, install, packaging, and Codex compatibility
+type: reviews
+scope: project
+feature: null
+status: active
+created: 2026-07-01
+session: 019f1ef9-a676-7f12-8d78-922f12cb64e9
+tags: [evaluation, codex, process]
+keywords: [d6, runtime, plugin, install, packaging, codex-compatibility]
+author: codex
+review_kind: adversarial-review
+subject: "Gobbi general surface — D6 runtime, plugin, install, packaging, and Codex compatibility"
+verdict: needs-attention
+---
+
+# Lane F — D6 Runtime, Plugin, Install, Packaging, And Codex Compatibility
+
+This lane reviews runtime packaging plus Codex compatibility as an add-on, not the whole review frame.
+
+## Method
+
+Lane F reviewed runtime packaging, plugin manifests, hooks, smoke/check scripts, symlink
+topology, installed-cache assumptions, and Codex compatibility add-on points. Prior D6
+findings from `2026-06-29-gobbi-adversarial-review-d6.md` were treated as existing and were
+not re-filed.
+
+Commands and checks used:
+
+- `git status --short --branch`
+- `git rev-parse HEAD`
+- `find -L .agents/skills ...`
+- `find -L plugins/gobbi/skills ...`
+- `readlink ...`
+- `git ls-files -s ...`
+- `jq empty` on Codex/Claude manifests, marketplace JSON, and hook JSON
+- `bash scripts/check-codex-compatibility.sh`
+- `bash scripts/sync-plugin-package.sh --check`
+- targeted `rg -n` absence checks
+- line reads with `nl -ba`
+
+`scripts/check-codex-plugin-smoke.sh` was inspected but not run by the lane reviewer because it
+performs a plugin install into a temporary Codex home. That is acceptable as a future
+verification step, but this lane kept its delegated research read-only.
+
+## Findings
+
+### GEN-D6-001: Codex smoke samples two skills and one hook manifest, so a mostly missing installed cache can still look clean
+- Type: checklist_gap
+- Domain: test
+- Severity: Medium
+- Confidence: 100
+- Priority: medium
+- Disposition: open
+- Runner: codex
+- Dimension: D6
+- Owner-surface: plugin
+- Location: `scripts/check-codex-plugin-smoke.sh:89`; `plugins/gobbi/.codex-plugin/plugin.json:18`; `plugins/gobbi/hooks/codex-hooks.json:7`
+- Expected: the Codex smoke should verify the installed cache contains the full component graph declared by the Codex manifest: all shipped skills and every hook command target.
+- Observed: the manifest declares `skills: "./skills/"` and `hooks: "./hooks/codex-hooks.json"`, the source package exposes 22 `SKILL.md` files, and `codex-hooks.json` calls `hooks/session-start.sh` plus `hooks/post-tool-use-agents.sh`; the smoke checks only `skills/codex/SKILL.md`, `skills/principles/SKILL.md`, and `hooks/codex-hooks.json`.
+- Evidence: `find -L plugins/gobbi/skills -mindepth 2 -maxdepth 2 -name SKILL.md | wc -l` returned `22`; `nl -ba scripts/check-codex-plugin-smoke.sh` shows the sampled component paths at lines 89-98; `jq -r '.hooks | to_entries[] | .value[] | .hooks[] | .command' plugins/gobbi/hooks/codex-hooks.json` shows two shell script command targets not checked by the smoke.
+- False-positive check: none. This is not prior D6-003; that finding covered a Claude installed-cache allow-set rejecting `.codex-plugin`, not the Codex smoke's partial component coverage.
+- Proposed remediation: make the smoke enumerate all installed `skills/*/SKILL.md` against the source skill set and verify each hook command target exists under the installed cache.
+- Verification: a cache missing any one of the 22 skills or either Codex hook script fails the smoke.
+
+### GEN-D6-002: Codex smoke hard-fails on a Claude-only manifest while warning on missing Codex runtime components
+- Type: design_flaw
+- Domain: process
+- Severity: Medium
+- Confidence: 100
+- Priority: medium
+- Disposition: open
+- Runner: codex
+- Dimension: D6
+- Owner-surface: plugin
+- Location: `scripts/check-codex-plugin-smoke.sh:79`; `scripts/check-codex-plugin-smoke.sh:89`
+- Expected: a Codex install smoke should fail on missing Codex-required artifacts and treat Claude-only artifacts as non-blocking shared-package context.
+- Observed: `.claude-plugin/plugin.json` is in the `required_file` loop and fails the Codex smoke if absent, while missing `skills/codex/SKILL.md`, `skills/principles/SKILL.md`, or `hooks/codex-hooks.json` only increments warnings.
+- Evidence: `nl -ba scripts/check-codex-plugin-smoke.sh` shows `.codex-plugin/plugin.json` and `.claude-plugin/plugin.json` both hard-required at lines 79-87; the Codex component paths are warnings at lines 89-98.
+- False-positive check: none. This is the inverse of prior D6-003, not a duplicate: prior D6 found a Claude validator rejecting a Codex manifest; this finds the Codex smoke requiring a Claude manifest while softening Codex component absence.
+- Proposed remediation: fail on Codex manifest and Codex runtime component absence; downgrade the Claude manifest to an informational shared-package check unless Codex actually requires it.
+- Verification: a cache with valid Codex manifest, skills, and hooks but no `.claude-plugin/` does not fail the Codex smoke; a cache missing Codex skills or Codex hook command targets does fail.
+
+### GEN-D6-003: Codex compatibility gate does not validate the Codex marketplace file
+- Type: checklist_gap
+- Domain: test
+- Severity: Medium
+- Confidence: 100
+- Priority: medium
+- Disposition: open
+- Runner: codex
+- Dimension: D6
+- Owner-surface: plugin
+- Location: `scripts/check-codex-compatibility.sh:130`; `.agents/plugins/marketplace.json:8`
+- Expected: the static Codex compatibility gate should validate `.agents/plugins/marketplace.json`, because that file maps `gobbi@gobbi-workspace` to the bounded package.
+- Observed: the compatibility script validates the Codex plugin manifest, package symlinks, hooks, agents, and docs, but never checks `.agents/plugins/marketplace.json` or its `source.path`.
+- Evidence: `rg -n "\\.agents/plugins|agents/plugins|marketplace\\.json|source\\.path|gobbi-workspace" scripts/check-codex-compatibility.sh` produced no output; `.agents/plugins/marketplace.json:8-15` contains the plugin name, source path, installation policy, and auth policy.
+- False-positive check: none. The smoke script uses marketplace registration, but the static compatibility check can still report "Codex compatibility checks passed" while the marketplace file is broken.
+- Proposed remediation: add JSON validation and exact value checks for marketplace name, plugin name, `source.source`, `source.path`, and policy fields.
+- Verification: changing `.agents/plugins/marketplace.json` `source.path` away from `./plugins/gobbi` makes `scripts/check-codex-compatibility.sh` fail.
+
+### GEN-D6-004: Trust prerequisite is stated in AGENTS but absent from the Codex install procedure and smoke evidence
+- Type: checklist_gap
+- Domain: docs-sync
+- Severity: Medium
+- Confidence: 100
+- Priority: medium
+- Disposition: open
+- Runner: codex
+- Dimension: D6
+- Owner-surface: docs
+- Location: `AGENTS.md:31`; `.agents/skills/codex/SKILL.md:96`; `scripts/check-codex-plugin-smoke.sh:49`
+- Expected: the Codex install path should tell an operator how to satisfy or verify the project-trust prerequisite before claiming config, hooks, and rules will load.
+- Observed: `AGENTS.md` says the project must be trusted before project config, hooks, and rules are loaded, but the Codex skill's install block only gives `codex plugin marketplace add` and `codex plugin add`, and the smoke script registers/adds the plugin without any trust check.
+- Evidence: `rg -n "trust|trusted" AGENTS.md .codex/AGENTS.md .agents/skills/codex/SKILL.md scripts/check-codex-plugin-smoke.sh scripts/check-codex-compatibility.sh .agents/plugins/marketplace.json plugins/gobbi/.codex-plugin/plugin.json` returned only `AGENTS.md:31` and `.codex/AGENTS.md:31`; `.agents/skills/codex/SKILL.md:96-103` has the install commands but no trust step.
+- False-positive check: new-variant. Prior D1-020 covered the complete absence of Codex trust/install docs; current state has the trust sentence, but no operational trust verification.
+- Proposed remediation: add a trust step or verification note to the Codex skill install procedure and decide whether the smoke script can assert it or must explicitly say trust remains unverified.
+- Verification: the install doc and smoke output distinguish "plugin installed in cache" from "new trusted project thread will load config/hooks/rules."
+
+### GEN-D6-005: Hook smoke bypasses the installed hook commands and `PLUGIN_ROOT` expansion path
+- Type: checklist_gap
+- Domain: test
+- Severity: Medium
+- Confidence: 100
+- Priority: medium
+- Disposition: open
+- Runner: codex
+- Dimension: D6
+- Owner-surface: hook
+- Location: `scripts/check-codex-compatibility.sh:89`; `plugins/gobbi/hooks/codex-hooks.json:7`
+- Expected: a Codex hook compatibility check should exercise the same command shape the installed Codex hook uses, including `${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}` resolution.
+- Observed: `check_codex_hook_smoke` directly runs `bash "$repo_root/$path" <<< '{}'` with `CODEX_THREAD_ID` and `CODEX_CI`; it never evaluates the command strings from `codex-hooks.json` and never proves `PLUGIN_ROOT` resolves to an installed hook root.
+- Evidence: `scripts/check-codex-compatibility.sh:89-97` shows direct source-file invocation; `plugins/gobbi/hooks/codex-hooks.json:7` and `:15` show the real installed command form.
+- False-positive check: none. Prior D6-007 covered matcher shape; this is the command-path execution gap.
+- Proposed remediation: add a hook command smoke that sets `PLUGIN_ROOT` to a fixture or installed cache path and executes the command strings parsed from `codex-hooks.json`.
+- Verification: changing the command in `codex-hooks.json` to a missing script path makes the compatibility check fail.
+
+## Must Preserve
+
+- Keep the source package symlinked.
+- Keep Codex custom agents repo-local under `.codex/agents`.
+- Keep evaluator sandbox `read-only`.
+- Keep `scripts/check-codex-plugin-smoke.sh` isolated from the user's real Codex home.
+- Keep native Codex hooks non-blocking when Claude environment variables are absent.

--- a/.gobbi/projects/gobbi/reviews/adversarial-review/2026-07-01-codex-conducted-adversarial-review-lane-templates.md
+++ b/.gobbi/projects/gobbi/reviews/adversarial-review/2026-07-01-codex-conducted-adversarial-review-lane-templates.md
@@ -1,0 +1,135 @@
+---
+name: codex-conducted-adversarial-review-lane-templates
+description: Lane D review for D4 templates and schema usability
+type: reviews
+scope: project
+feature: null
+status: active
+created: 2026-07-01
+session: 019f1ef9-a676-7f12-8d78-922f12cb64e9
+tags: [evaluation, docs-sync, design]
+keywords: [d4, templates, schemas, memory, record, codex-conducted]
+author: codex
+review_kind: adversarial-review
+subject: "Gobbi general surface — D4 templates and schema usability"
+verdict: needs-attention
+---
+
+# Lane D — D4 Templates And Schema Usability
+
+This lane reviews templates, schema docs, writer/reader ownership, and validation expectations.
+
+## Method
+
+Lane D reviewed memory templates, session templates, settings/state/session schemas, review
+formats, generated scaffolds, and delegation templates for writer/reader ownership, required
+fields, lifecycle timing, validation expectations, and wrong-write prevention.
+
+Prior D2/D4 findings were checked for duplicates. This lane did not re-file already covered
+items such as `session.template.json` missing `iterations[]`, mistake timing, exact
+`skill-writing` frontmatter issues, Claude-only `AskUserQuestion` wording, or executor example
+nonexistent skills.
+
+Commands and checks used included:
+
+- required load reads for AGENTS, evaluator role prompt, principles, mistake, evaluation,
+  research, coding, memory, record, and this charter
+- `find .gobbi/projects/gobbi/reviews/adversarial-review -maxdepth 1 -type f -name '2026-06-29-*.md' -print | sort`
+- `rg -n "^author: claude" .agents/skills/memory/templates`
+- `rg -n "validate.*session|session.*validate|validate.*state|state.*validate|session\\.template|state\\.template" .agents/skills scripts`
+- `jq empty` on orchestration JSON templates
+- targeted line reads of cited templates, memory rules, evaluation metadata, and validation scripts
+
+## Findings
+
+### GEN-D4-001: Memory templates stamp Claude as author even when Codex writes
+- Type: design_flaw
+- Domain: docs-sync
+- Severity: Medium
+- Confidence: 100
+- Priority: high
+- Disposition: open
+- Runner: codex
+- Dimension: D4
+- Owner-surface: memory
+- Location: `.agents/skills/memory/templates/decisions.md:38`
+- Expected: Memory templates should make `author` runtime-derived, or visibly placeholdered, because memory rules allow `claude | codex | user` and define it as the runtime/system that authored the file.
+- Observed: Concrete templates default to `author: claude`, while only the trailing comment mentions `codex`.
+- Evidence: `.agents/skills/memory/rules.md:186` requires `author: claude | codex | user`; `.agents/skills/memory/rules.md:205` defines `author` as the runtime/system that authored the file. `rg -n "^author: claude" .agents/skills/memory/templates` returned concrete Claude defaults in every memory template, including `decisions.md`, `reviews.md`, `feature.md`, and both checklist blocks.
+- False-positive check: none. The enum comment is present, but the copyable field value is still Claude, which is the part a writer will preserve under time pressure.
+- Proposed remediation: Replace concrete `author: claude` defaults with a runtime placeholder or explicit auto-stamp instruction, and require Wrap-up/session promotion to fill it from the active runtime.
+- Verification: `rg -n "^author: claude" .agents/skills/memory/templates` returns no copyable defaults except clearly labeled historical examples.
+
+### GEN-D4-002: Codex delegation templates load canonical skill paths instead of Codex entrypoint paths
+- Type: design_flaw
+- Domain: process
+- Severity: High
+- Confidence: 100
+- Priority: high
+- Disposition: open
+- Runner: codex
+- Dimension: D4
+- Owner-surface: template
+- Location: `.agents/skills/delegation/templates/leader.md:31`
+- Expected: Native Codex delegation prompts should direct fresh Codex specialists to load repo-local Codex skill paths under `.agents/skills/<skill>/SKILL.md`, matching the Gobbi Codex entrypoint contract.
+- Observed: Shared delegation templates tell subagents to load `.gobbi/projects/<<project-name>>/skills/...` paths.
+- Evidence: `.agents/skills/codex/SKILL.md:41` says native Codex loads Gobbi skills from `.agents/skills/<skill-name>/SKILL.md`; `.agents/skills/codex/SKILL.md:63` says Codex uses project custom agents from `.codex/agents`; `.agents/skills/codex/SKILL.md:70` says fresh Codex subagents need explicit load directives. Delegation templates hard-code canonical paths in leader, executor, assistant, and evaluator templates. Prior D2/D4 review did not contain this exact native-Codex template-path issue.
+- False-positive check: none. The canonical paths exist, but the template violates the documented Codex entrypoint and bypasses the `.agents/skills` surface that the repo explicitly says Codex should load.
+- Proposed remediation: Parameterize load-root by runtime, with native Codex prompts rendering `.agents/skills/...` paths and bridge/internal canonical prompts rendering `.gobbi/projects/...` only when intended.
+- Verification: Render each native Codex delegation template and verify mandatory load directives contain `.agents/skills/principles/SKILL.md`, `.agents/skills/mistake/SKILL.md`, and phase/domain skills under `.agents/skills`.
+- Second-pass: rejected as duplicate by Godel (`019f1f2d-20a4-71f0-a5e5-0ef5512dd3dc`). Source evidence is true, but aggregate counts this under `GEN-D2-002` only.
+
+### GEN-D4-003: Producer templates hard-code Claude as producer and Codex as proposer
+- Type: assumption_risk
+- Domain: process
+- Severity: High
+- Confidence: 100
+- Priority: high
+- Disposition: open
+- Runner: codex
+- Dimension: D4
+- Owner-surface: template
+- Location: `.agents/skills/delegation/templates/executor.md:82`
+- Expected: Delegation templates should distinguish Claude Code bridge dual-production from native Codex specialist execution, or use runtime placeholders for producer/proposer identity.
+- Observed: Producer templates instruct the worker that they are the Claude producer and degraded output should be stamped `production_mode: claude-only`, even when the template is used to brief a native Codex role.
+- Evidence: `.agents/skills/delegation/SKILL.md:152` states native Codex leader/executor/assistant dispatches are fresh specialist spawns with full load directives. `.agents/skills/delegation/SKILL.md:363` defines dual-production as Claude producer plus Codex proposer. Templates mirror that as concrete worker identity: leader says "You are the Claude producer"; executor does the same; assistant says Wrap-up Claude-producer and degraded Claude-only.
+- False-positive check: none. This is not the prior finding about duplicated dual-system blocks in loop skills; this is the reusable delegation template surface that would mislabel a native Codex producer.
+- Proposed remediation: Split or parameterize producer templates so native Codex workers are not told they are Claude, and reserve `production_mode: claude-only` for actual Claude-side degraded runs.
+- Verification: Render leader/executor/assistant prompts for native Codex and confirm they do not contain "You are the Claude producer", "Wrap-up Claude producer", or `production_mode: claude-only` unless the runtime is actually Claude Code bridge mode.
+- Second-pass: validated by Godel (`019f1f2d-20a4-71f0-a5e5-0ef5512dd3dc`). Severity remains High.
+
+### GEN-D4-004: Durable review template drops required evaluation routing and idempotency fields
+- Type: checklist_gap
+- Domain: process
+- Severity: Medium
+- Confidence: 100
+- Priority: high
+- Disposition: open
+- Runner: codex
+- Dimension: D4
+- Owner-surface: memory
+- Location: `.agents/skills/memory/templates/reviews.md:59`
+- Expected: Review-memory findings, especially evaluator-driven reviews, should preserve the evaluation finding metadata needed for RECORD routing and re-run idempotency.
+- Observed: The durable `reviews.md` template says evaluator-driven reviews mirror evaluation metadata, but the actual finding block omits `Type`, `Domain`, `finding-id`, `Priority`, `Runner`, `Dimension`, `Owner-surface`, `False-positive check`, and other charter fields.
+- Evidence: `.agents/skills/memory/templates/reviews.md:59-60` says evaluator-driven reviews mirror evaluation metadata. The mini-template at `.agents/skills/memory/templates/reviews.md:62-68` only lists Severity, Confidence, Description, Evidence, Proposed remediation, and Disposition. The evaluation contract requires Type values, deterministic Domain routing, stable `finding-id` idempotency, and Domain on findings. The July 1 charter requires fuller review fields.
+- False-positive check: none. Narrative human reviews may be looser, but the template explicitly covers evaluator-driven reviews and should not discard their routing schema.
+- Proposed remediation: Make `reviews.md` include or directly reference the complete evaluation/charter finding shape for evaluator-driven reviews, including `finding-id`, Type, Domain, Disposition, and false-positive checks.
+- Verification: A staged review generated from an evaluator report can be round-tripped back into RECORD routing without inventing Type/Domain or losing stable IDs.
+
+### GEN-D4-005: Root session/state/settings schemas have no validation guard
+- Type: checklist_gap
+- Domain: test
+- Severity: Medium
+- Confidence: 100
+- Priority: medium
+- Disposition: open
+- Runner: codex
+- Dimension: D4
+- Owner-surface: template
+- Location: `.agents/skills/record/scripts/verify-record-map.sh:12`
+- Expected: The session root templates and their lifecycle-critical schemas should have a mechanical validation gate for required keys, allowed values, and cross-field invariants.
+- Observed: Existing record-map verification intentionally excludes session-root JSON invariants, and no separate session/state/settings schema validator appears in the skill/script surface.
+- Evidence: Configuration bootstraps the full record skeleton and stamps `state.json` and `session.json`; RECORD later requires `workflow.{loop}.iterations[]` upserts and checks `evaluation_dir`. But `verify-record-map.sh` says it never diffs root invariants including `session.json`, `state.json`, and `settings.json`. `rg -n "validate.*session|session.*validate|validate.*state|state.*validate|session\\.template|state\\.template" .agents/skills scripts` returned no session/state schema validator. `jq empty` passed for JSON templates, checking syntax only.
+- False-positive check: none. This is distinct from already-filed `iterations[]` schema drift; the finding is the absence of a guard that would catch that class of drift.
+- Proposed remediation: Add a schema/check script, or extend an existing guard, to validate session-root JSON templates and stamped instances for required keys, allowed enums, lifecycle fields, and Codex/Claude metadata expectations.
+- Verification: The guard fails a fixture missing `workflow.<loop>.iterations[]`, a bad `state.workflow.*.state` enum, or invalid/misplaced Codex metadata, and passes corrected canonical templates.

--- a/.gobbi/projects/gobbi/reviews/adversarial-review/2026-07-01-codex-conducted-adversarial-review-lane-workflow.md
+++ b/.gobbi/projects/gobbi/reviews/adversarial-review/2026-07-01-codex-conducted-adversarial-review-lane-workflow.md
@@ -1,0 +1,123 @@
+---
+name: codex-conducted-adversarial-review-lane-workflow
+description: Lane A review for D1 end-to-end workflow correctness
+type: reviews
+scope: project
+feature: null
+status: active
+created: 2026-07-01
+session: 019f1ef9-a676-7f12-8d78-922f12cb64e9
+tags: [evaluation, process, verification]
+keywords: [d1, workflow, lifecycle, state, record, codex-conducted]
+author: codex
+review_kind: adversarial-review
+subject: "Gobbi general surface — D1 end-to-end workflow correctness"
+verdict: needs-attention
+---
+
+# Lane A — D1 End-To-End Workflow Correctness
+
+This lane reviews Configuration -> Ideation -> Preparation -> Planning -> Execution -> Wrap-up.
+
+## Method
+
+Lane A reviewed Configuration -> Ideation -> Preparation -> Planning -> Execution -> Wrap-up,
+with emphasis on loop transitions, output/input contracts, state/session/memory boundaries,
+PASS/REVISE/FAIL paths, artifact freeze points, and failure recovery.
+
+The lane deduped against the previous `2026-06-29-*` review corpus and did not re-file known
+workflow findings unless current evidence showed a distinct variant.
+
+Commands and checks used included:
+
+- required load reads for `AGENTS.md`, evaluator role prompt, principles, mistake, evaluation,
+  research, coding, codex, and this charter
+- targeted `nl -ba` reads of `.agents/skills/orchestration/{SKILL.md,auto-mode.md,chat-mode.md,workflow/*.md,templates/*.json}`
+- targeted reads of `.agents/skills/{record,wrap-up,preparation,evaluation}/SKILL.md`
+- `rg -n` dedup checks against `.gobbi/projects/gobbi/reviews/adversarial-review/2026-06-29-*.md`
+- `git rev-parse --show-toplevel`, `git branch --show-current`, `git rev-parse HEAD`, and `git status --short`
+
+## Findings
+
+### GEN-D1-001: Preparation `RE-IDEATE` is a transition the evaluator/session-state contract cannot emit
+- Type: design_flaw
+- Domain: process
+- Severity: High
+- Confidence: 100
+- Priority: high
+- Disposition: open
+- Runner: codex
+- Dimension: D1
+- Owner-surface: workflow
+- Location: `.agents/skills/orchestration/workflow/preparation.md:51`; `.agents/skills/orchestration/workflow/preparation.md:110`; `.agents/skills/orchestration/workflow/evaluation.md:5`; `.agents/skills/orchestration/workflow/evaluation.md:149`; `.agents/skills/preparation/SKILL.md:311`; `.agents/skills/orchestration/SKILL.md:263`; `.agents/skills/orchestration/templates/state.template.json:5`
+- Expected: If Preparation can re-enter Ideation after evaluation/ITER, that transition is represented in the same verdict/state vocabulary used by evaluators, manager aggregation, RECORD, and `state.json` / `session.json`; otherwise it is modeled only as a pre-evaluation user decision.
+- Observed: Preparation says re-Ideate halts Preparation and is not a Preparation `REVISE`, then lists `RE-IDEATE` as a special ITER/EXIT verdict. Auto mode also says a `RE-IDEATE` verdict re-enters Ideation. The manager evaluation contract emits only `PASS` / `REVISE` / `FAIL`; Preparation's skill records only those three; orchestration aggregation lists only those three; `state.template.json` has no `RE-IDEATE` enum.
+- Evidence: `rg -n "RE-IDEATE|re-Ideate" .gobbi/projects/gobbi/reviews/adversarial-review/2026-06-29-*.md` found no prior review duplicate; targeted `nl -ba` traces show `RE-IDEATE` present in Preparation/Auto transition prose but absent from evaluation aggregation and state/session field references.
+- False-positive check: none. This is an enum/transition mismatch, not a wording preference. The pre-evaluation discussion path exists, but the separate row-5 verdict path is not representable.
+- Proposed remediation: Choose one model: either keep re-Ideate strictly as a Preparation DISCUSSION user decision before WORK/EVALUATION, or add a formal `RE-IDEATE` transition/status to evaluation aggregation, RECORD, state/session templates, and resume logic.
+- Verification: A future pass traces every Preparation re-Ideate path from DISCUSSION or EVALUATION through RECORD and state/session persistence with no out-of-band enum.
+- Second-pass: validated by Godel (`019f1f2d-20a4-71f0-a5e5-0ef5512dd3dc`). Severity remains High.
+
+### GEN-D1-002: Manager-side finding routing table contradicts canonical Type+Domain routing
+- Type: design_flaw
+- Domain: docs-sync
+- Severity: High
+- Confidence: 100
+- Priority: high
+- Disposition: open
+- Runner: codex
+- Dimension: D1
+- Owner-surface: workflow
+- Location: `.agents/skills/orchestration/workflow/evaluation.md:165`; `.agents/skills/evaluation/SKILL.md:363`
+- Expected: The manager-facing EVALUATION workflow should point to the canonical evaluator/RECORD routing contract or restate it completely so PASS-iter staging receives the right destinations.
+- Observed: `.agents/skills/orchestration/workflow/evaluation.md:165-178` gives a narrowed type-only table: `general` routes only when it has a citable external pattern to `staging/references/`, and `design_flaw` / `assumption_risk` always go to decisions. The canonical table at `.agents/skills/evaluation/SKILL.md:363-390` routes Type=`general` by Domain across decisions, checklists, references, process mistake-candidates, and an error for `general/general`. RECORD says it applies the canonical Type+Domain table with no shortcut routing.
+- Evidence: Prior review D5-012 covers stale routing duplicated inside `ideation/SKILL.md`, not this manager-facing `workflow/evaluation.md` table. `rg -n "Routing Findings to RECORD|general with citable|Complete Domain|Type \\+ Domain|D5-012" .gobbi/projects/gobbi/reviews/adversarial-review/2026-06-29-*.md` confirms the prior location/class but not this runtime manager surface.
+- False-positive check: pre-existing checked; this is a new variant because the manager orchestration doc is a different handoff surface that feeds RECORD.
+- Proposed remediation: Replace the local table in `workflow/evaluation.md` with a pointer to `evaluation/SKILL.md` + `record/SKILL.md`, or restate the full Type+Domain table exactly once from the canonical source.
+- Verification: A future pass can diff all manager/evaluator/record routing prose and show there is one complete routing source, with no `general with citable external pattern` shortcut.
+- Second-pass: validated by Godel (`019f1f2d-20a4-71f0-a5e5-0ef5512dd3dc`). Severity remains High.
+
+### GEN-D1-003: Chat narrowed RECORD defers staging to Wrap-up, but Wrap-up forbids the deferred sources
+- Type: design_flaw
+- Domain: process
+- Severity: High
+- Confidence: 75
+- Priority: high
+- Disposition: open
+- Runner: codex
+- Dimension: D1
+- Owner-surface: workflow
+- Location: `.agents/skills/orchestration/chat-mode.md:246`; `.agents/skills/wrap-up/SKILL.md:71`
+- Expected: If Chat Mode skips per-slice typed-finding staging, Wrap-up must have an explicit, executable reconstruction step that reads the deferred sources and materializes promotable staging or memory entries.
+- Observed: Chat Mode says PASS RECORD skips typed-finding staging, then says Wrap-up must mine transcript, task records, and per-loop evaluation files. It also says Wrap-up RECORD reads task records and transcript. Wrap-up's promotion-inventory rule inventories `staging/` only and never promotes from `transcripts/`, `working/`, `evaluation/`, or `outputs`. Its WORK inputs use prior evaluation outputs for closure audit only; Step 2 enumerates staging only; Step 2.5 can auto-backfill malformed staging but treats absent/empty staging as `NEEDS_CONTEXT`, not transcript/evaluation reconstruction.
+- Evidence: `rg -n "Chat|task-record|transcript|reconstruct|narrowed|evaluation files|mine" .agents/skills/wrap-up/SKILL.md .agents/skills/orchestration/chat-mode.md` shows reconstruction promised in Chat docs, while Wrap-up only references transcript preservation and staging-only promotion. Prior `2026-06-29` searches for `Chat narrowed|task-record` returned no duplicate.
+- False-positive check: none; this changes whether Chat-mode findings reach durable memory.
+- Proposed remediation: Add a Chat-specific Wrap-up WORK sub-step that reconstructs typed findings into a staging-compatible inventory before promotion, or remove the deferred-staging model and run base RECORD staging per slice.
+- Verification: A future Chat-mode dry run with one evaluation finding should produce either a per-slice staging file or a Wrap-up-generated staging/promotion-manifest entry sourced from the task record/evaluation file.
+- Second-pass: validated by Godel (`019f1f2d-20a4-71f0-a5e5-0ef5512dd3dc`). Severity remains High.
+
+### GEN-D1-004: Execution iteration history has incompatible idempotency keys
+- Type: design_flaw
+- Domain: process
+- Severity: Medium
+- Confidence: 100
+- Priority: medium
+- Disposition: open
+- Runner: codex
+- Dimension: D1
+- Owner-surface: workflow
+- Location: `.agents/skills/orchestration/workflow/execution.md:91`; `.agents/skills/record/SKILL.md:192`; `.agents/skills/record/SKILL.md:275`
+- Expected: Execution's per-task iteration history should have one schema and one idempotency key across execution workflow docs, RECORD procedure, field reference, and templates.
+- Observed: Execution says per-task iteration boundaries live at `session.json.workflow.execution.iterations[]` keyed by `{task-id, iter}`. RECORD says all loops upsert `workflow.{loop}.iterations[]` keyed only by `iter`; execution-specific per-task data is separately keyed by `taskNo` in `workflow.execution.integration.tasks[]`. The field reference documents `workflow.execution.integration.tasks[]` but not the `{task-id, iter}` key for execution iterations.
+- Evidence: Prior D1-009 covers the broader missing `iterations[]` array in the template; this is a new variant because the current conflict is not just missing seed fields, but contradictory idempotency keys for multiple Execution tasks.
+- False-positive check: pre-existing checked; same schema family as D1-009, distinct trigger/runtime effect.
+- Proposed remediation: Define Execution iterations either as a task-scoped array keyed by `{taskNo|slug, iter}` everywhere, or keep generic `iterations[]` keyed by loop-level `iter` and store task-specific history only under a documented `tasks[]` subrecord.
+- Verification: A future session with two Execution tasks both on iter 1 can re-run RECORD and preserve both histories without overwrite or duplicate entries.
+
+## Existing Findings Not Re-Filed
+
+- Existing: Ideation PASS handoff skips Preparation in one doc. Prior finding: `2026-06-29-gobbi-adversarial-review.md` D1-003.
+- Existing: `session.template.json` omits generic `iterations[]`. Prior finding: `2026-06-29-gobbi-adversarial-review.md` D1-009.
+- Existing: Preparation `outputs/` has no documented Planning consumer in workflow docs. Prior finding: `2026-06-29-gobbi-adversarial-review.md` D1-013.
+- Existing: evaluation mandatory/optional/skip policy drift. Prior finding: `2026-06-29-gobbi-adversarial-review-d4.md` D4-001.
+- Existing/new-variant boundary: stale finding-routing duplication in `ideation/SKILL.md` is already D5-012; GEN-D1-002 is the separate manager workflow/evaluation surface.

--- a/.gobbi/projects/gobbi/reviews/adversarial-review/2026-07-01-codex-conducted-adversarial-review.md
+++ b/.gobbi/projects/gobbi/reviews/adversarial-review/2026-07-01-codex-conducted-adversarial-review.md
@@ -1,0 +1,198 @@
+---
+name: codex-conducted-adversarial-review
+description: Aggregate Codex-conducted general adversarial review of Gobbi
+type: reviews
+scope: project
+feature: null
+status: active
+created: 2026-07-01
+session: 019f1ef9-a676-7f12-8d78-922f12cb64e9
+tags: [evaluation, codex, process]
+keywords: [general-review, docs-design, templates, naming, codex-compatibility, aggregate]
+author: codex
+review_kind: adversarial-review
+subject: "Gobbi full surface — Codex-conducted general adversarial review"
+verdict: needs-attention
+---
+
+# Codex-Conducted General Adversarial Review Of Gobbi
+
+This aggregate preserves the prior `2026-06-29-*` review files and records only the new
+`2026-07-01` Codex-conducted pass.
+
+The review is general, not Codex-only. Codex compatibility was reviewed as an add-on lane and as
+cross-cutting evidence where native Codex behavior changes the workflow contract. The revised charter
+is `.gobbi/projects/gobbi/plans/workflow/2026-07-01-codex-conducted-adversarial-review-charter.md`.
+
+## Method
+
+Eight lanes reviewed the current Gobbi surface:
+
+| Lane | Dimension | Report | Raw findings | Raw severity |
+|---|---|---|---:|---|
+| A | D1 workflow correctness | `2026-07-01-codex-conducted-adversarial-review-lane-workflow.md` | 4 | 3 High, 1 Medium |
+| B | D2 agents, skills, delegation | `2026-07-01-codex-conducted-adversarial-review-lane-agents-skills.md` | 5 | 1 High, 3 Medium, 1 Low |
+| C | D3 docs design and information architecture | `2026-07-01-codex-conducted-adversarial-review-lane-docs-design.md` | 5 | 2 High, 3 Medium |
+| D | D4 templates and schemas | `2026-07-01-codex-conducted-adversarial-review-lane-templates.md` | 5 | 2 High, 3 Medium |
+| E | D5 naming and wording | `2026-07-01-codex-conducted-adversarial-review-lane-naming-language.md` | 6 | 4 Medium, 2 Low |
+| F | D6 runtime, plugin, install, Codex add-on | `2026-07-01-codex-conducted-adversarial-review-lane-runtime-plugin-codex.md` | 5 | 5 Medium |
+| G | D7 live-session UX and operator ergonomics | `2026-07-01-codex-conducted-adversarial-review-lane-live-ux.md` | 5 | 2 High, 3 Medium |
+| H | D8 reference harness and gap discovery | `2026-07-01-codex-conducted-adversarial-review-lane-harness-gap.md` | 4 | 4 Medium |
+
+The lanes were run by fresh Codex subagents. High findings received a second-pass validation by
+Godel (`019f1f2d-20a4-71f0-a5e5-0ef5512dd3dc`), which validated 9 raw High findings and rejected
+1 raw High finding as a duplicate of an existing current-lane finding.
+
+No source fixes were applied. This session wrote review artifacts only.
+
+## Aggregate Counts
+
+Raw lane corpus:
+
+- Total raw findings: 39
+- Raw severity: 0 Critical, 10 High, 26 Medium, 3 Low
+
+Deduplicated aggregate:
+
+- Unique findings counted: 38
+- Unique severity: 0 Critical, 9 High, 26 Medium, 3 Low
+- Duplicate folded out: `GEN-D4-002`, because the second pass found it is the same issue as `GEN-D2-002`
+
+Aggregate verdict: `needs-attention`. There are no Critical findings, but 9 validated High findings
+affect workflow state, RECORD routing, role bootstrap, docs information architecture, template
+runtime identity, and Codex degraded-metadata behavior.
+
+## High Findings
+
+| Finding | Second pass | Summary |
+|---|---|---|
+| `GEN-D1-001` | Validated, High | Preparation documents `RE-IDEATE` as an ITER/EXIT verdict, but evaluation/state/session contracts cannot emit or persist it. |
+| `GEN-D1-002` | Validated, High | Manager-side finding routing narrows Type=`general` and contradicts canonical Type+Domain routing. |
+| `GEN-D1-003` | Validated, High | Chat narrowed RECORD defers staging to Wrap-up, but Wrap-up only inventories prior `staging/` trees. |
+| `GEN-D2-001` | Validated, High | Canonical role prompts require `.gobbi/projects/gobbi/rules/`, but that directory is absent and custom agents point at those prompts. |
+| `GEN-D3-001` | Validated, High | Bootstrap enters Ideation directly and can bypass the selected Auto/Chat mode doc after Configuration. |
+| `GEN-D3-002` | Validated, High | Mode workflow tables point specialist rows at manager-only orchestration docs instead of specialist skill docs. |
+| `GEN-D4-003` | Validated, High | Producer templates hard-code Claude as producer and Codex as proposer, which mislabels native Codex production and degraded metadata. |
+| `GEN-D7-001` | Validated, High | Resume can restamp Ideation active and clobber a persisted active Planning/Execution state. |
+| `GEN-D7-002` | Validated, High | Codex allows `transcriptPath: null`, but RECORD treats that allowed degraded state as a recurring Critical unevaluable gap. |
+
+Rejected duplicate:
+
+| Finding | Disposition | Summary |
+|---|---|---|
+| `GEN-D4-002` | Duplicate of `GEN-D2-002` | Same evidence and remediation as the native Codex delegation-template load-root issue. Not counted as a distinct High. |
+
+## Main Themes
+
+The strongest cluster is workflow-state coherence. `RE-IDEATE`, resume, Chat RECORD, and Chat status
+all show the same class of problem: docs describe a live state transition or record path that the
+schemas, scaffolds, or Wrap-up readers do not actually support.
+
+The second cluster is docs information architecture. Gobbi has the right high-level split between
+manager orchestration, specialist skills, and role prompts, but several entry tables send readers or
+spawned agents to the wrong layer. That makes the docs harder to use and can make subagents load the
+wrong contract.
+
+The third cluster is template/runtime identity. Shared templates still assume Claude as producer or
+author in places where native Codex can be the current runtime. This creates provenance drift and
+wrong degraded-mode labels.
+
+The user-requested docs/template/naming emphasis produced concrete Medium findings beyond the High
+set: fragmented memory-read guidance, hidden evaluation child docs, review template field loss,
+state/schema validation gaps, `task-id`/task schema drift, lower-case verdict enum drift, resurrected
+`Rawdata` wording, and `task-record`/`taskRecord` naming drift.
+
+The Codex-specific add-on review found no Critical blocker, but it found install/runtime gaps:
+Codex smoke coverage is too partial, marketplace validation is missing, trust prerequisites are not
+validated, and hook smoke does not exercise installed hook commands or `PLUGIN_ROOT` expansion.
+
+## Finding Index
+
+### D1 Workflow
+
+- `GEN-D1-001` High, validated: Preparation `RE-IDEATE` cannot be emitted or persisted by the current evaluator/session-state contract.
+- `GEN-D1-002` High, validated: Manager-side routing table contradicts canonical Type+Domain routing.
+- `GEN-D1-003` High, validated: Chat narrowed RECORD skips staging sources Wrap-up expects.
+- `GEN-D1-004` Medium: Execution iteration history uses incompatible idempotency keys.
+
+### D2 Agents, Skills, Delegation
+
+- `GEN-D2-001` High, validated: Canonical role prompts send spawned agents to an absent rules directory.
+- `GEN-D2-002` Medium: Delegation templates bypass the native Codex `.agents/skills` load path.
+- `GEN-D2-003` Medium: Codex bootstrap and delegation taxonomy understate where Evaluation runs.
+- `GEN-D2-004` Medium: Canonical role status contracts do not require `SKILLS LOADED`.
+- `GEN-D2-005` Low: Codex role table labels canonical TOML files as Codex wrappers.
+
+### D3 Docs Design
+
+- `GEN-D3-001` High, validated: Bootstrap entry path bypasses the selected mode doc.
+- `GEN-D3-002` High, validated: Mode workflow tables point spawned agents at manager-only orchestration docs.
+- `GEN-D3-003` Medium: Evaluation child docs are hidden behind a same-basename manager doc.
+- `GEN-D3-004` Medium: Memory read guidance is fragmented and the memory entry point points only to mistakes.
+- `GEN-D3-005` Medium: Required project-rules reads have no empty-state contract.
+
+### D4 Templates
+
+- `GEN-D4-001` Medium: Memory templates stamp Claude as author even when Codex writes.
+- `GEN-D4-002` duplicate: folded into `GEN-D2-002`.
+- `GEN-D4-003` High, validated: Producer templates hard-code Claude as producer and Codex as proposer.
+- `GEN-D4-004` Medium: Durable review template drops required evaluation routing and idempotency fields.
+- `GEN-D4-005` Medium: Root session/state/settings schemas have no validation guard.
+
+### D5 Naming And Language
+
+- `GEN-D5-001` Medium: Chat task boundary names schema fields as pseudo-states.
+- `GEN-D5-002` Medium: Execution RECORD invents `{task-id}` and `workflow.execution.tasks`.
+- `GEN-D5-003` Medium: `workflow.{step}.verdict` enum is lower-case and includes `skipped`.
+- `GEN-D5-004` Medium: RECORD resurrects retired `Rawdata` wording.
+- `GEN-D5-005` Low: Production calls the Codex proposer a producer.
+- `GEN-D5-006` Low: Chat display uses `task-record` and `taskRecord` for the same object.
+
+### D6 Runtime, Plugin, Codex Add-On
+
+- `GEN-D6-001` Medium: Codex smoke samples two skills and one hook manifest, so a mostly missing cache can look clean.
+- `GEN-D6-002` Medium: Codex smoke hard-fails on a Claude-only manifest while warning on missing Codex components.
+- `GEN-D6-003` Medium: Codex compatibility gate does not validate the Codex marketplace file.
+- `GEN-D6-004` Medium: Trust prerequisite is stated in AGENTS but absent from install procedure and smoke evidence.
+- `GEN-D6-005` Medium: Hook smoke bypasses installed hook commands and `PLUGIN_ROOT` expansion.
+
+### D7 Live UX
+
+- `GEN-D7-001` High, validated: Resume path can reset active state to Ideation.
+- `GEN-D7-002` High, validated: Codex missing rollout path is allowed but treated as Critical by RECORD.
+- `GEN-D7-003` Medium: Agent metadata collapses actionable statuses into `ok|failed`.
+- `GEN-D7-004` Medium: Chat task-record path is outside the canonical session tree and scaffold.
+- `GEN-D7-005` Medium: Chat status renderer references missing `currentIndex` and non-canonical `InProgress`.
+
+### D8 Harness And Gap Discovery
+
+- `GEN-D8-001` Medium: Reference records cannot preserve the dated harness-refresh matrix D3 said future work needs.
+- `GEN-D8-002` Medium: Codex skill invocation policy is not modeled in Gobbi skill authoring.
+- `GEN-D8-003` Medium: Review methodology has no executable regression corpus for prior adversarial findings.
+- `GEN-D8-004` Medium: Critical/High second-pass validation is required but not part of the finding schema.
+
+## Suggested Remediation Order
+
+1. Fix state and RECORD contract blockers first: `GEN-D1-001`, `GEN-D1-003`, `GEN-D7-001`, `GEN-D7-002`.
+2. Fix role and load contracts next: `GEN-D2-001`, `GEN-D3-001`, `GEN-D3-002`, `GEN-D2-002`.
+3. Fix runtime-neutral templates: `GEN-D4-001`, `GEN-D4-003`, then the related D5 naming drift.
+4. Add schema/scaffold validation for Chat state, task records, session/state/settings, and review findings.
+5. Expand Codex smoke and compatibility checks after the docs/template contract is stable.
+6. Add the reference provenance fields and review regression corpus so future adversarial reviews are rerunnable.
+
+## Preserve
+
+- Preserve Gobbi's dual-system anti-groupthink design. The review found drift around it, not evidence
+  that the model should be removed.
+- Preserve markdown as the canonical memory substrate. D8 reference improvements should add structured
+  metadata, not replace markdown memory with a separate database.
+- Preserve source package symlinks. The Codex install/runtime findings target checks and documentation,
+  not a materialization workaround for installed-cache limitations.
+
+## Limits
+
+- This aggregate is a review artifact, not a fix plan with assigned implementation tasks.
+- The full evidence lives in the lane files; this aggregate deduplicates and prioritizes.
+- `scripts/check-codex-plugin-smoke.sh` was inspected by Lane F but not run because it performs a
+  plugin install into a temporary Codex home.
+- The prior `2026-06-29-*` review files were used only for deduplication and were not edited.


### PR DESCRIPTION
## Summary
- Adds the Codex-conducted adversarial review charter for the July 1 session.
- Publishes the lane reports, aggregate findings, and evaluation result as durable project review artifacts.
- Keeps this review independent from the prior Claude Code review while adding Codex compatibility coverage.

## Changes
- `.gobbi/projects/gobbi/plans/workflow/`: adds the session review charter.
- `.gobbi/projects/gobbi/reviews/adversarial-review/`: adds eight lane reports, the aggregate review, and the evaluation record.

## Test plan
- [x] `bash .agents/skills/memory/scripts/validate-frontmatter.sh .gobbi/projects/gobbi/plans/workflow/2026-07-01-codex-conducted-adversarial-review-charter.md .gobbi/projects/gobbi/reviews/adversarial-review/2026-07-01-codex-conducted-adversarial-review*.md`
- [x] `bash scripts/sync-plugin-package.sh --check`
- [x] `bash scripts/check-codex-compatibility.sh`
- [x] `git diff -- .gobbi/projects/gobbi/reviews/adversarial-review/2026-06-29-*`

## Linked issues
None