### PR TITLE
docs(reviews): 2026-07-06 skill/agent review — 3 review docs + 4 mistakes

### DIFF
--- a/.gobbi/projects/gobbi/mistakes/refactor/blast-radius-map-from-named-files-not-exhaustive-grep.md
+++ b/.gobbi/projects/gobbi/mistakes/refactor/blast-radius-map-from-named-files-not-exhaustive-grep.md
@@ -1,0 +1,34 @@
+---
+name: blast-radius-map-from-named-files-not-exhaustive-grep
+description: A blast-radius / co-touch edit-site map must be built from an exhaustive form-covering grep across all surfaces, not by reading the files a brief named.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-06
+session: 0d898156-8d5b-4142-9b93-308d3b692995
+tags: [refactor, process, docs-sync]
+keywords: [enumeration, blast-radius, co-touch]
+author: claude
+priority: high
+domain: process
+---
+
+# Blast-radius map built from named files, not an exhaustive grep
+
+## What happened
+During Point-1 investigation, the leader built the §1.1 change-set / blast-radius map by reading the three files the manager's brief named (`chat-mode.md`, `settings.chat.json`, `SKILL.md`) and reported that as the complete edit-site set. A later exhaustive grep found 6+ additional "default 5" sites (five `workflow/*.md` sub-docs + `record.md`) plus the `state.template.json` propagation gap that the named-file read missed. The leader self-caught it after reading the project enumeration traps.
+
+## Why it happens
+It treated the brief's named files as the full surface. A brief names entry points, not the complete blast radius. Enumeration built by reading a handful of named files silently under-counts co-touch sites and semantic-equivalent restatements of the same rule.
+
+## Correct approach
+Build every blast-radius / co-touch map from an exhaustive, form-covering grep across ALL surfaces (skills, `workflow/` sub-docs, templates, scripts, the three mirror trees), then manually classify each hit. Never treat the brief's named files as the complete set. Recurrence class of [[enumerate-all-restatements-and-classify-deferral-before-claiming-map-complete]] + [[cotouch-enumeration-must-cover-semantic-equivalents]] + [[sweep-grep-literal-loop-name-blindspot]].
+
+## How to detect
+Any task that must enumerate a change's blast radius / co-touch set / every restatement of a rule — rename, count change, cap change, term change, doc-sync. If the enumeration was produced by reading named files rather than a repo-wide form-covering grep + manual classification, it is incomplete.
+
+## Related
+- [[enumerate-all-restatements-and-classify-deferral-before-claiming-map-complete]] — same recurrence class: enumerate every restatement before claiming a map complete
+- [[cotouch-enumeration-must-cover-semantic-equivalents]] — co-touch enumeration must cover semantically-equivalent restatements, not one phrasing
+- [[sweep-grep-literal-loop-name-blindspot]] — a form-specific grep misses other-form occurrences

--- a/.gobbi/projects/gobbi/mistakes/verification/clean-verdict-unreliable-without-edge-case-stress.md
+++ b/.gobbi/projects/gobbi/mistakes/verification/clean-verdict-unreliable-without-edge-case-stress.md
@@ -1,0 +1,33 @@
+---
+name: clean-verdict-unreliable-without-edge-case-stress
+description: A review that reports "clean / no findings" is unreliable unless it stressed the edge-case classes (portability, parser corners, fail-open); cross-check with an independent reviewer before trusting a clean verdict.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-06
+session: 0d898156-8d5b-4142-9b93-308d3b692995
+tags: [verification, evaluation, process]
+keywords: [code-review, dual-system, portability, fail-open, parser-edge-cases]
+author: claude
+priority: high
+domain: process
+---
+
+# A "clean" verdict is unreliable without edge-case stress
+
+## What happened
+In Point 3's adversarial script review, the leader reported `check-markdown-links.sh` + `validate-integration-log.sh` as "clean (counter-evidence, no findings)." The independent Codex pass found real MEDIUM issues in both — a non-portable `\b` ERE word-boundary (breaks on BSD/macOS grep) and a `find` without `-L` that skips symlink mirrors plus a parser that breaks on link titles / nested parens. On verification the leader CONCEDED: its "clean" checked systemic patterns + happy-path + bash-3.2-safety but did not stress regex portability or parser edge cases.
+
+## Why it happens
+A single reviewer's "clean" verdict reflects only the axes it happened to check. A happy-path + systemic-pattern pass misses whole edge-case classes: cross-platform tool/regex portability, parser corner cases, and fail-open-on-missing-dependency. "No findings" is easily a coverage gap, not a real absence — and it reads as reassurance while hiding one.
+
+## Correct approach
+Treat a "clean" verdict skeptically. Before trusting it: (1) run an INDEPENDENT reviewer (dual-system) and reconcile — divergence on "clean" is the signal (this is exactly what caught it this session); (2) explicitly stress the edge-case classes the happy-path pass skips — cross-platform tool/regex portability, parser corner cases, and fail-open-on-missing-dependency; a verification gate especially must be checked for fail-closed behavior. Relates to [[teammate-finalize-brief-crosses-with-in-progress-turn]] and [[blast-radius-map-from-named-files-not-exhaustive-grep]] — all verify-don't-assume disciplines.
+
+## How to detect
+Any review concluding "clean / no findings / looks fine" on a non-trivial artifact — especially shell scripts (portability), parsers (edge inputs), and verification gates (fail-open modes). The reassuring verdict is the smell.
+
+## Related
+- [[teammate-finalize-brief-crosses-with-in-progress-turn]] — sibling verify-don't-assume discipline from this session
+- [[blast-radius-map-from-named-files-not-exhaustive-grep]] — build the map from exhaustive evidence, don't trust a partial pass

--- a/.gobbi/projects/gobbi/mistakes/verification/offered-memory-home-without-verifying-type-schema.md
+++ b/.gobbi/projects/gobbi/mistakes/verification/offered-memory-home-without-verifying-type-schema.md
@@ -1,0 +1,32 @@
+---
+name: offered-memory-home-without-verifying-type-schema
+description: Before offering the user a memory home/area (or naming one in a plan), verify it is valid for that memory type's schema — reviews route by kind (area == review_kind), so an invented sub-collection name fails the validator.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-06
+session: 0d898156-8d5b-4142-9b93-308d3b692995
+tags: [process, verification, memory]
+keywords: [type-schema, area-allowlist, review-kind]
+author: claude
+priority: medium
+domain: process
+---
+
+# Offered a memory home without verifying the type's schema
+
+## What happened
+At session start the manager offered `reviews/skill-agent-review/` as the review-doc home and the user chose it. The `reviews` memory type routes by the KIND axis — its area allowlist IS the `review_kind` enum (`code-review`, `adversarial-review`, …) — so `skill-agent-review` is not a valid area. The wrap-up `validate-frontmatter.sh` (fail-closed) would have bounced it; the promotion assistant caught it and blocked, forcing a mid-wrap-up re-route to the kind-axis dirs.
+
+## Why it happens
+The manager proposed a memory home without checking the target memory type's area/naming schema. `reviews/{free-form-name}/` looked plausible, but reviews-type uses area == kind, not an arbitrary collection name. The schema was knowable up front (memory/rules.md + memory-vocabulary.json) but not checked before offering the option.
+
+## Correct approach
+Before offering a memory home/area, verify it against the type's schema: the area allowlist in `memory-vocabulary.json` and the type's rules in `memory/rules.md`. For `reviews`, area MUST be a `review_kind`. Offer only schema-valid homes; if a genuinely new area is wanted, flag up front that it needs an Always-Ask `memory-vocabulary.json` edit and may break a type invariant (e.g. reviews area == kind). Relates to [[clean-verdict-unreliable-without-edge-case-stress]] and the verify-don't-assume family.
+
+## How to detect
+Any time the manager offers the user a memory home/area — or names one in a plan or delegation brief — for a typed memory artifact (reviews, reports, mistakes, decisions, notes, …), especially a free-form-looking sub-collection.
+
+## Related
+- [[clean-verdict-unreliable-without-edge-case-stress]] — sibling verify-don't-assume discipline from this session

--- a/.gobbi/projects/gobbi/mistakes/verification/teammate-finalize-brief-crosses-with-in-progress-turn.md
+++ b/.gobbi/projects/gobbi/mistakes/verification/teammate-finalize-brief-crosses-with-in-progress-turn.md
@@ -1,0 +1,32 @@
+---
+name: teammate-finalize-brief-crosses-with-in-progress-turn
+description: Send a finalize/revise delta-brief to an Agent-Teams teammate only after it is confirmed IDLE, not immediately on a DONE — else the brief lands against a superseded state.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-06
+session: 0d898156-8d5b-4142-9b93-308d3b692995
+tags: [verification, process]
+keywords: [agent-teams, delegation, coordination, idle-notification]
+author: claude
+priority: medium
+domain: process
+---
+
+# Finalize/revise brief crosses with a teammate's in-progress turn
+
+## What happened
+Twice this session the manager sent a finalize/revise delta-brief to the persistent leader teammate while it was still mid-turn on the prior brief. The teammate produced output against the superseded understanding (Point 1: MF-2 as a Config-overlay instead of the user's state-template split; Point 2: the pre-decision compaction target), then had to be re-briefed, and the manager had to re-verify the on-disk artifact before presenting.
+
+## Why it happens
+Agent-Teams teammate messages are async and queued. The manager treated a teammate `DONE` as "ready for the next brief" without confirming the teammate was IDLE — but the teammate had already queued or started its next action, so the new brief was processed against a stale state. A decision that changed between the teammate's turn-start and the brief made the crossover visible.
+
+## Correct approach
+Send a finalize/revise brief only after the teammate's `idle_notification` (confirmed idle), not immediately on a `DONE`. If a brief must be sent while the teammate may be busy, expect a crossover: verify the on-disk artifact reflects the LATEST brief (files-as-truth) before presenting, and re-brief if stale. Prefer one consolidated brief over rapid sequential briefs. Relates to [[blast-radius-map-from-named-files-not-exhaustive-grep]] (both are verify-the-artifact-against-latest-intent disciplines).
+
+## How to detect
+Any Agent-Teams session where the manager sends a follow-up delta-brief (finalize / revise / next-step) right after a teammate `DONE`, especially when a user decision changed between the teammate's turn-start and the brief.
+
+## Related
+- [[blast-radius-map-from-named-files-not-exhaustive-grep]] — sibling verify-the-artifact-against-latest-intent discipline

--- a/.gobbi/projects/gobbi/notes/workflow/2026-07-06-orchestration-skill-agent-review.md
+++ b/.gobbi/projects/gobbi/notes/workflow/2026-07-06-orchestration-skill-agent-review.md
@@ -1,0 +1,62 @@
+---
+name: orchestration-skill-agent-review
+description: 3-point Chat-mode dual-system review of the orchestration skill + agents (chat-mode, skill compaction, adversarial review); no implementation — 3 review docs produced.
+type: notes
+scope: project
+feature: null
+status: active
+created: 2026-07-06
+session: 0d898156-8d5b-4142-9b93-308d3b692995
+tags: [evaluation, process, docs-sync]
+keywords: [orchestration, chat-mode, compaction, adversarial-review, agent-teams, review-only]
+author: claude
+features_touched: []
+loops_completed: [ideation, wrap-up]
+shipped: [blast-radius-map-from-named-files-not-exhaustive-grep, teammate-finalize-brief-crosses-with-in-progress-turn, clean-verdict-unreliable-without-edge-case-stress]
+---
+
+# Orchestration skill + agent review (3-point Chat-mode)
+
+## What happened
+A Chat-mode session ran a 3-point dual-system review of the orchestration skill and its agents. Each point paired an independent leader pass with a Codex pass; Point 3 added a `claude-code-guide` currency check. The session did NO implementation — the deliverables are three implementation-ready review docs plus one currency ground-truth report. Each point moved through its own Ideation loop; a future session executes the change-sets.
+
+- **Point 1 — Chat-mode compact cycles + doc length.** Proposes compact caps (planning 1 / execution 3 / wrap-up 3) and a ~30% length cut of `chat-mode.md`. Decisions: a planning `REVISE` becomes a user gate; ADRs route to `decisions/`; and — the user's call — split `state.template.json` into `state.auto.json` + `state.chat.json`. Two correctness must-fixes: the compact-cycle counting convention and the settings→state propagation.
+- **Point 2 — Orchestration skill compaction.** A full ~40% gate-preserving compaction. De-duplicates `workflow/{loop}.md` against each peer skill via an 8-point loop skeleton plus the in-tree "do not re-derive" pointer pattern. Catalogs ~12 fix-first correctness bugs. Rule B11: a FAIL escalates rather than auto-fixing.
+- **Point 3 — Orchestration adversarial review.** Three change-sets: (a) a full scripts refactor (`lib/common.sh` + a record-map manifest + fixtures + a smoke test; fixes C-BUG-1 canonicalization fail-open + 2 agent-token bugs + bash-4 tier assumptions + retires the frozen baseline); (b) an `agent-teams.md` currency refresh (doc baseline v2.1.32 → v2.1.178+); (c) completeness gaps — no `workflow/configuration.md`, a Codex-runtime doc↔mistake contradiction that a runtime matrix resolves, and a scenario suite.
+
+## What shipped
+- **3 process mistakes promoted** (the verify-don't-assume family):
+  - [[blast-radius-map-from-named-files-not-exhaustive-grep]] → `mistakes/refactor/`
+  - [[teammate-finalize-brief-crosses-with-in-progress-turn]] → `mistakes/verification/`
+  - [[clean-verdict-unreliable-without-edge-case-stress]] → `mistakes/verification/`
+- **3 review docs + 1 currency report promoted to memory:**
+  - [[point-01-chat-mode-cycles-and-length]] → `reviews/code-review/2026-07-06-point-01-chat-mode-cycles-and-length.md`
+  - [[point-02-orchestration-skill-compaction]] → `reviews/code-review/2026-07-06-point-02-orchestration-skill-compaction.md`
+  - [[point-03-orchestration-adversarial-review]] → `reviews/adversarial-review/2026-07-06-point-03-orchestration-adversarial-review.md`
+  - [[agent-teams-currency]] → `reports/analytics/2026-07-06-agent-teams-currency.md` (Point 3 §3.2 ground truth)
+
+## What got stuck
+The 3 review docs' initially requested destination (`reviews/skill-agent-review/`) was not resolvable: `reviews` uses the kind axis (the area equals `review_kind`), so its area allowlist is the kind enum and `skill-agent-review` is not a member. This was escalated to the manager as a user-decision and resolved: the 3 reviews route by kind (`code-review` for points 1+2, `adversarial-review` for point 3), and the currency report (not a `reviews`-type doc) routes to `reports/analytics/`. All 4 promoted files pass `validate-frontmatter.sh`.
+
+## What shifted
+Point 1's `state.template.json` handling shifted mid-session from an MF-2 Config-overlay to the user's chosen split into `state.auto.json` + `state.chat.json`. This crossed with an in-progress teammate turn twice (captured as [[teammate-finalize-brief-crosses-with-in-progress-turn]]), forcing re-briefs and on-disk re-verification.
+
+## Decisions to respect
+- **No implementation this session** — the three points are reviews only; a future session executes the change-sets.
+- **`state.template.json` splits into `state.auto.json` + `state.chat.json`** (Point 1, user-ratified).
+- **Cross-point coordination for the future implementation session:**
+  - Point 3's change-set E edits `workflow/{evaluation,record,production}.md`, which Point 2 ALSO compacts — sequence or fold these so one does not clobber the other.
+  - Point 1's `maxIterations` "default 5" lines collide with Point 2's edits — land Point 1 first.
+  - Do ONE combined dead-xref cleanup: Point 3's dead links + Point 2's 2 missing mistake files + the recurring `skills-mirror-symlinks-not-copies.md`.
+
+## Next session
+A future implementation session executes the three change-sets. Priority #1 is Point 3's **Codex runtime matrix** (resolves the runtime doc↔mistake contradiction). Respect the cross-point sequencing above (Point 1 before Point 2's colliding edits; fold Point 3 change-set E with Point 2's compaction of the same `workflow/*` docs).
+
+## Related
+- [[blast-radius-map-from-named-files-not-exhaustive-grep]] — process mistake promoted this session
+- [[teammate-finalize-brief-crosses-with-in-progress-turn]] — process mistake promoted this session
+- [[clean-verdict-unreliable-without-edge-case-stress]] — process mistake promoted this session
+- [[point-01-chat-mode-cycles-and-length]] — review doc, `reviews/code-review/`
+- [[point-02-orchestration-skill-compaction]] — review doc, `reviews/code-review/`
+- [[point-03-orchestration-adversarial-review]] — review doc, `reviews/adversarial-review/`
+- [[agent-teams-currency]] — currency report, `reports/analytics/`

--- a/.gobbi/projects/gobbi/reports/analytics/2026-07-06-agent-teams-currency.md
+++ b/.gobbi/projects/gobbi/reports/analytics/2026-07-06-agent-teams-currency.md
@@ -1,0 +1,43 @@
+---
+name: agent-teams-currency
+description: Currency ground-truth check of agent-teams.md against live Claude Code docs and observed session behavior — doc baseline v2.1.32 vs current ~v2.1.199.
+type: reports
+scope: project
+feature: null
+status: active
+created: 2026-07-06
+session: 0d898156-8d5b-4142-9b93-308d3b692995
+tags: [process]
+keywords: [agent-teams, currency-check, claude-code-guide, versioning, ui-helpers]
+author: claude
+report_type: analytics
+---
+
+# agent-teams.md currency report (3.2 ground-truth)
+
+Source: claude-code-guide agent, 2026-07-06, checked against code.claude.com/docs/en/agent-teams (docs state "as of v2.1.178"; current ~v2.1.199). Several items independently confirmed by THIS session's observed behavior (async idle-notifications; the "another Claude session" trust banner on every teammate message). Version-specific numbers below should be RE-VERIFIED against live docs at implementation time; the direction (doc stale at v2.1.32; missing UI/helper docs) is high-confidence.
+
+## CONFIRMED-CURRENT (doc is right)
+Flag `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`; env in settings.json; leader/executor/assistant roster; evaluator-never-teammate; shared task list (lead creates, teammates claim); hooks TeammateIdle/TaskCreated/TaskCompleted; no nested teams; teammates lost on /resume //compact //rewind; SendMessage by name; no cross-talk; first-spawn-full-brief / continuation-delta-brief.
+
+## STALE / WRONG
+| Doc claim | Current reality | Impact |
+|---|---|---|
+| min version **v2.1.32** | current ~v2.1.199; docs baseline v2.1.178. Doc reads as static since v2.1.32 | recommend bumping the referenced baseline; the doc misses ~6 versions of features |
+| **"Shift+Down cycles teammates"** | Up/Down arrows select a teammate; Enter opens its transcript; Escape interrupts. No Shift+Down binding | wrong shortcut — verify against the actual doc line, then fix |
+| **`"auto"` is default teammateMode** | v2.1.179: default is now **`"in-process"`**; `"auto"` now auto-detects tmux/iTerm2 | explanation stale |
+| **three display modes** | four now — `in-process` / `auto` / `tmux` / **`iterm2`** (v2.1.186) | missing a mode |
+| (no mention) TeamCreate/TeamDelete | **removed v2.1.178** — team setup/cleanup now automatic | doc implies manual setup may still apply |
+
+## MISSING (should be added — the 3.2 "how to show teammates + useful helpers" ask)
+1. **Teammate display in the session UI (the direct 3.2 ask):** an **agent panel** below the prompt shows teammate rows (name + status). Up/Down select; **Enter** opens a teammate's transcript. Idle-row collapse: >3 idle rows fold into one `N idle agents` row (v2.1.199); working + failed teammates always keep their rows; idle rows hide only after the WHOLE panel idles 30s, reappear on next turn. Split-pane mode = one pane per teammate.
+2. **SendMessage specifics:** message types `message` / `broadcast` / `shutdown_request`/`_response` / `plan_approval_response`; always available even under a tight `tools` allowlist; **trust model — the receiver is told the message came from "another Claude session", NOT the user; teammates cannot approve permission prompts for each other** (exactly the banner seen this session).
+3. **Helpers:** **Ctrl+T** toggles the task-list display; teammate-local vs lead-local commands (plain text + skills → viewed teammate; `/model` `/fast` → lead only; `/effort` → viewed teammate, v2.1.199); effort inheritance lead→teammates (v2.1.186).
+4. **Limitations (hard constraints):** session resumption does NOT restore in-process teammates (spawn fresh + re-prime); an in-process teammate CANNOT spawn background subagents; split-pane unsupported in VS Code / Windows Terminal / Ghostty; task-status lag (teammates sometimes miss marking complete → manual nudge).
+5. **Subagent-def-as-teammate caveat (critical for gobbi delegation):** a subagent definition's `tools` + `model` ARE honored and its body appends to the system prompt, but its `skills` / `mcpServers` frontmatter is NOT auto-loaded — load them via the first-spawn Load-Directives brief.
+6. **Plan approval mode** — a conversation-based gate: a teammate sends a plan-approval request; the lead approves/rejects; reject → revise+resubmit. Useful for gobbi Preparation/Execution gates.
+7. **Automatic task-dependency resolution** — completing a task auto-unblocks dependents; Planning can rely on this instead of "wait for X" prose.
+8. **Async delivery + error notifications (v2.1.198):** messages arrive automatically (no poll); a teammate auto-notifies the lead on idle; a turn ending on an API error now notifies the lead with the error text (stall detection).
+
+## Recommendation
+Bump the doc to the v2.1.178+ baseline; add the agent-panel UI section (answers 3.2); document the SendMessage interface + trust model; add the helpers (Ctrl+T, command locality, effort inheritance); add the limitations + the subagent-def-as-teammate skills/mcpServers caveat. Re-verify exact version numbers against live docs at implementation.

--- a/.gobbi/projects/gobbi/reviews/adversarial-review/2026-07-06-point-03-orchestration-adversarial-review.md
+++ b/.gobbi/projects/gobbi/reviews/adversarial-review/2026-07-06-point-03-orchestration-adversarial-review.md
@@ -1,0 +1,185 @@
+---
+name: point-03-orchestration-adversarial-review
+description: 3-way adversarial review of the orchestration skill — scripts refactor, agent-teams currency, and completeness gaps (incl. the Codex runtime matrix).
+type: reviews
+scope: project
+feature: null
+status: active
+created: 2026-07-06
+session: 0d898156-8d5b-4142-9b93-308d3b692995
+tags: [evaluation]
+keywords: [orchestration, adversarial-review, scripts, shell-lib, codex-runtime-matrix, agent-teams-currency, completeness, configuration-doc]
+author: claude
+review_kind: adversarial-review
+subject: orchestration/scripts/*.sh + record/scripts/*.sh + agent-teams.md + workflow/*.md (completeness)
+verdict: needs-attention
+---
+
+# Point 3 — Orchestration adversarial review
+
+## Point (verbatim user text)
+
+> Point3 is the last point. Let's do adversarial-review about orchestration skill.
+> 1. I think the scripts look messy and hard-coded. We need to make them clearer.
+> 2. Validate agent-teams.md contains latest information and other utility descriptions like how to show teammates in claude code session UI. Consider other useful helpers.
+> 3. Completeness of orchestration based on the scenarios and checklists including dual-system with codex.
+
+## Session context
+
+- **Mode:** Chat-mode review. **Implementation is DEFERRED** — this is the review + change-set.
+- **3-way investigation:** `leader` (Claude, this producer, read all 11 scripts in full) + independent frozen `codex` proposal (879L, independently fetched the Claude Code docs) + a `claude-code-guide` currency report (`working/research/agent-teams-currency-report.md`) that owns 3.2's ground-truth. The producer SELECT-integrated (never blend), and **verified Codex's line anchors against the files** (as in Point 2). Cross-system record in § Cross-system reconciliation + `working/reconciliation-iter1.md`.
+- **Verdict `needs-attention`:** the design is directionally strong; the weak spots are the implementation surface — a real dual-system correctness contradiction (#1), a fail-open in a verification gate, script duplication, stale Agent Teams docs, and completeness gaps. All fixable.
+
+## Decisions locked
+
+**User decisions (locked this session):**
+1. **Codex runtime = ADOPT Codex's runtime matrix (priority #1 — silent dual-system loss).** One authoritative Codex-runtime section reconciling `codex/SKILL.md` + `workflow/production.md` + `workflow/evaluation.md`: **foreground under the host cap / background + file-poll above the host cap / assistant-wrapper ONLY if it validates the contracted output files SAME-TURN (files-as-truth)**. Mark the superseded foreground-`timeout 1200` guidance. Resolves C-HIGH-2 + C-HIGH-3.
+2. **Scripts = FULL refactor.** `scripts/lib/common.sh` (strict-mode `set -euo pipefail`, `require_cmd`, shared path-resolution, `die`/`usage`) + `record-map.manifest.json` single-source (scaffold + verify + doc all consume it — fixes the S-HIGH-4 "drift-gate verifies its own twin" gap) + externalized fixtures (retire the S-HIGH-5 frozen FAMILY_B baseline) + a `--self-test` smoke suite.
+
+**Priority order (user-confirmed, Codex's):** 1 runtime matrix → 2 shell lib + manifest → 3 Agent Teams refresh → 4 scenario suite.
+
+---
+
+## Findings 3.1 — Scripts (ADVERSARIAL) — change-set A (lib) + B (manifest) + fixtures
+
+11 scripts, 2,835 lines. The user's "messy + hard-coded" read is CORRECT. Both systems converged on the systemic story; anchors verified.
+
+### The systemic patterns (ranked)
+
+| ID | Finding | Evidence (file:line, verified) | Sev | Fix |
+|---|---|---|---|---|
+| S-HIGH-1 | **Not fail-closed** — 9 scripts `set -uo pipefail` (no `-e`); a guard that continues after a failed `cd`/`grep`/subst can report a false PASS | all check-scripts (`check-merge:127`, `validate-integration-log:65`, `agent-token-usage:28`, etc.); only scaffold/init/verify use `-euo` | High | Standardize `set -euo pipefail` + explicit `|| true` on intentional-nonzero; `require_cmd`. **Nuance (leader):** the accumulator check-scripts legitimately continue-on-VIOLATION — apply `-e` with care so a `grep` no-match (exit 1) doesn't abort a scan mid-loop |
+| S-HIGH-2 / M4 | **Portability: 3 audit gates are bash-4-mandatory + GNU-only** | `declare -A` (check-merge:366, check-skill-mistakes:145, check-residual-vocab:195), `mapfile` (check-merge:452), `realpath -m` (check-merge:304), `flock` (reconcile:206) | High | `require_bash_4` + `require_cmd`; document "GNU coreutils + bash≥4" OR replace GNU-only calls. Runtime materializers + validate-integration-log + check-markdown-links are bash-3.2-safe (two tiers) |
+| **C-BUG-1 (leader-only)** | **`canon()` is FAIL-OPEN** — `realpath -m 2>/dev/null` returns EMPTY on failure → all Family-1/1b/1c path checks silently compare empty keys → gate prints "REF-INTEGRITY OK" with checks disabled | `check-merge-ref-integrity.sh:304` | High | Probe `realpath -m` at startup + fail-CLOSED (exit 2), or a portable canon fallback. **A verification gate must fail closed** — Codex's S-HIGH-1/2 touch the general class; this is the specific silent-false-pass mechanism |
+| S-HIGH-3 (Codex-only) | **`agent-token-usage.sh` null totals** — `map(.x//0)\|add` returns `null` over an empty array → null token fields flow into `reconcile:159` | `agent-token-usage.sh:54-59,62-67` | High | `add // 0` on every aggregate + fixtures (empty transcript / no-usage / all-sidechain) |
+| **AGENT-TOKEN bug #2 (leader-only, DISTINCT)** | **`main_filter` built but never injected** — line 42 builds the filter string, but the jq is copy-pasted into two branches instead of interpolating it (dead string + duplicated pipeline) | `agent-token-usage.sh:42,54-68` | Med | one jq with the filter interpolated; delete the dead string. **BOTH agent-token bugs are real and distinct** — Codex's null-total + leader's dead-filter |
+| S-HIGH-4 | **record-tree contract triple-copied** — the drift-gate builds its baseline from its OWN twin of the scaffold array, not the SSOT | scaffold:116-126 ≡ verify:61-66; verify:90-109 re-creates the subtree | High | `record-map.manifest.json` single source (scaffold + verify + doc consume it) |
+| S-HIGH-5 | **`check-residual-vocab.sh` embeds a frozen migration baseline** — 26 hardcoded carriers + 147 "MEASURED" lines the header says to "regenerate after any edit"; both families are COMPLETED migrations (D18 memorization-rename + #310/#312 `_shared`) | check-residual-vocab:157-186,188-201 | High | Externalize to `fixtures/residual-vocab-family-b.tsv` + a `--regenerate` mode, OR **RETIRE** if migrations confirmed complete (leader recommends confirm→retire) |
+| S-MED-1 | verify-record-map doc checks are weak `grep -qF` anywhere-in-prose | verify:70-81 | Med | parse a generated fenced manifest block, not arbitrary prose |
+| **S-MED-2 (leader CONCEDES)** | `validate-integration-log.sh` `\b` word-boundary is GNU-only ERE — BSD/macOS grep doesn't support it, breaking the names-both-sides heuristic | validate-integration-log:70-71,123-124 | Med | `(^\|[^[:alnum:]_])(...)([^[:alnum:]_]\|$)` explicit boundaries |
+| **S-MED-3 (leader CONCEDES)** | `check-markdown-links.sh` `find -type f` (no `-L`) skips symlinked mirror docs; the `]\([^)]*\)` parser breaks on link titles + nested parens | check-markdown-links:57,81-86 | Med | decide canonical-vs-mirror scope; `find -L` if mirrors; document/parse the supported subset + fixtures |
+| S-MED-4 | self-location + repo-root `../../..` duplicated + fragile across ~7 scripts (inconsistent var names + `$0` vs `${BASH_SOURCE[0]}`) | check-skill-mistakes:86-89, check-residual-vocab:97-101, check-workflow-mirror:60-63,81-83, init:70-72, verify:27-29, reconcile:76-78 | Med | shared `script_dir`/`project_dir`/`repo_root` helpers with marker validation |
+| S-MED-5 | reconcile brittle option-parse + undeclared deps (`jq`/`flock`/`tail`) | reconcile:52,60-62,206 | Med | `require_cmd jq flock grep tail` + explicit `[ $# -ge 2 ]` option branches |
+| S-LOW-1 | init-record-map hardcodes the README body in code | init:93-103 | Low | `templates/session-readme.template.md` |
+
+Also duplication (leader H2, verified in the full read): **`slugify()` VERBATIM-duplicated** (check-merge:309-313 ≡ check-skill-mistakes:98-102); `trim()` defined ≥3×; `log`/`usage`/`add`+accumulator idiom everywhere → the `lib/common.sh` exports these too.
+
+### The divergence I had to resolve (leader "clean" vs Codex "MEDIUM") — CONCEDED
+
+My iter1 draft called `check-markdown-links.sh` + `validate-integration-log.sh` "clean (counter-evidence)." **I verified against the files: Codex is right on BOTH (S-MED-2, S-MED-3); I concede.** My "clean" checked the systemic patterns + happy-path correctness + bash-3.2-safety, but did NOT stress-test the `\b` regex portability or the markdown-parser edge cases + symlink walking. The nuance that SURVIVES: their internal algorithms are still high-quality and bash-3.2-safe — but "no findings" was wrong.
+
+### Refactor-not-rewrite guardrail (leader-only, load-bearing)
+
+The gates' ALGORITHMS are high-quality and MUST be preserved: `check-merge`'s rules.md-parsing self-test (anti-drift, fail-closed on class-set drift); `validate-integration-log`'s escaped-pipe COLUMN discipline (COD-STRUCT-1 — reads field $4, never a body grep); `check-skill-mistakes`'s `## Archived`-boundary handling. **Do NOT flatten the necessarily-complex `reconcile-session-metadata.sh`** (flock RMW + the documented codex-preserve "erasure bug" guard) into "simpler" code — its complexity is inherent to correct metadata reconciliation. The refactor extracts the shared lib + retires dead weight; it preserves the defensive logic.
+
+---
+
+## Findings 3.2 — agent-teams.md currency + structural (3 sources merged)
+
+Merges the leader's structural review (S1-S5) + the `claude-code-guide` currency report + Codex's AT-* (which independently fetched the docs — **triple-confirmed** where all three agree). Change-set D. Currency version numbers should be re-verified against live docs at implementation (all three sources caveat this); the DIRECTION is high-confidence.
+
+| ID | Finding (agent-teams.md) | Sources | Fix |
+|---|---|---|---|
+| CUR-1 | **min version `v2.1.32` stale** (current ~v2.1.199; docs baseline v2.1.178) — misses ~6 versions | currency + AT-HIGH-1 | version matrix (v2.1.178/179/186/198/199) + "re-check the experimental docs before editing" |
+| CUR-2 | **lifecycle wrong: `TeamCreate`/`TeamDelete` REMOVED (v2.1.178); setup/cleanup is AUTOMATIC** — contradicts the doc's "manager creates the team → cleans up the team" (`:113-114,123`) | currency + AT-HIGH-2 | rewrite: team forms on first-teammate-spawn; Claude Code owns cleanup at session exit; Gobbi triggers formation + requests graceful shutdown only |
+| CUR-3 | **`Shift+Down` (`:141`) is WRONG** — Up/Down select, **Enter** opens the teammate's transcript, Escape interrupts, `x` stops, **Ctrl+T** toggles the task list | leader S2 (flagged) + currency + AT-MED-1 | replace the keybindings |
+| CUR-4 | **teammateMode: default is now `in-process` not `auto` (v2.1.179); 4 modes not 3** (added `iterm2`, v2.1.186) | currency + AT-MED-1 | update the display-mode table |
+| CUR-5 | **the direct 3.2 ask (show teammates in UI) is thin + split** — answerable now: an **agent panel** below the prompt shows teammate rows (name+status); idle-row collapse (>3 → one row, v2.1.199); split-pane = one pane per teammate | leader S2 + currency MISSING-1 | add a consolidated "Teammate UI + helpers" section (panel, keybindings, Ctrl+T, command locality: plain-text/skills→viewed teammate, `/model`/`/fast`→lead, `/effort`→viewed teammate; effort inheritance) |
+| CUR-6 | **SendMessage interface + trust model undocumented** — message types (`message`/`broadcast`/`shutdown_request`/`plan_approval_response`); available even under a tight `tools` allowlist; **trust: the receiver is told the message is from "another Claude session", NOT the user; teammates can't approve permission prompts for each other** | currency MISSING-2 + AT-MED-2/3 | add the SendMessage + trust subsection |
+| CUR-7 | **native-capability vs Gobbi-policy table** (native any-to-any messaging / shared task list / direct operator→teammate / lead auto-approves plans → Gobbi: manager-mediated / manager-owned / steering-only / Always-Ask still routes) | AT-MED-3 (leader S3 partial) | add the table |
+| CUR-8 (gobbi-critical) | **an in-process teammate CANNOT spawn background subagents** | currency MISSING-4 | add to limitations |
+| CUR-9 (confirmed-current) | the subagent-def-as-teammate `skills`/`mcpServers`-not-auto-loaded caveat is ALREADY in the doc (`:95-99`) — correct; ADD that `SendMessage`+task tools stay available under a restrictive `tools` allowlist | AT-MED-2 | small addition |
+| CUR-10 | teammate death is a rule, not a **recovery checklist** (leader S3/G2) | AT-MED-5 + leader | add a liveness/replacement checklist (hidden-idle vs dead; re-prime from `working/`+`outputs/`+`state.json`; record `continuationOf`) |
+| S4/S5 (leader) | hooks table (`:131-139`) points nowhere; **dead link `:187` → `mistakes/skills-mirror-symlinks-not-copies.md` (absent)** | leader | add a pointer; fold the dead link into the cross-point cleanup |
+
+---
+
+## Findings 3.3 — Completeness (ADVERSARIAL) — change-set E
+
+Codex was **more thorough** on completeness (it found the structural gaps the leader flagged only as verify-against-child-docs). Taken with anchors verified.
+
+| ID | Gap | Evidence (verified) | Sev |
+|---|---|---|---|
+| **C-HIGH-1** | **No `workflow/configuration.md`** — the 8 other loops each have a workflow child doc; Configuration (fresh/resume/`/compact`/`/clear`/worktree/mode — the highest-risk paths) has none | `ls workflow/*.md` → 8 docs, no configuration.md (confirmed absent) | High |
+| **C-HIGH-2** | **Codex-runtime doc↔mistake CONTRADICTION (the #1 locked fix)** — `codex/SKILL.md:152-153` + `production.md:30` mandate foreground-blocking `timeout ≥ 1200s`, but `mistakes/codex/codex-exec-timeout-exceeds-bash-cap.md` says the Claude Code Bash ~10-min cap KILLS the foreground run → long runs MUST background. `codex/SKILL.md:181` itself already acknowledges backgrounding (internal inconsistency). **Verified in full** — the mistake even anticipated this review | codex/SKILL.md:152-153,181; production.md:30; the mistake file (whole) | High |
+| **C-HIGH-3** | **assistant-wrapper guidance internally inconsistent** — `codex/SKILL.md:297` says the wrapper resolves the tradeoff; `codex/mistakes.md` says a wrapper failed to persist files and the fix was manager-run-direct-foreground + validate; no doc states which supersedes | codex/SKILL.md:297,327-384; codex/mistakes.md:59-67,92-99 | High |
+| C-HIGH-4 | **proposer source-read-only not mechanically enforced** — proposer runs `workspace-write`; prompt-only "don't touch source" is insufficient; no post-proposer `git diff` gate in production.md | codex/SKILL.md:157-179; the 2 proposer mistakes; production.md:116-124 | High |
+| C-MED-1 | producer DONE-handshake before freeze/spawn not explicit (idle ≠ DONE) | production.md:36-44 + the handshake mistake | Med |
+| C-MED-2 | evaluator degraded-mode scenario coverage thin (timeout/7-of-8/no-VERDICT/retry/both-fail/cost-cap/independence-leak) | evaluation.md:180-219 | Med |
+| C-MED-3 | no-gh/PR-deferred needs a Wrap-up/Git finalization checklist | wrap-up.md:43-48 | Med |
+| C-MED-4 | concurrent-session + orphan-cleanup scenario suite missing (leader G1) | git mistakes; record.md:216-221 | Med |
+| C-MED-5 | RECORD value-telemetry needs degraded-production cases (single vs degraded-dual; per-task degraded roll-up) | record.md:69-91; production.md:88-99; execution.md:83-85 | Med |
+
+**The Codex runtime matrix (adopted — locked decision 1):**
+
+| Runtime / workload | Launch mode | Completion signal |
+|---|---|---|
+| Native Codex shell, under host cap | foreground `timeout <cap>` | process exit + file validation |
+| Claude Code Bash, under ~10 min | foreground, timeout BELOW the host cap | file validation before reporting |
+| Claude Code Bash, may exceed host cap | background, explicit PID, `< /dev/null` | poll output file for closing marker; ignore detached exit code |
+| Assistant wrapper | ONLY if it blocks/polls until contracted output files pass validation | files-as-truth, never "started" |
+
+Invariant (state first in codex/SKILL.md): **the entity that reports DONE must have read + validated the contracted output files in the same turn.** Add: a missing proposer is not a safety gate, but an UNVALIDATED proposer completion IS a process failure.
+
+Leader's proposed checklists (C4/C5/G1/G2 from iter1) map onto Codex's change-set E scenario families — take the union.
+
+---
+
+## Cross-system reconciliation (dual-system record)
+
+Full per-delta log: `working/reconciliation-iter1.md`. The dual-system + 3-way process paid off — each party caught what the others missed:
+
+**Codex found (leader missed / under-framed) → took-codex, anchors verified:**
+- **C-HIGH-1 (no `workflow/configuration.md`)** — leader only flagged G3 "config-time failure, verify-against-child-docs"; Codex found the bigger structural gap.
+- **C-HIGH-2 (the timeout doc↔mistake contradiction)** — the #1 finding; leader's iter1 C4 flagged "codex-exec preflight" but not the concrete doc contradiction. Verified in full (my first grep used wrong patterns; the file confirms it).
+- **S-HIGH-3 (agent-token null-total)** — a real jq bug distinct from the leader's.
+- The full completeness scenario families (C-MED-1..5) + the runtime matrix + the architecture (lib/common.sh + manifest + fixtures + smoke) + AT-* currency (independently fetched docs → corroborates the currency report).
+
+**Leader found (Codex missed) → kept-own:**
+- **agent-token bug #2** (`main_filter` built-but-never-injected) — DISTINCT from Codex's null-total; BOTH in the doc.
+- **C-BUG-1** (`canon()` fail-OPEN) — the specific silent-false-pass mechanism; Codex's S-HIGH-1/2 touch the general fail-closed/realpath class but not this.
+- The **refactor-not-rewrite guardrail** (don't flatten `reconcile`'s flock+codex-preserve guard) — a load-bearing constraint on change-set A.
+- The **cross-point dead-xref consolidation** (S5 + B12 + Points 1/2 dangling xrefs → ONE follow-up).
+
+**Divergence resolved (leader CONCEDES):** the leader's "clean" verdict on `check-markdown-links.sh` + `validate-integration-log.sh` was INCOMPLETE — Codex's S-MED-2 (`\b` non-portable) + S-MED-3 (symlink-blind find + limited parser) are correct, verified against the files. Kept the surviving nuance (their algorithms are sound + bash-3.2-safe) but corrected "no findings."
+
+**Currency triple-confirmed:** leader S1-S5 (structural) + the claude-code-guide report + Codex AT-* agree on the stale items (Shift+Down, teammateMode default, v2.1.32, TeamCreate/Delete-removed).
+
+**No major divergence requiring user adjudication** beyond the two forks the user already locked (runtime matrix; full refactor).
+
+---
+
+## Implementation plan (Codex's prioritized change-sets A-E)
+
+Priority order (user-locked): **C → A → B → D → E.**
+
+- **Change-set C (PRIORITY 1) — Codex runtime contract.** Reconcile `codex/SKILL.md` + `production.md` + `evaluation.md` to the runtime matrix; mark the foreground-`timeout 1200` guidance superseded; state the files-as-truth DONE invariant; add the proposer source-read-only post-`git diff` gate (C-HIGH-4). Verify: `grep 'timeout 1200'` — every use has host-cap context; `grep` wrapper-recommendations — each states the same-turn file-validation invariant.
+- **Change-set A (PRIORITY 2) — shell foundation.** `scripts/lib/common.sh` (strict-mode, `require_cmd`, `require_bash_4`, shared path-resolution + `slugify`/`trim`/`die`/`usage`/accumulator/tempdir-trap); source it in all 11; **FIX C-BUG-1 (canon fail-closed)**, S-HIGH-3 (`add // 0`), agent-token bug #2 (inject the filter), S-HIGH-1 (fail-closed with the accumulator nuance), S-HIGH-2/M4 (bash-4 guard). **Preserve** the self-tests + column discipline + reconcile's flock guard.
+- **Change-set B (PRIORITY 3) — record-map manifest.** `record-map.manifest.json` (loop dirs, staging vocab, working dirs, task regex, pass-only rule); scaffold + verify + record-map.md all consume it (fixes S-HIGH-4); externalize/retire check-residual-vocab's baseline (S-HIGH-5).
+- **Change-set D (PRIORITY 4) — Agent Teams refresh.** CUR-1..10 + S4/S5; native-vs-policy table; liveness/replacement + token checklists. Verify: `grep v2.1.32|TeamCreate|TeamDelete|Shift+Down|"auto" (default)` → removed/contextualized.
+- **Change-set E (PRIORITY 5) — scenario suite.** Add `workflow/configuration.md` (C-HIGH-1) + scenario families across evaluation/production/record/wrap-up (C-MED-1..5 + leader C4/C5/G1/G2): fresh/resume/compact/clear, concurrent sessions, no-gh/PR-deferred, worktree orphan/bulk cleanup, teammate death, Codex proposer degraded, evaluator failure/fallback, wrapper hang/timeout, cross-tree source-write, producer DONE-handshake + freeze.
+
+**Coordination:** these are largely NEW files + doc edits, low collision with Points 1/2 (which touch chat-mode.md + workflow/*.md caps/compaction). Change-set E's edits to workflow/{evaluation,record,production}.md should sequence AFTER Point 2's compaction of those same docs (or fold in) — flag for planning.
+
+---
+
+## Verification plan
+
+- **Scripts smoke suite** (change-set A): each script `--help` + self-test/check mode + a planted missing-dependency test; `check-merge --self-test`; `verify-record-map --check` with planted doc-drift + scaffold-drift; empty/no-usage/all-sidechain transcript fixtures for agent-token; malformed-integration-log + broken-link fixtures.
+- **C-BUG-1:** run check-merge in a PATH without GNU `realpath` → must exit 2 (fail-closed), not "REF-INTEGRITY OK".
+- **Runtime matrix (C):** `grep 'timeout 1200'` across codex/SKILL.md + production.md → every use host-cap-qualified; the superseded foreground guidance is marked.
+- **Currency (D):** the grep list above; confirm `.claude/settings.json` still ships `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` + `teammateMode`; re-verify version numbers against live docs.
+- **Completeness (E):** `workflow/configuration.md` exists with the fresh/resume/compact/clear + worktree + mode scenarios; each new scenario states manager action + output files + session.json fields + RECORD routing.
+
+## Out-of-scope / cross-point follow-ups
+
+1. **Dead mistake-xref cleanup (cross-point):** fold S5/CUR (agent-teams.md:187) + B12 (Point 2's `manager-skipped-dual-system-eval.md` + `skills-mirror-symlinks-not-copies.md`) + Points 1/2 dangling xrefs into ONE combined "create-or-repoint dead mistake references" follow-up.
+2. **Change-set E ↔ Point 2 sequencing** on workflow/{evaluation,record,production}.md (compaction vs scenario-add).
+
+## Open items for the implementer
+
+- **C-HIGH-2/3 runtime matrix** is the #1 correctness item — land change-set C first; a manager following the current foreground-`timeout 1200` guidance in Claude Code hits the known-bad invocation and silently loses dual-system.
+- **C-BUG-1 fail-closed** — a verification gate that fail-opens on a missing tool is worse than a loud failure.
+- **Refactor-not-rewrite** — change-set A must preserve the self-tests, escaped-pipe column discipline, and reconcile's flock+codex-preserve guard.
+- **Currency numbers** re-verify against live Claude Code docs at implementation (experimental feature, all 3 sources caveat this).
+- **check-residual-vocab retire-vs-externalize (S-HIGH-5)** — confirm the memorization→memory (D18) + `_shared` (#310/#312) migrations are complete before retiring.

--- a/.gobbi/projects/gobbi/reviews/code-review/2026-07-06-point-01-chat-mode-cycles-and-length.md
+++ b/.gobbi/projects/gobbi/reviews/code-review/2026-07-06-point-01-chat-mode-cycles-and-length.md
@@ -1,0 +1,345 @@
+---
+name: point-01-chat-mode-cycles-and-length
+description: Dual-system review of the Chat-mode compact-cycles + doc-length change request, with an implementation-ready change-set.
+type: reviews
+scope: project
+feature: null
+status: active
+created: 2026-07-06
+session: 0d898156-8d5b-4142-9b93-308d3b692995
+tags: [evaluation]
+keywords: [workflow, chat-mode, maxIterations, compact-cycles, token-cost, condensation, state-template-split]
+author: claude
+review_kind: code-review
+subject: orchestration/chat-mode.md + templates/settings.chat.json (Chat compact-cycles + doc length)
+verdict: needs-attention
+---
+
+# Point 1 — Chat-mode compact cycles + doc length
+
+## Point (verbatim user text)
+
+> Point 1 — chat-mode of orchestration skill.
+> 1. The chat-mode should have more compact cycles. Current chat-mode includes maxIter=5. But Planning loop should only have maxIter=1, Execution Loop should have maxIter=3, Wrap-up Loop should have maxIter=3. Ideation should stay deep. Expectation: shorter turn-over per topic while keeping ideation deep.
+> 2. The chat-mode.md looks too long / narrative-heavy. It causes a lot of token usage in every skill-loading phase.
+
+## Session context
+
+- **Mode:** Chat-mode review. **Implementation is DEFERRED** — this doc edits no skill / agent / settings file; it is the review + implementation-ready change-set a future session executes.
+- **Reviewers (dual-system):** `leader` (Claude, this producer) + an independent `codex` proposer. The Codex proposal was frozen before integration; the producer selectively integrated it (SELECT the stronger element, never blend). The cross-system record is in § Cross-system reconciliation.
+- **Verdict `needs-attention`:** direction is fully approved and all three decision forks are resolved. The verdict is not `pass` because the change-set carries **correctness-implementation work that must not be skipped**: MF-1 (the shared-rule counting-convention pin) and MF-2 (the state-template split + its parity guard + the three-mirror deployment). These are specified below, not open questions.
+
+## Decisions locked
+
+**User decisions (locked this session):**
+1. **Planning REVISE handling:** keep Planning `maxIter=1`, keep `evaluate.mode: always`; on a REVISE, route to Chat's **existing after-EVALUATION user gate** (accept / revise-once / reframe). **No hard `Aborted`.** (Leader option (b) = Codex Option A + Option C gate wording.)
+2. **ADR / provenance history in chat-mode.md §1–§2:** **RECLASSIFY** to a `decisions/` record (preserve per never-delete, memory/rules.md §4.3) — not delete, not footnote.
+3. **Fork #3 — the settings→state propagation gap is resolved by SPLITTING the state template by mode** (parallel to the existing `settings.{mode}.json`): create `state.auto.json` + `state.chat.json`, replacing the generic `state.template.json`. `settings.{mode}.json` stays the **authoritative** cap source; the split only makes the DEFAULT seed born mode-correct; Config still stamps any customize-gate override into `state.json` from resolved settings; a parity guard prevents the two mode-template families from drifting. Full design in MF-2.
+
+**Manager-locked confirmations:**
+4. **Chat-only** — Auto keeps `maxIterations: 5` across the board; `settings.auto.json` + the Auto defaults table are untouched (and `state.auto.json` keeps all-5).
+5. **Pin the counting convention** — `maxIterations` = "max WORK passes", so `1` reliably means one-shot. Clarifies the **shared** SKILL.md iteration rule (Auto reads it too). See MF-1.
+6. **Two separate implementation tasks / two PRs** — 1.1 (compact cycles + the state split + correctness fixes) and 1.2 (length) ship separately, from this one review doc.
+7. **Out-of-scope adjacents are SEPARATE backlog follow-ups** — not folded in: (a) the dangling `mistakes/skills-mirror-symlinks-not-copies.md` xref; (b) the D4-008 glossary drift (`EVAL` / `MEMO` / `InProgress` tokens), fixable opportunistically only IF the 1.2 length pass already edits those lines.
+
+---
+
+## Findings 1.1 — Compact cycles
+
+### Cap values (as decided)
+
+| Loop | Current Chat | New Chat | Auto (unchanged) | Note |
+|---|---:|---:|---:|---|
+| Ideation | 5 | **5** | 5 | stays deep — user intent |
+| Preparation | 0 / `skip: true` | **0 / skip** | 5 | already Skipped at loop entry in Chat |
+| Planning | 5 | **1** | 5 | one-shot; REVISE → user gate (not Aborted) |
+| Execution | 5 | **3** | 5 | up to 3 WORK passes per sub-step |
+| Wrap-up | 5 | **3** | 5 | up to 3 remediation iterations |
+
+Behavioral risk: execution=3 and wrap-up=3 are safe budget trims (auto-iteration preserved; exhaustion escalates to the present user). planning=1 changes the loop's *shape* — see Planning-REVISE semantics + MF-1.
+
+### Full edit-site change-set
+
+The blast radius is **~9 doc files + settings.chat.json + one script edit + a parity-guard addition + the state-template split (2 new files, 1 deletion) across canonical + 3 mirror surfaces.** Every `file:line` is from the versions read this session.
+
+**Behavioral source — `templates/settings.chat.json`:**
+
+| Line | Current | New |
+|---|---|---|
+| 24 | `planning.maxIterations: 5` | `1` |
+| 31 | `execution.maxIterations: 5` | `3` |
+| 38 | `wrap-up.maxIterations: 5` | `3` |
+| 10 | `ideation.maxIterations: 5` | unchanged |
+| 16-17 | `preparation.skip: true`, `maxIterations: 0` | unchanged |
+| 22 | `planning.evaluate.mode: always` | **unchanged** (eval kept per locked decision 1) |
+
+**Mode doc — `orchestration/chat-mode.md` (canonical only; `.claude/…` mirror is a symlink — edit canonical, symlink reflects):**
+
+| Line | Current (excerpt) | New |
+|---|---|---|
+| 48 | "up to 5 remediation … (`wrap-up.maxIterations: 5`)" | `5 → 3` (count + inline value) |
+| 76 | diagram "Ideation Loop (maxIter=5)" | unchanged |
+| 99 | diagram "mini Planning Loop (maxIter=5)" | `→ maxIter=1` |
+| 105 | diagram "mini Execution Loop … (maxIter=5)" | `→ maxIter=3` |
+| 121 | diagram "Wrap-up Loop (maxIter=5)" | `→ maxIter=3` |
+| 146 | "ideation … (Chat default = 5)" | unchanged |
+| 176 | "planning … (Chat default = 5)" | `→ 1` + one-shot note |
+| 194 | "execution … (Chat default = 5)" | `→ 3` |
+| 229 | "wrap-up … (Chat default = 5)" | `→ 3` |
+| 237 | "up to `max=5` remediation iterations" | `→ max=3` |
+| 301 | §5 "Iteration cap is 5 for Ideation / Planning / Execution …" | **rewrite per-loop** (see below) |
+| 524 | §8.2 "ideation … iter == maxIter (5)" | unchanged |
+| 530 | §8.2 "planning … iter == maxIter (5) → Aborted" | `(5) → (1)` + **reword the To-state/Guard to the user-gate, not `Aborted`** (locked decision 1) |
+| 535 | §8.2 "execution … iter == maxIter (5)" | `(5) → (3)` |
+| 559-562 | §8.3 worked example "iter 1 PASS" | no cap change (first-pass illustration) |
+
+§5 L301 rewrite (per-loop):
+> "**Iteration caps are per-loop in Chat:** Ideation 5, Planning 1 (one-shot — a REVISE routes to the after-EVALUATION user gate, §3 Step 4 / §8.2, not a hard abort), Execution 3, Wrap-up 3; Preparation skipped. (Auto keeps 5 across the board — `auto-mode.md §4`.) Exhausting a loop's budget without `PASS` is a signal to reframe or split — at the tighter Chat caps this is deliberate: short turn-over per topic while Ideation stays deep."
+
+**Shared state-machine doc — `orchestration/SKILL.md` (cap semantics):**
+
+| Line | Current | New |
+|---|---|---|
+| 264 | "`maxIterations` is read from `workflow.{step}.maxIterations` (default `5`)." | Clarify: read from **resolved settings**; defaults are mode-specific (Auto 5 all loops; Chat 5 / 0-skipped / 1 / 3 / 3). |
+| 274-282 | Iteration rule (`iter` starts 0; abort at `iter == maxIterations`) | **MF-1** — pin "`maxIterations` = max WORK passes" so `1` = one-shot. |
+
+**Shared state-machine doc — `orchestration/SKILL.md` (state-template references, updated for the split, MF-2):**
+
+| Line | Current | New |
+|---|---|---|
+| 111 (Config row 4) | stub source "`templates/state.template.json`" + "Set `mode` from resolved settings" | name the mode template `state.{mode}.json`; **document that Config stamps any customize-gate `maxIterations` override into `state.json` from resolved settings** |
+| 112 (Config row 4R) | link `[state.template.json]` | update the link; note 4R rehydrates the persisted `state.json` unchanged (no template re-read on resume) |
+| 247 | "Initial template \| [`templates/state.template.json`]" | the two mode templates `state.auto.json` / `state.chat.json` |
+| 357 | "Both `templates/state.template.json` and `templates/session.template.json` seed `workflow.chat: { tasks: [] }`" | name `state.chat.json` (+ `state.auto.json` keeps the empty `chat.tasks`) |
+
+**Workflow sub-docs (consistency — the "generic default 5 → mode-specific" clarification; NOT per-value edits):**
+
+| File:line | Current | New |
+|---|---|---|
+| `workflow/evaluation.md:276` | "default 5 for Ideation/Planning/Execution, 5 for Wrap-up" | mode-specific (Auto 5; Chat 5/0/1/3/3) |
+| `workflow/planning.md:115` | "planning.maxIterations (default 5)" | "Auto 5; Chat 1" + note first-REVISE → user gate |
+| `workflow/execution.md:107` | "execution.maxIterations per task (default 5)" | "Auto 5; Chat 3" |
+| `workflow/wrap-up.md:47, 53` | "wrap-up.maxIterations default 5" | "Auto 5; Chat 3" |
+| `workflow/preparation.md:121` | "preparation.maxIterations (default 5)" | "Auto 5; Chat 0/skipped" |
+| `workflow/record.md:316` | "loop's iteration cap (…default 5)" | generic note (or leave; lowest priority) |
+
+**Auto side must NOT change:** `settings.auto.json:24/31/38`, `auto-mode.md:74/92/110/128/146/205-209`, and the new `state.auto.json` all keep 5. Optional: an `auto-mode.md` cross-ref note that the Chat-vs-Auto difference now includes compact caps, not only preparation-skip.
+
+**Disambiguation (must be LEFT):** "5-row loop" (chat-mode.md:100/106, auto-mode.md) is the phase COUNT (DISCUSSION/WORK/EVAL/RECORD/ITER-EXIT), NOT a cap.
+
+### Correctness must-fix MF-1 — the counting-convention off-by-one (co-headline)
+
+`SKILL.md:264/276-282` says **`iter` starts at `0`** and aborts at **`iter == maxIterations`**, incrementing while `iter < maxIterations`. Read literally, `maxIterations:1` yields **two** WORK passes (iter 0, then iter 1). But the Status Display (`SKILL.md:131` "1/5") and the §8.3 worked example (`chat-mode.md:559` "iter 1 PASS") render the **first pass as iter 1** — a 1-based display over a 0-based counter. The conventions disagree about whether `maxIterations` is "max WORK passes" or "max re-entries after the first pass."
+
+At `maxIter=5` nobody notices; at `maxIter=1` it is the whole point — one pass vs two. **Fix (locked decision 5):** pin **"`maxIterations` = max WORK passes"** so `1` = exactly one pass. Reword the SKILL.md iteration rule (e.g. "the loop runs at most `maxIterations` WORK passes; on the `maxIterations`-th REVISE it exits to the mode's cap-exhaustion path") and confirm the display renders `current/max` consistently. Shared rule — Auto reads it too — a deliberate cross-mode clarification landed in task 1.1.
+
+> Codex under-weighted this: it restated the literal rule but did not flag the contradiction, and its Option B ("set Planning to 2 for one automatic fix pass") implicitly assumed the 1-based reading — precisely the ambiguity MF-1 resolves. Kept as a leader-owned co-headline correctness fix.
+
+### Correctness must-fix MF-2 — settings→state propagation, RESOLVED by the state-template split (fork #3)
+
+**Root gap.** `state.template.json:6-10` seeds every productive loop's `maxIterations` to `5` and stamps a NEW session's `state.json` (Config row 4). `state.json` carries `maxIterations` per loop (`SKILL.md:251`) and per chat task sub-record (`SKILL.md:357`). Config row 4 (`SKILL.md:111`) documents only "set `mode` and states" — NOT a copy of `maxIterations` from resolved settings. So a mode-agnostic template seeding `5` could survive into `state.json` and make the Chat value flip **docs-only** (caps stay 5) if the runtime reads the cap from `state.json`.
+
+**Resolution (fork #3 — the user's third option, better than the leader's A/B or Codex's Option B).** Split the state template by mode, exactly parallel to the existing `settings.{mode}.json`:
+
+1. **Create `templates/state.auto.json`** — all productive loops `maxIterations: 5` (identical to today's generic template).
+2. **Create `templates/state.chat.json`** — ideation 5, preparation 0, planning 1, execution 3, wrap-up 3. (Keep the same rest-of-shape: `configuration` null, `chat: { tasks: [] }`, `activeNote`.)
+3. **Delete `templates/state.template.json`** (after the one live reader is repointed — see the reader sweep).
+4. **Edit `record/scripts/init-record-map.sh:86`** — `stub state.template.json state.json` → `stub "state.$mode.json" state.json`, mirroring the adjacent line 87 `stub "settings.$mode.json" settings.json`. `$mode` is `$2` (already validated by the settings stub). Result: a fresh `state.json` is born mode-correct; **no resume-time overlay needed** (row 4R rehydrates the persisted `state.json` unchanged).
+5. **`settings.{mode}.json` stays AUTHORITATIVE.** The split only fixes the DEFAULT seed. If the user overrides a cap at the Config customize gate (`SKILL.md:110` row 3), Config (row 4) MUST stamp that override into `state.json` from resolved settings — otherwise the seed is stale. Document this explicitly (the row-4 edit above).
+6. **Parity guard.** Add a check (extend `record/scripts/verify-record-map.sh` or a sibling guard) asserting `state.{mode}.json` caps == `settings.{mode}.json` caps for each loop, so the two mode-template families cannot drift.
+
+**Why the split is low-risk (precedent):** `settings.{auto,chat}.json` already exists and is already mirrored across all runtime surfaces — the state split follows the identical, proven pattern. It also removes the mode-agnostic-template hazard entirely rather than papering over it with an overlay.
+
+**Three-mirror deployment (feasibility — verified this session).** `templates/` is mirrored three ways, so the 2-create + 1-delete must reach every surface:
+
+| Surface | Kind | Action |
+|---|---|---|
+| `.gobbi/projects/gobbi/skills/orchestration/templates/` | canonical (real files) | create `state.auto.json` + `state.chat.json`; delete `state.template.json` |
+| `.claude/skills/orchestration/templates/` | per-file **symlinks** to canonical | add 2 symlinks; remove the `state.template.json` symlink (content auto-reflects; the symlink entries themselves must be created/removed) |
+| `.agents/skills/orchestration/templates/` | physical **copies** (Codex runtime) | add 2 copies; delete 1 |
+| `plugins/gobbi/skills/orchestration/templates/` | physical **copies** (Claude Code plugin) | add 2 copies; delete 1 |
+
+The `init-record-map.sh:86` edit likewise must reach the physical-copy mirrors (`.agents`, `plugins`); `.claude` reflects it via its script symlink. Run the standard deployment/mirror-sync step (G1 deployment-hygiene precedent) so canonical → mirrors, and confirm presence on all four surfaces.
+
+### state.template.json reader sweep (exhaustive — feasibility check)
+
+Repo-wide grep (`state\.template\.json`, plus `state[._-]template` / `stateTemplate`; worktrees/.git/node_modules excluded):
+
+| Class | Site(s) | Action |
+|---|---|---|
+| **Live code reader (repoint)** | `record/scripts/init-record-map.sh:86` | THE edit — `stub "state.$mode.json" state.json` |
+| **Live doc readers (update for the split)** | `orchestration/SKILL.md:111, 112, 247, 357` | update per the SKILL.md split-reference table above |
+| **Frozen — archive/ (LEAVE, §4.6)** | `archive/design/workflow/2026-07-03-{d1-001,d7-001,d7-002}*.md` | none |
+| **Historical memory (LEAVE; optional parenthetical only)** | `features/workflow/decisions/…/2026-06-08-session-tree-spec-doc.md:25`; `features/workflow/design/…/{codex-proposer-model,d7-001…shipped,d7-002…shipped}.md`; `features/workflow/plans/…/2026-07-03-workflow-state-record-coherence-fix-plan.md` (×4) | none required (describe past decisions/scoping) |
+| **Frozen review records (LEAVE)** | `reviews/adversarial-review/2026-06-29*.md`, `…/2026-07-01-codex-*.md` (×several; also cite the `.agents/…/state.template.json` mirror) | none |
+
+**Confirmed:** `scaffold-session-dir.sh` has NO state-template reference (tolerates the split); `verify-record-map.sh` only asserts `state.json` exists (tolerates it, and is the natural home for the new parity guard). The ONLY live code reader is `init-record-map.sh:86`. No TS/JS/hook reader exists.
+
+### Planning `maxIter=1` REVISE semantics (as decided)
+
+Per locked decision 1: Planning stays one-shot with mandatory evaluation. On a REVISE at the single pass, the manager does **not** stamp a hard `Aborted`; it routes to Chat's **existing after-EVALUATION user gate** (`chat-mode.md §5` L296-300 — "after EVALUATION → discuss findings and remediation"), where the user picks **accept-as-is / revise-once (ad-hoc cap raise) / reframe**. Keeps the dual-system plan-evaluation signal, avoids the `Aborted` stigma, matches Chat's user-driven posture. Reinforced by `workflow/evaluation.md:266` (Chat already escalates a stuck finding to the user before the cap; it notes "chat-mode.md is silent on stuck detection" — a reconciliation point). Implementation: one clarifying sentence in §5 + the §8.2 planning row (L530) reworded from `→ Aborted` to `→ user gate`.
+
+Alternative considered and rejected (recorded): Codex Option B — Planning `maxIterations: 2` (one automatic repair pass). Rejected: does not match the user's requested value; the user chose one-shot + user gate.
+
+---
+
+## Findings 1.2 — Length / token cost
+
+### Measurement (dual-system cross-check)
+
+| Doc | Lines | Words | Bytes (`wc -c`) | Chars (`wc -m`) | Rough tokens |
+|---|---:|---:|---:|---:|---:|
+| **chat-mode.md** | **617** | 5,124 | 40,348 | 39,206 | **~9,800–10,600** |
+| auto-mode.md (peer) | 413 | 4,237 | 32,628 | 32,268 | ~8,100–8,600 |
+| SKILL.md | 446 | 7,448 | 56,463 | 55,901 | ~14,000 |
+
+(bytes-vs-chars gap = multi-byte box-drawing / status glyphs.) chat-mode.md is **~204 lines longer and ~1.5× the token weight of its peer auto-mode.md**, for a simpler runtime shape.
+
+**When it loads (recurring cost):** dispatched at Configuration end (`SKILL.md:80-86`) — Chat → chat-mode.md, Auto → auto-mode.md. **Confirmed it does NOT load in Auto sessions.** It reloads into the manager's context at session start + every resume / `/clear` / `/compact` re-prime; the manager is the durable cross-task agent, so on a long chat session the ~10K tokens recur several times, alongside `SKILL.md`.
+
+### Normative content to PRESERVE (verbatim or condense-only)
+
+| Range | Why preserved |
+|---|---|
+| §2 term lock "per-task slice" (L39-41) | naming lock |
+| §3 per-step tables (L148-237) | the actual procedure; carries the cap values 1.1 edits |
+| §4 Chat RECORD R5 lock blockquote (L246-270) | single-canonical-statement lock |
+| §6 task-record spec (L338-441) | session-artifact contract |
+| §8.2 state-transition table (L519-539) | normative state contract |
+| §9 discuss-first contract (L578-588) | mode-level regression guard |
+
+### Condensable / redundant content (line ranges + per-cut estimate + risk)
+
+| # | Range | What | Cut | ~Saving | Risk |
+|---|---|---|---|---:|---|
+| K1 | §1 ADR history L15-29 | "why this doc exists" provenance | **RECLASSIFY to `decisions/`** + 1-line `## Source` pointer (locked decision 2; never delete) | ~250-350 tok | Low |
+| K2 | §1↔§2 overlap L34-57 | mode-posture stated ~3× + re-frame list pre-echoing §3 | merge to one ~12-line posture section | ~250-380 tok | Low-med |
+| K3 | §3 ASCII diagram L68-128 | duplicates the per-step tables below | replace with a compact table (step / cap / owner / exit) carrying the new caps | ~900-1,200 tok | Med — table MUST preserve all caps + skip |
+| K4 | §4 sub-bullets L272-282 | re-enumerate base RECORD steps the R5 lock says run "unmodified" | keep the lock quote + promotion-source para; drop the restatement | ~150-250 tok | Low |
+| K5 | §5 discipline L286-327 | overlaps §3 + SKILL.md State Machine + production.md | 6 short bullets + links; **keep the 3 in-loop gates + mistake moment-of-capture** | ~500-800 tok | Med |
+| K6 | §8.3 worked example L541-575 | one status-display render | move to appendix or delete (§8.2 table is the normative source) | ~600-800 tok | Low |
+| K7 | cross-refs L591-617 | long list, some duplicate inline links | shrink to essential owner docs | ~300-450 tok | Low |
+| (K6.2) | §6.2 frontmatter-deferred L386-401 | deferred-decision history | condense to the current default rule + a backlog pointer — **only if Planning resolved the frontmatter choice; else keep a short warning** | ~250-350 tok | Med |
+
+### Recommended condensation approach
+
+**In place, no file split.** Target **~30% reduction** (~150-215 lines / ~2,500-3,500 tokens), toward peer parity with auto-mode.md (~410-430 lines). Preserve every NORMATIVE anchor; take all cuts from the condensable list. **Reclassify, never delete** (K1 per locked decision 2 + memory/rules.md §4.3). **Edit canonical only** (mirror is a symlink). Acceptance test: after condensation, chat-mode.md states no rule already owned elsewhere (record/SKILL.md for RECORD, SKILL.md State Machine for gates, production.md for integration) — it keeps only Chat-specific deltas + its own locks.
+
+---
+
+## Cross-system reconciliation (dual-system record)
+
+Full per-delta log: `working/reconciliation-iter1.md`. Summary:
+
+**Both systems agreed (independent convergence — the strong signal):**
+- The cap value set (planning 1 / exec 3 / wrap-up 3; ideation 5; prep skip) and the chat-mode.md doc-site list.
+- The `state.template.json` settings→state propagation gap (MF-2). Codex surfaced it as a "runtime consistency caveat" + open question; the leader's post-mistake addendum reached it independently. Two paths, one finding — high confidence.
+- The broader blast radius including the workflow sub-docs.
+- Planning REVISE → keep `maxIter=1` + keep eval + user gate (leader (b) = Codex A + C).
+
+**Fork #3 evolution (recorded — the dual-system → user path):**
+- Leader offered options (a) document-the-overlay / (b) verify-then-overlay in SKILL.md rows 4/4R.
+- Codex offered "stamp from resolved settings during Configuration, OR split state initialization by mode" (its Open Q2) — i.e. Codex named the split as one branch.
+- **The user chose the split** (`state.auto.json` + `state.chat.json`), a cleaner third option than an overlay: it removes the mode-agnostic-template hazard at the source and reuses the proven `settings.{mode}.json` pattern. Adopted as locked decision 3.
+
+**Codex-only additions (integrated):**
+- The five workflow sub-doc consistency sites with `file:line` (took the union incl. `preparation.md:121` as an edit site).
+- The D4-008 glossary drift (`EVAL` / `MEMO` at L525, `InProgress`) — routed to an out-of-scope follow-up (opportunistic-only).
+- The concrete `rg` verification patterns (incl. `EVAL|MEMO|InProgress`).
+- The Planning `maxIter=2` alternative — recorded as considered-and-rejected.
+
+**Leader-only (kept-own):**
+- **MF-1, the counting-convention off-by-one** — co-headline correctness fix; Codex under-weighted it.
+- **ADR history → reclassify, not delete** — Codex leaned delete; overridden by locked decision 2.
+
+**No major divergence** requiring user adjudication; the substantive fork (delete-vs-reclassify ADR history) and the state-source fork were both resolved by user decisions.
+
+---
+
+## Implementation plan (two ordered tasks / two PRs)
+
+**Order matters:** Task 1.1 first, then Task 1.2. Task 1.2 renumbers most of chat-mode.md, which would invalidate 1.1's line anchors — so 1.1 lands the behavior first, and 1.2 is authored against the post-1.1 file.
+
+### Task 1.1 (PR 1) — compact cycles: value flip + state-template split + correctness fixes
+
+1. `settings.chat.json`: planning `1`, execution `3`, wrap-up `3` (ideation/prep unchanged; `evaluate.mode` unchanged).
+2. **State-template split (MF-2 / fork #3):** create `templates/state.auto.json` (all-5) + `templates/state.chat.json` (5/0/1/3/3); delete `templates/state.template.json`; edit `record/scripts/init-record-map.sh:86` to `stub "state.$mode.json" state.json`. Propagate to all three mirror surfaces (`.claude` symlinks: +2/−1; `.agents` + `plugins` copies: +2/−1) via the deployment/mirror-sync step.
+3. **Parity guard:** extend `record/scripts/verify-record-map.sh` (or a sibling) to assert `state.{mode}.json` caps == `settings.{mode}.json` caps per loop.
+4. `chat-mode.md`: the ~11 doc sites above, incl. the §5 L301 per-loop rewrite and the §8.2 L530 planning-REVISE → user-gate reword.
+5. `SKILL.md`: **MF-1** (pin `maxIterations` = max WORK passes, L274-282) + L264 mode-specific-defaults clarify + the state-template split references (L111 incl. the customize-gate override-stamping, L112, L247, L357).
+6. Workflow sub-docs consistency: `evaluation.md:276`, `planning.md:115`, `execution.md:107`, `wrap-up.md:47/53`, `preparation.md:121` (optional `record.md:316`).
+7. Optional `auto-mode.md` consistency note.
+8. Verify per the Verification plan.
+
+### Task 1.2 (PR 2) — length: in-place condensation
+
+1. Apply K1-K7 (+ K6.2) cuts; target ~30% / ~410-430 lines.
+2. Reclassify the §1 ADR history to a `decisions/` record (never delete); leave a 1-line `## Source` pointer.
+3. Preserve every NORMATIVE anchor; edit canonical only.
+4. Opportunistic ONLY if a cut already edits those lines: repair the D4-008 `EVAL` / `MEMO` / `InProgress` tokens (else leave to the separate backlog item).
+5. Verify per the Verification plan.
+
+---
+
+## Verification plan (for the implementer)
+
+**After Task 1.1 — cap vocabulary (form-covering, not single-pattern — per the recorded enumerate-across-forms traps):**
+
+```sh
+rg -n 'maxIter=5|Chat default = 5|Iteration cap is 5|up to .max=5|wrap-up\.maxIterations: 5|iter == maxIter \(5\)' \
+  .gobbi/projects/gobbi/skills/orchestration/chat-mode.md \
+  .gobbi/projects/gobbi/skills/orchestration/SKILL.md \
+  .gobbi/projects/gobbi/skills/orchestration/workflow
+# Expect: only Ideation-specific hits (chat-mode.md:76, :146) + intentional generic "default 5" after clarify.
+
+rg -n '"maxIterations": 5' .gobbi/projects/gobbi/skills/orchestration/templates/state.chat.json
+# Expect: ONE hit (Ideation). state.chat.json: planning 1 / execution 3 / wrap-up 3 / preparation 0.
+```
+
+**After Task 1.1 — state-template split integrity:**
+
+```sh
+# (a) zero LIVE readers of the deleted template remain (archive/reviews/plans historical hits are expected):
+rg -n 'state\.template\.json' \
+  .gobbi/projects/gobbi/skills .claude .agents plugins/gobbi
+# Expect: no hit under skills/ scripts or the runtime mirrors; init-record-map.sh now says state.$mode.json.
+
+# (b) the split files exist on ALL four surfaces:
+for d in .gobbi/projects/gobbi/skills/orchestration/templates \
+         .claude/skills/orchestration/templates \
+         .agents/skills/orchestration/templates \
+         plugins/gobbi/skills/orchestration/templates; do
+  ls "$d"/state.auto.json "$d"/state.chat.json 2>&1
+done
+# Expect: present on all four; state.template.json absent on all four.
+
+# (c) parity guard: state.{mode}.json caps == settings.{mode}.json caps (the new guard automates this).
+```
+
+**MF-1 runtime check:** confirm a fresh chat session's `state.json` shows planning `1` / exec `3` / wrap-up `3` after Config (born from `state.chat.json`), and that a customize-gate override is stamped through from resolved settings.
+
+**After Task 1.2:** form-covering grep of every removed phrase family before/after; re-read the §4 R5 lock, §8.2 table, §6 task-record spec, §9 discuss-first to confirm no lock was dropped. If the state-transition area was touched:
+
+```sh
+rg -n 'EVAL|MEMO|InProgress' .gobbi/projects/gobbi/skills/orchestration/chat-mode.md
+# Expect: zero non-historical hits in canonical state / sub-phase slots (D4-008), or each remaining hit explicitly classified historical.
+```
+
+---
+
+## Out-of-scope follow-ups (separate backlog items — do NOT fold into 1.1/1.2)
+
+1. **Dangling xref** — `chat-mode.md:613-615` + `auto-mode.md:411-413` reference `mistakes/skills-mirror-symlinks-not-copies.md`, which does not exist as a file (verified). Backlog: create the mistake or repoint the references.
+2. **D4-008 glossary drift** — stale `EVAL` / `MEMO` (chat-mode.md:525) + non-canonical `InProgress` tokens in the §8.2 table. Backlog; opportunistic during 1.2 only if that pass already edits the same lines.
+
+## Open items for the implementer
+
+- **MF-1 wording:** land the "max WORK passes" pin as a shared-rule edit; confirm the Status Display `current/max` rendering stays consistent for both modes.
+- **Customize-gate override stamping (MF-2):** the split fixes the default seed, but a user cap override at the Config customize gate must still be stamped into `state.json` from resolved settings — verify and document at SKILL.md row 4.
+- **Deployment sync:** the 2-create/1-delete template change + the `init-record-map.sh` edit must reach `.agents` + `plugins` physical-copy mirrors (and the `.claude` symlink entries be created/removed). Run the standard mirror/deployment step; verify presence on all four surfaces (see Verification (b)).
+- **Planning REVISE ↔ stuck-detection reconciliation:** reconcile the after-EVALUATION user-gate wording with `workflow/evaluation.md:266` so the two do not describe the one-shot-planning REVISE differently.
+- **1.2 frontmatter-deferred cut (K6.2):** only condense §6.2 if Planning has resolved the `task-record` frontmatter choice; else keep the short warning.
+
+## Process mistake-candidate (for RECORD staging — self-caught)
+
+**Symptom:** the iter1 blast-radius map was built by reading only the three files the brief named; it missed `state.template.json`, the five workflow sub-docs, and the three-mirror deployment surface. **Why:** enumeration by named-file reading instead of an exhaustive form-covering grep + manual classification across all surfaces (templates, scripts, mirrors, state schema). **Detect:** any "full blast radius / affected-file map" claim not backed by a repo-wide, multi-form grep. **Correct approach:** for any cross-cutting contract, grep every syntactic form of the concept across the whole tree (skills, scripts, hooks, templates, mirrors) and classify each hit before declaring the map complete. Recurrence-class of `mistakes/refactor/enumerate-all-restatements-and-classify-deferral-before-claiming-map-complete.md` + `mistakes/refactor/cotouch-enumeration-must-cover-semantic-equivalents.md`. (Corrected this session after the user prompt; the finalized change-set above is the post-correction map.)

--- a/.gobbi/projects/gobbi/reviews/code-review/2026-07-06-point-02-orchestration-skill-compaction.md
+++ b/.gobbi/projects/gobbi/reviews/code-review/2026-07-06-point-02-orchestration-skill-compaction.md
@@ -1,0 +1,205 @@
+---
+name: point-02-orchestration-skill-compaction
+description: Dual-system review of the orchestration skill compaction — per-doc targets (Codex ceiling + gate-limited floors), the workflow↔skill duplication map, ~12 correctness bugs, and a fix-first implementation plan.
+type: reviews
+scope: project
+feature: null
+status: active
+created: 2026-07-06
+session: 0d898156-8d5b-4142-9b93-308d3b692995
+tags: [evaluation]
+keywords: [orchestration, workflow, compaction, duplication-map, ssot, correctness-bugs, loop-skeleton, gate-preservation]
+author: claude
+review_kind: code-review
+subject: orchestration/SKILL.md + auto-mode.md + agent-teams.md + workflow/*.md (compaction + manager/skill split)
+verdict: needs-attention
+---
+
+# Point 2 — Orchestration skill compaction
+
+## Point (verbatim user text)
+
+> The next point is compacting orchestration skill.
+> 1. The docs in orchestration skill look too long and large. Polish and compact the narrative sentences. We can delete unnecessary sections or sentences.
+> 2. The docs in orchestration/workflow/*.md should describe what the MANAGER must know for orchestration. The details should NOT be duplicated with each skill.
+> 3. Find any other improvement points.
+
+## Session context
+
+- **Mode:** Chat-mode review. **Implementation is DEFERRED** — this doc is the review + implementation-ready change-set.
+- **Reviewers (dual-system):** `leader` (Claude, this producer) + an independent frozen `codex` proposal (441L). The producer selectively integrated (SELECT the stronger element, never blend). Cross-system record in § Cross-system reconciliation + `working/reconciliation-iter1.md`.
+- **Scope:** IN — `SKILL.md` (446L), `auto-mode.md` (413L), `agent-teams.md` (189L), all 8 `workflow/*.md` (1,539L); ~2,587L total. OUT — `chat-mode.md` length (Point 1.2 owns it).
+- **Verdict `needs-attention`:** the compaction is well-specified and approved in direction, but it must be **fix-first** (~12 latent correctness bugs, 2 semantic, fixed as pass 1 before any deletion) AND **gate-limited** (the target is a ceiling; every manager gate is preserved even where that keeps a doc above Codex's number).
+
+## Decisions locked
+
+**User decisions (locked this session, definitive — decided WITH the leader's both-sides read in hand):**
+1. **Aggressiveness = FULL CORPUS ~40% — Codex's per-doc target table is the CEILING (§2.1), with a HARD gate-preservation constraint.** Compact all in-scope docs toward ~2,587 → ~1,515. **Where Codex's per-doc number would cut a manager gate, THE GATE WINS** — keep the orchestration content and annotate that doc "gate-limited (actual reduction < ceiling; gate preserved)." The leader's both-sides read DEFINES the gates. Gate-limited docs named in §2.1; `evaluation.md` is the prime one.
+2. **Correctness bugs = FIX-FIRST, BUNDLED.** All ~12 (§2.3) fixed as **pass 1 before deleting text**, in the same compaction PR. The 2 remaining semantic ones (Ideation PASS→Preparation, `outputs/` PASS-only) need careful cross-doc alignment.
+3. **B11 FAIL-behavior — RESOLVED (user): FAIL escalates to the user.** Separate FAIL from REVISE at `SKILL.md:298-299` (REVISE auto-iterates on budget; any FAIL is a safety-gate escalation). This aligns the per-loop ITER/EXIT tables + `evaluation.md` — which already assume FAIL=escalate — with the root state machine. This is the canonical behavior; it is a pass-1 correctness fix, not an open question.
+
+**Manager-locked confirmations:**
+4. **Structure = hoist to existing SSOTs** (`record-map.md`, the peer skills, `production.md`); "point, don't restate; never redraw the record-map tree." **NO new `_loop-common.md`.** Extend the in-tree RECORD-deferral precedent (§2.2).
+5. **Adopt the uniform 8-point `workflow/{loop}.md` skeleton** (§2.2).
+6. **PR shape = ONE compaction PR** (2.1+2.2+2.3 bundled), **coordinated with Point 1's PRs** on the `maxIterations` "default 5" lines (collision noted in §Plan).
+7. **The doc-authoring guard** ("point, don't restate; never redraw the record-map tree") is a recommendation only — `rules/` is currently EMPTY (`NO_PROJECT_RULES`), so establish it as the first `rules/` entry OR fold into the (absent) claude doc-authoring standard; implementer decides.
+8. **The 2 missing mistake files** → out-of-scope follow-up (create or repoint), same disposition as Point 1's dangling-xref item.
+
+---
+
+## Findings 2.1 — Per-doc compaction targets (Codex ceiling + gate-limited floor)
+
+**Codex's per-doc table is the CEILING; the gate-floor is what the leader's both-sides read shows can be cut without losing a manager gate.** Where the two differ, the floor wins (locked decision 1).
+
+| Doc | Now | Codex ceiling | Gate-floor | Disposition |
+|---|---:|---:|---:|---|
+| `SKILL.md` | 446 | 300 | 300 | Ceiling OK — cuts are §Workflow Metadata + §Teammate-aware + session-tree/quartet ASCII + the sample status table; state-machine + Configuration fresh/resume branch (gates) preserved |
+| `auto-mode.md` | 413 | 240 | 240 | Ceiling OK — cuts are §2 per-step manuals (dup) + §7 rationale; Always-Ask + safety-gate carve-out (gates) preserved |
+| `agent-teams.md` | 189 | 115 | 115 | Ceiling OK — cuts are operator setup + delegation dup + hook list; teammate constraints + no-survival + evaluator-never-teammate (gates) preserved |
+| `workflow/ideation.md` | 184 | 95 | 95 | Ceiling OK — cuts are the boilerplate spine (dup); escalation list + ITER/EXIT (gates) preserved |
+| `workflow/preparation.md` | 158 | 80 | 80 | Ceiling OK — spine cut; Re-Ideate routing + generated-skill exception (gates) preserved |
+| `workflow/planning.md` | 156 | 75 | 75 | Ceiling OK — spine cut; escalation + ITER/EXIT preserved |
+| `workflow/execution.md` | 145 | 75 | 75 | Ceiling OK — executor lifecycle → peer skill; executor-continuation rule + exit gates preserved |
+| `workflow/wrap-up.md` | 84 | 55 | 55 | Ceiling OK — overview/tree cut; non-skippable eval + commit boundary preserved |
+| `workflow/evaluation.md` | 328 | 190 | **~210 (GATE-LIMITED)** | **Floor > ceiling.** ~150L of spawn/reconciliation/divergence/failure/degraded/regression/stuck/caps has NO peer-skill equivalent → condense ONLY narrative + the 7-perspective table + the disposition/inheritance procedure + output trees. Do NOT cut to 190 if that means cutting orchestration. |
+| `workflow/record.md` | 347 | 185 | **~185-200 (gate-limited)** | The 7 manager validation gates (`132-235`) are the manager's mechanical acceptance test → **compress, do NOT cut**. Output-tree + value-telemetry + iteration/idempotency restatements cut freely. 185 achievable only if the gates compress cleanly. |
+| `workflow/production.md` | 137 | 105 | 105 | Ceiling OK — all content is manager-owned (no peer skill); only rationale + crossrefs trimmed |
+| **Total** | **2,587** | **1,515** | **~1,535-1,550** | **~40% either way.** The gate-floor adds back ~20-35L (evaluation +~20; record +~0-15) to protect gates. |
+
+**Gate-limited docs (named per locked decision 1):**
+- **`evaluation.md` (PRIME) — floor ~210, not 190.** Its manager-reconciliation content (spawn+independence `40-69`, aggregation/divergence/verdict/failure/degraded `105-219`, regression/stuck/caps `254-279`) has NO peer-skill twin; it IS the manager's evaluation orchestration. Cut only the (D) rows: perspective table (`19-37`), disposition/inheritance procedure (`223-252`), output trees (`73-101`, `282-317`), rationale (`11-16`), crossrefs.
+- **`record.md` (SECONDARY) — floor ~185-200.** The validation gates (`132-235`) are load-bearing manager acceptance criteria — compress the prose, keep every gate. All other cuts (output tree, value-telemetry, iteration/idempotency) are free.
+- **All other docs hit Codex's ceiling** — their reductions are duplication/narrative, not gates.
+
+---
+
+## Findings 2.2 — workflow/*.md ↔ peer-skill duplication map (THE HEADLINE)
+
+**Contract:** `workflow/{loop}.md` = ONLY manager orchestration (entry, who-to-spawn, what-to-pass, gates, verdict handling, exit). The PROCEDURE belongs in the peer skill. Both sides of all 7 pairs read in full this session.
+
+**Root cause (leader framing):** the five per-loop docs restate a shared boilerplate spine. Three verbatim-across-5 blocks dominate:
+- **No-commit block** ("Per-iteration session record is NOT committed") — `ideation:117` `preparation:98` `planning:96` `execution:87` `wrap-up:43` → hoist to `record.md`/`SKILL.md § Workflow Session Record`.
+- **Output ASCII tree** — redrawn ×5 (~80L) despite `record-map.md` being the declared SSOT AND `record.md:121-128` tabling it → point, don't redraw.
+- **Dual-system-production content — a TRIPLE-statement across 11 docs** (leader-only find; Codex saw 2 of 3 tiers): (1) `production.md` SSOT; (2) each peer skill's own `### Dual-system production (Codex proposer)` section — `ideation/SKILL.md:358` `preparation:298` `planning:365` `execution:151` `wrap-up:280` (~40L); (3) each `workflow/{loop}.md` 1-para version (~20L). Collapse tiers 2+3 to pointers (~45-50L).
+
+**The fix already exists in-tree.** Every peer skill's RECORD section carries a `> Canonical procedure: record/SKILL.md … do not re-derive` deferral (`ideation:408` `preparation:351` `planning:418` `execution:205` `wrap-up:502`). The uniform 8-point skeleton (locked decision 5) generalizes that proven pattern:
+
+> **8-point `workflow/{loop}.md` skeleton:** 1 Purpose + peer-skill owner · 2 Manager entry conditions/inputs · 3 DISCUSSION orchestration (who to spawn / what to ask / when to escalate) · 4 WORK orchestration (who owns production, what artifact must exist, pointer to procedure) · 5 EVALUATION (pointer to `workflow/evaluation.md` + phase child) · 6 RECORD (pointer to `workflow/record.md`, loop-specific exceptions only) · 7 ITER/EXIT decision table · 8 Output pointer to `record-map.md`.
+
+**Duplication map (per pair — (D)=delete/point to peer, (M)=keep manager-only):**
+
+| Pair | (D) duplicated content → peer owner | (M) keep in workflow/ |
+|---|---|---|
+| `ideation.md` ↔ `ideation/SKILL.md` | `:3-15` phase table, `:47-58` sub-step table (→`ideation/SKILL.md:94-288`), `:75-88` WORK artifact rules, `:102-121` RECORD+no-commit, `:140-166` output tree | `:60-72` escalation triggers, `:125-136` ITER/EXIT (with fixes) |
+| `preparation.md` ↔ `preparation/SKILL.md` | `:3-12` phase table, `:32-42` sub-step table (→`:121-226`), `:62-75` WORK, `:89-104` RECORD, `:125-145` output tree | `:43-58` escalation + **Re-Ideate routing** (manager changes the path), generated-skill exception |
+| `planning.md` ↔ `planning/SKILL.md` | `:3-15` phase table, `:37-47` sub-step table (→`:142-282`), `:64-75` artifact schema, `:88-100` RECORD, `:119-143` output tree | `:48-60` escalation, `:104-115` ITER/EXIT |
+| `execution.md` ↔ `execution/SKILL.md` | `:25-64` executor 5-phase lifecycle + production (→`execution/SKILL.md:107-161`), `:79-93` telemetry/no-commit, `:113-130` output tree | `:9-22` prompt-construction, `:35-48` **executor-continuation rule**, `:97-109` ITER/EXIT |
+| `wrap-up.md` ↔ `wrap-up/SKILL.md` | `:3-6` overview, `:21-25` five-stage pipeline (→`wrap-up/SKILL.md:132-437`), `:57-74` output tree | `:29-35` non-skippable eval gate, `:39-47` commit boundary, `:51-53` exit |
+| `evaluation.md` ↔ `evaluation/SKILL.md` | `:19-37` perspective table (→`evaluation/SKILL.md:85-123`), `:73-101` output tree, `:223-252` inheritance/disposition procedure, `:282-317` output paths | `:40-69` spawn+independence, `:105-219` reconciliation/verdict/failure/degraded, `:254-279` regression/stuck/caps — **mostly legitimate (gate-limited)** |
+| `record.md` ↔ `record/SKILL.md` | `:55-129` output tree + loop table, `:69-91` value-telemetry rule (→`record/SKILL.md:200-217`), `:261-319` iteration/idempotency restatement, `:322-334` output paths | `:23-52` assistant spawn + prompt fields, `:132-235` validation gates (**compress, don't cut**), `:237-258` failure handling |
+
+**Correction to the leader's first pass (both systems agree):** `workflow/evaluation.md` is *mostly legitimate manager-orchestration* — its reconciliation/divergence/aggregation/failure/degraded content is NOT in `evaluation/SKILL.md` and must stay. Only the perspective table + disposition procedure are true (D). **Gate-limited floor ~210L — do NOT over-compact to 190 (§2.1).**
+
+**`workflow/production.md` has NO peer skill (confirmed both systems)** — the Codex proposer runs as the `codex/SKILL.md` wrapper; production.md is unique manager orchestration. Not a 2.2 offender; only trim its rationale/crossrefs.
+
+**Reverse direction (manager-needs buried in a skill):** LOW risk. The Scope Contract schema is correctly SSOT'd in `evaluation/SKILL.md:179-213` and pointed to; no manager-needed content is trapped un-pointed.
+
+---
+
+## Findings 2.3 — Correctness bugs (fix-first) + other improvements
+
+### The ~12 latent bugs (VERIFIED this session; anchors re-pinned where Codex's were off)
+
+| # | Site (verified) | Bug | Fix | Class |
+|---|---|---|---|---|
+| B1 | `SKILL.md:279` (Codex said :261 — corrected) | RECORD postcondition "Memory writes complete" | → "Session record updated / iteration staged"; RECORD writes session staging, memory is Wrap-up's | semantic-ish |
+| B2 | `auto-mode.md:100` | "PASS or Skipped → promote generated skills" | PASS-only (no generated skills exist on Skipped) | wording |
+| B3 | `ideation.md:131` | "advance to Planning Loop" | Auto's next loop is **Preparation** (Chat skips prep → Planning). Make mode-explicit | **SEMANTIC** |
+| B4 | `ideation.md:58` | loop-entry scaffold lists `outputs/` | `outputs/` is PASS-only (`scaffold --pass`); remove from loop-entry bootstrap | **SEMANTIC** |
+| B5 | `preparation.md:34` | "five sub-steps" (table has A-D) | "four sub-steps" | wording |
+| B6 | `evaluation.md:3` | loop list omits Preparation | add Preparation | wording |
+| B7 | `evaluation.md:276` | defaults omit Preparation | add Preparation. **Point-1 collision** — this is also Point 1's ADD-2 "default 5" line; coordinate | wording |
+| B8 | `record.md:121-128` | per-loop summary table omits Preparation | add Preparation (or delete table in compaction) | wording |
+| B9 | `wrap-up.md:84` | "Memory promotion → `record/SKILL.md`" | repoint to `wrap-up/SKILL.md` (durable promotion owner); `record/SKILL.md` stays session-record owner | xref |
+| B10 | `ideation.md:7` + `planning.md:7` | "four-phase iteration shape" then a 5-item arrow (incl. ITER/EXIT) | standardize: "four sub-phases + the manager ITER/EXIT decision" (matches CLAUDE.md) | wording |
+| B11 | `SKILL.md:298-299` vs `ideation.md:133`/`preparation.md:116`/`planning.md:112` + `evaluation.md` verdict-aggregation | **FAIL-behavior conflict:** SKILL.md groups `FAIL` with `REVISE` for auto-re-entry (iter<max → re-enter DISCUSSION); the per-loop ITER/EXIT tables + `evaluation.md` treat any `FAIL` as **escalate-to-user** (safety gate) | **RESOLVED (user, locked decision 3):** FAIL = escalate. Edit `SKILL.md:298-299` to split FAIL from REVISE (REVISE auto-iterates on budget; any FAIL is a safety-gate escalation). This is the canonical behavior the per-loop tables + `evaluation.md` already assume — a pass-1 correctness fix | SEMANTIC — resolved |
+| B12 | `auto-mode.md:301`+`evaluation.md:5` → `mistakes/manager-skipped-dual-system-eval.md`; `auto-mode.md:411`+`agent-teams.md:187` → `mistakes/skills-mirror-symlinks-not-copies.md` | both files ABSENT (verified) | create the mistake OR repoint/remove — **out-of-scope follow-up** (locked decision 8) | dead-link |
+
+**Fix-first ordering (locked decision 2):** apply B1-B11 as **pass 1 before any deletion**, so compaction does not bury stale behavior. B3/B4 are the semantic pair needing careful cross-doc alignment; B11 is now resolved (FAIL=escalate, locked decision 3) and lands in the same pass 1.
+
+### Other improvements
+
+- **2.3-A — value-telemetry count rule stated 3× (leader-only; more complete than Codex's double):** `record/SKILL.md:200-217` (assistant SSOT) + `workflow/record.md:69-91` (manager validation) + `SKILL.md:356+362-375` (session.json shape). Reduce the latter two to field-list + pointer.
+- **2.3-B — output-tree SSOT (`record-map.md`) violated in 6 places** → the "never redraw the record-map tree" guard (locked decision 7).
+- **2.3-C — dead-link gate:** run `check-markdown-links.sh` (exists at `orchestration/scripts/`) after edits. No `chat-mode.md:NN` line-refs exist in orchestration/, so Point 1.2's renumber will NOT break orchestration cross-refs. No stray `TODO`/`MEMO` tokens outside chat-mode.md.
+
+---
+
+## Cross-system reconciliation (dual-system record)
+
+Full per-delta log: `working/reconciliation-iter1.md`. Summary:
+
+**Took from Codex (Codex was stronger):**
+- The **per-doc target table** (2,587 → ~1,515) with per-doc preserve/condense line-ranges — adopted as the CEILING (see the aggressiveness arc below).
+- The **~12 correctness bugs** — the leader's first pass had not hunted latent bugs. Taken in full, but the producer **verified each against the files and re-pinned 2 anchors** (B1 `:261→:279`; B11 located at `:298-299` + the per-loop rows).
+- The **uniform 8-point workflow skeleton** — a cleaner articulation than the leader's "extend the RECORD deferral"; adopted (they are the same pattern generalized).
+- The **FAIL-behavior reconciliation** finding (B11) — leader had not flagged it; now user-resolved to FAIL=escalate (locked decision 3).
+
+**Kept leader's own (more complete or Codex-absent):**
+- The **both-sides gate-preservation findings** — `evaluation.md` mostly-legitimate + the reverse-direction low-risk result. These DEFINE the gate-floors in §2.1; without them, Codex's aggressive 190/185 numbers would have cut manager orchestration.
+- The **in-tree RECORD-deferral precedent** (`ideation:408`/`prep:351`/`planning:418`/`exec:205`/`wrapup:502`) — the pattern to EXTEND.
+- The **proposer TRIPLE-statement** — Codex found tiers 1+3 (production.md + workflow paras) but MISSED tier 2 (the 5 peer-skill `### Dual-system production` sections). The leader's triple is the complete finding.
+- The **value-telemetry TRIPLE** (2.3-A) — Codex found the record.md↔record/SKILL.md double; the leader adds the third `SKILL.md:356/362` copy.
+- The **Point-1 line-collision** coordination (`maxIterations` "default 5" lines, incl. B7's `evaluation.md:276`) — Codex does not mention Point 1.
+
+**Merged-selective:** the 2.2 duplication map (Codex's per-pair line-ranges + leader's "evaluation.md mostly legitimate" nuance + proposer-triple); the no-commit + output-tree centralization (both found); the target table = Codex's ceiling annotated with the leader's gate-limited floors.
+
+**THE dual-system divergence that mattered — the aggressiveness fork (logged as such):**
+- **Codex** proposed ~41% (aggressive per-doc numbers, e.g. `evaluation.md`→190, `record.md`→185).
+- **Leader's grounded both-sides read** showed a conservative ~20% floor if every gate is protected literally — because `evaluation.md`/`record.md` carry ~150L/~100L of manager orchestration with no peer-skill home.
+- **User's re-decision (with both reads in hand): FULL ~40% as a CEILING + hard gate-preservation.** The synthesis is neither system's default — Codex's ambition bounded by the leader's gate map. Result: ~1,535-1,550 (≈40%), with `evaluation.md` floored at ~210 and `record.md` at ~185-200. This is the value of the dual-system: one system pushed for reduction, the other mapped what must survive; the user chose the envelope.
+
+---
+
+## Implementation plan (ONE compaction PR, fix-first, 5 passes)
+
+Per Codex's ordering + the locked decisions. **One PR** (2.1+2.2+2.3 bundled), **coordinated with Point 1**.
+
+1. **Pass 1 — FIX correctness (B1-B11) before deleting anything.** Land the 8 wording/xref fixes; apply the user-resolved **B11 FAIL=escalate** split at `SKILL.md:298-299` (locked decision 3); align the 2 remaining semantic ones (B3 mode-explicit transition, B4 outputs/ PASS-only).
+2. **Pass 2 — root docs:** compact `SKILL.md` + `auto-mode.md` + `agent-teams.md` to the §2.1 ceilings (all hit ceiling — no gate-limit); hoist the value-telemetry rule (2.3-A) + teammate metadata to their SSOTs.
+3. **Pass 3 — workflow docs:** rewrite each `workflow/{loop}.md` to the 8-point skeleton; replace duplicated specialist procedure (executor lifecycle, perspective table, sub-step tables, output trees, no-commit block, proposer tiers 2+3) with pointers per the §2.2 map. **Honor the gate-floors:** `evaluation.md` → ~210 (not 190), `record.md` → ~185-200 with the validation gates compressed-not-cut. Leave `production.md` as the cross-cutting contract (trim only).
+4. **Pass 4 — link/path gate:** run `check-markdown-links.sh`; verify every hoisted block appears ONCE; resolve the 2 missing-mistake refs (B12) per the follow-up.
+5. **Pass 5 — line-count check** against the §2.1 gate-floor totals (~1,535-1,550, minor variance allowed).
+
+**Point-1 coordination (explicit collision):** the `maxIterations` "default 5" lines in `workflow/{planning,execution,wrap-up,preparation,evaluation,record}.md` are edited by **both** Point 1 (value change) and Point 2 (B7 Preparation-add + escalation-prose re-point). Land Point 1's value PRs first, then rebase Point 2's compaction; OR fold both per line at planning. `evaluation.md:276` is the sharpest overlap (B7 + Point-1 ADD-2).
+
+---
+
+## Verification plan
+
+**ACCEPTANCE TEST (the gate-by-gate preservation test — the primary gate).** After compaction, a manager reading each compacted doc must STILL be able to determine, from that doc alone plus its pointers:
+1. **who to spawn** (which specialist for the loop's phases),
+2. **what to pass** (the delegation inputs / prompt fields),
+3. **what output proves completion** (the artifact + the manager's validation gates),
+4. **which decisions require the user** (the escalation triggers / Always-Ask / safety gates),
+5. **which doc owns each specialist procedure** (the peer-skill pointers).
+Any paragraph that answers one of these STAYS; anything else points to a peer skill / reference doc / nowhere. Walk this test per `workflow/{loop}.md` — a doc that fails any of the five was over-compacted (a gate was cut). This is the acceptance gate for the whole compaction.
+
+**Mechanical gates:**
+- **Dedup re-scan (form-covering):** `grep -n "Per-iteration session record is NOT committed" workflow/*.md` → 0; `grep -n "Dual-system production" workflow/*.md` + the 5 peer skills → pointers only; `grep -rn "The canonical tree is" workflow/*.md` → pointer lines, no following fence.
+- **Correctness re-verify:** re-grep B1-B11 sites show the fixed text; Preparation now present in `evaluation.md:3/276`, `record.md` table; `SKILL.md:298-299` now splits FAIL (escalate) from REVISE (auto-iterate).
+- **Gate-floor check:** `evaluation.md` ≥ ~210, `record.md` retains all 7 validation gates (compressed, not removed).
+- **Link gate:** `orchestration/scripts/check-markdown-links.sh` to zero; the 2 missing-mistake refs resolved.
+- **Line-count:** per the §2.1 gate-floor totals.
+
+## Out-of-scope follow-ups (separate backlog items)
+
+1. **B12 — 2 missing mistake files** (`manager-skipped-dual-system-eval.md`, `skills-mirror-symlinks-not-copies.md`): create or repoint. Same disposition as Point 1's dangling-xref item — consider one combined "dead mistake-xref" cleanup across Points 1+2.
+2. **FLAG-2 — no claude doc-authoring standard exists:** the "point, don't restate; never redraw the record-map tree" guard has no home. Either the first `rules/` entry or a new doc-authoring standard (implementer decides — locked decision 7).
+
+## Open items for the implementer
+
+- **Gate-floors are a hard constraint** — `evaluation.md` ~210, `record.md` ~185-200; the gate-by-gate acceptance test is the arbiter, not the line-count ceiling.
+- **B3/B4 mode-awareness** — the Ideation→next-loop transition and the outputs/ scaffold timing must align across `ideation.md`, `SKILL.md`, and the scaffold rule; verify holistically.
+- **Point-1 sequencing** on the shared `maxIterations` lines — coordinate PR order.
+- **`rules/` guard placement (FLAG-2)** — first `rules/` entry vs doc-authoring standard.


### PR DESCRIPTION
## Summary

Chat-mode point-by-point **review** of gobbi skills/agents — dual-system (Claude leader + Codex, plus a claude-code-guide currency check for Point 3.2). **Review-only: no source/skill changes.** The deliverables are three implementation-ready review docs a future session executes.

## Points reviewed

**Point 1 — chat-mode.md** (`reviews/code-review/…point-01…`)
- Compact Chat caps: Planning 1 / Execution 3 / Wrap-up 3; ~30% length cut.
- Decisions: planning-REVISE → user-gate; ADR history → `decisions/`; **split `state.template.json` → `state.{auto,chat}.json`**. Two correctness must-fixes (counting-convention pin; settings→state propagation).

**Point 2 — orchestration compaction** (`reviews/code-review/…point-02…`)
- Full ~40% **gate-preserving** compaction; `workflow/{loop}.md` ↔ peer-skill dedup via an 8-point skeleton (extends the in-tree "do not re-derive" pattern). ~12 fix-first bugs. B11: FAIL = escalate.

**Point 3 — adversarial review** (`reviews/adversarial-review/…point-03…`)
- Scripts: full refactor (`lib/common.sh` + `record-map.manifest.json` + fixtures + smoke); real bugs (C-BUG-1 `canon()` fail-open, two `agent-token-usage.sh` bugs, bash-4 tiers, retire the frozen migration baseline).
- `agent-teams.md`: currency refresh (v2.1.32 → 178+), triple-confirmed.
- Completeness: no `workflow/configuration.md`; **priority #1 = a real doc-vs-mistake contradiction** on the Codex-exec runtime → a runtime matrix; a scenario suite.

## Cross-point coordination (for the implementation session)
- Point 3 change-set E edits `workflow/{evaluation,record,production}.md` that Point 2 also compacts → sequence/fold.
- Point 1's `maxIterations` lines collide with Point 2's edits → land Point 1 first.
- One combined dead-xref cleanup (Point 3 dead links + Point 2's two missing mistake files).

## Also promoted
- `reports/analytics/2026-07-06-agent-teams-currency.md` — live-docs currency ground-truth backing Point 3.2.
- `notes/workflow/…` — session journal.
- 4 process mistakes (`mistakes/{refactor,verification}/`) — the "verify-don't-assume" family surfaced this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJCqvFsS53KXPKMSMNfvcf
