### PR TITLE
fix(codex): runtime matrix supersedes foreground timeout-1200 guidance (Point 3 change-set C)

### DIFF
--- a/.gobbi/projects/gobbi/mistakes/verification/git-gate-blind-to-gitignored-writes.md
+++ b/.gobbi/projects/gobbi/mistakes/verification/git-gate-blind-to-gitignored-writes.md
@@ -1,0 +1,38 @@
+---
+name: git-gate-blind-to-gitignored-writes
+description: A git-based confinement gate cannot see writes inside a gitignored path; diff --stat also misses untracked files.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-07
+session: 122609f7-3c4c-44ea-af90-efe1531a5cbf-p3
+tags: [verification, git]
+keywords: [gitignore, git-status-porcelain, git-diff-stat, confinement-gate, untracked-files, source-read-only-gate]
+author: claude
+priority: high
+domain: verification
+related: [gitignore-aware-residual-gate]
+---
+
+# Git-based confinement gates cannot see writes inside a gitignored path
+
+## What happened
+
+While designing the Codex proposer source-read-only gate (C-HIGH-4, `workflow/production.md`), the first draft used `git status --porcelain` OR `git diff --stat` to verify "changes confined to `working/proposals/codex/`." Two dual-system evaluation rounds caught the same defect from different angles: (a) the session tree is gitignored (`.gitignore` excludes `.gobbi/projects/*/sessions/`), so `git status` cannot see any write inside it — the claimed "confined to `working/proposals/codex/`" state can never appear, because git never reports paths under a gitignored tree at all, pass or fail; (b) `git diff --stat` also misses untracked new files entirely, so it is not a safe substitute for `git status --porcelain` even on the tracked surface.
+
+## Why it happens
+
+The gate was designed to prove a confinement property ("only the proposals directory changed") by reading git's output, without first checking what git can actually observe given `.gitignore` plus tracked-vs-untracked semantics. `git status --porcelain` reports only the tracked-plus-untracked paths that git's index and working-tree comparison can see; a path matched by `.gitignore` never surfaces there, in either direction. Treating "git shows nothing under the session tree" as "confined to the session tree" inverts the actual guarantee — it means "git cannot look there," not "git looked and found nothing there." Separately, `git diff --stat` only reports changes to files git already tracks, so a newly created untracked file passes it silently — a different blind spot from the gitignore one, but often reached for as if it were interchangeable with `status --porcelain`.
+
+## Correct approach
+
+Point a git-based gate only at the surface git can actually observe: the tracked, non-ignored tree. Phrase and verify a "no stray writes outside the intended target" gate as "no tracked/skill/source file changed" via `git status --porcelain` — which does include newly created untracked files, as long as they are not gitignored. Never phrase the gate as "confined to `<subpath>`" when `<subpath>` is itself gitignored; an empty (or source-clean) `status --porcelain` there is the expected pass, not proof that writes stayed inside that subpath. Never substitute `git diff --stat` for `git status --porcelain` — `diff --stat` misses untracked new files, so a stray new file would pass the gate silently. If a genuine filesystem-level confinement check is needed (e.g., proving nothing outside `working/proposals/codex/` changed even inside the gitignored session tree), use a filesystem check instead of git — for example `find <session-tree> -newer <pre-run-marker> -not -path '*/proposals/codex/*'` — and document it as a distinct, non-git-based check with its own limitations.
+
+## How to detect
+
+A gate description that claims a git-based check will show "changes confined to `<gitignored-subpath>`" — check whether that subpath (or an ancestor of it) is listed in `.gitignore`; if so, the claimed positive-confinement observation can never occur. Also flag any gate that offers `git diff --stat` as interchangeable with `git status --porcelain` — the two diverge on untracked files, and a gate built on the wrong one fails open.
+
+## Related
+
+- [[gitignore-aware-residual-gate]] — companion trap, same root cause from the opposite direction: a residual-reference grep gate over a worktree session must use `git grep`, because plain `grep` recurses into gitignored session content that a git-aware tool would correctly exclude

--- a/.gobbi/projects/gobbi/notes/codex/2026-07-07-point-03-change-set-c-shipped.md
+++ b/.gobbi/projects/gobbi/notes/codex/2026-07-07-point-03-change-set-c-shipped.md
@@ -1,0 +1,56 @@
+---
+name: point-03-change-set-c-shipped
+description: Point-3 review change-set C shipped — one authoritative codex exec launch runtime matrix replaces the contradictory foreground timeout-1200 guidance
+type: notes
+scope: project
+feature: null
+status: active
+created: 2026-07-07
+session: 122609f7-3c4c-44ea-af90-efe1531a5cbf-p3
+tags: [codex, process]
+keywords: [runtime-matrix, codex-exec, production, evaluation, c-high-4, source-read-only-gate, dual-system]
+author: claude
+features_touched: []
+loops_completed: [execution, wrap-up]
+shipped: [git-gate-blind-to-gitignored-writes]
+---
+
+# Point 3 change-set C shipped
+
+## What happened
+
+This session implemented change-set C from the locked Point-3 orchestration adversarial review (`reviews/adversarial-review/2026-07-06-point-03-orchestration-adversarial-review.md`): reconcile all `codex exec` launch guidance to one authoritative "`codex exec` launch runtime matrix" in `codex/SKILL.md`, replacing a real contradiction — foreground `timeout 1200` guidance versus the ~600s Claude Code Bash foreground cap — that had silently degraded dual-system production and evaluation to single-system in prior sessions. The runtime matrix became the single source of truth (SSOT); `production.md` and `evaluation.md` now point to it instead of restating launch mechanics. The work also added the DONE invariant (files-as-truth: a wrapper is done only when it has validated its contracted output files in the same turn) and the C-HIGH-4 proposer source-read-only gate for the Codex proposer's `--sandbox workspace-write` boundary. Execution ran two dual-system evaluation rounds; both rounds caught real correctness defects in the gate design, and both were fixed before this Wrap-up. The change landed in commit `9b723897` (3 files: `codex/SKILL.md`, `orchestration/workflow/production.md`, `orchestration/workflow/evaluation.md`).
+
+## What shipped
+
+- One authoritative `codex exec` launch runtime matrix in `codex/SKILL.md` (foreground-under-cap vs background, ~600s Claude Code Bash foreground cap / ~540s safety margin, a note to re-verify the cap before relying on it, and native Codex uses its own cap).
+- `orchestration/workflow/production.md` and `orchestration/workflow/evaluation.md` updated to point at the matrix as SSOT instead of restating launch mechanics.
+- The foreground `timeout 1200` guidance is marked superseded by the runtime matrix.
+- The DONE invariant (files-as-truth, same-turn output validation) stated at `codex/SKILL.md` § Files-as-truth.
+- The C-HIGH-4 proposer source-read-only gate in `production.md`: after the proposer completes and before the producer integrates, `git status --porcelain` on the worktree confirms no tracked source/skill file changed (the proposer runs under `--sandbox workspace-write`, so the prompt-only "write only your proposal" instruction is not mechanically enforced).
+- One project mistake: `mistakes/verification/git-gate-blind-to-gitignored-writes.md` — the fail-open gate design that the two evaluation rounds caught (a git-based confinement claim inside a gitignored path can never be observed by git, and `git diff --stat` is not a safe substitute for `git status --porcelain` because it misses untracked files).
+
+## What got stuck
+
+Nothing stuck in this session's own scope (change-set C). The remaining four change-sets from the same review were out of this session's scope by the user-confirmed priority order, not stuck — see Next session.
+
+## What shifted
+
+The C-HIGH-4 gate went through two corrections during dual-system evaluation before it was correct: the first draft claimed a `git status --porcelain` OR `git diff --stat` check would show "changes confined to `working/proposals/codex/`" — both evaluation rounds caught that this can never be true, because the session tree is gitignored (git cannot observe writes inside it at all) and `git diff --stat` separately misses untracked new files. The gate now correctly asserts "no tracked source/skill file changed," which is what `git status --porcelain` can actually verify, and the noted residual limitation (a proposer writing a sibling gitignored session file, e.g. its own canonical draft, is not caught by any git-based check) is documented in `production.md` rather than papered over.
+
+## Decisions to respect
+
+- The `codex exec` launch runtime matrix in `codex/SKILL.md` is the SSOT for launch mode. Do not restate foreground/background/timeout mechanics in `production.md` or `evaluation.md` — point to the matrix.
+- Threshold: Claude Code Bash foreground cap is ~600s; background any `codex exec` invocation that may exceed ~540s (the safety margin under the cap); native Codex uses its own cap, not the Claude Code Bash cap. Re-verify the ~600s figure before relying on it — it is not independently pinned to a versioned source in this session's work.
+- A git-based gate must never claim to observe a confinement/absence property inside a gitignored path, and must never treat `git diff --stat` as equivalent to `git status --porcelain` (see the shipped mistake above).
+- Priority order for the Point-3 review's five change-sets is user-confirmed: C (this session, done) → A → B → D → E.
+- `production.md` was edited here (change-set C) and is also targeted for compaction by a separate PR's design (Point 2) — coordinate the two before either lands, to avoid one overwriting the other's edit to the same file. Also still open: a combined dead-cross-reference cleanup across the two efforts.
+
+## Next session
+
+Pick up change-set A next (user-confirmed priority order): shell `lib/common.sh` extraction, the fail-closed `canon()` fix (C-BUG-1), the agent-token bugs, and bash-4 compatibility guards, all from the same Point-3 review. After A: change-set B (record-map manifest single-source; retire the frozen residual-vocabulary baseline), then D (Agent Teams currency refresh), then E (scenario suite + `workflow/configuration.md`). Before starting A, check whether the Point-2 `production.md` compaction PR has landed, since both efforts touch that file.
+
+## Related
+
+- [[point-03-orchestration-adversarial-review]] — the locked review this change-set implements; findings C-HIGH-2/3 (runtime matrix) and C-HIGH-4 (source-read-only gate) resolved here.
+- [[git-gate-blind-to-gitignored-writes]] — the mistake promoted from this session's dual-system evaluation catch.

--- a/.gobbi/projects/gobbi/skills/codex/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/codex/SKILL.md
@@ -126,8 +126,23 @@ Rules:
 - Use `workspace-write` only when Codex must write files.
 - Pass `--cd <main-tree>` when a worktree is active and output paths live in the main tree.
 - Pass `--add-dir <session-path>` for cross-tree session writes.
-- Wrap every call with `timeout 600`, unless the user explicitly approves a different cap.
+- Wrap every bridge call with `timeout 600`, unless the user explicitly approves a different cap. Note: `600` sits AT the Claude Code Bash foreground cap (~600s) — foreground is safe only for SHORT bridge calls; background the call per the [§ `codex exec` launch runtime matrix](#codex-exec-launch-runtime-matrix) if it may approach the cap.
 - Do not pass `--model` or `--effort` unless the user explicitly requests it.
+
+### `codex exec` launch runtime matrix
+
+`codex exec` launch mode is not one-size-fits-all — it depends on the host runtime's per-call wall-clock cap and on whether the call may exceed it. This matrix is the single authority for HOW every `codex exec` run is launched; § Dual-System Evaluation, § Dual-System Production, [`orchestration/workflow/production.md`](../orchestration/workflow/production.md), and [`orchestration/workflow/evaluation.md`](../orchestration/workflow/evaluation.md) all defer here for launch mode and never restate it.
+
+| Runtime / workload | Launch mode | Completion signal |
+|---|---|---|
+| Native Codex shell, under the host cap | foreground `timeout <cap>` | process exit + file validation |
+| Claude Code Bash, fits under ~540s | foreground, `timeout` under ~540s | validate output files before reporting |
+| Claude Code Bash, may exceed ~540s | **background** (`run_in_background`), explicit PID, `< /dev/null` | poll the output file for its closing marker; ignore the detached exit code |
+| Assistant wrapper | ONLY if it blocks/polls until the contracted output files pass validation | files-as-truth, never "started" |
+
+**The binding foreground limit in Claude Code is the Bash tool cap, not the `timeout` flag.** The Claude Code Bash tool caps a single foreground call at ~600s (10 min) — its documented max. Background any `codex exec` that may exceed ~540s (9 min) — a ~60s margin below the ~600s (10-min) Bash cap. A `timeout 1200` only governs a run that is ALREADY backgrounded in Claude Code (once detached, the `timeout` flag — not the Bash cap — is the binding limit), or a native-Codex context where the host grants that budget. A foreground `timeout 1200` in Claude Code is dead past ~600s: the harness kills the call first (recorded mistake `codex-exec-timeout-exceeds-bash-cap.md`).
+
+**Re-verify the cap before relying on the number.** The ~600s foreground cap is a harness value that can change — confirm the current Claude Code Bash foreground cap before trusting the 600s figure.
 
 ### Dual-System Evaluation
 
@@ -135,7 +150,7 @@ For Claude Code dual-system evaluation, use the assistant-wrapper pattern:
 
 1. Manager spawns two assistant subagents in parallel.
 2. Claude-side assistant evaluates directly with read/search tools.
-3. Codex-side assistant runs `codex exec` foreground.
+3. Codex-side assistant runs `codex exec` per the [§ `codex exec` launch runtime matrix](#codex-exec-launch-runtime-matrix) — foreground when the eval fits under the ~600s Claude Code Bash cap, background otherwise.
 4. Codex-side assistant verifies output files and required content before reporting `DONE`.
 5. Manager reads the actual per-perspective files before acting on findings.
 
@@ -149,12 +164,14 @@ The Codex proposer NEVER writes the canonical `working/draft-iter{n}.md`. It wri
 
 1. Manager spawns the Claude producer and a Codex-side proposer assistant in parallel (parallel-independent — neither sees the other while generating).
 2. The Codex-side assistant writes the proposer prompt to a file in a **foreground** step and verifies it on disk (`test -s`) BEFORE invoking codex — never a stdin heredoc inside a backgrounded command.
-3. The Codex-side assistant runs `codex exec` **foreground-blocking** (the whole turn blocks until codex exits), writing the proposal to the proposal path above.
-4. Use `timeout ≥ 1200s` on the proposer `codex exec`. The `timeout 600` cap documented for the evaluation bridge proved too short for a full proposer workload (large skill reads + a complete draft); 600s is the bridge default, not the proposer cap.
+3. The Codex-side assistant runs `codex exec` per the [§ `codex exec` launch runtime matrix](#codex-exec-launch-runtime-matrix). A full proposer workload (large skill reads + a complete draft) routinely exceeds the ~600s Claude Code Bash foreground cap, so in Claude Code it launches as a **background** command (`run_in_background`) with `< /dev/null` — NOT foreground-blocking. Only a native-Codex host that grants the budget runs it foreground `timeout <cap>`.
+4. Cap the backgrounded proposer run with `timeout 1200`. Once the run is detached, the `timeout` flag (not the Bash foreground cap) is the binding limit. `timeout 600` (the evaluation-bridge default) is too short for a full proposer workload; the proposer cap is `1200`. This `1200` governs a BACKGROUNDED run in Claude Code or a native-Codex context — never a Claude Code foreground call (the harness kills a foreground call at ~600s, per the matrix).
 5. To clean up a hung proposer run, kill by explicit **PID** (`ps` / captured `$!`), never `pkill -f '<pattern>'` — a `-f` pattern that is a substring of the cleanup command kills the issuing shell.
 6. Validate the proposal **structurally** before reporting `DONE`: the file exists, is > 0 bytes, and carries a `PROPOSAL:` header. Do NOT gate on a content-vocabulary grep — a valid proposal can lawfully omit any given token, so a vocab grep false-blocks a clean proposal.
 
-**Proposer `codex exec` invocation — the proposer is NOT read-only; do NOT reuse the evaluator example.** The proposer MUST write its proposal file, so it runs with `--sandbox workspace-write` — never the `read-only` sandbox the § `codex exec` bridge rule reserves for evaluation-only work. A manager who copies a `read-only` evaluation invocation gets a proposer that cannot write its draft: every loop silently degrades to Claude-only and the feature appears to run while never invoking Codex. The proposer adds the session proposals dir to the writable set via `--add-dir` and writes its draft to `working/proposals/codex/draft-iter{n}.md`. Per-loop form (Ideation / Preparation / Planning / Wrap-up):
+> **Superseded (runtime-matrix):** the earlier guidance to run the proposer **foreground-blocking with `timeout ≥ 1200s`** is superseded by the [§ `codex exec` launch runtime matrix](#codex-exec-launch-runtime-matrix). In Claude Code the proposer runs **background** — its workload exceeds the ~600s foreground cap — and `timeout 1200` is the detached-run cap, not a foreground budget. Foreground `timeout <cap>` applies only in a native-Codex host that grants the budget.
+
+**Proposer `codex exec` invocation — the proposer is NOT read-only; do NOT reuse the evaluator example.** The proposer MUST write its proposal file, so it runs with `--sandbox workspace-write` — never the `read-only` sandbox the § `codex exec` bridge rule reserves for evaluation-only work. A manager who copies a `read-only` evaluation invocation gets a proposer that cannot write its draft: every loop silently degrades to Claude-only and the feature appears to run while never invoking Codex. The proposer adds the session proposals dir to the writable set via `--add-dir` and writes its draft to `working/proposals/codex/draft-iter{n}.md`. Per-loop form (Ideation / Preparation / Planning / Wrap-up), **background-launched in Claude Code** per the [§ `codex exec` launch runtime matrix](#codex-exec-launch-runtime-matrix):
 
 ```bash
 timeout 1200 codex exec \
@@ -176,7 +193,7 @@ timeout 1200 codex exec \
   < /dev/null
 ```
 
-Deltas from the evaluator example, all load-bearing: `--sandbox workspace-write` (the proposer writes; the evaluator is `read-only`), the `--add-dir` points at the session `working/proposals/codex/` dir (not an evaluation staging dir), and `timeout 1200` (≥ 1200s per step 4, not the `600` evaluation-bridge default). Keep `--cd <main-tree>` so codex anchors on the main-tree root — the worktree CWD is NOT the write root — keep the run **foreground-blocking** (steps 2–3) with the explicit-PID kill discipline (step 5), and do NOT pass `--model` / `--effort` unless the user asked.
+Deltas from the evaluator example, all load-bearing: `--sandbox workspace-write` (the proposer writes; the evaluator is `read-only`), the `--add-dir` points at the session `working/proposals/codex/` dir (not an evaluation staging dir), and `timeout 1200` as the DETACHED-run cap (per step 4 — the binding limit once backgrounded, not the `600` evaluation-bridge foreground default). Keep `--cd <main-tree>` so codex anchors on the main-tree root — the worktree CWD is NOT the write root — launch the run per the [§ `codex exec` launch runtime matrix](#codex-exec-launch-runtime-matrix): **background** in Claude Code (steps 3–4) with `< /dev/null`, foreground only in a native-Codex host under the cap, with the explicit-PID kill discipline (step 5), and do NOT pass `--model` / `--effort` unless the user asked.
 
 **Stdin hardening.** A backgrounded proposer `codex exec` MUST redirect stdin from `/dev/null` (the `< /dev/null` shown above) and write+verify the prompt file in a separate foreground step first (step 2) to avoid the stdin-read hang — observed this session stuck at `Reading additional input from stdin...`; kill a hung run by explicit PID (step 5), never `pkill -f`. This generalizes the existing `codex-exec-prompt-via-background-heredoc-hangs` discipline.
 
@@ -262,6 +279,8 @@ timeout 600 codex exec \
   "<prompt>"
 ```
 
+The `timeout 600` here is a foreground bridge cap that sits AT the ~600s Claude Code Bash foreground limit — background per the [§ `codex exec` launch runtime matrix](#codex-exec-launch-runtime-matrix) if the call may approach the cap.
+
 ### Post-eval sanity check
 
 After any Codex evaluator completes, verify output files landed at the correct main-tree absolute path before advancing:
@@ -282,7 +301,9 @@ If the Codex sandbox prevents writing to the main-tree path (e.g., the `--add-di
 
 ### Foreground vs background tradeoff
 
-**Foreground** (default recommendation):
+This section is the **notification-timing** tradeoff, NOT the launch-cap decision — the [§ `codex exec` launch runtime matrix](#codex-exec-launch-runtime-matrix) owns WHEN a run must be backgrounded. Foreground below is the default only for runs that fit under the ~600s Claude Code Bash cap; a run that may exceed it must be backgrounded per the matrix.
+
+**Foreground** (default recommendation, for runs under the cap):
 - Bash blocks synchronously until codex exits.
 - No notification timing issue — the calling agent knows immediately when codex finishes.
 - The agent can read stdout and verify output files before reporting done.
@@ -294,7 +315,7 @@ If the Codex sandbox prevents writing to the main-tree path (e.g., the `--add-di
 - Stdout is not directly available; validation requires reading output files.
 - Downside: notification timing class; manager cannot verify output without a separate tool call.
 
-The assistant-wrapper pattern (Section 2(d)) resolves this tradeoff: the manager spawns assistants in background (parallelism at the manager level), but each assistant runs its own codex exec foreground (synchronous from the assistant's perspective). The manager gets verified DONE via the assistant's Agent completion notification.
+The assistant-wrapper pattern (Section 2(d)) resolves this tradeoff: the manager spawns assistants in background (parallelism at the manager level), but each assistant runs its own codex exec foreground (synchronous from the assistant's perspective) — **only for a run that fits under the cap**. An assistant's Bash carries the SAME ~600s foreground cap, so a run that may exceed it must be BACKGROUNDED even inside the assistant (or the assistant polls the output file for its closing marker), per the matrix. The manager gets verified DONE via the assistant's Agent completion notification.
 
 For longer-running codex jobs that span multiple worktree-bound tool calls, see [`git/SKILL.md` § Worktree CWD discipline](../git/SKILL.md#worktree-cwd-discipline) — codex inherits CWD from the calling shell, and worktree-bound CWD applies to both file reads/writes and `--cd` defaults.
 
@@ -307,6 +328,8 @@ For jobs running via the codex companion runtime (not `codex exec` direct):
 These controls do NOT apply to direct `codex exec` invocations. For direct exec, `timeout(1)` and Bash job control (`kill $!`) are the controls.
 
 ### Files-as-truth completion signal
+
+**The DONE invariant.** The entity that reports `DONE` MUST have read + validated the contracted output files in the SAME turn. A missing Codex proposer/evaluator is not itself a failure (the proposer degrades to Claude-only; the evaluator is a safety gate) — but an UNVALIDATED completion reported as `DONE` IS a process failure.
 
 Never treat stdout parsing or broker.json polling as the completion signal. After codex finishes, verify by:
 
@@ -346,7 +369,8 @@ You are the Codex-side assistant for this dual-system evaluation.
 
 Task: Run the Codex evaluator on [target artifact] and write findings to the session staging path.
 
-Step 1. Run codex exec FOREGROUND via your Bash tool:
+Step 1. Run codex exec via your Bash tool:
+  # launch mode per the codex exec launch runtime matrix — BACKGROUND if the run may exceed ~540s; foreground below is safe only under the ~600s cap
   timeout 600 codex exec \
     --sandbox workspace-write \
     --cd <main-tree> \
@@ -374,6 +398,8 @@ Session writes MUST use the absolute main-tree path above.
 Do NOT use relative paths or pwd-derived paths.
 The worktree CWD is NOT the session-write root.
 ```
+
+The sketch's `timeout 600 codex exec` is a foreground evaluator call at the ~600s Claude Code Bash cap; if the evaluation may exceed it, launch background per the [§ `codex exec` launch runtime matrix](#codex-exec-launch-runtime-matrix).
 
 After both assistants return DONE, run the post-eval sanity check:
 

--- a/.gobbi/projects/gobbi/skills/orchestration/workflow/evaluation.md
+++ b/.gobbi/projects/gobbi/skills/orchestration/workflow/evaluation.md
@@ -52,6 +52,8 @@ Model selection follows `settings.json` `models.{system}.evaluator`:
 - Claude Code evaluator: `models.claude.evaluator` (default `opus`)
 - Codex evaluator: `models.codex.evaluator`; `null` means inherit the parent Codex session model and reasoning effort.
 
+**Codex evaluator launch mode.** The Codex evaluator runs as a `codex exec` assistant-wrapper; its launch mode follows the [`codex/SKILL.md` § `codex exec` launch runtime matrix](../../codex/SKILL.md#codex-exec-launch-runtime-matrix). This doc points to that matrix and does not restate the launch mechanics.
+
 ### Pre-spawn independence classification — Codex evaluator (D6.2)
 
 Before spawning the **Codex evaluator**, the manager classifies its prompt for proposer↔evaluator independence: the Codex proposal must NOT leak into the Codex evaluator prompt, or the self-preference bias the dual-system mandate removes is re-introduced (see [`production.md` § Proposer ↔ evaluator independence](production.md)).

--- a/.gobbi/projects/gobbi/skills/orchestration/workflow/production.md
+++ b/.gobbi/projects/gobbi/skills/orchestration/workflow/production.md
@@ -27,7 +27,7 @@ Per enabled WORK sub-phase, the manager spawns two producers in **parallel-indep
 | **Claude producer** | leader (Ideation / Preparation / Planning) · executor (Execution) · assistant (Wrap-up) | canonical `working/draft-iter{n}.md` | no |
 | **Codex proposer** | `codex exec` assistant-wrapper ([`codex/SKILL.md` § Dual-System Production](../../codex/SKILL.md)) | `working/proposals/codex/draft-iter{n}.md` | no |
 
-The Codex proposer follows the `codex exec` discipline owned by [`codex/SKILL.md`](../../codex/SKILL.md): write+verify the prompt file foreground before invoking, run `codex exec` foreground-blocking, cap with `timeout ≥ 1200s`, kill by explicit PID (never `pkill -f`), and validate the proposal **structurally** (file exists / > 0 bytes / a `PROPOSAL:` header) — never by a content-vocabulary grep. The manager does not re-implement that discipline here; it spawns the wrapper and reads the frozen proposal file.
+The Codex proposer follows the `codex exec` discipline owned by [`codex/SKILL.md`](../../codex/SKILL.md): write+verify the prompt file before invoking, launch `codex exec` per the [§ `codex exec` launch runtime matrix](../../codex/SKILL.md#codex-exec-launch-runtime-matrix), kill by explicit PID (never `pkill -f`), and validate the proposal **structurally** (file exists / > 0 bytes / a `PROPOSAL:` header) — never by a content-vocabulary grep. The manager does not re-implement that discipline here; it spawns the wrapper and reads the frozen proposal file.
 
 When `propose.mode: single`, the manager spawns only the Claude producer. This is a **deliberate, configured Claude-only run** — it is NOT degraded mode, so it does **NOT** stamp the degraded-mode label. The degraded-mode label (`production_mode: claude-only` + `codex_proposal_absent_reason`) is stamped ONLY when `propose.mode: dual` but the Codex proposal is empty / times out / errors (see § Degraded-mode policy).
 
@@ -42,6 +42,10 @@ The parallel-generate-then-integrate model widens the window in which an evaluat
 3. **POST-INTEGRATION freeze.** The canonical artifact is frozen before the manager spawns the EVALUATION evaluators — no moving target during review.
 
 The manager confirms the proposer's terminal output is the one on disk (read it; it carries the `PROPOSAL:` header) before releasing the producer to integrate, and confirms the canonical draft is terminal before dispatching evaluators.
+
+**Proposer source-read-only gate (C-HIGH-4).** The Codex proposer runs under `--sandbox workspace-write`, so the prompt-only "write only your proposal" instruction is UNENFORCED — a proposer CAN write a source / skill / tracked file it was never meant to touch. The gate's job is to catch exactly that: it checks the SOURCE tree, NOT the proposal dir. Run it **right after the proposer completes and BEFORE the producer integrates** — at that point no legitimate source change exists yet, so a stray write cannot be confused with the producer's (or, in Execution, the executor's) later tracked-source edits. The manager runs `git -C <worktree-abs> status --porcelain` and confirms **no source / skill / tracked-file change appears**. The proposal writes live under the gitignored session tree (`.gitignore` → `.gobbi/projects/*/sessions/`), so `git status` cannot see them by design — an empty (or source-clean) porcelain output is the expected pass, NOT "changes confined to `working/proposals/codex/`" (that can never show). Any tracked-file modification OR untracked non-ignored file that appears is a proposer boundary violation and a **process failure**: the manager reverts the stray write and re-runs the proposer (or degrades to Claude-only per § Degraded-mode policy); it NEVER integrates a proposal from a boundary-violating run. Use `status --porcelain` ONLY — `git diff --stat` is fail-open here, since it misses untracked new files.
+
+> **Residual limitation:** a proposer writing a SIBLING ignored session file (e.g. the canonical `working/draft-iter{n}.md`) is NOT caught — that path is gitignored too. If that confinement must be enforced, a filesystem check is required: `find <session-tree> -newer <pre-proposer-marker> -not -path '*/proposals/codex/*'`. Noted as a known limitation; not built here.
 
 ---
 
@@ -129,7 +133,7 @@ All proposer + integration writes are **session-scoped**. The proposer never tou
 
 ## Cross-references
 
-- Codex proposer wrapper pattern + foreground / timeout / PID-kill / structural-validation discipline + degraded-mode label → [`codex/SKILL.md` § Dual-System Production](../../codex/SKILL.md)
+- Codex proposer wrapper pattern + launch-mode (per the § `codex exec` launch runtime matrix) / timeout / PID-kill / structural-validation discipline + degraded-mode label → [`codex/SKILL.md` § Dual-System Production](../../codex/SKILL.md)
 - Degraded-mode label preservation into `outputs/` → [`record/SKILL.md` § Artifact frontmatter schema](../../record/SKILL.md)
 - The dual EVALUATION that reviews the integrated artifact → [`workflow/evaluation.md`](evaluation.md), [`evaluation/SKILL.md`](../../evaluation/SKILL.md)
 - Per-loop WORK orchestration → [`workflow/ideation.md`](ideation.md), [`workflow/preparation.md`](preparation.md), [`workflow/planning.md`](planning.md), [`workflow/execution.md`](execution.md), [`workflow/wrap-up.md`](wrap-up.md)


### PR DESCRIPTION
## Summary

Implements **change-set C** (priority #1) of the 2026-07-06 orchestration adversarial review (Point 3): the **Codex-runtime launch matrix**. Resolves a real dual-system-loss bug — `codex/SKILL.md` + `production.md` mandated foreground `codex exec` with `timeout ≥ 1200s`, but the Claude Code Bash tool kills any foreground call past ~600s, so a manager following the docs silently lost Codex. **Dogfooded this session** (the proposer + evaluators only worked as background commands).

## What changed (3 files)

- **`codex/SKILL.md`** — new authoritative `### codex exec launch runtime matrix` (native-Codex / Claude-Code-under-cap / Claude-Code-may-exceed / assistant-wrapper) with the concrete threshold: Claude Code Bash foreground cap ~600s, **background any run that may exceed ~540s**, `< /dev/null` + explicit PID + file-poll, plus a "re-verify the cap" note. The `timeout 1200` foreground guidance is marked **superseded**; the § Foreground-vs-background tradeoff + § Dual-System Evaluation defer to the matrix. Adds the **DONE invariant** (the entity reporting DONE must have validated the contracted files that turn).
- **`production.md`** — the proposer launch clause now **points** to the matrix (SSOT, no restatement); adds the **C-HIGH-4 proposer source-read-only gate** (`git status --porcelain` on the source tree, run post-proposer/pre-integration) with an honest residual-limitation note (git can't see the gitignored session tree).
- **`evaluation.md`** — Codex-evaluator launch guidance points to the matrix.

## Dual-system evaluation (2 rounds)

Both a Claude and a Codex evaluator reviewed the change. Round 1 → REVISE with **complementary** real findings: the first C-HIGH-4 gate was **fail-open** (Codex: `diff --stat` misses untracked + the session tree is gitignored so `git status` can't see confinement within it; Claude: the arithmetic error + a copy-paste-hazard in the evaluator sketch). Round 2 fixed all four (gate redesigned to check the tracked source surface only; SSOT restatement removed; `~540s`/margin arithmetic corrected; fence qualifier added). Manager-verified.

## Scope

Change-set C only. A (shell lib + `canon()` fail-closed + agent-token bugs), B (record-map manifest), D (agent-teams currency), E (scenario suite) remain — see the handoff note. `production.md` is also touched by PR #339's compaction design (Point 2) — coordinate when that compaction is implemented.

## Recorded

`mistakes/verification/git-gate-blind-to-gitignored-writes.md` (the gate trap the dual-eval surfaced) + a handoff note. `validate-frontmatter.sh` PASS; link checks resolve; mirrors are symlinks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)