### PR TITLE
refactor(skill-writing): project-agnostic overhaul — SOP model + P10 + agnostic anti-monolith rule

### DIFF
--- a/.claude/skills/skill-writing/checklists.md
+++ b/.claude/skills/skill-writing/checklists.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/skill-writing/checklists.md

--- a/.gobbi/projects/gobbi/skills/skill-writing/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/skill-writing/SKILL.md
@@ -1,59 +1,67 @@
 ---
 name: skill-writing
-description: "Use when authoring a new gobbi skill — frontmatter schema, section skeleton, length norm, and the script-owned mirror wiring procedure."
+description: "Use when authoring a project skill, or revising, migrating, or splitting one — the frontmatter schema, the six-section standard form, the design gates, and the wiring + conformance procedure."
 allowed-tools: Read, Grep, Glob, Bash
 ---
 
 # Skill Writing
 
-Reference skill for authoring a NEW gobbi skill. Load it when a task creates a new
-`SKILL.md` under `.gobbi/projects/{project-name}/skills/{name}/`, or asks how a skill is
-written and wired. It teaches the frontmatter schema, the four discoverability axes, the
-six-section skeleton, the length norm, the standalone-vs-child-doc rule, and the exact
-wiring procedure that makes a new skill loadable in both runtimes.
+Skill for authoring a project skill — a standard operating procedure for one capability. Load it when
+creating a new skill, or when revising, migrating, or splitting an existing one.
 
-This skill is self-contained — it restates no owner it relies on. Every fact it borrows has
-one owning file, named in § References; the body states the fact and References records the
-owner, so a change in the owner does not silently rot a copy here. The discipline that
-governs this skill governs the skills you write with it.
+A skill does not just describe a capability; it standardizes how the capability is performed. It does
+that by defining the specifications for its operations — how each step is done — so every agent that
+loads it works the one specified way instead of improvising. A second, lesser standard governs the
+document itself — every skill uses the same standard form: the same sections in the same order, the
+same rules, one owner per borrowed fact. You standardize the operations; you fill a standard form to
+present the procedure.
 
 ---
 
 ## Principles
 
-> **A skill teaches one coherent capability to an agent that loads it cold.**
+> **A skill is a standard operating procedure for one capability.**
 
-A skill is loaded fresh by an agent with no prior context. The first paragraph states what
-the skill is and when to load it; the rest teaches the capability in the section order every
-other skill uses. A reader who opens the skill cold learns the capability from the skill
-alone — not from the session that wrote it.
+A skill is loaded by an agent with no prior context that must perform the work, not study a
+subject. So it is written as an executable procedure for one coherent capability — ordered steps,
+clear boundaries, and enough orientation to act without reconstructing the session that wrote it. It
+standardizes the work by defining the specifications for its operations — how each step is done — so
+every agent that loads the skill performs it the one specified way instead of improvising. A document
+that only describes a topic transfers information but not a reliable practice; and because a skill
+exists to be run, its worth is realized only when an agent can load it and follow it.
 
-> **Understanding and enforcement are different jobs.**
+> **Evidence and the user shape the design.**
 
-Principles teach the mental model; Rules state the pass/fail floor; Procedure gives the steps.
-Mixing those jobs makes the same fact appear in several sections, where the copies drift. The
-six-section order exists to keep each job in exactly one place.
+A skill is a shared contract every agent will obey, so its design is worth getting right over
+getting done fast. Two sources shape it: research into how the capability actually works and where
+it fails, and discussion with the user about intent and tradeoffs. The same discipline governs the
+skill's claims — a statement about behavior or wiring is trustworthy only when read from the
+mechanism that makes it true, never assumed. Together they keep a polished procedure from
+standardizing the wrong work.
 
-> **Single source of truth — every fact has one owning file, and a copy drifts.**
+> **Standard form makes skills predictable to read.**
 
-Every fact a skill states has exactly one owning file. The skill states the fact plainly and
-records its owner in § References; it never copies the owner's content. A copied fact drifts
-the moment the owner changes, so single source of truth is the rule the whole tree obeys — a
-skill that restates an owner breaks it.
+A set of skills is usable only if any one of them reads the same way. A shared section grammar gives
+each kind of guidance — orientation, mental model, enforcement, action, ownership — a stable home,
+so a cold-loading agent finds what it needs without learning a new layout each time. The uniformity
+is functional, not cosmetic: it is what makes the corpus navigable and its skills interchangeable,
+and a skill that deviates taxes every future reader. The standard form governs how a skill reads, not
+how its operations are specified — that substance is the procedure's.
 
-> **A wiring claim is only as true as the owner it was read from.**
+> **The SKILL.md holds the top-level flow; depth lives in child docs.**
 
-A claim about a wiring mechanism — a symlink, a sync script, a permission — is trustworthy
-only when it was read from the owner itself: the script's source, the live symlink, the
-settings file. An assumption or an end-state guess is not evidence. This is the
-highest-value discipline here: a load-path once asserted without a file-existence check
-shipped a dead reference into a briefing.
+The entry document is loaded first and often, so it stays legible by carrying the whole top-level
+procedure and nothing heavier. Detail with its own depth — a long reference, a set of templates, a
+per-unit sub-procedure — moves into a child doc the reader opens only when a step calls for it.
+Separating the layers keeps the operation visible as a whole while giving complex detail room to
+grow one hop away — present when needed, never crammed into the parent.
 
-> **A skill is not done until it is loadable.**
+> **Every fact has one owner; a copy drifts.**
 
-Authoring the `SKILL.md` body is half the job. The skill exists for an agent to load, so it
-is done only when both runtimes can load it and the wiring check confirms it. A skill on disk
-that no runtime loads is an unfinished skill.
+A skill leans on facts owned by other documents — a frontmatter standard, a script, a template. Copy
+such a fact and the copy rots the moment the owner changes, and the two quietly disagree. So a skill
+states the fact and records its owner, never restating what another file owns — which is why the
+body stays free of borrowed detail and one source can settle any factual disagreement.
 
 ---
 
@@ -61,18 +69,25 @@ that no runtime loads is an unfinished skill.
 
 ### Must-Follow
 
+- **MUST scope a skill to ONE coherent capability, cold-load-sufficient** — an agent with no prior
+  context can perform the capability from the Intro + Procedure alone. A skill that bundles two
+  capabilities, or needs the authoring session's context to act, fails this.
+- **MUST ground the design in prior art and user alignment before locking the Procedure** — study
+  the existing skills that share the shape and decide the design with the user; never author a new
+  skill's shape from a first guess.
 - **MUST name the file `SKILL.md`** in the canonical skill directory, with `name` matching that
   directory — the loader resolves a skill by its dir name.
 - **MUST carry the three required keys, plus optional keys ONLY from the named allowlist in
-  § Procedure P1; NEVER a memory-file field.** The three required keys (`name`, `description`,
-  `allowed-tools`) are the baseline; an allowlist key is added only for non-default behavior. A
-  skill is not a memory file, so `type` / `scope` / `status` / `tags` never appear.
+  § Procedure P4; NEVER a field from another schema.** The three required keys (`name`, `description`,
+  `allowed-tools`) are the baseline; an allowlist key is added only for non-default behavior. A skill
+  carries only skill frontmatter, so keys like `type` / `scope` / `status` / `tags` (from a memory or
+  config schema) never appear.
 - **MUST match the description grammar to the load mode** — `MUST load …` for a deterministic
   load, `Use when …` / `Load when …` for an on-demand load. A mismatched grammar misleads the
   reader about when the skill loads.
 - **MUST follow the six-section order** (Frontmatter → Intro → Principles → Rules → Procedure
   → References; § Procedure preamble), writing one section per step; place Memory Access Matrix
-  and Output paths as Procedure sub-sections ONLY when the skill's work writes (§ Procedure P5).
+  and Output paths as Procedure sub-sections ONLY when the skill's work writes (§ Procedure P8).
   A read-only reference skill omits both.
 - **MUST keep Intro, Principles, and Rules source-free** — those three sections name no other
   file. Ownership links live in § References; load/read actions live in § Procedure. A cross-doc
@@ -83,8 +98,9 @@ that no runtime loads is an unfinished skill.
 - **MUST base every wiring claim on the owner read directly** — the script source, the live
   symlink, the settings file — never an assumption. Assert "the script creates the mirror"
   only after reading the loop that creates it.
-- **MUST verify loadability empirically before declaring the skill done** — the sync check
-  exits 0 and each mirror symlink resolves under `readlink`. A skill no runtime loads is
+- **MUST verify loadability empirically before declaring the skill done** — the project's skill
+  guards pass and each runtime mirror resolves, AND the skill loads cold in each runtime and a fresh
+  agent can follow it. Structural checks are necessary but not sufficient; a skill no runtime loads is
   unfinished.
 
 ### Must-Not-Follow
@@ -92,50 +108,120 @@ that no runtime loads is an unfinished skill.
 - **NEVER copy an owner's content into the body** instead of stating the fact and naming the
   owner — the copy drifts the moment the owner changes. Fix: state the fact plainly; record
   the owner path + section in § References.
-- **NEVER assert a wiring surface without verifying it** — writing "the skill is mirrored to
-  Codex" without running the sync check, or "the load path exists" without `test -f`. A
-  load-path once asserted without a check shipped a dead reference into a briefing. Fix: verify
-  the MECHANISM by reading its owner (script / settings / symlink), not the end-state.
-- **NEVER hand-create the script-owned mirror symlinks** — a hand-made one drifts from what the
-  sync check expects. Fix: run the sync script and let it build every mirror.
-- **NEVER edit the plugin manifests for a new skill** — conventional skill directories auto-load
-  with no manifest key, and a manifest key has caused load failures. Fix: leave the manifests
+- **NEVER assert a wiring surface without verifying it** — writing "the skill is mirrored"
+  without running the check, or "the load path exists" without testing it. Fix: verify the
+  MECHANISM by reading its owner (script / settings / mirror), not the end-state.
+- **NEVER hand-create the runtime mirrors** — a hand-made one drifts from what the project's sync
+  mechanism produces. Fix: run the sync mechanism and let it build every mirror.
+- **NEVER edit the plugin / package manifest to register a skill** — conventional skill directories
+  auto-load with no manifest key, and a manifest key can break loading. Fix: leave the manifest
   untouched.
-- **NEVER add a `Skill()` permission unless zero-prompt preapproval is wanted** — it is a
-  tool-permission gate, not a discoverability gate; the skill loads without it. Fix: omit it
-  and accept a first-use tool prompt, or add it only to silence that prompt.
-- **NEVER add a Skill-Map table row for a meta/authoring skill** — those belong in the
-  value-feature prose, not the Loop / Cross-cutting / Supporting table. Fix: add the dedicated
-  prose mention instead.
+- **NEVER add a tool-permission entry unless zero-prompt preapproval is wanted** — it is a
+  permission gate, not a discoverability gate; the skill loads without it. Fix: omit it and accept a
+  first-use tool prompt, or add it only to silence that prompt.
+- **NEVER register a skill in the project's skill index against its convention** — follow the index's
+  rule for the skill's kind (a project may list operational skills, name meta skills in prose, or omit
+  some). Fix: place the skill by the index's convention, not by default.
 - **NEVER split a skill into child docs by length alone** — a child doc is justified by
   ownership of a SET of artifacts, a too-long lookup reference, per-unit orchestration, or an
   independent-audience sub-procedure. Fix: default to standalone; split only on one of those.
-- **NEVER inline a workflow-loop skill's per-perspective evaluation scenarios, checks, and
-  procedure into one monolithic `evaluation.md`** — the monolith hides scenario/check drift,
-  blocks stable CHECK-ID reuse, and ships no copyable checklist for the evaluator's
-  copy-then-tick pass. Fix: split into the three-file `scenario.md` + `checklist.md` +
-  `evaluation.md` bundle (owner in § References).
+- **NEVER collapse a per-unit artifact SET the skill owns into one monolithic file** — per-perspective
+  review scenarios, per-item checklists, and the like. A monolith hides per-unit drift, blocks stable
+  per-unit references, and ships no independently reusable piece. Fix: give each unit its own child doc
+  per the P3 (a)/(c) split criteria; the owning skill records the multi-file contract.
 
 ---
 
 ## Procedure
 
-Author a new skill by writing its six sections in the fixed order below, then wiring it so both
-runtimes can load it. Before writing, read two or three existing skills that match the shape you
-need as shape references — `research/SKILL.md` for a short standalone skill, `claude-plugin/SKILL.md`
-for a standalone meta/authoring skill. The codebase is the style guide.
+Author a skill in three parts. **FRAME (P1–P3)** — lock the one capability, the evidence, and the user's
+direction first. **WRITE (P4–P9)** — the six sections in fixed order, one per step, never paired or
+collapsed. **WIRE (P10)** — build the mirrors, then prove a fresh agent finds and follows it.
 
-The section order is fixed: **Frontmatter → Intro → Principles → Rules → Procedure → References.**
-Steps P1–P6 write one section each, in order; P7 wires the finished skill and verifies it loads.
-Same-file `§` pointers are in-file navigation and are allowed in any section; a cross-doc see-also
-is not — it belongs in References.
+**P1–P3 are a hard design gate:** draft no section until the capability, evidence, and direction are locked.
+A skill framed wrong standardizes the wrong work under a polished, trustworthy-looking surface.
 
-### P1 — Write the Frontmatter
+One flow fits every origin — create from scratch, extract from a session, revise, migrate, split. Only the
+set of already-existing files differs, and P3's affected-file map captures that.
 
-A skill's frontmatter carries three REQUIRED keys, in this order — `name`, `description`,
-`allowed-tools` (verify: every head under `.gobbi/projects/gobbi/skills/*/SKILL.md` carries these
-three). The schema is "three required keys plus a named optional allowlist," NOT "exactly three and
-no others": an official optional field is valid when the skill needs the non-default behavior.
+Every skill in the project uses the same **standard form** — the same six sections in the same order, the
+same rules, one owner per borrowed fact. The steps below fill that fixed shape; after P9, the **conformance
+checklist** (`checklists.md`) confirms the finished skill conforms to the standard form before wiring. The
+shape is fixed; the operations the skill specifies are yours to design.
+
+### P1 — Frame the one capability
+
+Name the single capability in four parts:
+
+- **Actor** — who loads and runs it. Pick the NARROWEST that always needs it: a phase or role that loads it
+  every run → `phase:{x}` / `role:{x}`; many unrelated callers → `any-agent`. Take the name from a real
+  consumer, not the topic.
+- **Trigger / load mode** — by rule, not feel. **Deterministic** iff a phase or role loads it every time
+  that phase/role runs; else **on-demand** (a task loads it when it touches the domain). The load mode sets
+  the description grammar and the P4 frontmatter.
+- **Outcome** — what a fresh agent produces by following the skill end to end.
+- **Non-goals** — what it deliberately skips. One coherent, cold-load-sufficient capability; a second
+  capability is a second skill. Can't state the outcome and non-goals in a sentence each? It isn't one thing
+  yet — narrow it.
+
+Draft the **description** — the line that makes the skill load: what it does AND when to load it (its
+triggers), specific and a little pushy (skills under-trigger on vague ones), never first- or second-person.
+The grammar matches the load mode — `MUST load …` (deterministic) or `Use when …` / `Load when …`
+(on-demand; a new authoring/reference skill is on-demand). It goes into the P4 frontmatter.
+
+### P2 — Study the evidence and pass the user design gate
+
+Ground the design in prior art and in the mechanisms that own its facts, before locking anything.
+
+- **Analogous skills** — read those sharing the shape (reference vs loop vs role, read-only vs state-writing)
+  and follow their form; never author a shape from a first guess. Extract-from-session: the session record is
+  a source too. Revise/migrate: the existing skill and its history are the prior art.
+- **Consumers** — read the callers that will load this skill (a workflow step, a role, a delegation prompt),
+  so the description and Procedure fit the real load. A net-new capability may have no consumer yet — say so,
+  and design for the first intended caller.
+- **External prior art** — study an established outside practice and keep only what improves the procedure;
+  adapt it to the project's standard, never import it wholesale.
+- **Applicable mistakes** — load `skills/skill-writing/mistakes.md` and any domain mistakes.
+- **Owner mechanisms, not assumptions** — read every behavior or wiring claim from the mechanism that makes
+  it true (script source, live symlink, settings file). A claim not read from its owner is a guess.
+- **User design gate** — the user locks the direction (shape, altitude, scope) from reference-backed options,
+  not a finished draft. **An explicit task direction already satisfies the gate:** when the user or the brief
+  has stated the shape, record it and proceed — do not re-ask a settled decision.
+
+### P3 — Map ownership, affected files, and altitude; lay the skeleton
+
+With the capability and direction locked, design the structure before filling it.
+
+- **Claim-owner ledger** — list every fact the skill will borrow and its ONE owner (path + section); this
+  becomes § References at P9. A borrowed fact with no single owner: state it locally or drop it, never copy.
+- **Affected-file map (blast radius)** — list every file the change touches beyond `SKILL.md`: the runtime
+  mirror(s) the skill syncs into, the project's skill index, the permission / settings file, the skill
+  guards, and any caller that loads the skill. On a migrate or split this map IS the job — which files move,
+  shrink, or gain a child-doc pointer, kept consistent across all. Mark each surface by how it is touched —
+  **authored** (you write it), **generated** (the mirrors the sync builds — never hand-edited),
+  **conditionally-updated** (the skill index, the settings file), or **read-only** (guards you only run) — so
+  you never run line-level CRUD on a generated mirror.
+- **CRUD + 5W1H over the set** — for the target and each authored file, name what to Create, what to Read for
+  consistency, what to Update (to the line), what to Delete; then who depends on it, what changes, when it
+  applies, where else it must change, why, and how it propagates. Scale it: a one-file standalone collapses
+  to a few lines; the full pass earns its keep on a migrate or multi-file split.
+- **Altitude — standalone vs child docs** — default to one standalone `SKILL.md`. Split detail into a child
+  doc ONLY when the skill owns one of: **(a)** a SET of stamped per-instance artifacts (a `templates/` set
+  the skill ships); **(b)** a deterministic rule-reference too long for the body, read by
+  lookup; **(c)** per-step / per-loop / per-role orchestration docs, one per unit; **(d)** a self-contained
+  sub-procedure another phase or audience reads on its own, or a block whose inline length would push the
+  parent well past the length norm. Never split by length alone. A child doc stays ONE hop from `SKILL.md`
+  (no child of a child), and one over ~100 lines opens with a table of contents.
+- **Lay the empty skeleton** — Frontmatter → Intro → Principles → Rules → Procedure → References as empty
+  headings, plus stubs for any child docs the altitude decision requires. Fill it in the fixed order below,
+  one section per step.
+
+### P4 — Write the Frontmatter
+
+Three REQUIRED keys, in order: `name`, `description`, `allowed-tools` (verify: every skill head in the
+project carries all three). The schema is "three required keys plus a
+named optional allowlist," NOT "exactly three and no others" — an official optional field is valid when the
+skill needs its non-default behavior.
 
 ```yaml
 ---
@@ -146,224 +232,156 @@ allowed-tools: Read, Grep, Glob, Bash
 ```
 
 - **`name`** — MUST equal the skill's directory name (`skills/{name}/` → `name: {name}`).
-- **`description`** — one line; quote-wrap if it contains a colon. The grammar matches how the skill
-  loads: a **deterministic** load (a phase or role always loads it) opens with `MUST load …`; an
-  **on-demand** load (loaded only when a task touches the domain) opens with `Use when …` / `Load when …`.
-  A new authoring/reference skill is on-demand.
-- **`allowed-tools`** — the smallest tool surface the skill's work needs. A read-only reference skill
-  lists `Read, Grep, Glob, Bash`; a skill whose work edits files adds `Write, Edit`.
-- **Optional allowlist keys set two of the four reach axes here.** `user-invocable: false` hides the
-  skill from `/`; `disable-model-invocation: true` stops the model auto-loading it; the rare official
-  `license` / `compatibility` / `metadata` only with a stated reason. Both discoverability defaults are
-  visible / auto-loadable, so omit the key unless you want the non-default. (The other two reach axes —
-  **mirror availability** and **`Skill()` permission** — are wiring decisions, set in P7.)
-- **NEVER a memory-file field.** A skill is not a memory file; do not stamp it with `type` / `scope` /
-  `status` / `tags` or any other memory field.
+- **`description`** — the P1 draft, one line; quote-wrap if it holds a colon. Grammar matches the load:
+  `MUST load …` (deterministic) or `Use when …` / `Load when …` (on-demand).
+- **`allowed-tools`** — the smallest surface the skill's OWN work needs. Reads-and-informs →
+  `Read, Grep, Glob, Bash`; work that PRODUCES or edits a file — even a "reference" skill whose output is a
+  written artifact (a doc, a changelog entry) — adds `Write, Edit`. "Reference" is the shape, not the tool
+  surface. Scope to the work, not to what you used to research it.
+- **Optional allowlist keys** set two of the four reach axes: `user-invocable: false` hides it from `/`;
+  `disable-model-invocation: true` stops the model auto-loading it; the rare official `license` /
+  `compatibility` / `metadata` only with a stated reason. Both discoverability defaults are visible /
+  auto-loadable — omit the key unless you want the non-default. (The other two axes — mirror availability and
+  the `Skill()` permission — are P10 wiring.)
+- **NEVER a field from another schema** — a skill carries only skill frontmatter, never keys borrowed from
+  the project's memory, config, or other file standards (e.g. `type` / `scope` / `status` / `tags`).
 
-**Trap:** do not revive the "exactly three keys and no others" contradiction — the schema is required
-baseline plus a named optional allowlist.
+**Trap:** do not revive "exactly three keys and no others" — the schema is required baseline plus a named
+optional allowlist.
 
-### P2 — Write the Intro
+### P5 — Write the Intro
 
-Write the H1 title (the skill name, Title Case) plus one or two short paragraphs: what the skill is,
-and when to load it. The Intro orients a cold-loading agent; it does not instruct.
+The H1 title (skill name, Title Case) plus one or two short paragraphs: what the skill is, and when to load
+it. The Intro orients a cold-loading agent; it does not instruct.
 
-- **Keep it source-free** — name no other file, add no owner link, no exemplar pointer. Ownership lives
-  in § References; load actions live in § Procedure.
+- **Source-free** — name no other file, no owner link, no exemplar pointer. Ownership lives in § References;
+  load actions in § Procedure.
 - **No procedure detail, no enforcement bullet** — those are Procedure's and Rules' jobs.
-- **Role-defining skill exception** — a skill that defines an agent role MAY carry a longer Intro: the
-  role definition plus its reference tables. The exception is the role content itself, not extra rationale.
-- **Trap: do not state rationale the Principles section owns.** If a sentence explains WHY something is
-  true, it belongs in Principles, not the Intro. The same concept in both places is the exact drift the
-  six-section split removes.
+- **Role-defining exception** — a skill that defines an agent role MAY carry a longer Intro: the role
+  definition plus its reference tables. The exception is the role content, not extra rationale.
+- **Trap** — a WHY sentence belongs in Principles, not the Intro.
 
-### P3 — Write the Principles
+### P6 — Write the Principles
 
-Write three to six entries. Each is a one-line concept in a `> **…**` blockquote, followed by a short
-paragraph explaining WHY the concept is true. Principles teach the mental model — judgment, not compliance.
+Three to six entries, each a one-line concept in a `> **…**` blockquote followed by a short WHY paragraph.
+Principles teach the mental model — judgment, not compliance.
 
 - **Conceptual only** — no `MUST` / `NEVER` / `ALWAYS`, no procedure step, no cross-doc citation.
-- **The boundary test** — if a line can be graded pass/fail against a specific edit, it is a Rule, not a
-  Principle; move it to § Rules.
-- **Pair with Rules** — each Principle should have at least one matching Rule that makes it checkable; not
-  every Rule needs a Principle (some are purely mechanical).
-- **Trap:** a principle that says "do X" is a Rule in disguise.
+- **Boundary test** — a line gradable pass/fail against a specific edit is a Rule; move it to § Rules.
+- **Pair with Rules** — each Principle has at least one matching Rule that makes it checkable; not every Rule
+  needs a Principle.
+- **Trap** — a principle that says "do X" is a Rule in disguise.
 
-### P4 — Write the Rules
+### P7 — Write the Rules
 
-Write the enforceable floor as scannable bullets in two labeled sub-groups: `### Must-Follow`
-(`MUST` / `ALWAYS`) and `### Must-Not-Follow` (`NEVER` bullets / anti-patterns).
+The enforceable floor, as scannable bullets in two labeled sub-groups: `### Must-Follow` (`MUST` / `ALWAYS`)
+and `### Must-Not-Follow` (`NEVER` bullets / anti-patterns).
 
-- **Each bullet is self-contained** — a terse inline rationale, and for an anti-pattern its one-line fix.
+- **Self-contained** — each bullet carries a terse inline rationale, and each anti-pattern its one-line fix.
   A reader never jumps to Principles to understand a Rule.
 - **Checkable** — every bullet reads as a review-checklist item, gradable against a draft skill.
-- **Source-free** — no owner link, no other file name. A same-file `§` pointer is navigation, allowed.
-- **Two sub-groups are the norm**; a very short skill with only a rule or two per side MAY use a single
+- **Source-free** — no owner link, no other file name; a same-file `§` pointer is navigation, allowed.
+- **Two sub-groups are the norm** — a very short skill with only a rule or two per side MAY use a single
   `## Rules` list when the split would leave near-empty sub-headings.
-- **Trap:** do not duplicate a Procedure step as a Rule unless it is a true pass/fail boundary.
+- **Rule vs Procedure step** — a Rule states an **invariant** (a condition any *finished* skill must satisfy,
+  gradable without knowing the authoring order); a Procedure step states an **ordered action**. The same
+  sentence never appears verbatim as both — the invariant once as the Rule, the act once as the Procedure
+  gate.
 
-### P5 — Write the Procedure
+### P8 — Write the Procedure
 
-Write the operational SOP: numbered `### P#` steps for a reference skill, or phase tables for a loop
-skill. Every step says what to do, in what order, and how to know it is done.
+The operational SOP: numbered `### P#` steps for a reference skill, or phase tables for a loop skill. Every
+step says what to do, in what order, and how to know it is done.
 
-- **The only section that may name another file** — and only as a load / read / run ACTION ("Read
-  `<path>` § … when …", "run `<script>`"). A see-also pointer is not an action; it goes to References. A
-  path used as a value (a file the procedure reads or writes) stays inline as a code span.
-- **Conditional write-only sub-sections** — if the skill's work writes to the session record or memory,
-  place `### Memory Access Matrix` and `### Output paths` here as sub-sections (or a child-doc pointer
-  when large). A read-only skill omits both. These two are the only sections beyond the six that ever
-  appear, and only inside Procedure.
-- **Length norm.** Gobbi skills run ~140-600 lines (median ~340). A plain reference skill aims short; an
-  authoring-SOP skill (this one, `agent-writing`) runs longer because the walkthrough itself is the value
-  — completeness of the SOP wins over the line count. Length is still bounded by single source of truth: a
-  skill that copies its owners' content bloats; one that states the fact and records the owner stays tight.
-- **Standalone vs child-doc.** Default to a single standalone `SKILL.md`. Split into child docs ONLY when
-  the skill owns one of: **(a)** a SET of stamped per-instance artifacts (templates, e.g.
-  `delegation/templates/{role}.md`); **(b)** a deterministic rule-reference too long for the body, read by
-  lookup; **(c)** per-step / per-loop / per-role orchestration docs, one per unit; **(d)** a self-contained
-  sub-procedure a different phase or audience reads independently, or a block whose inline length would
-  push the parent well past the norm. Never split by length alone. When the skill has child docs, the
-  Procedure MUST map when to read each one. A workflow-loop skill that seeds a per-perspective review is
-  the reference case of (c): its evaluation child doc splits into the three-file `scenario.md` +
-  `checklist.md` + `evaluation.md` bundle — the bundle contract is owned by `evaluation/SKILL.md`
-  (§ References).
-- **The `mistakes.md` companion.** Separately from length-driven child docs, a skill MAY carry a
-  `mistakes.md` companion in its dir — the skill-owned mistakes home (the hybrid model), one `## ` section
-  per trap. It is a skill-surface doc OUT of the memory frontmatter standard, governed by its own
-  `check-skill-mistakes.sh` guard, not by `validate-frontmatter.sh`. Wrap-up promotion writes it
-  (Always-Ask routing). A brief that lists `skills/{name}/SKILL.md` in its Load Directives ALSO lists
-  `skills/{name}/mistakes.md` as a companion path, so the trap loads in the skill's context. It is mirrored
-  into `.claude/skills/{name}/` by the same DERIVED per-file sync as `SKILL.md`, so it needs no separate
-  wiring step (P7).
-- **Trap:** do not copy an owner's content into a step — state the local action, record ownership in
+- **Match specificity to fragility** — judgment steps as prose that trusts the agent; fragile steps pinned to
+  exact commands. State only what the agent cannot infer.
+- **The only body section that names a file *as an action*** — a load / read / run action ("Read `<path>`
+  § … when …", "run `<script>`"). References also names files, but as *ownership* links, not actions — that
+  is its distinct job. A see-also pointer is not an action; it goes to References. A path used as a value
+  stays inline as a code span.
+- **Conditional write-only sub-sections** — if the skill's work writes to the session record or memory, place
+  `### Memory Access Matrix` and `### Output paths` here (or a child-doc pointer when large); a read-only
+  skill omits both. These two are the only sections beyond the six that ever appear, and only inside
+  Procedure.
+- **Child-doc mapping** — if P3's altitude decision moved detail into child docs, map when to read each one
+  ("Read `<child>` when …"). The split criteria live in P3, not here.
+- **Length norm** — skills run ~140–600 lines (median ~340). A reference skill aims short; an authoring-SOP
+  skill (this one) runs longer — completeness beats line count. Length is still bounded by single source of
+  truth: copying an owner's content bloats; stating the fact and recording the owner stays tight.
+- **A per-skill companion (optional)** — separately from length-driven child docs, a skill MAY carry a
+  companion doc in its dir if the project keeps one (e.g. a `mistakes.md` of recorded traps). It is a
+  skill-surface doc governed by the project's skill guards, not by any other frontmatter standard, and a
+  caller that loads `SKILL.md` also loads the companion. The same per-file sync that mirrors `SKILL.md`
+  mirrors the companion, so it needs no separate wiring step (P10).
+- **Trap** — do not copy an owner's content into a step; state the local action, record ownership in
   § References.
 
-### P6 — Write the References
+### P9 — Write the References
 
-Write a section-level ownership register: one entry per owner, naming WHICH FACT it validates —
-`{owner path + section} validates {the claim in this skill}`. This is the one section that holds the
-inline markdown links (each `[label]` pointing to an owner path), so the markdown-link guard resolves
-them.
+A section-level ownership register: one entry per owner naming WHICH FACT it validates —
+`{owner path + section} validates {the claim in this skill}`. This is the one section holding the inline
+markdown links (each `[label]` pointing to an owner path), so the markdown-link guard resolves them.
 
-- **One owner per borrowed claim** — every fact the body borrows has exactly one entry; no bare see-also list.
+- **One owner per borrowed claim** — every borrowed fact has exactly one entry, drawn from the P3 ledger; no
+  bare see-also list.
+- **No borrowed facts?** A skill that owns all its content — the project files it touches are runtime inputs,
+  not borrowed claims — writes a one-line section ("No borrowed claims; this skill owns its content."), never
+  omitting it or inventing a link.
 - **States no new fact** — References only names owners for facts the body already stated.
-- **Link shape is mirror-stable** — prefer sibling-skill and same-directory links; a deep `../` climb can
-  resolve from the canonical path yet break through the `.claude` / `.agents` runtime mirrors. A repo-root
-  script usually appears as a Procedure command code span, not a Reference link.
-- **Trap:** a "related docs" list with no claim mapping is not an ownership register.
+- **Mirror-stable links** — prefer sibling-skill and same-directory links; a deep `../` climb can resolve
+  from the canonical path yet break through the runtime mirrors. A repo-root file (a script, or a doc like
+  `CHANGELOG.md`) usually appears as a Procedure code span or a plain path, not a fragile `../` link.
+- **Anchored entries** — link a `#anchor` only when the named section is the real owner, and record the exact
+  target heading so P10 can verify its slug (the link guard is anchor-blind).
+- **Trap** — a "related docs" list with no claim mapping is not an ownership register.
 
-### P7 — Wire the skill and verify it loads
+### Conformance checklist — close P1–P9 before wiring
 
-Wiring sets the remaining two reach axes and proves the skill loads. **Mirror availability** (default:
-both runtimes; set one-runtime-only only when a skill is intentionally single-runtime) and **`Skill()`
-permission** (default: no entry; add only for zero-prompt preapproval) are both decided here. A skill
-on disk that no runtime loads is unfinished.
+Before P10 wiring, run the judgment-free conformance checklist — read `checklists.md`. A single NO sends you
+back to the step that owns it; the skill moves to P10 only when every line is YES.
 
-A skill has three mirror surfaces, at different granularity (verified by `readlink`). All three
-are SCRIPT-OWNED — `scripts/sync-plugin-package.sh` builds and validates every one:
+### P10 — Wire the skill and verify it loads cold
 
-| Surface | Shape | Owner |
-|---|---|---|
-| `.claude/skills/{name}/` | a REAL directory holding one symlink PER FILE — every agent-exposed child of the canonical skill, DERIVED (`SKILL.md`, any companion such as `mistakes.md`, and support subdirs `scripts/`/`templates/`/`workflow/` mirrored as real dirs of per-file symlinks) | **SCRIPT-OWNED** |
-| `.agents/skills/{name}` | ONE whole-dir symlink (`-> ../../.gobbi/projects/gobbi/skills/{name}`) | **SCRIPT-OWNED** |
-| `plugins/gobbi/skills` | ONE whole-dir symlink for ALL skills (`-> ../../.gobbi/projects/gobbi/skills`) | **SCRIPT-OWNED** |
+Writing the body is half the job. A skill exists to be loaded and run, so it is done only when a runtime
+can load it and a fresh agent can follow it. Wiring also sets the last two reach axes: **mirror
+availability** (default: every runtime the project mirrors into; make a skill single-runtime only as a
+deliberate decision) and the **tool-permission entry** (default: none; add one only for zero-prompt
+preapproval). P4 forward-references both as P10 wiring.
 
-`scripts/sync-plugin-package.sh` iterates every canonical skill dir and creates/refreshes ALL
-three mirrors: the `.agents/skills/{name}` whole-dir symlink (its loop), the plugin whole-dir
-symlinks, AND the `.claude/skills/{name}` per-file mirror. The `.claude/skills` mirror is built
-from a DERIVED per-skill enumeration of agent-exposed children (no hardcoded file list) —
-per-file symlinks inside real directories, for top-level files AND support subdirs, at the `../`
-depth that matches each leaf's nesting. `--check` validates it as per-skill BIDIRECTIONAL parity
-(the mirror child set equals the canonical child set, with `readlink -e` per leaf), exiting
-non-zero on any drift. Read the script's build loop and `--check` mode before relying on this.
-No mirror surface is wired by hand.
+Wire and prove the skill in order, each step with its check:
 
-Wire a new skill in this order, each step with its verify command:
+- **Build the mirrors with the project's sync mechanism — never by hand.** Run the mechanism that owns the
+  runtime mirrors; it derives every mirror from the canonical skill, including each child doc and companion
+  the skill added. P3 marks the mirrors *generated* for this reason — a hand-made mirror drifts from what
+  the guard expects.
+- **Confirm mirror and reference integrity with the project's structural guards.** Run the mirror-parity
+  check and the link / reference checks; both must report clean. Spot-check that one mirror leaf resolves
+  to the canonical file. A failure means the sync did not build what the runtimes load — fix the sync and
+  run it again, never hand-patch the mirror.
+- **Leave the plugin / package manifest untouched.** Conventional skill directories auto-load with no
+  manifest entry, and adding one can break loading. Registering the skill is the skill index's job, not
+  the manifest's.
+- **Place the skill in the project's skill index by the index's own convention.** The convention varies by
+  the skill's kind — an operational skill may get an index row, a meta / authoring skill a prose mention,
+  and some skills no entry at all. Follow the rule for this kind, do not add a row by default, and confirm
+  the entry you added is present.
+- **Add a tool-permission entry only for zero-prompt preapproval.** It is a permission gate, not a
+  discoverability gate — the skill loads and appears without it. Omit it and accept a first-use tool
+  prompt, or add it only to silence that prompt.
+- **Prove each target runtime loads it cold.** Start the runtime with a clean context and load the skill
+  through its normal entry; confirm it is found without help from the authoring session. Structural checks
+  are necessary but not sufficient.
+- **Run the fresh-agent proof in every target runtime.** Give an agent no prior context and confirm it can
+  find the skill and perform the capability from the Intro + Procedure alone. A skill that passes every
+  guard but that a fresh agent cannot follow is not done.
 
-1. **Run the sync script — it builds every mirror.** From the worktree root:
-   ```bash
-   bash scripts/sync-plugin-package.sh
-   ```
-   This creates/refreshes `.agents/skills/{name}`, the plugin whole-dir symlinks, AND the
-   `.claude/skills/{name}` per-file mirror. The `.claude/skills` mirror is DERIVED from the
-   canonical skill's agent-exposed children, so a new `SKILL.md`, a `mistakes.md` companion, any
-   child doc, and any support subdir (`scripts/`/`templates/`/`workflow/`) are mirrored
-   automatically — you name none of them and wire nothing by hand.
-2. **Confirm every mirror is intact.** The check must exit 0:
-   ```bash
-   bash scripts/sync-plugin-package.sh --check; echo "exit=$?"
-   ```
-   `--check` validates all three mirrors, including `.claude/skills/{name}` per-skill
-   bidirectional parity (a missing child OR a stale extra both fail). Spot-check a leaf:
-   `readlink -e .claude/skills/{name}/SKILL.md` resolves to the canonical file.
-3. **plugin.json — NO edit.** Both `plugin.json` manifests are metadata-only; conventional
-   `skills/` directories auto-load without a manifest key. Adding a `skills` key has caused load
-   failures. Do not edit `plugin.json` for a new skill.
-4. **Add a value-features prose mention in `gobbi/SKILL.md`.** A meta/authoring skill gets a
-   dedicated prose mention in the Product value-features section (mirror the existing "Install /
-   runtime is documented, not a skill." paragraph), NOT a Loop / Cross-cutting / Supporting
-   Skill-Map table row. Skill-Map placement is not uniform: some skills have a table row, some
-   are named only in value-feature prose (`skill-writing` and `agent-writing` are named in the
-   authoring-skills paragraph), and some are not in `gobbi/SKILL.md` at all — `claude-plugin`
-   appears NOWHERE in it (verify: `grep -c claude-plugin .gobbi/projects/gobbi/skills/gobbi/SKILL.md`
-   → 0). So a new meta skill does not need a row; this step is the deliberate choice to give it a
-   dedicated prose paragraph. Verify your mention landed:
-   `grep -n '{name}' .gobbi/projects/gobbi/skills/gobbi/SKILL.md`.
-5. **`Skill()` permission — ONLY if zero-prompt preapproval is wanted.** Add a `Skill({name})`
-   entry to `.claude/settings.json` ONLY when you want the runtime to never prompt on the skill's
-   tool use. It is NOT required for the skill to load (P1). If you skip it, `.claude/settings.json`
-   is UNCHANGED.
-
-   **`Skill()` is a permission, not discoverability.** A skill loads and appears without any
-   `Skill()` entry — `claude-plugin` and `codex`, for example, are mirrored and load with no
-   `Skill()` perm. The mirror count and the perm count are not equal; confirm the gap live rather
-   than trusting a number that drifts as skills are added:
-   ```bash
-   ls .claude/skills | wc -l                  # mirrored skills
-   grep -c 'Skill(' .claude/settings.json     # preapproved skills
-   ```
-   The difference is the count of mirrored-but-unpermissioned skills. Omitting the entry does not
-   hide the skill; it only means the first tool use may prompt.
-
-Final verify across the wiring: run the markdown-link guard to confirm no new broken links. The
-guard REQUIRES at least one path argument (no-arg exits 2) — pass the new skill's file or dir:
-```bash
-bash .gobbi/projects/gobbi/skills/orchestration/scripts/check-markdown-links.sh \
-  .gobbi/projects/gobbi/skills/{name}/SKILL.md
-```
-A clean run prints `ALL LINKS RESOLVE (...)` and exits 0.
+P10 passes only when the sync, the structural guards, the mirror spot-check, the cold load, and the
+fresh-agent proof all pass.
 
 ---
 
 ## References
 
-Each entry names an owner and the specific claim in this skill that the owner validates. To
-audit a fact, find its claim here and follow the one owner link.
-
-- [`claude-plugin/SKILL.md`](../claude-plugin/SKILL.md) § Component auto-loading — validates:
-  conventional `skills/` directories auto-load with no `plugin.json` manifest key (P7 step 3;
-  the "NEVER edit the plugin manifests" Rule).
-- [`claude-plugin/SKILL.md`](../claude-plugin/SKILL.md) — validates: the plugin package layout,
-  the three script-owned mirror surfaces, symlink dereference rules, and the standalone
-  meta/authoring-skill exemplar shape (P7 mirror surfaces; the Procedure preamble shape-reference).
-- [`research/SKILL.md`](../research/SKILL.md) — validates: the short standalone skill exemplar
-  shape (the Procedure preamble shape-reference load-action).
-- [`gobbi/SKILL.md`](../gobbi/SKILL.md) — validates: a meta/authoring skill gets a value-feature
-  prose mention, not a Skill-Map table row (P7 step 4; the Skill-Map Rule).
-- [`memory/rules.md`](../memory/rules.md) § 2 — validates: the 11-field memory-FILE frontmatter
-  standard governs the typed memory trees (contrast — a skill carries NONE of these fields; P1).
-- [`memory/rules.md`](../memory/rules.md) § Scope boundary — validates: skill-surface docs
-  (`SKILL.md`, the `mistakes.md` companion) are OUT of the memory frontmatter standard (P1; P5).
-- [`mistake/SKILL.md`](../mistake/SKILL.md) — validates: Wrap-up promotion writes the skill-owned
-  `mistakes.md` companion under Always-Ask routing (P5).
-- [`evaluation/SKILL.md`](../evaluation/SKILL.md) § Evaluation child-doc bundle — validates: a
-  workflow-loop skill splits its evaluation child doc into the three-file `scenario.md` +
-  `checklist.md` + `evaluation.md` bundle (P5 child-doc guidance; the "NEVER inline evaluation
-  scenarios into a monolithic `evaluation.md`" Rule).
-- [`mistakes.md#planning-asserted-skill-without-verifying`](mistakes.md#planning-asserted-skill-without-verifying)
-  — validates: the verify-before-asserting trap — a load-path asserted without `test -f` shipped
-  a dead reference into a briefing (the "wiring claim" Principle; the "NEVER assert a wiring
-  surface" Rule).
-- [`agent-writing/SKILL.md`](../agent-writing/SKILL.md) — validates: authoring a NEW agent — the
-  sibling skill that shares the mirror + verify-before-assert discipline.
+No borrowed claims — this skill owns its content: the standard form, its sections, and the authoring
+procedure. It borrows no project-specific fact, so there is no external owner to register. A skill you
+write with it that DOES borrow facts fills this section per P9 — one owner per borrowed claim.

--- a/.gobbi/projects/gobbi/skills/skill-writing/checklists.md
+++ b/.gobbi/projects/gobbi/skills/skill-writing/checklists.md
@@ -1,0 +1,39 @@
+# Skill-Writing — Conformance Checklist
+
+Sub-document of the `skill-writing` skill. Run it after P9, before P10 wiring, to confirm the finished
+skill conforms to the standard form. Each line is answerable yes/no against the artifact with no judgment; a
+single NO returns the skill to the step that owns it. The skill ships only when every line is YES.
+
+## Frame (P1–P3)
+
+- **P1** — the actor and load mode were set by their rules (not guessed); the outcome is one end state;
+  the non-goals fence it; the description states the capability and its trigger.
+- **P2** — two or three analogous skills were read; every borrowed claim's owner mechanism was read;
+  conflicting conventions were resolved; the user locked the direction.
+- **P3** — the claim-owner ledger is complete; the affected-file map is complete (every surface edited or
+  marked N/A with a reason); the altitude decision is made; the six-section skeleton was laid.
+
+## Sections (P4–P9)
+
+- **P4** — `name` equals the directory; the three required keys appear in order; the description grammar
+  matches the load mode; `allowed-tools` matches the write / no-write answer; no field from another schema
+  appears.
+- **P5** — the H1 is the skill name in Title Case; the Intro is at most two short paragraphs (what + when);
+  it names no file, holds no link, and carries no WHY-clause.
+- **P6** — three to six blockquote-plus-WHY Principles; none carries an imperative; each pairs to at least
+  one Rule.
+- **P7** — every Rule sits in a sub-group and opens MUST / ALWAYS or NEVER; each is self-contained
+  (rationale present; every NEVER carries a Fix) and gradable yes/no on a finished skill; no Rule repeats a
+  Procedure step verbatim.
+- **P8** — the Procedure names another file only as an action; the write-only sub-sections and child-doc
+  maps appear iff P3 required them; no step copies an owner's content.
+- **P9** — every borrowed fact has exactly one § References owner (or the one-line empty case applies);
+  § References states no new fact; links prefer sibling / same-directory over a fragile `../` climb.
+
+## Whole skill
+
+- The six sections are present, in order: Frontmatter → Intro → Principles → Rules → Procedure → References.
+- The skill is one coherent, cold-load-sufficient capability — a fresh agent can perform it from the Intro
+  and Procedure alone (proven empirically at the P10 cold-load).
+
+Only when every line is YES does the skill move to P10 wiring.


### PR DESCRIPTION
## What

Ports the stranded `skill-writing` project-agnostic overhaul onto current `develop`, and lands two additions from this session.

**Background:** PR #345 squash-merged the *earlier* 6-section rewrite. The subsequent overhaul (project-agnostic Principles + hybrid-lifecycle Procedure) landed on the old branch *after* #345 closed, so it was never merged. This PR carries it forward onto develop (which now also has #346/#347).

## Changes (skill-writing only — 2 files + 1 mirror)

1. **SOP specification model.** A skill IS a standard operating procedure for one capability; it DEFINES the specifications for its operations — that is HOW it standardizes the work. "Specification" is what a skill *defines*, not what it *is*. The six-section document house-format is a separate, lesser standard, named **"standard form"**.
2. **P10 rewrite.** The wiring step was a title-only placeholder; now a full project-agnostic wiring + cold-load procedure (reach axes → build mirrors via the project's sync mechanism → structural guards → manifest untouched → skill index by convention → tool-permission optional → cold-load + fresh-agent proof).
3. **Agnostic anti-monolith Rule.** Preserves #346's insight ("don't collapse a per-unit review artifact set into one monolithic file") in project-neutral form. #346's original lines named project-specific files (`evaluation/SKILL.md`, the `scenario`/`checklist`/`evaluation` bundle); the overhaul is intentionally fully agnostic, so those exact lines are not re-added — the specific contract stays owned by `evaluation/SKILL.md`.
4. New `checklists.md` conformance sub-doc (+ its runtime mirror).

## Verification

- Fully project-agnostic: 0 "gobbi" / hardcoded paths in `SKILL.md`.
- Source-free: Procedure names files only as generic actions; same-file `P3`/`P4` nav only.
- Guards green: `sync-plugin-package.sh --check`, markdown-links (SKILL + checklists), residual-vocab, codex-compatibility.
- Dual-system production throughout: Claude producer + independent Codex proposer, integrated per part.

## Note

This PR intentionally does **not** re-add #346's exact skill-writing lines (they were project-specific). If reviewers prefer the specific evaluation-bundle pointer restored, that's a follow-up decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTHpv9oUPoNtMCJ5FQW3D6
