### PR TITLE
feat(coding): add the typescript language skill

### DIFF
--- a/.agents/skills/typescript
+++ b/.agents/skills/typescript
@@ -1,0 +1,1 @@
+../../.gobbi/projects/gobbi/skills/typescript

--- a/.claude/skills/typescript/SKILL.md
+++ b/.claude/skills/typescript/SKILL.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/typescript/SKILL.md

--- a/.claude/skills/typescript/async-resources.md
+++ b/.claude/skills/typescript/async-resources.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/typescript/async-resources.md

--- a/.claude/skills/typescript/checklists.md
+++ b/.claude/skills/typescript/checklists.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/typescript/checklists.md

--- a/.claude/skills/typescript/convention.md
+++ b/.claude/skills/typescript/convention.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/typescript/convention.md

--- a/.claude/skills/typescript/design.md
+++ b/.claude/skills/typescript/design.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/typescript/design.md

--- a/.claude/skills/typescript/evaluation.md
+++ b/.claude/skills/typescript/evaluation.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/typescript/evaluation.md

--- a/.claude/skills/typescript/modules-tooling.md
+++ b/.claude/skills/typescript/modules-tooling.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/typescript/modules-tooling.md

--- a/.claude/skills/typescript/packaging-publishing.md
+++ b/.claude/skills/typescript/packaging-publishing.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/typescript/packaging-publishing.md

--- a/.claude/skills/typescript/runtime-deltas.md
+++ b/.claude/skills/typescript/runtime-deltas.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/typescript/runtime-deltas.md

--- a/.claude/skills/typescript/scenarios.md
+++ b/.claude/skills/typescript/scenarios.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/typescript/scenarios.md

--- a/.claude/skills/typescript/testing.md
+++ b/.claude/skills/typescript/testing.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/typescript/testing.md

--- a/.claude/skills/typescript/typing.md
+++ b/.claude/skills/typescript/typing.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/typescript/typing.md

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,11 @@ packages/*/node_modules/
 # `.gobbi/projects/gobbi/{skills,agents,rules}/`; this copy only exists
 # so `npm pack` can ship it inside the tarball.
 packages/cli/.gobbi/
+
+# TypeScript example-verification harness (examples/typescript/). The harness
+# installs `typescript` as a local devDep to type-check the skill's fenced ts
+# examples; its node_modules / bun cache are never committed and must never be
+# mirrored into .claude/.agents/plugins. (node_modules/ above already matches
+# this by name; these lines are explicit + scoped for the harness surface.)
+examples/typescript/node_modules/
+examples/typescript/.bun/

--- a/.gobbi/projects/gobbi/learnings/evaluation/compile-harness-is-blind-to-prose-claims.md
+++ b/.gobbi/projects/gobbi/learnings/evaluation/compile-harness-is-blind-to-prose-claims.md
@@ -1,0 +1,18 @@
+---
+name: compile-harness-is-blind-to-prose-claims
+description: A compile-harness proves code EXAMPLES compile, not that the PROSE around them is TRUE; the Codex Execution evaluator caught 9 real TS-technical prose defects that 84 green tsc runs + all guards could not
+type: learnings
+scope: project
+feature: coding
+status: active
+created: 2026-07-16
+session: c8fe196d-c20d-451d-ac9c-2b366c49aa95
+tags: [evaluation, codex, dual-system, verification]
+keywords: [prose-vs-code, compile-harness-blind-spot, typescript-skill, execution-eval, void-promise, noinfer, branded-type]
+author: claude
+related: []
+---
+
+Building the `typescript` skill, every fenced `ts` example was machine-verified — a committed harness compiled all 84 under a maximal-strict tsconfig, and the markdown-link + residual-vocab guards were green. That proves the CODE compiles; it does NOT prove the PROSE around it is TRUE. The Codex Execution evaluator's TS-technical-accuracy pass then found **9 real conf-100 defects the harness structurally cannot see**: `void promise` taught as rejection handling (a bare `void` silences the lint but leaves the rejection unhandled); `(): void` written as Python's `-> void`; a `NoInfer` example whose claim "a non-member is rejected" was false because `T` widened to `string` (fixed with a `const` type parameter); a branded-ID "checked"/"unforgeable" constructor that only did `raw as UserId` with no validation; a typed-`EventTarget` `emit` that ignored its key and dispatched by `ev.type`; and Deno/Bun grouped with Node's type-STRIPPING when they in fact transpile. The Claude Execution evaluator was blocked by a usage limit, so Codex was the ONLY reviewer that ran — and it fully earned its place.
+
+**Apply:** on a code/config skill, the compile-gate + guards are necessary but NOT sufficient — a green example set is a false sense of done. Always run an independent (Codex) prose-accuracy review that reads the CLAIMS, not just whether the code compiles. Reinforces [[weight-codex-evaluator-on-technical-accuracy]] and [[compile-verified-examples-still-carry-false-prose]].

--- a/.gobbi/projects/gobbi/mistakes/codex/no-convergence-claim-from-degraded-codex-run.md
+++ b/.gobbi/projects/gobbi/mistakes/codex/no-convergence-claim-from-degraded-codex-run.md
@@ -1,0 +1,26 @@
+---
+name: no-convergence-claim-from-degraded-codex-run
+description: When the Codex proposer degrades (timeout/empty), never mine its partial reasoning log and claim "dual-system convergence" — a Codex-timeout production is Claude-only, full stop
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-16
+session: c8fe196d-c20d-451d-ac9c-2b366c49aa95
+tags: [process, codex, dual-system, provenance]
+keywords: [degraded-mode, codex-proposer-timeout, convergence-claim, provenance, anti-groupthink]
+author: claude
+related: []
+---
+
+## What happened
+The Codex proposer timed out (exit 124, no proposal file) during Ideation dual-system production, so production correctly degraded to Claude-only. But the manager then read Codex's partial REASONING LOG (which mentioned "TypeScript 5.9 minimum") and edited the design draft to claim "Codex independently proposed 5.9 — dual-system convergence" in three places. The Claude evaluator caught this (F-PROV-01, High/100): the frontmatter says `production_mode: claude-only` / `codex_proposal_absent_reason: timeout`, so a "convergence" claim fabricates the anti-groupthink signal it pretends to carry.
+
+## Why it happens
+A timed-out proposer still emits a reasoning stream to its log. It is tempting to mine that for "what Codex thought" and present it as an independent proposal. But an incomplete reasoning trace is not a frozen completed proposal, and citing it as convergence manufactures cross-system agreement that never occurred.
+
+## How to recognize
+`production_mode: claude-only` (or any `codex_proposal_absent_reason`) is set, AND the artifact text claims Codex "proposed", "agreed", "converged", or "independently arrived at" anything.
+
+## Correct approach
+A Codex-timeout/empty production is Claude-only, full stop. Claim NO convergence anywhere. If the partial log shows a lean, at most note it as "an observation from an incomplete run — not an independent proposal", and never let it validate a locked decision. The cross-family signal is recovered at the dual EVALUATION, not by mining a dead proposer's log. See [[weight-codex-evaluator-on-technical-accuracy]].

--- a/.gobbi/projects/gobbi/mistakes/codex/weight-codex-evaluator-on-technical-accuracy.md
+++ b/.gobbi/projects/gobbi/mistakes/codex/weight-codex-evaluator-on-technical-accuracy.md
@@ -1,0 +1,26 @@
+---
+name: weight-codex-evaluator-on-technical-accuracy
+description: On code/technical-accuracy axes, weight the Codex evaluator and never treat a Claude "no errors found" as coverage — a Claude evaluator systematically misses real technical defects a Codex pass catches
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-16
+session: c8fe196d-c20d-451d-ac9c-2b366c49aa95
+tags: [process, evaluation, codex, dual-system]
+keywords: [codex-evaluator, technical-accuracy, no-errors-not-coverage, typescript-skill, deepen-not-restate]
+author: claude
+related: []
+---
+
+## What happened
+Twice this session (`typescript` skill), the Codex evaluator caught real TS-technical defects the Claude side missed. In Ideation, the Claude evaluator concluded "no technically-wrong TS claim found" while Codex independently found 4 real contradictions (ESM/CJS lock breach, `.js`/`.ts` extension conflict, TS7-no-programmatic-API, browser-bundler-false). In the Execution evaluation, the Claude evaluator was blocked by a usage limit and Codex — running alone — found 9 more conf-100 prose defects (`void` promise, `-> void`, NoInfer, branded-type, EventTarget, Deno/Bun strip-vs-transpile, browser-annotations, skipLibCheck/isolatedDeclarations/noUncheckedIndexedAccess wording).
+
+## Why it happens
+Same-model-family evaluation shares the producer's blind spots. On deep technical/code-correctness axes, a Claude evaluator's "looks correct" is systematically weaker than an independent Codex pass that cross-checks against primary docs. This reproduces the python-session pattern on TS.
+
+## How to recognize
+A Claude evaluator returns "no technical/correctness errors found" on a technically-dense artifact (config flags, module semantics, tooling compatibility, version behavior, API contracts). Read that as "Claude did not find them," NOT "there are none."
+
+## Correct approach
+On code/technical-accuracy axes, WEIGHT the Codex evaluator and spot-verify its findings against primary sources; never treat a Claude "no errors" as coverage. Ensure the Codex evaluator runs even when the Codex proposer degraded, and even when a compile-harness already passed — a green example set proves code compiles, not that the PROSE claims are true ([[compile-harness-is-blind-to-prose-claims]]). Codex reliably underproduces the full 9-file frame on heavy workloads, so prompt it overall-first (verdict + findings before any timeout).

--- a/.gobbi/projects/gobbi/mistakes/docs-sync/sweep-every-occurrence-when-fixing-a-multi-surface-claim.md
+++ b/.gobbi/projects/gobbi/mistakes/docs-sync/sweep-every-occurrence-when-fixing-a-multi-surface-claim.md
@@ -1,0 +1,62 @@
+---
+name: sweep-every-occurrence-when-fixing-a-multi-surface-claim
+description: A fix corrected a claim in its primary doc but left the same claim stated in a sibling child/scenario/checklist, so the "fixed" defect resurfaced as a residual round after round.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-16
+session: 054f402b-a9ab-4af6-875d-078233778a0b
+tags: [process, docs-sync, verification]
+keywords: [fix-propagation, residual, grep-sweep, multi-doc, crud-9w1h, half-applied-fix]
+author: claude
+priority: high
+domain: docs-sync
+---
+
+# A spot-fixed claim left residuals in sibling docs and re-failed every review round
+
+## What happened
+
+Across a multi-doc skill review, the same corrected claim kept resurfacing as a "residual of a fixed defect":
+
+- The bare-`void`-is-not-a-promise-handler correction was applied to `SKILL.md` and `async-resources.md` but
+  missed `scenarios.md` (a seed scenario still called a bare `void` "Good handling").
+- The Node-strips-vs-Bun/Deno-transpile correction was applied to `runtime-deltas.md` line 223 but left ~6 other
+  surfaces (SKILL.md H3, modules-tooling §4, checklists TS-CHECK-03, scenarios TS-SCENARIO-05, …) still calling
+  the shared direct-run mode "type-stripping."
+
+Each was caught in a LATER review round (iter2, iter3) as a fresh High/Medium finding, costing extra
+review+fix cycles for what was one logical correction.
+
+## Why it happens
+
+A skill (or any doc set) states the same rule on multiple surfaces by design — the SKILL.md rule, the child-doc
+mechanics, the seed scenario, the checklist item, the eval crosswalk. Fixing "the doc" naturally means editing
+the surface in front of you (the one the finding cited), and the fix then LOOKS complete. But a claim that lives
+in N surfaces needs N edits; a spot-fix of one is a half-applied fix. The other surfaces are exactly where an
+adversarial reviewer (or the next reader) hits the stale version.
+
+## Correct approach
+
+When a fix corrects a factual/normative CLAIM (not a one-off typo), treat it as a project-wide sweep, not a
+single edit: `grep` the whole doc set for every phrasing of the claim and fix each occurrence in the SAME
+change. This is principle-9 CRUD+5W1H applied to a claim — enumerate the affected surfaces (parent rule, child
+mechanics, scenario, checklist, crosswalk, examples) before editing, and verify with a residual grep to zero
+afterward. A residual grep ("no occurrence of the old phrasing remains") is the completion check, the same way a
+harness/link guard is a completion check.
+
+## How to detect
+
+Signals you are about to leave a residual: the cited finding is in ONE file but the claim is a general rule the
+skill teaches (rules/scenarios/checklists all restate it); or the fix reword touches a term that appears many
+times (`grep -c` shows > 1). Signal it already happened: a re-eval returns a finding that is the "same class" as
+one you fixed last round, in a different file. Before committing a claim-fix, run `grep -rniE "<old phrasing>"`
+over the whole doc set and require zero hits outside the intended edits.
+
+## Related
+
+- [[verify-time-sensitive-facts-not-hedge-from-stale-cutoff]] — a sibling review-round lesson from the same
+  session.
+- Reinforces principle 9 (Think CRUD-and-5W1H before editing) and principle 10 (finish in-scope work) — a
+  half-propagated fix is both an un-traced blast radius and an unfinished edit.

--- a/.gobbi/projects/gobbi/mistakes/verification/adversarially-test-a-newly-authored-acceptance-predicate.md
+++ b/.gobbi/projects/gobbi/mistakes/verification/adversarially-test-a-newly-authored-acceptance-predicate.md
@@ -1,0 +1,64 @@
+---
+name: adversarially-test-a-newly-authored-acceptance-predicate
+description: A newly-authored checklist acceptance predicate named specific constructs as "sufficient" that a compiled counterexample proved unsound, twice — a new check needs the same adversarial soundness test as any taught fact.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-16
+session: 054f402b-a9ab-4af6-875d-078233778a0b
+tags: [process, verification, execution]
+keywords: [acceptance-predicate, new-check, soundness, compile-proof, readonly-depth, harness-blind]
+author: claude
+priority: high
+domain: verification
+---
+
+# A new acceptance check claimed constructs "sufficient" that a compiled probe falsified
+
+## What happened
+
+A coverage gap was closed by adding a new scenario + checklist item (a mutable-aliasing check). The check's
+PASS condition named specific TypeScript constructs as sufficient to protect private state — first "a
+`readonly`-typed boundary", then "`ReadonlyArray<Readonly<T>>` or a spread copy `[...items]`." A re-eval
+compiled counterexamples and proved BOTH unsound: a shallow `readonly T[]` over mutable objects lets a caller
+assign nested fields; a one-level `Readonly<T>` is shallow in `T` (so `view[0].inner.x = 7` compiles); and a
+spread `[...items]` of objects shares the element objects (so `copy[0].x = 7` mutates the owner). The check
+that was supposed to REJECT unhandled aliasing would have PASSED it. It took two rounds to get sound, finally by
+reframing the check as a PROPERTY ("no mutable path into private state") rather than naming any construct
+"sufficient."
+
+## Why it happens
+
+Authoring a check feels like documentation, not code, so it ships without being run. But an acceptance predicate
+IS an executable claim — "if the artifact does X, it passes" — and it can be false exactly like a taught code
+example can be false. Naming a construct "sufficient" is the trap: TypeScript immutability is shallow and
+erased, so almost every shallow guard (`readonly T[]`, `Readonly<T>`, `Object.freeze`, a spread copy) has a
+deeper case it does not cover. The compile-harness does not help — it proves the skill's EXAMPLES compile, not
+that a checklist's ACCEPTANCE condition is sound.
+
+## Correct approach
+
+Treat a newly-authored check / scenario / acceptance predicate as a claim to be adversarially tested before
+shipping, the same bar as a taught fact: construct the counterexample the predicate is supposed to reject and
+CONFIRM it fails the predicate (for code claims, compile it). Prefer framing an acceptance condition as a
+PROPERTY the artifact must have ("no mutable path into private state") over an enumerated list of "sufficient"
+constructs — a property is closed against the cases you did not think of; a construct list is only as sound as
+its longest-considered case. When immutability/soundness has a depth dimension, name the shallow traps
+explicitly rather than blessing a shallow construct.
+
+## How to detect
+
+Red flags in a check's PASS clause: it names a specific construct as "sufficient"/"enough" (`readonly T[]`,
+`Readonly<T>`, a copy, frozen) for a safety property; the property has an obvious depth/nesting dimension; or
+the check was added this session and never had a counterexample run against it. Before committing a new
+acceptance check, write the exact thing it must reject and verify the predicate rejects it. Remember the
+harness/link/crosswalk guards are all green while an unsound acceptance predicate ships — mechanical gates do
+not test a check's own soundness.
+
+## Related
+
+- [[acceptance-gate-and-conjunct-escape-hatch]] — the same class: an acceptance predicate that admits the case
+  it exists to reject; both were caught only by an adversarial semantic reviewer, not by mechanical guards.
+- [[weight-codex-evaluator-on-technical-accuracy]] — the Codex evaluator compiled the readonly counterexamples
+  the Claude evaluator's PASS missed across two rounds.

--- a/.gobbi/projects/gobbi/mistakes/verification/verify-time-sensitive-facts-not-hedge-from-stale-cutoff.md
+++ b/.gobbi/projects/gobbi/mistakes/verification/verify-time-sensitive-facts-not-hedge-from-stale-cutoff.md
@@ -1,0 +1,59 @@
+---
+name: verify-time-sensitive-facts-not-hedge-from-stale-cutoff
+description: A version/release-dependent claim was hedged as "unreleased/pending" from a stale knowledge cutoff, when the release had already shipped and the original concrete text was correct.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-16
+session: 054f402b-a9ab-4af6-875d-078233778a0b
+tags: [process, verification, docs-sync]
+keywords: [time-sensitive, knowledge-cutoff, web-verify, release-dependent, hedge, ts7]
+author: claude
+priority: high
+domain: verification
+---
+
+# Hedging a time-sensitive fact from a stale cutoff shipped a false claim
+
+## What happened
+
+The `typescript` skill originally named the TS 7.0 typed-lint compatibility package `@typescript/typescript6`
+and its `tsc6` binary as concrete fact. A first-round evaluator flagged that as "stated as fact though TS 7.0
+is unreleased" and the manager HEDGED it to "a JS-based TS compatibility API; exact package/binary name pending
+7.0 GA." A later re-eval web-searched and found TypeScript 7.0 had **already GA'd on 2026-07-08** (8 days before
+the review), and the GA announcement names exactly `@typescript/typescript6` + `tsc6`. So the original concrete
+text was correct; the "unreleased, hedge it" reasoning — and the hedge — were both wrong, based on a knowledge
+cutoff (Jan 2026) that predated the release. The hedge had to be reversed and the concrete names restored.
+
+## Why it happens
+
+A model reasons about a release/version/date-dependent fact from its training cutoff and treats "I don't know
+this shipped" as "it hasn't shipped." Hedging then FEELS safe and rigorous ("don't assert an unreleased detail"),
+but it is a positive claim too — "pending GA" asserts the thing has NOT shipped — and it is false once the
+release lands. The cutoff makes both the original author (who named it) and the reviewer (who called it
+unreleased) operate on stale ground; neither checked the world.
+
+## Correct approach
+
+When a claim depends on a release, version number, date, or other fast-moving external fact — especially one
+that could have changed after the knowledge cutoff — WEB-VERIFY it against a primary source before either
+asserting OR hedging it. "Pending release" / "unreleased" / "not yet available" are themselves time-sensitive
+positive claims and get the same verification bar as the concrete fact. Prefer a dated, sourced statement
+("as of TS 7.0, GA 2026-07-08, per the vendor announcement …") over a vague hedge — a hedge that turns out
+false is worse than the concrete fact it replaced.
+
+## How to detect
+
+Red-flag phrases in a doc or a review finding: "unreleased", "pending GA", "not yet", "upcoming", "expected in
+version N", a bare future version number, or "the exact name is TBD." Any of these on a fact that a user could
+check today is a web-verify trigger. Also: a reviewer calling a concrete named artifact "speculative/unreleased"
+is asserting a negative that itself needs verification — do not accept it (or hedge on it) without a source
+check. Mechanical gates (compile, lint, link) never catch a stale-fact hedge; only a primary-source lookup does.
+
+## Related
+
+- [[weight-codex-evaluator-on-technical-accuracy]] — the re-eval that caught the stale hedge was the Codex
+  evaluator, which web-verified the GA date; reinforces weighting Codex on technical/factual accuracy.
+- See also `evaluation/SKILL.md` § Verification by tools — a time-sensitive claim is a segment whose strongest
+  verification is a primary-source fetch, not reasoning from the cutoff.

--- a/.gobbi/projects/gobbi/mistakes/verification/watcher-fires-before-executor-done-and-slow-executor-race.md
+++ b/.gobbi/projects/gobbi/mistakes/verification/watcher-fires-before-executor-done-and-slow-executor-race.md
@@ -1,0 +1,28 @@
+---
+name: watcher-fires-before-executor-done-and-slow-executor-race
+description: A file-size/commit-appears watcher can fire before an executor is DONE (it may still amend or be slow to write) — treating that snapshot as "done" and acting/re-dispatching risks a concurrent-writer race on the shared worktree
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-16
+session: c8fe196d-c20d-451d-ac9c-2b366c49aa95
+tags: [process, orchestration, git, concurrency, agent-teams]
+keywords: [watcher, executor-done, commit-amend, slow-executor, concurrent-writer, no-commit-pattern, duplicate-dispatch]
+author: claude
+related: []
+---
+
+## What happened
+Two variants of the same misread hit this session's Execution.
+(1) A watcher keyed on "the commit subject appeared in `git log`" fired for T3 (SKILL.md), the manager treated T3 as done and immediately made its OWN harness edits + commit — but the T3 executor was still finalizing (`git commit --amend`), so the two git operations interleaved (resolved cleanly only by luck).
+(2) A watcher timed out with `testing.md` still a 29-line stub, so the manager judged the T12 executor "stalled", shut it down, and re-dispatched T12b — but T12 was merely SLOW (still reading/planning before writing the body in one burst). Both executors then targeted the same file; T12b correctly refused to overwrite T12's work, but this was a duplicate-dispatch / concurrent-writer race.
+
+## Why it happens
+A background watcher that keys on a file-size threshold or a commit's appearance fires at the FIRST signal, but an executor may still amend, re-verify, or write its whole body later — the executor's `STATUS: DONE` report is the real completion signal, not the file/commit snapshot. Agent-Teams executors share ONE worktree, so any manager write or re-dispatch during an executor's finalization races it.
+
+## How to recognize
+You set a watcher on file size / `git log` and then act on the worktree (edit, commit, re-dispatch) BEFORE the executor emitted `STATUS: DONE`. Symptoms: an unexpected amended commit hash, a "concurrent uncommitted edits" flag from an executor, a hash you recorded that no longer matches HEAD, or two executors on the same file.
+
+## Correct approach
+Treat the executor's actual `STATUS: DONE` report — not a file/commit watcher — as the completion signal before any concurrent manager write or re-dispatch. A slow executor with no output for a while is not necessarily stalled: confirm liveness (or wait for DONE) before re-dispatching onto the same file. And prefer the **no-commit executor pattern for parallel/overlapping work**: executors WRITE + self-verify their own disjoint file but do NO git ops; the manager commits sequentially. That removes the executor-git-op-vs-manager-write race entirely.

--- a/.gobbi/projects/gobbi/notes/coding/typescript-skill-session-handoff.md
+++ b/.gobbi/projects/gobbi/notes/coding/typescript-skill-session-handoff.md
@@ -1,0 +1,42 @@
+---
+name: typescript-skill-session-handoff
+description: Handoff — the `typescript` skill was authored+wired+pushed this session (branch claude-2026-07-16-c8fe196d); dual-system Execution eval Codex-REVISE 9 defects fixed; Claude holistic eval + Codex re-confirm are the follow-ups before merge
+type: notes
+scope: project
+feature: coding
+status: active
+created: 2026-07-16
+session: c8fe196d-c20d-451d-ac9c-2b366c49aa95
+tags: [handoff, typescript, coding, skill-writing, execution-eval]
+keywords: [typescript-skill, next-session, pr, execution-eval, session-limit, claude-eval-deferred]
+author: claude
+related: []
+---
+
+## What shipped this session (full `/gobbi` Auto run)
+The `typescript` language skill — the concrete TS-idiom layer beneath `coding`, sibling to `python`.
+- **SKILL.md + 11 child docs** (~3,430 lines): design, convention, typing, modules-tooling, async-resources, packaging-publishing, runtime-deltas, testing + the eval triad (evaluation/scenarios/checklists).
+- **Committed example harness** at repo-root `examples/typescript/` (extract-blocks.mjs + run-examples.sh + examples tsconfig, `typescript@5.9.3` + DOM lib): **84 fenced `ts` examples all machine-verified to compile** under a maximal-strict tsconfig.
+- **Wired** via `sync-plugin-package.sh` (`.claude/skills/typescript`, `.agents/skills/typescript`); `sync --check` intact; no skill-index row (on-demand like coding/python).
+- Locked baseline: min **TS 5.9** / target 7.0; maximal-strict ESM-only + `verbatimModuleSyntax`; ban `any`; the `.js`(emit)/`.ts`(strip)+`rewriteRelativeImportExtensions` import fork; principle count follows content (landed 7); P1–P8 procedure operationalizing coding+principles.
+- **Branch:** `claude-2026-07-16-c8fe196d-c20d-451d-ac9c-2b366c49aa95` (pushed to origin). Base: `develop`. ~15 commits `e6175808..e49a33c5`.
+
+## Dual-system evaluation status (the key follow-up)
+- **Codex Execution eval (iter1): REVISE** — found 9 real TS-technical PROSE defects the compile-harness cannot catch (`void` promise, `-> void`, NoInfer, branded-type, EventTarget, Deno/Bun strip-vs-transpile, browser-annotations, skipLibCheck/isolatedDeclarations/noUncheckedIndexedAccess/`as const` wording). **ALL 9 FIXED + re-verified (84 examples still compile, crosswalk 25/25, guards green) + pushed** (commit e49a33c5).
+- **Codex Execution eval (iter2 re-confirm): running at session end** — check `4-execution/evaluation/iter2/codex/overall.md` for its verdict; address any residual before merge.
+- **Claude holistic Execution eval: NOT RUN — blocked by a usage limit** (reset 8:50am UTC 2026-07-16). This is the one gap. Rerun it next session (holistic: deepen-not-restate, coverage vs design, cross-doc consistency, usage) before merging.
+
+## NEXT SESSION (in order)
+1. Read the Codex iter2 re-confirm verdict; fix any residual defect it flags.
+2. Run the **Claude holistic Execution evaluator** (deferred this session); address findings.
+3. **Open/merge the PR** once both eval sides are satisfied (worktree + `gh` ready; base `develop`).
+4. Minor cleanups (non-blocking): standardize the branch's commit provenance trailers from `session=…/task=…/role=…` to canonical `gobbi://session/{id}/task/{id}` (one scoped pass, per `provenance-trailer-syntax-drift`); `testing.md` names tracked `skip`/`todo` but not `xfail` explicitly (add one sentence).
+5. Consider consolidating the two `mistakes/codex/*` promoted this session into `skills/codex/mistakes.md` (skill-owned) if preferred over the project tier.
+
+## Learnings promoted this session
+- `learnings/evaluation/compile-harness-is-blind-to-prose-claims` — the headline (a green example set ≠ true prose).
+- `mistakes/codex/weight-codex-evaluator-on-technical-accuracy`, `mistakes/codex/no-convergence-claim-from-degraded-codex-run`, `mistakes/verification/watcher-fires-before-executor-done-and-slow-executor-race`.
+
+## Process notes for the runner
+- The no-commit parallel-wave pattern (executors write+self-verify disjoint files, manager commits) worked well for authoring 8 child docs in 3 waves — safe + fast.
+- Agent-Teams shared-task-board caused reassignment noise; orchestrate via direct spawns, claim manager-owned workflow tasks.

--- a/.gobbi/projects/gobbi/notes/coding/typescript-skill-session-handoff.md
+++ b/.gobbi/projects/gobbi/notes/coding/typescript-skill-session-handoff.md
@@ -23,8 +23,9 @@ The `typescript` language skill — the concrete TS-idiom layer beneath `coding`
 
 ## Dual-system evaluation status (the key follow-up)
 - **Codex Execution eval (iter1): REVISE** — found 9 real TS-technical PROSE defects the compile-harness cannot catch (`void` promise, `-> void`, NoInfer, branded-type, EventTarget, Deno/Bun strip-vs-transpile, browser-annotations, skipLibCheck/isolatedDeclarations/noUncheckedIndexedAccess/`as const` wording). **ALL 9 FIXED + re-verified (84 examples still compile, crosswalk 25/25, guards green) + pushed** (commit e49a33c5).
-- **Codex Execution eval (iter2 re-confirm): running at session end** — check `4-execution/evaluation/iter2/codex/overall.md` for its verdict; address any residual before merge.
-- **Claude holistic Execution eval: NOT RUN — blocked by a usage limit** (reset 8:50am UTC 2026-07-16). This is the one gap. Rerun it next session (holistic: deepen-not-restate, coverage vs design, cross-doc consistency, usage) before merging.
+- **Codex Execution eval (iter2 re-confirm): ATTEMPTED but FAILED — "Selected model is at capacity" (gpt-5.6-sol) after ~335k tokens; no `overall.md` verdict written.** RE-RUN when Codex capacity returns. (The iter1 fixes are independently verified — 84 examples compile, crosswalk 25/25, guards green — and each directly implements Codex's own cited iter1 correction, so residual risk is low; re-run for a clean loop-close.)
+- **Claude holistic Execution eval: NOT RUN — blocked by a usage limit** (reset 8:50am UTC 2026-07-16). Rerun next session (holistic: deepen-not-restate, coverage vs design, cross-doc consistency, usage) before merging.
+- **Both eval confirmations were capacity-blocked at session end** — the primary Codex iter1 eval (which found + drove the 9 fixes) DID complete; only the confirmation passes are pending.
 
 ## NEXT SESSION (in order)
 1. Read the Codex iter2 re-confirm verdict; fix any residual defect it flags.

--- a/.gobbi/projects/gobbi/notes/process/2026-07-16-typescript-skill-review-handoff.md
+++ b/.gobbi/projects/gobbi/notes/process/2026-07-16-typescript-skill-review-handoff.md
@@ -1,0 +1,79 @@
+---
+name: typescript-skill-review-handoff
+description: "Next-session handoff: 3-round dual-system adversarial review of the typescript skill (PR #353); all findings fixed + verified; merged to develop. 3 process mistakes promoted."
+type: notes
+scope: project
+feature: null
+status: active
+created: 2026-07-16
+session: 054f402b-a9ab-4af6-875d-078233778a0b
+tags: [process, verification, docs-sync]
+keywords: [handoff, typescript, adversarial-review, dual-system, ts7-ga, pr-353]
+author: claude
+features_touched: [coding]
+loops_completed: [ideation, planning, execution, wrap-up]
+shipped: [typescript]
+---
+
+# Handoff — typescript skill adversarial review (PR #353)
+
+## What this session did
+
+Ran a user-requested adversarial review + fix of the `typescript` skill (PR #353, branch
+`claude-2026-07-16-c8fe196d…`, continued in its existing worktree), on the user's 4 axes (scenario/checklist
+coverage, over-strict, best SOP, child-doc structure) plus technical-accuracy, deepen-not-restate, cross-doc
+consistency, and python-sibling alignment. Full `/gobbi` Auto workflow, dual-system throughout.
+
+Three review rounds, findings shrinking each time — all fixed and independently verified:
+
+- **iter1 review** (Claude PASS + Codex REVISE → REVISE): 26 findings fixed. Headline: `TypedBus extends
+  EventTarget` was UNSOUND (inherited `dispatchEvent` bypassed the typed gate — compile-proven); fixed by
+  COMPOSING a private `#target` (which also models the skill's own compose-not-inherit rule). Plus false
+  `passwordHash`-leak claim, bare-`void` residuals, Deno/Bun strip-vs-transpile, etc.
+- **iter2 re-eval** (both REVISE): Claude caught A2 was half-propagated; Codex caught 5 more incl. TS 7.0 had
+  GA'd (reversing an over-cautious hedge), an unsound readonly check, and a Deno `lib` conflict — all fixed.
+- **iter3 confirm** (Codex REVISE): readonly still shallow (one-level `Readonly<T>` + spread copy leak nested
+  state — compile-proven), API/binary attribution, and MORE strip residuals — all swept comprehensively.
+
+Every round: 84/84 examples compile, links 13/13, plugin mirror intact, crosswalk 25/25 live. Two soundness
+bugs compile-proven; two external facts (TS 7.0 GA 2026-07-08, Deno `deno.window` vs `dom` conflict)
+web-verified against primary sources.
+
+## Shipped
+
+- `typescript` skill review complete + merged to develop via PR #353. 8 fix commits
+  (`12d86451`…`307a0a0c`) on top of the original branch; see the PR.
+- The skill's final state: sound composed `TypedBus`; promise-handling consistent across rule/child/scenario/
+  checklist; Node-strips/Bun-Deno-transpile distinction uniform; Deno `lib` correct (`deno.ns`+`dom` for DOM);
+  TS 7.0 named as shipped; mutable-aliasing coverage added (TS-SCENARIO-11/TS-CHECK-20) framed as a property.
+
+## Process mistakes promoted (the durable lessons)
+
+- `mistakes/verification/verify-time-sensitive-facts-not-hedge-from-stale-cutoff.md` — a release/version claim
+  past the cutoff must be web-verified, not hedged; "pending GA" is itself a false-able claim (the TS 7.0 saga:
+  original naming was right, the hedge was wrong).
+- `mistakes/docs-sync/sweep-every-occurrence-when-fixing-a-multi-surface-claim.md` — a claim fix must grep-sweep
+  every surface (rule/child/scenario/checklist/crosswalk); a spot-fix leaves residuals that re-fail next round
+  (A2, A4 each half-applied).
+- `mistakes/verification/adversarially-test-a-newly-authored-acceptance-predicate.md` — a new check/scenario is
+  an executable claim; compile the counterexample it must reject before shipping; frame acceptance as a
+  property, not a list of "sufficient" constructs (the readonly check was unsound twice).
+
+## Decisions to respect
+
+- Locked defaults stand (maximal-strict, ESM-only, ban-`any`, erasable-only) — the review added a one-line
+  greenfield-vs-existing-code scope clarifier (not a migration mandate), not exceptions.
+- Over-strict Axis-2 resolution was "add a scope clarifier", not "weaken defaults".
+
+## Pointers / next session
+
+- The review campaign for the typescript skill is DONE + merged. No follow-up review owed.
+- Sibling reminder: the `python` skill review handoff (auto-memory `project_python_docs_review_handoff`) is
+  still open — a similar adversarial pass on the 10 python docs.
+- **Meta (strongly reinforced this session):** Codex caught the highest-value defects Claude's PASS missed in
+  EVERY round (TypedBus soundness, readonly depth ×2, the residuals, the TS 7.0 GA date). See
+  `mistakes/codex/weight-codex-evaluator-on-technical-accuracy.md` and
+  `learnings/evaluation/compile-harness-is-blind-to-prose-claims.md` — the harness is blind not only to prose
+  truth but to abstraction soundness and check-acceptance soundness.
+- Process note: the executor subagent died on a Claude session usage limit mid-fix; the manager applied all
+  fixes directly, committing incrementally (the documented delegation-blocked fallback).

--- a/.gobbi/projects/gobbi/skills/typescript/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/typescript/SKILL.md
@@ -108,8 +108,9 @@ function parseCount(raw: unknown): number {
 }
 ```
 
-- **MUST handle every promise** — `await` it, `void` it deliberately, or attach a `.catch`; an
-  un-awaited promise is an invisible unhandled rejection.
+- **MUST handle every promise** — `await` it, `return` it, or attach a real rejection handler. A bare
+  `void promise` silences the no-floating-promises lint but does NOT handle the rejection — only
+  `void promise.catch(handler)` does. An unhandled rejection is invisible until it fails.
 - **MUST throw only `Error` subclasses and catch as `unknown`** — narrow with `instanceof` before use
   and chain with `cause`; a thrown non-`Error` loses the stack and the cause chain.
 - **MUST keep syntax erasable** — `erasableSyntaxOnly`: model a closed set with a discriminated union or
@@ -138,8 +139,9 @@ enum Direction { Up, Down }
 - **NEVER ship dual ESM + CJS from one `verbatimModuleSyntax` source** — the two module systems are
   incompatible under verbatim erasure. Fix: publish ESM-only; treat a required CJS build as a separate,
   non-default emit.
-- **NEVER leave a `Promise` un-awaited to "fire and forget"** — the rejection is lost. Fix: `await`,
-  `void`, or `.catch` it; for background work, own it explicitly.
+- **NEVER leave a `Promise` un-awaited to "fire and forget"** — the rejection is lost. Fix: `await`
+  or `return` it, or attach a real handler with `void promise.catch(...)` — a bare `void` is not a
+  handler. For background work, own it explicitly.
 
 ---
 
@@ -329,7 +331,7 @@ review-mode surface is reconstructed and graded.
 *Deepens coding P7 and principles P2 — build bottom-up, skeleton first.*
 
 Materialize the approved design before any behavior: create the modules, the types, and the
-fully-annotated signatures (`-> void` included) with stub bodies. Verify it imports cleanly and passes
+fully-annotated signatures (an explicit `: void` return type included) with stub bodies. Verify it imports cleanly and passes
 `tsc --noEmit` under the maximal-strict base before growing any body; a structural defect returns
 through P2–P4 rather than being hidden in a body.
 

--- a/.gobbi/projects/gobbi/skills/typescript/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/typescript/SKILL.md
@@ -6,19 +6,78 @@ allowed-tools: Read, Grep, Glob, Bash
 
 # TypeScript
 
-The concrete TypeScript-idiom layer, sitting UNDER `coding`. It specializes the language-agnostic properties of
-good software into idiomatic, maximal-strict TypeScript; it does not repeat them.
+The concrete TypeScript-idiom layer, sitting UNDER `coding`. The `coding` standard states the
+language-agnostic properties of good software; this skill says what they look like in idiomatic,
+maximal-strict TypeScript — the type-system idioms, the ESM module and tooling model, async and
+resource patterns, packaging, and the runtime deltas. It specializes those properties for TypeScript;
+it does not repeat them, and it assumes the `coding` and gobbi behavioral layers are already in context.
 
-> Skeleton — this Intro is a stub finalized in T3-skill-body. Bodies for the Principles, Rules, Procedure, and
-> References sections below are authored in T3; the child docs are grown in T4–T12.
+Load it before writing or reviewing any TypeScript. The Principles, Rules, and Procedure below carry an
+ordinary strict module from first read to review without opening anything else; a Procedure step (P2)
+routes you to a child doc only when a decision needs depth this cold-load floor does not carry.
 
 ---
 
 ## Principles
 
-> Stub — the TypeScript principle set is authored in T3-skill-body. Each principle deepens a distinct
-> `coding` / `principles` discipline via a "parent says X; TS delta is Y" clause; a principle that adds no TS
-> delta is dropped, not padded. Count follows content.
+> **1. Study the TypeScript contract and neighboring code before design.**
+
+The parent says study first; the TypeScript delta is that the concrete contract is the *compiler
+configuration in force*, not the abstract problem — the `tsconfig` strict-flag set, the target
+runtime(s) and their import-extension mode, the module system (ESM + `verbatimModuleSyntax`), the
+declared TS version floor, and the artifact type (library / app / script). The same code is valid under
+one tsconfig and a compile error under another, so those surfaces — not intuition — decide which syntax
+is legal, which import extension resolves, and which verification path applies.
+
+> **2. Design the TypeScript surface with the user, from references.**
+
+The parent says design the contract with the user from prior art; the TypeScript delta is what the
+surface is made of — the *exported types* and the public `.d.ts` a consumer resolves against. TypeScript
+is structural, so an un-narrowed return type or an accidentally-`export`ed binding becomes part of the
+contract at one keystroke, and a downstream build breaks when it changes. Show and confirm the exported
+type surface — the interfaces, the generics, the discriminated unions — before bodies make it costly to
+reshape.
+
+> **3. Model with the type system: make illegal states unrepresentable.**
+
+The parent says build deep units and design seams the machine can check; the TypeScript delta is that
+the type system is itself the modeling tool. A discriminated union, `readonly`, a branded type, and a
+`never` exhaustiveness check let the compiler *prove* an invariant at build time that a nominal language
+would guard with a runtime check. Prefer a shape in which the wrong state cannot be constructed over one
+that is validated after the fact.
+
+> **4. Ban `any`; quarantine `unknown` at the boundary.**
+
+The parent says validate untrusted input and guard the trust boundary; the TypeScript delta is that
+`any` is not a type but the *absence* of checking — it silently disables the compiler for every value it
+touches and spreads through assignment. Use `unknown` for a value whose type is not yet known and narrow
+it with a guard or a schema parser before use. An annotation states a value's *shape* but never
+*validates* it, so parsing untrusted data stays a separate runtime act the type does not perform.
+
+> **5. Make async and resource lifetime explicit; never float a promise.**
+
+The parent says push side effects to the edges and make them visible; the TypeScript delta is that a
+`Promise` is a value the type system will happily let you discard — a call left un-awaited is an
+unhandled rejection that surfaces far from its cause, with no signature warning. Await every promise or
+handle it deliberately, carry cancellation on an `AbortSignal`, and bind a resource's release to its
+scope with `using` / `await using` so disposal runs on every path, including the throwing one.
+
+> **6. Choose the failure shape: throw for the exceptional, return a typed result for the expected.**
+
+The parent says surface failure where a caller can act on it; the TypeScript delta is that `throw` is
+untyped — a caught error is `unknown` and the signature never says what may be thrown. So the shape is a
+design act: throw only `Error` subclasses (carrying `cause`) for the genuinely exceptional and catch as
+`unknown`, narrowing before use; but model an *expected* failure — a validation miss, a not-found — as a
+typed result in the return type, where the compiler forces the caller to handle it.
+
+> **7. Type-erase cleanly: keep the runtime honest and the build strict.**
+
+The parent says the machine checks the design and the skeleton type-checks before it grows; the
+TypeScript delta is that types vanish at runtime — the emitted or type-stripped JavaScript carries none
+of them, so the strict `tsc` pass is the *only* place a type is ever checked. Keep syntax erasable
+(`erasableSyntaxOnly`: unions over `enum`, no `namespace` or parameter-properties), keep imports
+verbatim (`verbatimModuleSyntax` + `import type`), and treat a green maximal-strict `tsc --noEmit` as the
+proof, because nothing downstream re-checks it.
 
 ---
 
@@ -26,38 +85,331 @@ good software into idiomatic, maximal-strict TypeScript; it does not repeat them
 
 ### Must-Follow
 
-> Stub — the Must-Follow floor is authored in T3-skill-body.
+- **MUST compile under a maximal-strict `tsconfig`** — `strict` plus `noUncheckedIndexedAccess`,
+  `exactOptionalPropertyTypes`, `noPropertyAccessFromIndexSignature`, `noImplicitOverride`,
+  `noImplicitReturns`, and `noFallthroughCasesInSwitch`; an unchecked index, an exact-optional
+  violation, or a missing return then fails the build, not a reader.
+- **MUST use ESM with `verbatimModuleSyntax`** — a type-only import written `import type`, a value
+  import left plain; erasure is then deterministic and the emitted JavaScript matches the source.
+- **MUST pick the import extension by consumption mode** — a `tsc`-emitted library uses the `.js`
+  extension on relative imports (`import { util } from "./util.js"`); a directly type-stripped source
+  (Node 24+, Bun, Deno) uses `.ts` with `rewriteRelativeImportExtensions`. Never mix the two in one
+  source tree.
+- **MUST validate untrusted boundary data before use** — JSON, network, `env`, and file input arrive as
+  `unknown`; narrow with a guard or a schema parser into a domain type before any maintained logic
+  reads it. This example type-checks under the skill's own baseline:
+
+```ts
+function parseCount(raw: unknown): number {
+  if (typeof raw === "number" && Number.isFinite(raw)) {
+    return raw;
+  }
+  throw new Error("expected a finite number");
+}
+```
+
+- **MUST handle every promise** — `await` it, `void` it deliberately, or attach a `.catch`; an
+  un-awaited promise is an invisible unhandled rejection.
+- **MUST throw only `Error` subclasses and catch as `unknown`** — narrow with `instanceof` before use
+  and chain with `cause`; a thrown non-`Error` loses the stack and the cause chain.
+- **MUST keep syntax erasable** — `erasableSyntaxOnly`: model a closed set with a discriminated union or
+  an `as const` object, never an `enum`, a `namespace`, or a constructor parameter-property.
+- **MUST make every taught `ts` example type-check** — each fenced `ts` block in this skill and its
+  children compiles under the examples baseline (the harness proves it); an example is a taught fact,
+  not decoration.
 
 ### Must-Not-Follow
 
-> Stub — the Must-Not-Follow anti-patterns are authored in T3-skill-body.
+- **NEVER use `any`** — it disables the checker and spreads by assignment. Fix: `unknown` at the
+  boundary, narrowed by a guard or parser; a locally-documented `as` only for a static fact the checker
+  cannot see.
+- **NEVER assert with `as` to silence an error** — an assertion the value does not satisfy is a lie the
+  compiler stops catching. Fix: annotate (`: T`) so the value is checked, or `satisfies T` to validate
+  while keeping the narrow inferred type; reserve `as` for a fact verified by a prior runtime narrow.
+- **NEVER rely on an `enum` for a closed set** — it is non-erasable and its numeric form is unsound.
+  Fix: a discriminated union or an `as const` object with a derived type. `erasableSyntaxOnly` rejects
+  the `enum` outright:
+
+```ts expect-error
+// @ts-expect-error enum is not erasable syntax; erasableSyntaxOnly rejects it
+enum Direction { Up, Down }
+```
+
+- **NEVER ship dual ESM + CJS from one `verbatimModuleSyntax` source** — the two module systems are
+  incompatible under verbatim erasure. Fix: publish ESM-only; treat a required CJS build as a separate,
+  non-default emit.
+- **NEVER leave a `Promise` un-awaited to "fire and forget"** — the rejection is lost. Fix: `await`,
+  `void`, or `.catch` it; for background work, own it explicitly.
 
 ---
 
 ## Procedure
 
-> Stub — the P1–P8 procedure spine (plus the P2 router table and the TS decision tables) is authored in
-> T3-skill-body. It operationalizes `coding` and `principles`; it does not restate them.
+**MUST load `coding/SKILL.md` and `principles/SKILL.md` first** and keep them in context — this
+Procedure **operationalizes** their disciplines for TypeScript; it does not restate them.
 
-### Child docs
+Run P1–P8 in **author mode**; in **review mode**, run P1–P4 read-only to reconstruct and grade the
+existing design, skip P5–P6, and grade read-only at P7–P8, editing nothing unless the user authorizes a
+fix. **P2 is the router** for specialized depth; these steps plus the parent Rules are the floor for an
+ordinary strict module.
 
-The Procedure routes a reader to a child doc only when a decision needs depth this cold-load floor does not
-carry. The map (grown in T4–T12):
+### P1 — Study and lock the task and the TypeScript contract
 
-- [`design.md`](design.md) — TS unit/API design: function vs `const`-object vs class, model-with-unions, signatures, earned generics, module tree, ownership and failure shape.
-- [`convention.md`](convention.md) — casing matrix, file naming, import ordering, `import type`, TSDoc, formatter stance.
-- [`typing.md`](typing.md) — the type system: discriminated unions and `never` exhaustiveness, generics, guards, `satisfies`/`as`, branded types, utility types, `.d.ts` authoring.
-- [`modules-tooling.md`](modules-tooling.md) — ESM and `verbatimModuleSyntax`, `moduleResolution`, the import-extension fork, the strict base + overlays, typed lint, build.
-- [`async-resources.md`](async-resources.md) — promise idioms, no floating promises, `AbortSignal`, combinators, async iterators, `using`/`await using` disposal.
-- [`packaging-publishing.md`](packaging-publishing.md) — ESM-only `exports`, declaration emit, `publint` + `arethetypeswrong`, API evolution; CJS as an out-of-default exception.
-- [`runtime-deltas.md`](runtime-deltas.md) — the one doc isolating the Node / Bun / Deno / browser deltas.
-- [`testing.md`](testing.md) — runtime-agnostic behavior tests plus type-level testing and verification seams.
-- The eval triad — [`evaluation.md`](evaluation.md) + [`scenarios.md`](scenarios.md) + [`checklists.md`](checklists.md) — is one required SET: the TS-idiom review frame beside `coding`'s property-level frame.
+*Deepens principles P1 / P4 and coding P1 — study first, refine the task.*
+
+Lock What / Why / How + in/out scope + success with the user, or cite a Scope Contract. Read the
+relevant specs, design notes, README, public-API docs, project rules, applicable mistakes, neighboring
+modules, callers, tests, and local prior art. Then read the concrete **TypeScript contract**: the
+`tsconfig` strict-flag set; the target runtime(s) and the import-extension mode each requires; the module
+system (ESM + `verbatimModuleSyntax`); the declared TS version floor; the artifact type (library / app /
+script) and its `.d.ts` consumers. A new project with no declared config defaults to the maximal-strict
+base (Rules) and an ESM-only, TS 5.9-floor model. Record the boundary conditions — trusted vs untrusted
+inputs, sync vs async callers, resource and task lifetimes, the exported public names — and flag every
+boundary that needs runtime validation. **Declare author vs review mode.** For an **edit**, map the
+affected set (callers, tests, docs, the emitted `.d.ts`, config) with CRUD + 5W1H. For a **bug**,
+reproduce, then trace to the root before repair.
+
+**P1 is complete when** scope and success are explicit (or a Scope Contract cited), the TypeScript
+contract is known, patterns and prior art are read, the mode is declared, and the affected set or
+reproduced root is recorded.
+
+### P2 — Load the child docs for the forks in play
+
+*Deepens coding P1 — study the prior art the decision needs.*
+
+Read each child **before** the decision it governs; re-run routing when the design changes. An ordinary
+strict module needs no specialist child to be valid, but any TypeScript change uses the scenario and
+checklist material at P8 before handoff (an evaluator enters through `evaluation.md`).
+
+| Read | When the change involves |
+|---|---|
+| `typing.md` | a public boundary, a generic, a guard, a discriminated union, `satisfies` / `as`, a branded type, or `.d.ts` authoring |
+| `modules-tooling.md` | the tsconfig flag set and overlays, `moduleResolution`, the import-extension fork, the typed lint, or the build |
+| `async-resources.md` | promises, cancellation (`AbortSignal`), combinators, async iteration, or `using` / `await using` disposal |
+| `packaging-publishing.md` | an ESM-only `exports` map, declaration emit, `publint` / `arethetypeswrong`, or public-API evolution |
+| `runtime-deltas.md` | code that touches a Node / Bun / Deno / browser boundary — resolution, built-ins, `lib`, or type-stripping |
+| `design.md` | a unit or API shape choice — function vs `const`-object vs class, composition, or the input surface |
+| `convention.md` | casing, file naming, import ordering, `import type`, TSDoc, or the formatter stance |
+| `testing.md` | behavior changes, or type-level tests are written or reviewed |
+| `scenarios.md` / `checklists.md` | self-review before handoff (P8), or the good/bad/adversarial probes and binary `TS-CHECK-*` items an evaluator activates |
+| `evaluation.md` | grading the TypeScript idiom of a change-set — it routes the evaluator to the scenarios, checks, and verifications (see P8) |
+
+The parent Rules stay the floor after a child loads. **P2 is complete when** every active fork is loaded
+before its decision, and the pre-handoff or evaluation path includes the triad routing above.
+
+### P3 — Design the units and the type surface, decomposed
+
+*Deepens coding P2 / P3 / P4 and principles P3 — design the contract, deep units, decompose by responsibility.*
+
+Design the surface as ordered design acts, not one flat construct-pick, before any body; `design.md` and
+`typing.md` deepen each act.
+
+1. **Frame the module and the ESM boundary.** Fix its one responsibility, the acyclic import direction,
+   the exported names, and the import-extension mode the target runtime dictates.
+2. **Pick the unit shape.** A typed function over plain data is often the whole unit; reach for a class
+   only when identity, invariants across calls, or several behaviors over owned state must travel
+   together. Prefer composition over inheritance.
+3. **Model with the types.** Encode the domain so illegal states cannot be built — a discriminated union
+   with a `never` exhaustiveness check makes an unhandled variant a compile error:
+
+```ts
+type Shape =
+  | { kind: "circle"; radius: number }
+  | { kind: "square"; side: number };
+
+function assertNever(x: never): never {
+  throw new Error(`unhandled variant: ${JSON.stringify(x)}`);
+}
+
+function area(shape: Shape): number {
+  switch (shape.kind) {
+    case "circle":
+      return Math.PI * shape.radius ** 2;
+    case "square":
+      return shape.side ** 2;
+    default:
+      return assertNever(shape);
+  }
+}
+```
+
+4. **Sketch the contracts.** For every public and cross-unit interface record its name, inputs, output,
+   annotations, the error and lifetime shapes, and the exported `.d.ts` surface; keep one credible
+   alternative for the P4 gate. Apply the decision tables below.
+5. **Choose the failure shape.** Model an expected failure as a typed result in the return type; reserve
+   `throw` for the exceptional and catch as `unknown`:
+
+```ts
+type Result<T, E> =
+  | { ok: true; value: T }
+  | { ok: false; error: E };
+
+function parsePort(raw: string): Result<number, string> {
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1 || n > 65535) {
+    return { ok: false, error: `invalid port: ${raw}` };
+  }
+  return { ok: true, value: n };
+}
+```
+
+6. **Make lifetime explicit.** Name each resource's owner and bind its release to scope with `using` /
+   `await using`, so disposal runs on the throwing path too:
+
+```ts
+class Handle implements Disposable {
+  [Symbol.dispose](): void {
+    // release the resource here
+  }
+}
+
+function work(): void {
+  using h = new Handle();
+  void h; // disposed at end of scope, on every path
+}
+```
+
+**Decision tables** (the concrete idiom for the design acts above):
+
+*`interface` vs `type`:*
+
+| Use | For |
+|---|---|
+| `interface` | an object shape that may be `extend`ed / `implements`-ed, or a public API surface (clearer errors, declaration merging) |
+| `type` | a union, tuple, mapped, conditional, or function type, and any alias of a non-object type |
+
+*When a generic is earned:*
+
+| Add a type parameter | Keep it concrete |
+|---|---|
+| the same relationship holds across many types AND the parameter links an input to the output (or two inputs) | a single call site, or a parameter used once — a concrete type or a small union reads clearer |
+
+*Discriminated union vs `enum`:* always the discriminated union (above) — `enum` is non-erasable and its
+numeric form is unsound.
+
+*`satisfies` vs annotation vs `as`:*
+
+| Construct | Effect |
+|---|---|
+| `: T` (annotation) | checks the value AND widens it to `T` |
+| `satisfies T` | checks the value, keeps its narrow inferred type |
+| `as T` | asserts without checking — only for a fact the compiler cannot see, after a runtime narrow |
+
+```ts
+const config = {
+  host: "localhost",
+  port: 8080,
+} satisfies Record<string, string | number>;
+
+// An annotation `: Record<string, string | number>` would widen `port` to
+// `string | number`. `satisfies` validated the shape yet kept `port` narrow:
+const port: number = config.port;
+const host: string = config.host;
+```
+
+**P3 is complete when** each unit has an earned shape and one responsibility; the module boundary,
+import direction, and exported types are fixed; every contract, alternative, data / failure shape, and
+lifetime is concrete; and no behavior body exists.
+
+### P4 — Confirm the design, type surface, and names with the user
+
+*Deepens principles P3 — design with the user before building.*
+
+Run the design-with-user gate on the TypeScript **design packet** — the module tree, the exported types
+and generics, the interface/union choices, the signatures and annotations, the failure and lifetime
+models, the verification seams, and the P3 alternative. Record approval, or cite an already-explicit
+decision. **Author mode only:** in review mode, reconstruct and grade the existing packet without
+editing.
+
+**P4 is complete when** the author-mode surface is approved (or a prior decision cited), or the
+review-mode surface is reconstructed and graded.
+
+### P5 — Build the typed skeleton first
+
+*Deepens coding P7 and principles P2 — build bottom-up, skeleton first.*
+
+Materialize the approved design before any behavior: create the modules, the types, and the
+fully-annotated signatures (`-> void` included) with stub bodies. Verify it imports cleanly and passes
+`tsc --noEmit` under the maximal-strict base before growing any body; a structural defect returns
+through P2–P4 rather than being hidden in a body.
+
+**P5 is complete when** the skeleton matches the approved packet, imports cleanly, and type-checks green
+with no behavior implemented.
+
+### P6 — Grow in minimal verified slices
+
+*Deepens coding P7 / P8 / P15 — grow verified, build only what's needed, move the whole affected set.*
+
+Grow the bodies bottom-up, one verified slice at a time: implement the smallest dependency-setting slice
+first, verify that slice (format → lint → `tsc --noEmit` → focused test) before the next, and firm up
+each signature as you learn. Apply the § Rules floor and the active child guidance as you write, and
+follow the surrounding code where it does not contradict a Rule. Update every affected caller, test,
+doc, and emitted `.d.ts` in the **same slice**; add nothing beyond the contract and finish every
+in-scope path with no placeholder.
+
+**P6 is complete when** every in-scope path is implemented with no placeholder, each slice had fresh
+focused evidence before the next, and every affected surface moved in lockstep.
+
+### P7 — Verify the whole change
+
+*Deepens coding P6 and principles P8 — design for verification, prove the root cause is gone.*
+
+Prove the whole change after the per-slice checks, in this fixed order, fixing a failure before the
+next: **format** (deterministic formatter, check mode) → **lint** (`typescript-eslint` typed rules —
+under a TS 7.0 install this runs against the side-by-side TS 6.x-compat API, not the 7.0 binary) →
+**type-check** (`tsc --noEmit`, maximal-strict) → **focused tests** → **full tests** → **type-level
+tests** (`expectTypeOf` / `tsd` / `@ts-expect-error`) → **build** (declaration emit + `publint` +
+`arethetypeswrong`, when publishing a package). Each gate is self-failing (`cmd || exit 1`). For a bug,
+re-run the original P1 reproducer.
+
+**P7 passes only when** every applicable check exits clean on fresh output, the reproducer no longer
+fires, and — when publishing — the built package, not only the checkout, satisfies its `.d.ts` and
+`exports` claims.
+
+### P8 — Review: trace to the approved design and affected set
+
+*Deepens principles P9 and coding P15 — CRUD + 5W1H, change with blast-radius awareness.*
+
+Review on two independent axes, then trace. Grade the language-agnostic **property** with
+`../coding/evaluation.md` and the TypeScript **idiom** with `evaluation.md`. For a pre-handoff check,
+read `scenarios.md` for the task-relevant good/bad/adversarial probes, then answer the activated binary
+`TS-CHECK-*` items from `checklists.md` — a failed item returns to its owning step. An evaluator enters
+through `evaluation.md`, which loads `scenarios.md` + `checklists.md`. Then run **traceability**: every
+approved design item (P4) maps to an implemented unit, type, name, error shape, and test seam; every
+scope item maps to a diff line and nothing exceeds it; every affected-set file (P1) is updated or a
+justified no-op; every success criterion has fresh evidence; and no caller, test, doc, or `.d.ts` is
+stale.
+
+**P8 is complete when** both reviews pass, all activated binary checks pass, the code traces to the
+approved design, names, scope, and affected set with no stale dependent, and every success criterion has
+fresh evidence.
 
 ---
 
 ## References
 
-> Stub — the section-level ownership register (one owner per borrowed claim) is authored in T3-skill-body.
-> It uses only sibling-skill (`../{skill}/SKILL.md`) and same-directory links, and names repo-root scripts as
-> Procedure code-spans, per the mirror-stable-link discipline.
+One owner per borrowed fact; the body states the fact and this register names its owner.
+
+- [`coding/SKILL.md`](../coding/SKILL.md#scope--language-agnostic) — owns the language-agnostic
+  properties of good software (design, construction, craftsmanship) that this skill specializes into
+  concrete TypeScript idioms.
+- [`principles/SKILL.md`](../principles/SKILL.md) — owns the ten gobbi behavioral principles that this
+  skill's Procedure operationalizes for TypeScript.
+- [TypeScript 5.9 release notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-9.html)
+  and the [TypeScript handbook](https://www.typescriptlang.org/docs/handbook/intro.html) — the language
+  and compiler facts this skill teaches: the version floor, `satisfies`, `using` / `Symbol.dispose`,
+  `verbatimModuleSyntax`, `erasableSyntaxOnly`, and `rewriteRelativeImportExtensions`.
+- [`@tsconfig/strictest`](https://github.com/tsconfig/bases/blob/main/bases/strictest.json) — the
+  strict-flag preset the maximal-strict base builds on.
+- [Choosing compiler options](https://www.typescriptlang.org/docs/handbook/modules/guides/choosing-compiler-options.html)
+  — the `nodenext`-for-libraries module model, the ESM-only publishing stance, and the browser paths.
+- [typescript-eslint](https://typescript-eslint.io/users/configs/) — the typed-lint layer (`no-floating-promises`,
+  `no-unsafe-*`, `no-misused-promises`) that `tsc` alone does not catch.
+- [Node.js: running TypeScript](https://nodejs.org/api/typescript.html) — runtime type-stripping and the
+  `.ts`-specifier resolution behind the import-extension fork.
+- [`arethetypeswrong`](https://arethetypeswrong.github.io/) and [`publint`](https://publint.dev/) — the
+  machine gates that validate a published package's `.d.ts` resolution and `exports` shape.
+- [Testing types (Vitest)](https://vitest.dev/guide/testing-types) and [`tsd`](https://github.com/tsdjs/tsd)
+  — the type-level testing surface (`expectTypeOf` / `@ts-expect-error`).
+- [Google TypeScript Style Guide](https://google.github.io/styleguide/tsguide.html) — the ban-`any`,
+  annotation-over-`as`, `interface`-for-object-shapes, and naming defaults.

--- a/.gobbi/projects/gobbi/skills/typescript/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/typescript/SKILL.md
@@ -83,12 +83,17 @@ proof, because nothing downstream re-checks it.
 
 ## Rules
 
+These Rules are the greenfield house default. When reviewing or maintaining EXISTING code, apply them to
+new and changed code — they are not a mandate to migrate an existing codebase's module system or syntax.
+
 ### Must-Follow
 
 - **MUST compile under a maximal-strict `tsconfig`** — `strict` plus `noUncheckedIndexedAccess`,
   `exactOptionalPropertyTypes`, `noPropertyAccessFromIndexSignature`, `noImplicitOverride`,
   `noImplicitReturns`, and `noFallthroughCasesInSwitch`; an unchecked index, an exact-optional
-  violation, or a missing return then fails the build, not a reader.
+  violation, or a missing return then fails the build, not a reader. This Rule names the type-safety
+  flags; the full base (resolution, target, `lib`, isolated-module and erasable flags) lives in
+  [`modules-tooling.md` §1](modules-tooling.md) — read it when authoring a `tsconfig`.
 - **MUST use ESM with `verbatimModuleSyntax`** — a type-only import written `import type`, a value
   import left plain; erasure is then deterministic and the emitted JavaScript matches the source.
 - **MUST pick the import extension by consumption mode** — a `tsc`-emitted library uses the `.js`
@@ -358,7 +363,7 @@ focused evidence before the next, and every affected surface moved in lockstep.
 
 Prove the whole change after the per-slice checks, in this fixed order, fixing a failure before the
 next: **format** (deterministic formatter, check mode) → **lint** (`typescript-eslint` typed rules —
-under a TS 7.0 install this runs against the side-by-side TS 6.x-compat API, not the 7.0 binary) →
+under a TS 7.0 install this runs against a JS-based TS compatibility API — not the native 7.0 binary — whose exact package is pending 7.0 GA) →
 **type-check** (`tsc --noEmit`, maximal-strict) → **focused tests** → **full tests** → **type-level
 tests** (`expectTypeOf` / `tsd` / `@ts-expect-error`) → **build** (declaration emit + `publint` +
 `arethetypeswrong`, when publishing a package). Each gate is self-failing (`cmd || exit 1`). For a bug,

--- a/.gobbi/projects/gobbi/skills/typescript/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/typescript/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: typescript
+description: "MUST load before writing or reviewing TypeScript code. The concrete TypeScript-idiom layer beneath the language-agnostic coding standard — typing, modules & tooling, async & resources, packaging, runtime deltas, conventions, design, testing."
+allowed-tools: Read, Grep, Glob, Bash
+---
+
+# TypeScript
+
+The concrete TypeScript-idiom layer, sitting UNDER `coding`. It specializes the language-agnostic properties of
+good software into idiomatic, maximal-strict TypeScript; it does not repeat them.
+
+> Skeleton — this Intro is a stub finalized in T3-skill-body. Bodies for the Principles, Rules, Procedure, and
+> References sections below are authored in T3; the child docs are grown in T4–T12.
+
+---
+
+## Principles
+
+> Stub — the TypeScript principle set is authored in T3-skill-body. Each principle deepens a distinct
+> `coding` / `principles` discipline via a "parent says X; TS delta is Y" clause; a principle that adds no TS
+> delta is dropped, not padded. Count follows content.
+
+---
+
+## Rules
+
+### Must-Follow
+
+> Stub — the Must-Follow floor is authored in T3-skill-body.
+
+### Must-Not-Follow
+
+> Stub — the Must-Not-Follow anti-patterns are authored in T3-skill-body.
+
+---
+
+## Procedure
+
+> Stub — the P1–P8 procedure spine (plus the P2 router table and the TS decision tables) is authored in
+> T3-skill-body. It operationalizes `coding` and `principles`; it does not restate them.
+
+### Child docs
+
+The Procedure routes a reader to a child doc only when a decision needs depth this cold-load floor does not
+carry. The map (grown in T4–T12):
+
+- [`design.md`](design.md) — TS unit/API design: function vs `const`-object vs class, model-with-unions, signatures, earned generics, module tree, ownership and failure shape.
+- [`convention.md`](convention.md) — casing matrix, file naming, import ordering, `import type`, TSDoc, formatter stance.
+- [`typing.md`](typing.md) — the type system: discriminated unions and `never` exhaustiveness, generics, guards, `satisfies`/`as`, branded types, utility types, `.d.ts` authoring.
+- [`modules-tooling.md`](modules-tooling.md) — ESM and `verbatimModuleSyntax`, `moduleResolution`, the import-extension fork, the strict base + overlays, typed lint, build.
+- [`async-resources.md`](async-resources.md) — promise idioms, no floating promises, `AbortSignal`, combinators, async iterators, `using`/`await using` disposal.
+- [`packaging-publishing.md`](packaging-publishing.md) — ESM-only `exports`, declaration emit, `publint` + `arethetypeswrong`, API evolution; CJS as an out-of-default exception.
+- [`runtime-deltas.md`](runtime-deltas.md) — the one doc isolating the Node / Bun / Deno / browser deltas.
+- [`testing.md`](testing.md) — runtime-agnostic behavior tests plus type-level testing and verification seams.
+- The eval triad — [`evaluation.md`](evaluation.md) + [`scenarios.md`](scenarios.md) + [`checklists.md`](checklists.md) — is one required SET: the TS-idiom review frame beside `coding`'s property-level frame.
+
+---
+
+## References
+
+> Stub — the section-level ownership register (one owner per borrowed claim) is authored in T3-skill-body.
+> It uses only sibling-skill (`../{skill}/SKILL.md`) and same-directory links, and names repo-root scripts as
+> Procedure code-spans, per the mirror-stable-link discipline.

--- a/.gobbi/projects/gobbi/skills/typescript/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/typescript/SKILL.md
@@ -363,7 +363,7 @@ focused evidence before the next, and every affected surface moved in lockstep.
 
 Prove the whole change after the per-slice checks, in this fixed order, fixing a failure before the
 next: **format** (deterministic formatter, check mode) → **lint** (`typescript-eslint` typed rules —
-under a TS 7.0 install (GA 2026-07-08) this runs against the `@typescript/typescript6` compatibility package — a `tsc6` binary that re-exports the TS 6.0 API — not the native 7.0 binary, which ships no stable programmatic API until 7.1) →
+under a TS 7.0 install (GA 2026-07-08) this runs against the `@typescript/typescript6` compatibility package — which ships a `tsc6` binary and re-exports the TS 6.0 API the tooling consumes — not the native 7.0 binary, which has no stable programmatic API until 7.1) →
 **type-check** (`tsc --noEmit`, maximal-strict) → **focused tests** → **full tests** → **type-level
 tests** (`expectTypeOf` / `tsd` / `@ts-expect-error`) → **build** (declaration emit + `publint` +
 `arethetypeswrong`, when publishing a package). Each gate is self-failing (`cmd || exit 1`). For a bug,

--- a/.gobbi/projects/gobbi/skills/typescript/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/typescript/SKILL.md
@@ -97,9 +97,9 @@ new and changed code — they are not a mandate to migrate an existing codebase'
 - **MUST use ESM with `verbatimModuleSyntax`** — a type-only import written `import type`, a value
   import left plain; erasure is then deterministic and the emitted JavaScript matches the source.
 - **MUST pick the import extension by consumption mode** — a `tsc`-emitted library uses the `.js`
-  extension on relative imports (`import { util } from "./util.js"`); a directly type-stripped source
-  (Node 24+, Bun, Deno) uses `.ts` with `rewriteRelativeImportExtensions`. Never mix the two in one
-  source tree.
+  extension on relative imports (`import { util } from "./util.js"`); a source run directly
+  (Node 24+ strips types, Bun/Deno transpile) uses `.ts` with `rewriteRelativeImportExtensions`. Never mix
+  the two in one source tree.
 - **MUST validate untrusted boundary data before use** — JSON, network, `env`, and file input arrive as
   `unknown`; narrow with a guard or a schema parser into a domain type before any maintained logic
   reads it. This example type-checks under the skill's own baseline:
@@ -363,7 +363,7 @@ focused evidence before the next, and every affected surface moved in lockstep.
 
 Prove the whole change after the per-slice checks, in this fixed order, fixing a failure before the
 next: **format** (deterministic formatter, check mode) → **lint** (`typescript-eslint` typed rules —
-under a TS 7.0 install this runs against a JS-based TS compatibility API — not the native 7.0 binary — whose exact package is pending 7.0 GA) →
+under a TS 7.0 install (GA 2026-07-08) this runs against the `@typescript/typescript6` compatibility package — a `tsc6` binary that re-exports the TS 6.0 API — not the native 7.0 binary, which ships no stable programmatic API until 7.1) →
 **type-check** (`tsc --noEmit`, maximal-strict) → **focused tests** → **full tests** → **type-level
 tests** (`expectTypeOf` / `tsd` / `@ts-expect-error`) → **build** (declaration emit + `publint` +
 `arethetypeswrong`, when publishing a package). Each gate is self-failing (`cmd || exit 1`). For a bug,

--- a/.gobbi/projects/gobbi/skills/typescript/async-resources.md
+++ b/.gobbi/projects/gobbi/skills/typescript/async-resources.md
@@ -369,7 +369,13 @@ class TypedBus extends EventTarget {
   on<K extends keyof BusEvents>(type: K, listener: (ev: BusEvents[K]) => void): void {
     super.addEventListener(type, listener as EventListener); // the one cast, behind the typed gate
   }
-  emit<K extends keyof BusEvents>(_type: K, ev: BusEvents[K]): void {
+  emit<K extends keyof BusEvents>(type: K, ev: BusEvents[K]): void {
+    // `dispatchEvent` routes by `ev.type`, NOT by the key `type` — the types cannot prove
+    // they agree, so bind them with a runtime check or `emit("data", …)` could dispatch a
+    // "wrong"-typed event that never reaches the "data" listener.
+    if (ev.type !== type) {
+      throw new Error(`event "${ev.type}" does not match key "${type}"`);
+    }
     super.dispatchEvent(ev);
   }
 }

--- a/.gobbi/projects/gobbi/skills/typescript/async-resources.md
+++ b/.gobbi/projects/gobbi/skills/typescript/async-resources.md
@@ -36,8 +36,9 @@ compiler does not check.
 ## 1. Promise idioms and no floating promises
 
 A `Promise` is an ordinary value, so the compiler lets you discard one — and a discarded rejection
-surfaces later as an unhandled rejection, far from its cause. SKILL.md Rules state the fix (`await`,
-`void`, or `.catch`); the mechanic is that each is a *deliberate* handling and a bare call is not:
+surfaces later as an unhandled rejection, far from its cause. SKILL.md Rules state the fix — `await`,
+`return`, or a real `void promise.catch(...)`; a bare `void promise` is NOT a handler. The mechanic is
+that each real form is a *deliberate* handling and a bare call is not:
 
 ```ts
 declare function save(id: string): Promise<void>;
@@ -143,12 +144,21 @@ rejecting timer (typed `Promise<never>`, since it only ever rejects):
 
 ```ts
 async function withTimeout<T>(work: Promise<T>, ms: number): Promise<T> {
-  const timer = new Promise<never>((_, reject) => {
-    setTimeout(() => reject(new Error("timed out")), ms);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error("timed out")), ms);
   });
-  return Promise.race([work, timer]); // Promise<T | never> is Promise<T>
+  try {
+    return await Promise.race([work, timeout]); // Promise<T | never> is Promise<T>
+  } finally {
+    clearTimeout(timer); // release the timer on every path — `race` never clears it
+  }
 }
 ```
+
+`Promise.race` does not *cancel* the losing input: after a timeout, `work` keeps running unless it is
+threaded an `AbortSignal` (§2). The `finally` above only clears the timer — race bounds the *wait*, not
+the *work*.
 
 `Promise.any` fulfills on the first input to *fulfill* — a rejection is ignored unless every input
 rejects, at which point it throws an `AggregateError` carrying them all. It is the "first success" idiom
@@ -185,8 +195,8 @@ async function sum(): Promise<number> {
 ```
 
 Type the *consumer* against `AsyncIterable<T>`, not a concrete generator, so any async source — a
-stream, a paginated API — satisfies it. `noUncheckedIndexedAccess` and `noImplicitReturns` force the
-empty-source path to be explicit:
+stream, a paginated API — satisfies it. `noImplicitReturns`, with the declared `Promise<T | undefined>`
+return type, forces the empty-source path to be explicit:
 
 ```ts
 async function firstOf<T>(source: AsyncIterable<T>): Promise<T | undefined> {
@@ -356,8 +366,9 @@ async function openAsync(): Promise<void> {
 
 The web-standard `EventTarget` is portable across Node, Deno, Bun, and the browser, so prefer it over
 Node's `EventEmitter` (which needs `@types/node` and is runtime-bound). Its base `addEventListener` is
-untyped (`type: string`, listener over a plain `Event`). Wrap it once with a typed `on` / `emit` keyed
-by an event map, so each event name resolves to its payload type:
+untyped (`type: string`, listener over a plain `Event`). Wrap it once — HOLD an `EventTarget` privately
+(compose it; do NOT `extends` it) and expose a typed `on` / `emit` keyed by an event map, so each event
+name resolves to its payload type:
 
 ```ts
 type BusEvents = {
@@ -365,18 +376,23 @@ type BusEvents = {
   done: Event;
 };
 
-class TypedBus extends EventTarget {
+// COMPOSE an EventTarget as a private field — do NOT `extends` it. Extending leaves the
+// inherited public `dispatchEvent(Event)` callable, an untyped escape that bypasses `emit`:
+// `bus.dispatchEvent(new CustomEvent<string>("data", { detail: "wrong" }))` would compile and
+// reach a `number`-typed listener. Held privately, the typed `on` / `emit` are the only way in.
+class TypedBus {
+  readonly #target = new EventTarget();
+
   on<K extends keyof BusEvents>(type: K, listener: (ev: BusEvents[K]) => void): void {
-    super.addEventListener(type, listener as EventListener); // the one cast, behind the typed gate
+    this.#target.addEventListener(type, listener as EventListener); // the one cast, behind the typed gate
   }
   emit<K extends keyof BusEvents>(type: K, ev: BusEvents[K]): void {
     // `dispatchEvent` routes by `ev.type`, NOT by the key `type` — the types cannot prove
-    // they agree, so bind them with a runtime check or `emit("data", …)` could dispatch a
-    // "wrong"-typed event that never reaches the "data" listener.
+    // they agree, so bind them with a runtime check before dispatching.
     if (ev.type !== type) {
       throw new Error(`event "${ev.type}" does not match key "${type}"`);
     }
-    super.dispatchEvent(ev);
+    this.#target.dispatchEvent(ev);
   }
 }
 
@@ -390,8 +406,9 @@ function useBus(): void {
 ```
 
 The single `as EventListener` is legitimate — it sits behind the typed wrapper (like the branded-type
-gate in `typing.md` §5), so callers never assert. The payoff is that the map catches a wrong payload at
-compile time — a `done` event has no `detail`:
+gate in `typing.md` §5), so callers never assert. Because the `EventTarget` is held privately, there is
+no inherited public `dispatchEvent` to slip past the map. The payoff is that the map catches a wrong
+payload at compile time — a `done` event has no `detail`:
 
 ```ts expect-error
 type BusEvents = {
@@ -399,9 +416,10 @@ type BusEvents = {
   done: Event;
 };
 
-class TypedBus extends EventTarget {
+class TypedBus {
+  readonly #target = new EventTarget();
   on<K extends keyof BusEvents>(type: K, listener: (ev: BusEvents[K]) => void): void {
-    super.addEventListener(type, listener as EventListener);
+    this.#target.addEventListener(type, listener as EventListener);
   }
 }
 

--- a/.gobbi/projects/gobbi/skills/typescript/async-resources.md
+++ b/.gobbi/projects/gobbi/skills/typescript/async-resources.md
@@ -1,37 +1,408 @@
 # TypeScript — Async and Resources
 
 **Ownership** — promise idioms and the no-floating-promises rule; `AbortSignal` / `AbortController`
-cancellation; `Promise.all` / `allSettled` / `race` / `any`; async iterators and `for await`; error
-propagation across `await`; and deterministic disposal via `using` / `await using`, `Symbol.dispose` /
-`asyncDispose`, and `DisposableStack`.
+cancellation; the four combinators (`all` / `allSettled` / `race` / `any`) and when each fits; async
+iterators and `for await`; error propagation across `await`; deterministic disposal via `using` /
+`await using`, `Symbol.dispose` / `Symbol.asyncDispose`, and `DisposableStack` / `AsyncDisposableStack`;
+and typed events on `EventTarget`.
 
-**Split criterion** — skill-writing P3 (d): a self-contained sub-procedure for async and resource-lifetime
-work, opened when a unit touches promises, cancellation, or disposal.
+**Split criterion** — skill-writing P3 (d): a self-contained sub-procedure for async and
+resource-lifetime work, opened when a unit touches promises, cancellation, or disposal.
 
-> Skeleton — sections below are stubs; the body is grown in T9-async-resources.
+This doc **deepens, and does not restate,** the SKILL.md async rules and Principle 5 (*make async and
+resource lifetime explicit; never float a promise*). SKILL.md owns the Rules — handle every promise,
+throw only `Error` subclasses and catch as `unknown`; this doc owns the *mechanics*: the exact idiom for
+each, and the footguns `tsc` alone does not catch. SKILL.md P6 owns the throw-vs-return-typed-result
+decision; §5 here owns only what changes when a failure crosses an `await`. `design.md` decides whether a
+unit should be async or own a resource at all; it points here for the spelling.
+
+Every fenced `ts` block below type-checks under the skill's maximal-strict examples baseline (TS 5.9
+floor; lib `ES2023` + `ESNext.Disposable` + `DOM`). Where a taught fact is enforced by the typed lint
+(`no-floating-promises`) and **not** by `tsc`, the prose says so — an example cannot fence a rule the
+compiler does not check.
+
+## Contents
+
+1. [Promise idioms and no floating promises](#1-promise-idioms-and-no-floating-promises)
+2. [Cancellation with `AbortSignal`](#2-cancellation-with-abortsignal)
+3. [Combinators: `all` / `allSettled` / `race` / `any`](#3-combinators-all-allsettled-race-any)
+4. [Async iterators and `for await`](#4-async-iterators-and-for-await)
+5. [Error propagation across `await`](#5-error-propagation-across-await)
+6. [Deterministic disposal: `using` and `await using`](#6-deterministic-disposal-using-and-await-using)
+7. [Typed events with `EventTarget`](#7-typed-events-with-eventtarget)
 
 ---
 
-## Promise idioms and no floating promises
+## 1. Promise idioms and no floating promises
 
-> Stub — grown in T9-async-resources.
+A `Promise` is an ordinary value, so the compiler lets you discard one — and a discarded rejection
+surfaces later as an unhandled rejection, far from its cause. SKILL.md Rules state the fix (`await`,
+`void`, or `.catch`); the mechanic is that each is a *deliberate* handling and a bare call is not:
 
-## Cancellation with `AbortSignal`
+```ts
+declare function save(id: string): Promise<void>;
+declare function reportError(err: unknown): void;
 
-> Stub — grown in T9-async-resources.
+// await — the default: propagate both the value and any rejection to the caller.
+async function persist(id: string): Promise<void> {
+  await save(id);
+}
 
-## Combinators
+// void + .catch — deliberately fire-and-forget, but never drop the rejection.
+function fireAndForget(id: string): void {
+  void save(id).catch((err: unknown) => {
+    reportError(err);
+  });
+}
+```
 
-> Stub — grown in T9-async-resources.
+The trap: a bare `save(id);` is **not** a `tsc` error. Only the typed-lint rule `no-floating-promises`
+flags it, so treat "handle every promise" as lint-enforced, not compiler-enforced — the maximal-strict
+`tsc` pass in P7 will not catch a floated promise on its own.
 
-## Async iterators
+## 2. Cancellation with `AbortSignal`
 
-> Stub — grown in T9-async-resources.
+Cancellation is cooperative: an `AbortController` owns the switch, and its `signal` is the read-only end
+you hand to the work. The work checks the signal and stops. `signal.throwIfAborted()` is the idiom —
+it throws the signal's `reason` at a checkpoint, so a long loop aborts promptly:
 
-## Error propagation across `await`
+```ts
+async function process(items: readonly number[], signal: AbortSignal): Promise<number> {
+  let sum = 0;
+  for (const item of items) {
+    signal.throwIfAborted(); // throws the abort reason at each checkpoint
+    sum += item;
+  }
+  return sum;
+}
 
-> Stub — grown in T9-async-resources.
+async function run(): Promise<number> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 1000);
+  try {
+    return await process([1, 2, 3], controller.signal);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+```
 
-## Deterministic disposal
+Two static factories build signals without a controller, and compose them: `AbortSignal.timeout(ms)`
+aborts itself after a delay, and `AbortSignal.any([...])` aborts as soon as the earliest input does —
+the way to merge a caller's signal with a local deadline:
 
-> Stub — grown in T9-async-resources.
+```ts
+function combined(userSignal: AbortSignal): AbortSignal {
+  return AbortSignal.any([userSignal, AbortSignal.timeout(5000)]);
+}
+
+// A DOM-style API takes the signal directly; the fetch rejects on abort.
+async function fetchJson(url: string, signal: AbortSignal): Promise<unknown> {
+  const res = await fetch(url, { signal });
+  return res.json();
+}
+```
+
+## 3. Combinators: `all` / `allSettled` / `race` / `any`
+
+The four static combinators differ in *which* settlement wins and *whether* one rejection sinks the
+group. Pick by the answer you need, not by habit:
+
+| Use | When |
+|---|---|
+| `Promise.all` | every task must succeed; fail fast on the first rejection; a tuple keeps position + type |
+| `Promise.allSettled` | you want every outcome regardless of failures; it never rejects |
+| `Promise.race` | first to **settle** (resolve *or* reject) wins — a timeout, a first-response |
+| `Promise.any` | first to **fulfill** wins; rejections are ignored until all reject (`AggregateError`) |
+
+`Promise.all` over a tuple preserves each element's type and order, and rejects the moment any input
+does:
+
+```ts
+declare function fetchUser(id: number): Promise<string>;
+
+async function loadTwo(): Promise<[string, string]> {
+  return Promise.all([fetchUser(1), fetchUser(2)]); // fail-fast, order preserved
+}
+```
+
+`Promise.allSettled` never rejects — each result is a `{ status, value }` / `{ status, reason }` you
+narrow on `status`, so a partial failure stays visible instead of sinking the batch:
+
+```ts
+declare function fetchUser(id: number): Promise<string>;
+
+async function countOk(ids: readonly number[]): Promise<number> {
+  const results = await Promise.allSettled(ids.map(fetchUser));
+  return results.filter((r) => r.status === "fulfilled").length;
+}
+```
+
+`Promise.race` settles on the first input to settle — the timeout idiom races real work against a
+rejecting timer (typed `Promise<never>`, since it only ever rejects):
+
+```ts
+async function withTimeout<T>(work: Promise<T>, ms: number): Promise<T> {
+  const timer = new Promise<never>((_, reject) => {
+    setTimeout(() => reject(new Error("timed out")), ms);
+  });
+  return Promise.race([work, timer]); // Promise<T | never> is Promise<T>
+}
+```
+
+`Promise.any` fulfills on the first input to *fulfill* — a rejection is ignored unless every input
+rejects, at which point it throws an `AggregateError` carrying them all. It is the "first success" idiom
+(a fastest-mirror fetch), the mirror of `race`, which settles on the first to reject too:
+
+```ts
+declare function fetchUser(id: number): Promise<string>;
+
+async function firstOk(ids: readonly number[]): Promise<string> {
+  return Promise.any(ids.map(fetchUser)); // first fulfilled wins; all-reject → AggregateError
+}
+```
+
+## 4. Async iterators and `for await`
+
+An async iterator yields values that each arrive over time. An `async function*` produces one, and
+`for await` consumes it — awaiting each step, so backpressure is automatic (the next pull waits for the
+body):
+
+```ts
+async function* countTo(n: number): AsyncGenerator<number> {
+  for (let i = 0; i < n; i++) {
+    yield i;
+  }
+}
+
+async function sum(): Promise<number> {
+  let total = 0;
+  for await (const x of countTo(3)) {
+    total += x;
+  }
+  return total;
+}
+```
+
+Type the *consumer* against `AsyncIterable<T>`, not a concrete generator, so any async source — a
+stream, a paginated API — satisfies it. `noUncheckedIndexedAccess` and `noImplicitReturns` force the
+empty-source path to be explicit:
+
+```ts
+async function firstOf<T>(source: AsyncIterable<T>): Promise<T | undefined> {
+  for await (const item of source) {
+    return item;
+  }
+  return undefined; // the source was empty — an explicit, typed outcome
+}
+```
+
+## 5. Error propagation across `await`
+
+The delta from the sync case is the boundary: a rejection only enters a `try` if the promise is
+`await`ed *inside* it. `return somePromise()` without `await` returns the pending promise before it
+settles, so its rejection bypasses the local `catch` entirely — a silent footgun `tsc` does not flag:
+
+```ts
+declare function load(): Promise<string>;
+
+// WRONG shape: no `await`, so a rejection escapes this try/catch.
+async function unguarded(): Promise<string> {
+  try {
+    return load(); // returns the pending promise; catch never runs on rejection
+  } catch {
+    return "default"; // unreachable on a rejection
+  }
+}
+```
+
+The correct shape awaits inside the `try`. Because `strict` types the catch variable as `unknown`
+(`useUnknownInCatchVariables`), narrow before use, and chain the original with `cause` to keep the
+stack:
+
+```ts
+class ConfigError extends Error {}
+
+async function load(): Promise<string> {
+  throw new ConfigError("missing config", { cause: new Error("no file") });
+}
+
+async function caller(): Promise<string> {
+  try {
+    return await load(); // `await` inside try — the rejection lands in catch
+  } catch (err: unknown) {
+    if (err instanceof ConfigError) {
+      return "default";
+    }
+    throw err; // re-throw what you cannot handle
+  }
+}
+```
+
+Skipping the narrow is a compile error, which is the point — `unknown` forces the guard the sync case
+also requires:
+
+```ts expect-error
+async function messageLength(p: Promise<string>): Promise<number> {
+  try {
+    return (await p).length;
+  } catch (err: unknown) {
+    // @ts-expect-error `err` is `unknown` across the await boundary; narrow first
+    return err.message.length;
+  }
+}
+```
+
+## 6. Deterministic disposal: `using` and `await using`
+
+A `using` binding calls the value's `[Symbol.dispose]()` at scope exit — on the normal path, an early
+`return`, and a `throw` alike — so release cannot be skipped. It replaces the hand-written
+`try`/`finally` close chain. The resource declares the contract with `implements Disposable`:
+
+```ts
+class FileHandle implements Disposable {
+  readonly name: string;
+  constructor(name: string) {
+    this.name = name;
+  }
+  [Symbol.dispose](): void {
+    // close the underlying handle here
+  }
+}
+
+function readConfig(): void {
+  using handle = new FileHandle("config.json");
+  void handle.name; // disposed at scope exit, on every path including a throw
+}
+```
+
+`await using` is the async form: it awaits `[Symbol.asyncDispose]()`, for a resource whose release is
+itself async (a connection flush, a graceful close):
+
+```ts
+class Connection implements AsyncDisposable {
+  async [Symbol.asyncDispose](): Promise<void> {
+    // await the graceful close
+  }
+}
+
+async function withConnection(): Promise<void> {
+  await using conn = new Connection();
+  void conn; // conn[Symbol.asyncDispose]() is awaited at scope exit
+}
+```
+
+The compiler enforces the contract: a value with no disposer cannot back a `using` binding, so a
+forgotten `[Symbol.dispose]` is a build error, not a leak:
+
+```ts expect-error
+function bad(): void {
+  // @ts-expect-error a `using` binding requires a value implementing Disposable
+  using plain = { size: 1 };
+  void plain;
+}
+```
+
+For a dynamic set of resources, `DisposableStack` (and `AsyncDisposableStack`) collects disposers and
+runs them in reverse order at scope exit. `use` tracks a `Disposable`; `defer` registers a bare
+callback; `adopt` wraps a value that is not itself disposable; and `move()` transfers ownership so the
+current scope stops disposing — the way to hand a fully-acquired resource back to a caller:
+
+```ts
+class Resource implements Disposable {
+  readonly id: number;
+  constructor(id: number) {
+    this.id = id;
+  }
+  [Symbol.dispose](): void {}
+}
+
+function acquireTwo(): void {
+  using stack = new DisposableStack();
+  const first = stack.use(new Resource(1));
+  const second = stack.use(new Resource(2));
+  stack.defer(() => {
+    // extra cleanup; runs before the used resources, in reverse order
+  });
+  void first;
+  void second;
+}
+
+function makeResource(): DisposableStack {
+  using stack = new DisposableStack();
+  stack.use(new Resource(1));
+  return stack.move(); // ownership passes to the caller; this scope disposes nothing
+}
+```
+
+`AsyncDisposableStack` is the `await using` sibling — the same API over async disposers, so `adopt`
+wraps a non-disposable value with an async cleanup callback:
+
+```ts
+class Conn implements AsyncDisposable {
+  async [Symbol.asyncDispose](): Promise<void> {}
+}
+
+async function openAsync(): Promise<void> {
+  await using stack = new AsyncDisposableStack();
+  stack.use(new Conn());
+  stack.adopt(42, (n) => {
+    void n; // an async cleanup for a value that is not itself disposable
+  });
+}
+```
+
+## 7. Typed events with `EventTarget`
+
+The web-standard `EventTarget` is portable across Node, Deno, Bun, and the browser, so prefer it over
+Node's `EventEmitter` (which needs `@types/node` and is runtime-bound). Its base `addEventListener` is
+untyped (`type: string`, listener over a plain `Event`). Wrap it once with a typed `on` / `emit` keyed
+by an event map, so each event name resolves to its payload type:
+
+```ts
+type BusEvents = {
+  data: CustomEvent<number>;
+  done: Event;
+};
+
+class TypedBus extends EventTarget {
+  on<K extends keyof BusEvents>(type: K, listener: (ev: BusEvents[K]) => void): void {
+    super.addEventListener(type, listener as EventListener); // the one cast, behind the typed gate
+  }
+  emit<K extends keyof BusEvents>(_type: K, ev: BusEvents[K]): void {
+    super.dispatchEvent(ev);
+  }
+}
+
+function useBus(): void {
+  const bus = new TypedBus();
+  bus.on("data", (ev) => {
+    void ev.detail; // ev is CustomEvent<number>; detail is number
+  });
+  bus.emit("data", new CustomEvent("data", { detail: 5 }));
+}
+```
+
+The single `as EventListener` is legitimate — it sits behind the typed wrapper (like the branded-type
+gate in `typing.md` §5), so callers never assert. The payoff is that the map catches a wrong payload at
+compile time — a `done` event has no `detail`:
+
+```ts expect-error
+type BusEvents = {
+  data: CustomEvent<number>;
+  done: Event;
+};
+
+class TypedBus extends EventTarget {
+  on<K extends keyof BusEvents>(type: K, listener: (ev: BusEvents[K]) => void): void {
+    super.addEventListener(type, listener as EventListener);
+  }
+}
+
+function useBus(bus: TypedBus): void {
+  bus.on("done", (ev) => {
+    // @ts-expect-error `done` carries a plain Event; it has no `detail`
+    void ev.detail;
+  });
+}
+```

--- a/.gobbi/projects/gobbi/skills/typescript/async-resources.md
+++ b/.gobbi/projects/gobbi/skills/typescript/async-resources.md
@@ -1,0 +1,37 @@
+# TypeScript — Async and Resources
+
+**Ownership** — promise idioms and the no-floating-promises rule; `AbortSignal` / `AbortController`
+cancellation; `Promise.all` / `allSettled` / `race` / `any`; async iterators and `for await`; error
+propagation across `await`; and deterministic disposal via `using` / `await using`, `Symbol.dispose` /
+`asyncDispose`, and `DisposableStack`.
+
+**Split criterion** — skill-writing P3 (d): a self-contained sub-procedure for async and resource-lifetime
+work, opened when a unit touches promises, cancellation, or disposal.
+
+> Skeleton — sections below are stubs; the body is grown in T9-async-resources.
+
+---
+
+## Promise idioms and no floating promises
+
+> Stub — grown in T9-async-resources.
+
+## Cancellation with `AbortSignal`
+
+> Stub — grown in T9-async-resources.
+
+## Combinators
+
+> Stub — grown in T9-async-resources.
+
+## Async iterators
+
+> Stub — grown in T9-async-resources.
+
+## Error propagation across `await`
+
+> Stub — grown in T9-async-resources.
+
+## Deterministic disposal
+
+> Stub — grown in T9-async-resources.

--- a/.gobbi/projects/gobbi/skills/typescript/checklists.md
+++ b/.gobbi/projects/gobbi/skills/typescript/checklists.md
@@ -1,16 +1,117 @@
-# TypeScript — Checklists
+# TypeScript — Implementation Checklist Register
 
-**Ownership** — the eval coverage register: the binary `TS-CHECK-*` items an evaluator ticks to confirm
-coverage of the TS-idiom review.
+A copyable binary PASS/FAIL register for a TypeScript implementation change-set. The evaluator copies the
+activated items into the phase checklist's `## Stage 1 Additions` and ticks each against the diff; the
+executor runs them as a Procedure step P8 self-review. Tick a box when resolved and annotate PASS or FAIL.
+This register deepens, it does not restate: every item carries a `SKILL.md` anchor (`H{n}` = a Rule,
+`P{n}` = a Principle, `Procedure P{n}` = a Procedure step) that resolves to its verbatim clause through
+[`evaluation.md`](evaluation.md)'s rule-key legend; nothing is checked that `SKILL.md` does not teach.
 
-**Split criterion** — skill-writing P3 (a): one member of the eval-triad SET (`evaluation.md` + `scenarios.md`
-+ `checklists.md`). The three are one required set the anti-monolith rule forbids collapsing; this doc owns the
-binary coverage register.
+Each item states **one positive acceptance predicate**: the box passes if and only if that single condition
+holds. The FAIL clause only lists the forms the one condition can be violated in — no `AND`-conjunct softens
+the PASS into an escape hatch, and ownership, ticket status, or review sign-off never stands in for the
+condition itself. Groups: Hard invariants · Design judgment · Operation & evidence.
 
-> Skeleton — sections below are stubs; the body is grown in T6-eval-triad.
+## Hard invariants
 
----
+- [ ] `TS-CHECK-01` — PASS if the change type-checks green under the maximal-strict base (`strict` plus
+  `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`, `noPropertyAccessFromIndexSignature`,
+  `noImplicitOverride`, `noImplicitReturns`, `noFallthroughCasesInSwitch`); FAIL if it relies on a loosened
+  flag, or an unchecked index, exact-optional violation, or missing return that a maximal-strict `tsc` rejects.
+  *(H1)*
+- [ ] `TS-CHECK-02` — PASS if every import uses ESM with `verbatimModuleSyntax` — a type-only import written
+  `import type`, a value import left plain — so erasure is deterministic; FAIL if a type import is left as a
+  value import (or the reverse), or a CJS `require` sits in the verbatim source. *(H2)*
+- [ ] `TS-CHECK-03` — PASS if every relative import extension matches the file's consumption mode (`.js` for a
+  tsc-emitted library, `.ts` with `rewriteRelativeImportExtensions` for a directly type-stripped source),
+  consistent across the tree; FAIL if the two modes are mixed in one source tree or an extension does not
+  resolve under the declared runtime. *(H3)*
+- [ ] `TS-CHECK-04` — PASS if every untrusted boundary value (JSON, network, `env`, file) enters as `unknown`
+  and is narrowed by a type guard or schema parser into a domain type before any maintained logic reads it;
+  FAIL if an annotation or an `as` cast stands in for the runtime validation. *(H4, P4)*
+- [ ] `TS-CHECK-05` — PASS if no `any` appears — implicit or explicit — with `unknown` at the boundary narrowed
+  by a guard or parser and, at most, a documented `as` for a static fact the checker cannot see; FAIL if `any`
+  is used or reintroduced by assignment spread. *(H9, P4)*
+- [ ] `TS-CHECK-06` — PASS if every value is checked by an annotation (`: T`) or `satisfies T`, with `as`
+  reserved for a fact verified by a prior runtime narrow; FAIL if an `as` (or a `!` non-null assertion or a
+  `@ts-ignore`) asserts a shape the value does not satisfy to silence an error. *(H10)*
+- [ ] `TS-CHECK-07` — PASS if every promise is awaited, `void`ed deliberately, or given a `.catch`, with any
+  background work owned explicitly; FAIL if a promise is left floating as a fire-and-forget invisible unhandled
+  rejection. *(H5, H13, P5)*
+- [ ] `TS-CHECK-08` — PASS if `throw` carries only `Error` subclasses (chaining `cause`), every catch types the
+  value as `unknown` and narrows with `instanceof` before use, and an expected failure is modeled as a typed
+  result in the return type; FAIL if a non-`Error` is thrown, a caught value is used without narrowing, or an
+  expected failure is thrown where the signature should carry it. *(H6, P6)*
+- [ ] `TS-CHECK-09` — PASS if all syntax is erasable — a closed set modeled by a discriminated union or an
+  `as const` object, with no `enum`, `namespace`, or constructor parameter-property; FAIL if any non-erasable
+  construct ships where a type-stripping runtime executes the source. *(H7, H11, P7)*
+- [ ] `TS-CHECK-10` — PASS if a published package emits ESM-only from its `verbatimModuleSyntax` source, any
+  required CJS build isolated as a separate non-default emit; FAIL if it ships dual ESM + CJS from the one
+  verbatim source. *(H12)*
+- [ ] `TS-CHECK-11` — PASS if every taught `ts` example type-checks under the skill's examples baseline with its
+  category marker, an intentionally-invalid example carrying `@ts-expect-error` so it is distinguishable from a
+  broken one; FAIL if a taught example does not compile or a bad example cannot be told from an accidentally
+  broken one. *(H8)*
 
-## Coverage register
+## Design judgment
 
-> Stub — grown in T6-eval-triad.
+- [ ] `TS-CHECK-12` — PASS if the domain is modeled so illegal states cannot be constructed — a discriminated
+  union ending in a `never` exhaustiveness check (with `readonly` or a branded type where an invariant must
+  hold), so an unhandled variant is a compile error; FAIL if an illegal combination is representable or a new
+  variant compiles without being handled. *(P3, H11)*
+- [ ] `TS-CHECK-13` — PASS if the exported type surface (interfaces, generics, unions, the public `.d.ts`) was
+  designed and confirmed before bodies, `interface` for an extendable object shape and `type` for a
+  union/tuple/mapped/conditional, and a generic added only when it links an input to an output across many
+  types; FAIL if the surface was reverse-engineered from bodies, a binding was accidentally exported, or a
+  generic serves a single call site. *(P2)*
+- [ ] `TS-CHECK-14` — PASS if every resource's release is bound to its scope with `using` / `await using` (or a
+  `finally`) so disposal runs on every path including the throwing one, cancellation is carried on an
+  `AbortSignal`, and a fan-out bounds its concurrent task creation; FAIL if release runs only on the happy
+  path, a long operation carries no cancellation, or the fan-out is unbounded. *(P5)*
+
+## Operation & evidence
+
+- [ ] `TS-CHECK-15` — PASS if the modules, types, and fully-annotated signatures type-checked green under the
+  maximal-strict base before any behavior body existed; FAIL if the signature fell out of finished bodies.
+  *(Procedure P1, Procedure P5)*
+- [ ] `TS-CHECK-16` — PASS if the implementation grew in minimal verified slices, each with fresh focused
+  evidence (format → lint → `tsc --noEmit` → focused test) before the next, and every affected caller, test,
+  doc, and emitted `.d.ts` moved in the same slice; FAIL if first evidence arrives only after a whole-feature
+  pass or an affected surface lagged behind. *(Procedure P6)*
+- [ ] `TS-CHECK-17` — PASS if the whole change was verified in the fixed order — format → lint → type-check →
+  focused tests → full tests → type-level tests → build when publishing — each gate self-failing on fresh
+  output; FAIL if a gate was skipped, asserted without running, or trusted stale output. *(Procedure P7)*
+- [ ] `TS-CHECK-18` — PASS if every runtime-boundary decision (module resolution, import-extension mode,
+  built-in API, `lib`, type-stripping) matches the declared target runtime read from `runtime-deltas.md`; FAIL
+  if one runtime's resolution, built-in, or `lib` is assumed across a different runtime. *(H3, Procedure P2)*
+- [ ] `TS-CHECK-19` — PASS if a published package validates from its built artifacts — declaration emit plus
+  `publint` and `arethetypeswrong` green on the packed output, its ESM-only `exports` resolving under
+  `nodenext` for a consumer; FAIL if the `.d.ts` resolution or `exports` shape is verified only from the
+  checkout. *(H12, Procedure P7)*
+
+## Guaranteed coverage map
+
+Every Rule `H1`–`H13` is anchored by at least one check, every Principle `P1`–`P7` is anchored by at least one
+check, and every check is exercised by at least one seed scenario in `scenarios.md`.
+
+| Check | Anchor(s) | Seed scenario |
+|---|---|---|
+| `TS-CHECK-01` | H1 | `TS-SCENARIO-08` |
+| `TS-CHECK-02` | H2 | `TS-SCENARIO-05` |
+| `TS-CHECK-03` | H3 | `TS-SCENARIO-05` |
+| `TS-CHECK-04` | H4, P4 | `TS-SCENARIO-01` |
+| `TS-CHECK-05` | H9, P4 | `TS-SCENARIO-01` |
+| `TS-CHECK-06` | H10 | `TS-SCENARIO-07` |
+| `TS-CHECK-07` | H5, H13, P5 | `TS-SCENARIO-02` |
+| `TS-CHECK-08` | H6, P6 | `TS-SCENARIO-03` |
+| `TS-CHECK-09` | H7, H11, P7 | `TS-SCENARIO-04` |
+| `TS-CHECK-10` | H12 | `TS-SCENARIO-05` |
+| `TS-CHECK-11` | H8 | `TS-SCENARIO-09` |
+| `TS-CHECK-12` | P3, H11 | `TS-SCENARIO-06` |
+| `TS-CHECK-13` | P2 | `TS-SCENARIO-07` |
+| `TS-CHECK-14` | P5 | `TS-SCENARIO-02` |
+| `TS-CHECK-15` | Procedure P1, Procedure P5 | `TS-SCENARIO-08` |
+| `TS-CHECK-16` | Procedure P6 | `TS-SCENARIO-08` |
+| `TS-CHECK-17` | Procedure P7 | `TS-SCENARIO-09` |
+| `TS-CHECK-18` | H3, Procedure P2 | `TS-SCENARIO-10` |
+| `TS-CHECK-19` | H12, Procedure P7 | `TS-SCENARIO-05` |

--- a/.gobbi/projects/gobbi/skills/typescript/checklists.md
+++ b/.gobbi/projects/gobbi/skills/typescript/checklists.md
@@ -7,10 +7,10 @@ This register deepens, it does not restate: every item carries a `SKILL.md` anch
 `P{n}` = a Principle, `Procedure P{n}` = a Procedure step) that resolves to its verbatim clause through
 [`evaluation.md`](evaluation.md)'s rule-key legend; nothing is checked that `SKILL.md` does not teach.
 
-Each item states **one positive acceptance predicate**: the box passes if and only if that single condition
-holds. The FAIL clause only lists the forms the one condition can be violated in — no `AND`-conjunct softens
-the PASS into an escape hatch, and ownership, ticket status, or review sign-off never stands in for the
-condition itself. Groups: Hard invariants · Design judgment · Operation & evidence.
+Each item states **one positive acceptance outcome**: the box passes if and only if that outcome holds. The
+outcome may require a conjunction of conditions (all must hold — a compound check is still one outcome), but
+never an `OR` / sign-off escape. The FAIL clause only lists the forms the outcome can be violated in, and
+ownership, ticket status, or review sign-off never stands in for the outcome itself. Groups: Hard invariants · Design judgment · Operation & evidence.
 
 ## Hard invariants
 
@@ -68,6 +68,10 @@ condition itself. Groups: Hard invariants · Design judgment · Operation & evid
   `finally`) so disposal runs on every path including the throwing one, cancellation is carried on an
   `AbortSignal`, and a fan-out bounds its concurrent task creation; FAIL if release runs only on the happy
   path, a long operation carries no cancellation, or the fan-out is unbounded. *(P5)*
+- [ ] `TS-CHECK-20` — PASS if every returned or exported reference to internal mutable state is a copy, an
+  immutable view, or a `readonly`-typed boundary, so a caller cannot mutate the owner's private state; FAIL if
+  a method, getter, or factory hands back a live mutable `T[]` / `Map` / `Set` a caller can mutate in place.
+  *(P3)*
 
 ## Operation & evidence
 
@@ -91,8 +95,9 @@ condition itself. Groups: Hard invariants · Design judgment · Operation & evid
 
 ## Guaranteed coverage map
 
-Every Rule `H1`–`H13` is anchored by at least one check, every Principle `P1`–`P7` is anchored by at least one
-check, and every check is exercised by at least one seed scenario in `scenarios.md`.
+Every Rule `H1`–`H13` is anchored by at least one check, every Principle `P2`–`P7` is anchored by at least one
+check (Principle `P1` — study the TypeScript contract — is operationalized through Procedure `P1` →
+`TS-CHECK-15`), and every check is exercised by at least one seed scenario in `scenarios.md`.
 
 | Check | Anchor(s) | Seed scenario |
 |---|---|---|
@@ -115,3 +120,4 @@ check, and every check is exercised by at least one seed scenario in `scenarios.
 | `TS-CHECK-17` | Procedure P7 | `TS-SCENARIO-09` |
 | `TS-CHECK-18` | H3, Procedure P2 | `TS-SCENARIO-10` |
 | `TS-CHECK-19` | H12, Procedure P7 | `TS-SCENARIO-05` |
+| `TS-CHECK-20` | P3, coding P16 | `TS-SCENARIO-11` |

--- a/.gobbi/projects/gobbi/skills/typescript/checklists.md
+++ b/.gobbi/projects/gobbi/skills/typescript/checklists.md
@@ -68,10 +68,11 @@ ownership, ticket status, or review sign-off never stands in for the outcome its
   `finally`) so disposal runs on every path including the throwing one, cancellation is carried on an
   `AbortSignal`, and a fan-out bounds its concurrent task creation; FAIL if release runs only on the happy
   path, a long operation carries no cancellation, or the fan-out is unbounded. *(P5)*
-- [ ] `TS-CHECK-20` — PASS if every returned or exported reference to internal mutable state is a copy, an
-  immutable view, or a `readonly`-typed boundary, so a caller cannot mutate the owner's private state; FAIL if
-  a method, getter, or factory hands back a live mutable `T[]` / `Map` / `Set` a caller can mutate in place.
-  *(P3)*
+- [ ] `TS-CHECK-20` — PASS if every returned or exported reference to internal mutable state is a copy, or a
+  view whose immutability REACHES the mutable state (primitive or `readonly` elements, `ReadonlyArray<Readonly<T>>`,
+  or frozen data), so a caller cannot mutate the owner's private state; FAIL if a method, getter, or factory
+  hands back a live mutable `T[]` / `Map` / `Set`, OR a shallow `readonly T[]` over mutable objects whose nested
+  fields a caller can still assign. *(P3)*
 
 ## Operation & evidence
 
@@ -120,4 +121,4 @@ check (Principle `P1` — study the TypeScript contract — is operationalized t
 | `TS-CHECK-17` | Procedure P7 | `TS-SCENARIO-09` |
 | `TS-CHECK-18` | H3, Procedure P2 | `TS-SCENARIO-10` |
 | `TS-CHECK-19` | H12, Procedure P7 | `TS-SCENARIO-05` |
-| `TS-CHECK-20` | P3, coding P16 | `TS-SCENARIO-11` |
+| `TS-CHECK-20` | P3 | `TS-SCENARIO-11` |

--- a/.gobbi/projects/gobbi/skills/typescript/checklists.md
+++ b/.gobbi/projects/gobbi/skills/typescript/checklists.md
@@ -23,7 +23,7 @@ ownership, ticket status, or review sign-off never stands in for the outcome its
   `import type`, a value import left plain — so erasure is deterministic; FAIL if a type import is left as a
   value import (or the reverse), or a CJS `require` sits in the verbatim source. *(H2)*
 - [ ] `TS-CHECK-03` — PASS if every relative import extension matches the file's consumption mode (`.js` for a
-  tsc-emitted library, `.ts` with `rewriteRelativeImportExtensions` for a directly type-stripped source),
+  tsc-emitted library, `.ts` with `rewriteRelativeImportExtensions` for a directly-run source (stripped or transpiled)),
   consistent across the tree; FAIL if the two modes are mixed in one source tree or an extension does not
   resolve under the declared runtime. *(H3)*
 - [ ] `TS-CHECK-04` — PASS if every untrusted boundary value (JSON, network, `env`, file) enters as `unknown`
@@ -68,11 +68,11 @@ ownership, ticket status, or review sign-off never stands in for the outcome its
   `finally`) so disposal runs on every path including the throwing one, cancellation is carried on an
   `AbortSignal`, and a fan-out bounds its concurrent task creation; FAIL if release runs only on the happy
   path, a long operation carries no cancellation, or the fan-out is unbounded. *(P5)*
-- [ ] `TS-CHECK-20` — PASS if every returned or exported reference to internal mutable state is a copy, or a
-  view whose immutability REACHES the mutable state (primitive or `readonly` elements, `ReadonlyArray<Readonly<T>>`,
-  or frozen data), so a caller cannot mutate the owner's private state; FAIL if a method, getter, or factory
-  hands back a live mutable `T[]` / `Map` / `Set`, OR a shallow `readonly T[]` over mutable objects whose nested
-  fields a caller can still assign. *(P3)*
+- [ ] `TS-CHECK-20` — PASS if a returned or exported reference gives the caller NO mutable path into the owner's
+  private state — a deep copy, a deeply-immutable or frozen structure, or primitive / fully-`readonly` elements;
+  FAIL if the caller can reach and mutate private state through the returned value: a live reference, a shallow
+  copy (`[...items]`) that shares mutable element objects, or a shallow `readonly` / one-level `Readonly<T>`
+  whose nested fields stay assignable. *(P3)*
 
 ## Operation & evidence
 

--- a/.gobbi/projects/gobbi/skills/typescript/checklists.md
+++ b/.gobbi/projects/gobbi/skills/typescript/checklists.md
@@ -35,9 +35,9 @@ condition itself. Groups: Hard invariants · Design judgment · Operation & evid
 - [ ] `TS-CHECK-06` — PASS if every value is checked by an annotation (`: T`) or `satisfies T`, with `as`
   reserved for a fact verified by a prior runtime narrow; FAIL if an `as` (or a `!` non-null assertion or a
   `@ts-ignore`) asserts a shape the value does not satisfy to silence an error. *(H10)*
-- [ ] `TS-CHECK-07` — PASS if every promise is awaited, `void`ed deliberately, or given a `.catch`, with any
-  background work owned explicitly; FAIL if a promise is left floating as a fire-and-forget invisible unhandled
-  rejection. *(H5, H13, P5)*
+- [ ] `TS-CHECK-07` — PASS if every promise is awaited, `return`ed, or given a real rejection handler
+  (`void promise.catch(...)`), with any background work owned explicitly; FAIL if a promise is left floating,
+  OR a bare `void` is used as if it handled the rejection. *(H5, H13, P5)*
 - [ ] `TS-CHECK-08` — PASS if `throw` carries only `Error` subclasses (chaining `cause`), every catch types the
   value as `unknown` and narrows with `instanceof` before use, and an expected failure is modeled as a typed
   result in the return type; FAIL if a non-`Error` is thrown, a caught value is used without narrowing, or an

--- a/.gobbi/projects/gobbi/skills/typescript/checklists.md
+++ b/.gobbi/projects/gobbi/skills/typescript/checklists.md
@@ -1,0 +1,16 @@
+# TypeScript — Checklists
+
+**Ownership** — the eval coverage register: the binary `TS-CHECK-*` items an evaluator ticks to confirm
+coverage of the TS-idiom review.
+
+**Split criterion** — skill-writing P3 (a): one member of the eval-triad SET (`evaluation.md` + `scenarios.md`
++ `checklists.md`). The three are one required set the anti-monolith rule forbids collapsing; this doc owns the
+binary coverage register.
+
+> Skeleton — sections below are stubs; the body is grown in T6-eval-triad.
+
+---
+
+## Coverage register
+
+> Stub — grown in T6-eval-triad.

--- a/.gobbi/projects/gobbi/skills/typescript/convention.md
+++ b/.gobbi/projects/gobbi/skills/typescript/convention.md
@@ -1,32 +1,186 @@
 # TypeScript — Convention
 
-**Ownership** — the authoring-time lookup surface: the casing matrix (types/classes, values, constants), file
-naming, import ordering and `import type`, TSDoc tags, the formatter stance (Prettier / Biome), and comment
-mechanics.
+**Ownership** — the authoring-time lookup surface: the casing matrix (types/interfaces/classes, values,
+constants), file naming, import ordering and `import type` placement, TSDoc tag grammar, the formatter stance
+(Prettier / Biome), and comment mechanics.
 
-**Split criterion** — skill-writing P3 (b): a scannable lookup reference an agent consults at authoring time
-(casing rows, import order, TSDoc tags are looked up, not read narratively).
+**Split criterion** — skill-writing P3 (b): a scannable lookup reference an agent consults at authoring time —
+casing rows, import order, and TSDoc tags are looked up, not read narratively.
 
-> Skeleton — sections below are stubs; the body is grown in T8-convention.
+This doc **deepens, and does not restate,** the SKILL.md convention rules and the language-agnostic parent
+floor. It owns the *spelling* of TypeScript source; the mechanics and the rules live with their owners:
+
+| Surface | Owner | This doc adds |
+|---|---|---|
+| Naming for intent (choose a name that tells the truth) | `coding` Principle 5 | the TypeScript *casing* each kind takes |
+| The `import type` marker + the `.js`/`.ts` import-extension fork | SKILL.md Rules (`verbatimModuleSyntax`) / `modules-tooling.md` | the group *order* and *placement* of imports — not the marker rule or the extension |
+| `enum` ban / erasable syntax | SKILL.md Principle 7 | the casing of the `as const` set that replaces an `enum` |
+| Type-construct mechanics (generics, `satisfies`, branded types) | `typing.md` | only their *spelling and casing* |
+| Comment the *why*, not the *what* | `coding` Principle 13 | the TypeScript comment, TSDoc, and marker grammar |
+| Which public surface earns a doc | `coding` Principles 11 & 13 | the TSDoc *tag* grammar |
+
+## Contents
+
+1. [Naming and casing matrix](#1-naming-and-casing-matrix)
+2. [File naming](#2-file-naming)
+3. [Import ordering and `import type`](#3-import-ordering-and-import-type)
+4. [TSDoc grammar](#4-tsdoc-grammar)
+5. [Formatter stance, comments, and markers](#5-formatter-stance-comments-and-markers)
 
 ---
 
-## Casing matrix
+## 1. Naming and casing matrix
 
-> Stub — grown in T8-convention.
+Choose the name's words first (`coding` Principle 5), then apply the casing owned by its kind. TypeScript is
+structural, so a name is documentation the compiler does not check — the spelling is all the reader gets.
 
-## File naming
+| Kind | Casing | Example | Note |
+|---|---|---|---|
+| Class | `PascalCase` | `TokenBucket` | name the role or value, not the pattern |
+| Interface | `PascalCase`, **no `I` prefix** | `RateLimiter` | Google: never `IRateLimiter` |
+| Type alias | `PascalCase` | `JsonValue` | name the concept, not the container spelling |
+| Type parameter | single capital, or `PascalCase` with a `T` prefix | `T`, `TKey`, `TValue` | short only when the relationship is obvious |
+| Function / method | `camelCase`, verb-first | `acquireToken` | a precise verb for an action |
+| Variable / parameter / property | `camelCase` | `tokenCount` | name the domain role; add units when ambiguous |
+| Module-level constant | `CONSTANT_CASE` | `MAX_RETRIES` | only a value treated as fixed and deeply immutable |
+| Local `const` binding | `camelCase` | `nextToken` | `CONSTANT_CASE` is for module / static constants, not every `const` |
+| Private member | `private` or `#name`, **no `_` prefix** | `#available` | an underscore prefix is not privacy |
+| `enum` (avoided) | — | — | model a closed set as an `as const` object or union (SKILL Principle 7); see `typing.md` |
 
-> Stub — grown in T8-convention.
+```ts
+interface RateLimiter {          // PascalCase, no `I` prefix (Google)
+  readonly maxTokens: number;
+}
 
-## Import ordering and `import type`
+class TokenBucket implements RateLimiter {
+  readonly maxTokens = 60;       // property: camelCase
+  #available = 60;               // private via `#`, never an `_` prefix
 
-> Stub — grown in T8-convention.
+  acquireToken(): boolean {      // method: camelCase, verb-first
+    if (this.#available <= 0) {
+      return false;
+    }
+    this.#available -= 1;
+    return true;
+  }
+}
 
-## TSDoc
+type JsonValue = string | number | boolean | null;   // type alias: PascalCase
+const MAX_RETRIES = 3;           // module constant: CONSTANT_CASE
+```
 
-> Stub — grown in T8-convention.
+- **Acronyms are whole words in every case** — `HttpClient`, `parseXmlUrl`, `httpServer`, never `HTTPClient`
+  or `parseXMLUrl`; keep a platform-fixed name verbatim (`XMLHttpRequest`).
+- **Booleans read as predicates** — `isReady`, `hasToken`, `canRetry`, so a condition reads as a sentence.
+- **Never shadow a global or reserved word** (`String`, `Array`, `type`, `await`); pick the domain name first.
+  The set an `enum` would model is an `as const` object in `PascalCase` with `CONSTANT_CASE` keys.
 
-## Formatter stance and comment mechanics
+## 2. File naming
 
-> Stub — grown in T8-convention.
+| Element | Convention | Example |
+|---|---|---|
+| Source file | lowercase, hyphen-separated (kebab-case) is the common default; some projects name the file after its single primary export | `rate-limiter.ts` or `RateLimiter.ts` |
+| Barrel | `index.ts` re-exporting the directory's public surface | `index.ts` |
+| Unit test | `.test.ts` / `.spec.ts` beside the source | `rate-limiter.test.ts` |
+| Type-level test | `.test-d.ts` | `rate-limiter.test-d.ts` |
+| Declaration file | `.d.ts` | `globals.d.ts` |
+
+Follow the project's existing file-name style rather than inventing a second one. The relative-import
+*extension* (`.js` vs `.ts`) is not a naming choice — SKILL.md Rules and `modules-tooling.md` own it.
+
+## 3. Import ordering and `import type`
+
+Group imports top-down, one blank line between groups, sorted lexically within a group:
+
+| Order | Group | Example specifier |
+|---|---|---|
+| 1 | node built-ins (`node:` prefix) | `node:fs/promises` |
+| 2 | external packages | `zod`, `express` |
+| 3 | internal path-alias | `@app/logging` |
+| 4 | relative (`../` before `./`) | `./config.js` |
+
+```
+import { readFile } from "node:fs/promises";
+
+import { z } from "zod";
+
+import { logger } from "@app/logging";
+
+import { parseConfig } from "./config.js";
+import type { Config } from "./config.js";
+```
+
+- **Do not hand-order** — a lint plugin (`simple-import-sort`, `eslint-plugin-import`) fixes the order
+  deterministically, the same way the formatter owns whitespace.
+- **`import type` placement** — a type-only import is written `import type { Config } from "./config.js"` as
+  its own statement in the same group, or inline as `import { type Config, parseConfig } from "./config.js"`.
+  `verbatimModuleSyntax` (SKILL.md Rules) requires the marker; this doc only fixes where it sits.
+- **Side-effect imports** (`import "./register.js"`) carry no binding — place them first, where load order is
+  the point, and let the file name state the intent.
+- **Prefer named imports** — reach for a namespace import (`import * as`) only for an API that is genuinely
+  namespaced, never as a shorthand.
+
+## 4. TSDoc grammar
+
+TSDoc uses `/** … */`. Types live in the annotations — never repeat a type in a tag (no JSDoc-style
+`@param {type}`). Document the contract a signature cannot show; a name that adds nothing needs no tag.
+
+| Tag | Use |
+|---|---|
+| `@param name - desc` | each meaningful parameter — the signature already carries its type |
+| `@returns desc` | the returned value; omit for a `void` return |
+| `@throws {ErrorType} desc` | each error a caller can reasonably catch |
+| `@typeParam T - desc` | a type parameter whose role is not obvious |
+| `@example` | runnable usage |
+| `@remarks` | rationale or constraints beyond the one-line summary |
+| `@deprecated` | a retiring API and its replacement |
+
+```ts
+/**
+ * Acquire one token for the caller when the bucket has capacity.
+ *
+ * @param userId - the caller whose quota is charged
+ * @returns `true` when a token was granted, `false` when the bucket is empty
+ * @throws {RangeError} when `userId` is empty
+ */
+function acquire(userId: string): boolean {
+  if (userId.length === 0) {
+    throw new RangeError("userId must not be empty");
+  }
+  return true;
+}
+```
+
+- **Summary line first** — imperative mood ("Acquire a token", not "Acquires…"), one line, a blank line
+  before any tag.
+- **Document the surface that adds contract information** — the exported/public API; skip a doc that only
+  restates the annotations.
+- **Keep it true to the code** — a stale TSDoc is a defect at the same priority as stale code
+  (`coding` Principle 13), updated in the change that invalidates it.
+
+## 5. Formatter stance, comments, and markers
+
+A deterministic formatter owns whitespace, quotes, semicolons, and line width — take its output as
+authoritative and never hand-format. **Prettier** is the de-facto default; **Biome** is a faster all-in-one
+(formatter plus linter) alternative. Follow the project's configured tool; a new project picks one, commits
+its config, and runs it in check mode in CI. The formatter is layout only — type strictness and lint are
+separate gates (SKILL.md Principle 7 / `modules-tooling.md`).
+
+Comment the *why*, not the *what* (`coding` Principle 13): the rationale, the constraint, the rejected
+alternative. Delete commented-out code — version control holds the history.
+
+```ts
+// Retry only on 5xx: a 4xx is the caller's error and will never succeed on replay.
+function isRetryable(status: number): boolean {
+  return status >= 500 && status < 600;
+}
+```
+
+| Marker | Use |
+|---|---|
+| `//` | a short line comment above the code it explains |
+| `/* … */` | a rare multi-line non-doc note |
+| `/** … */` | TSDoc on an exported or public declaration (§ 4) |
+| `// TODO(owner): action` | an owned, greppable follow-up with a tracking reference (`// TODO(alice): drop after #1423`) |
+| `// FIXME(owner): defect` | a known-broken spot to repair |
+| `// eslint-disable-next-line <rule> -- reason` | a scoped, reason-bearing lint suppression, never a blanket file-wide disable |

--- a/.gobbi/projects/gobbi/skills/typescript/convention.md
+++ b/.gobbi/projects/gobbi/skills/typescript/convention.md
@@ -129,7 +129,7 @@ TSDoc uses `/** … */`. Types live in the annotations — never repeat a type i
 |---|---|
 | `@param name - desc` | each meaningful parameter — the signature already carries its type |
 | `@returns desc` | the returned value; omit for a `void` return |
-| `@throws {ErrorType} desc` | each error a caller can reasonably catch |
+| `@throws {@link ErrorType} desc` | each error a caller can reasonably catch — name it with `{@link}` or prose, not a JSDoc `{Type}` expression |
 | `@typeParam T - desc` | a type parameter whose role is not obvious |
 | `@example` | runnable usage |
 | `@remarks` | rationale or constraints beyond the one-line summary |
@@ -141,7 +141,7 @@ TSDoc uses `/** … */`. Types live in the annotations — never repeat a type i
  *
  * @param userId - the caller whose quota is charged
  * @returns `true` when a token was granted, `false` when the bucket is empty
- * @throws {RangeError} when `userId` is empty
+ * @throws {@link RangeError} when `userId` is empty
  */
 function acquire(userId: string): boolean {
   if (userId.length === 0) {

--- a/.gobbi/projects/gobbi/skills/typescript/convention.md
+++ b/.gobbi/projects/gobbi/skills/typescript/convention.md
@@ -1,0 +1,32 @@
+# TypeScript — Convention
+
+**Ownership** — the authoring-time lookup surface: the casing matrix (types/classes, values, constants), file
+naming, import ordering and `import type`, TSDoc tags, the formatter stance (Prettier / Biome), and comment
+mechanics.
+
+**Split criterion** — skill-writing P3 (b): a scannable lookup reference an agent consults at authoring time
+(casing rows, import order, TSDoc tags are looked up, not read narratively).
+
+> Skeleton — sections below are stubs; the body is grown in T8-convention.
+
+---
+
+## Casing matrix
+
+> Stub — grown in T8-convention.
+
+## File naming
+
+> Stub — grown in T8-convention.
+
+## Import ordering and `import type`
+
+> Stub — grown in T8-convention.
+
+## TSDoc
+
+> Stub — grown in T8-convention.
+
+## Formatter stance and comment mechanics
+
+> Stub — grown in T8-convention.

--- a/.gobbi/projects/gobbi/skills/typescript/design.md
+++ b/.gobbi/projects/gobbi/skills/typescript/design.md
@@ -1,0 +1,28 @@
+# TypeScript — Design
+
+**Ownership** — TS unit and API design: function vs `const`-object vs class, model-with-unions-vs-class,
+signature shape, composition, when a generic is earned, the module tree, the ownership and failure shape, and
+the least-demanding input surface, including the exported-type / `.d.ts` surface.
+
+**Split criterion** — skill-writing P3 (d): a self-contained design sub-procedure an author works through
+before writing bodies, distinct from the SKILL.md cold-load floor.
+
+> Skeleton — sections below are stubs; the body is grown in T7-design.
+
+---
+
+## Unit shape: function, `const`-object, or class
+
+> Stub — grown in T7-design.
+
+## Type surface and signatures
+
+> Stub — grown in T7-design.
+
+## Composition and ownership boundaries
+
+> Stub — grown in T7-design.
+
+## The input surface and the exported `.d.ts`
+
+> Stub — grown in T7-design.

--- a/.gobbi/projects/gobbi/skills/typescript/design.md
+++ b/.gobbi/projects/gobbi/skills/typescript/design.md
@@ -190,10 +190,9 @@ generic *form* — `const` type parameters, variance, and bounds.
 
 ## 3. Composition and ownership boundaries
 
-**Compose by holding a collaborator; do not inherit to borrow behavior.** Receive a collaborator at the
-constructor boundary and hold it as a `readonly` field, typed by a small structural `interface` so the surface
-stays swappable and testable. Inheriting merely to reuse a method welds two surfaces that should move
-independently; vary one behavior with a function value or an injected collaborator, not a subclass.
+**Compose by holding a collaborator; do not inherit to borrow behavior** — `coding` owns *why* (composition
+over inheritance); the TypeScript spelling is here. Receive a collaborator at the constructor boundary and hold
+it as a `readonly` field, typed by a small structural `interface` so the surface stays swappable and testable.
 
 **`readonly` marks the ownership and mutation boundary the signature would otherwise leave unstated.** A
 `readonly` field cannot be reassigned; a `readonly T[]` parameter tells the caller "I only read this array, I

--- a/.gobbi/projects/gobbi/skills/typescript/design.md
+++ b/.gobbi/projects/gobbi/skills/typescript/design.md
@@ -201,6 +201,12 @@ these erase at runtime they cost nothing, yet they document ownership at the exa
 `readonly` is *shallow*, so a value contract must reach one level in — `readonly tags: readonly string[]`, not
 `readonly tags: string[]`, which still permits `config.tags.push(...)`.
 
+And never RETURN a live reference to an internal mutable container: hand back a copy (`[...this.#items]`), an
+immutable view (`readonly T[]` / `ReadonlyMap`), or frozen data, so a caller cannot mutate the owner's private
+state (`coding` P16, in TypeScript form). A `readonly` return type documents that boundary, but — shallow and
+erased — it constrains only that reference's static type; an aliased non-`readonly` handle to the same object
+still mutates it (`scenarios.md` TS-SCENARIO-11).
+
 Note a TypeScript-specific trap at the constructor boundary: `erasableSyntaxOnly` bans parameter-properties
 (`constructor(private clock: Clock)`), so assign the field explicitly in the body.
 

--- a/.gobbi/projects/gobbi/skills/typescript/design.md
+++ b/.gobbi/projects/gobbi/skills/typescript/design.md
@@ -202,10 +202,10 @@ these erase at runtime they cost nothing, yet they document ownership at the exa
 `readonly tags: string[]`, which still permits `config.tags.push(...)`.
 
 And never RETURN a live reference to an internal mutable container: hand back a copy (`[...this.#items]`), an
-immutable view (`readonly T[]` / `ReadonlyMap`), or frozen data, so a caller cannot mutate the owner's private
-state (`coding` P16, in TypeScript form). A `readonly` return type documents that boundary, but — shallow and
-erased — it constrains only that reference's static type; an aliased non-`readonly` handle to the same object
-still mutates it (`scenarios.md` TS-SCENARIO-11).
+immutable view whose immutability REACHES the mutable state (`ReadonlyArray<Readonly<T>>` or primitive
+elements), or frozen data, so a caller cannot mutate the owner's private state (`coding` P16, in TypeScript
+form). A `readonly` type is SHALLOW and erased: a `readonly { x: T }[]` still lets a caller assign `view[0].x`,
+and an aliased non-`readonly` handle to the same object mutates it too (`scenarios.md` TS-SCENARIO-11).
 
 Note a TypeScript-specific trap at the constructor boundary: `erasableSyntaxOnly` bans parameter-properties
 (`constructor(private clock: Clock)`), so assign the field explicitly in the body.

--- a/.gobbi/projects/gobbi/skills/typescript/design.md
+++ b/.gobbi/projects/gobbi/skills/typescript/design.md
@@ -101,12 +101,18 @@ type Notification =
   | { readonly kind: "email"; readonly address: string }
   | { readonly kind: "sms"; readonly number: string };
 
+function assertNever(x: never): never {
+  throw new Error(`unhandled variant: ${JSON.stringify(x)}`);
+}
+
 function recipient(n: Notification): string {
   switch (n.kind) {
     case "email":
       return n.address;
     case "sms":
       return n.number;
+    default:
+      return assertNever(n); // a new variant becomes a compile error here
   }
 }
 ```
@@ -310,8 +316,9 @@ export interface PublicUser {
   readonly name: string;
 }
 
-// the explicit return annotation is the published contract; without it, inference
-// could widen the shape and leak `passwordHash` into the emitted .d.ts
+// the explicit return annotation pins the published contract to PublicUser; without it,
+// a later edit that returns an extra field (or `return row`) would silently widen the
+// emitted .d.ts and leak an internal field such as `passwordHash`
 export function loadUser(id: string): PublicUser {
   const row = { id, name: "Ada", passwordHash: "9f…" };
   return { id: row.id, name: row.name };

--- a/.gobbi/projects/gobbi/skills/typescript/design.md
+++ b/.gobbi/projects/gobbi/skills/typescript/design.md
@@ -201,11 +201,11 @@ these erase at runtime they cost nothing, yet they document ownership at the exa
 `readonly` is *shallow*, so a value contract must reach one level in — `readonly tags: readonly string[]`, not
 `readonly tags: string[]`, which still permits `config.tags.push(...)`.
 
-And never RETURN a live reference to an internal mutable container: hand back a copy (`[...this.#items]`), an
-immutable view whose immutability REACHES the mutable state (`ReadonlyArray<Readonly<T>>` or primitive
-elements), or frozen data, so a caller cannot mutate the owner's private state (`coding` P16, in TypeScript
-form). A `readonly` type is SHALLOW and erased: a `readonly { x: T }[]` still lets a caller assign `view[0].x`,
-and an aliased non-`readonly` handle to the same object mutates it too (`scenarios.md` TS-SCENARIO-11).
+And never hand the caller a mutable PATH into internal state: return a DEEP copy, a deeply-immutable or frozen
+structure, or primitive / fully-`readonly` elements (`coding` P16, in TypeScript form). `readonly` and
+`Readonly<T>` are SHALLOW and erased — a `readonly { x: T }[]` still lets a caller assign `view[0].x`, and a
+spread `[...this.#items]` of mutable objects shares those objects, so `copy[0].x` mutates the owner too. A
+shallow guard suffices only when the elements are themselves immutable (`scenarios.md` TS-SCENARIO-11).
 
 Note a TypeScript-specific trap at the constructor boundary: `erasableSyntaxOnly` bans parameter-properties
 (`constructor(private clock: Clock)`), so assign the field explicitly in the body.

--- a/.gobbi/projects/gobbi/skills/typescript/design.md
+++ b/.gobbi/projects/gobbi/skills/typescript/design.md
@@ -1,28 +1,323 @@
 # TypeScript — Design
 
-**Ownership** — TS unit and API design: function vs `const`-object vs class, model-with-unions-vs-class,
-signature shape, composition, when a generic is earned, the module tree, the ownership and failure shape, and
-the least-demanding input surface, including the exported-type / `.d.ts` surface.
+**Ownership** — the design *choice* for a TypeScript unit or API: function vs `const`-object vs class;
+modelling variants as a union vs a class hierarchy; signature shape and when a generic is *earned*;
+composition over inheritance; the ownership and mutation boundary (`readonly`); the least-demanding input
+surface; and the exported-type / public `.d.ts` surface as the deliberate contract.
 
 **Split criterion** — skill-writing P3 (d): a self-contained design sub-procedure an author works through
 before writing bodies, distinct from the SKILL.md cold-load floor.
 
-> Skeleton — sections below are stubs; the body is grown in T7-design.
+This doc **deepens, and does not restate,** SKILL.md § Procedure P3 (the six design acts) and Principles 2
+(*design the TypeScript surface*) and 3 (*model with the type system*). SKILL.md P3 owns the *decision tables*
+(`interface` vs `type`, when a generic is earned, discriminated union vs `enum`, `satisfies` vs annotation vs
+`as`); this doc owns the *choice behind them* — which unit shape, which contract, which input surface fits the
+caller. `typing.md` owns the type *form* (generic variance and bounds, guards, branded types, `.d.ts`
+mechanics); `convention.md` owns name spelling; `async-resources.md` owns promise and disposal lifetime. The
+parent P2 router sends a reader here on a unit-or-API shape choice; an ordinary module decides from `SKILL.md`
+alone.
+
+Every fenced `ts` block below type-checks under the skill's maximal-strict examples baseline (TS 5.9 floor); a
+`declare` line stubs an assumed collaborator so the fragment stands alone. Constructs are valid at TS 5.9; tool
+and library names are illustrative, not a lock.
+
+**One bottom-up design sequence:** module tree and ESM boundary → candidate functions over plain data → only
+the classes that earn their keep → signatures, earned generics, and the exported surface → typed skeleton
+stubs. Revisit an earlier step when a later seam exposes a bad choice.
+
+## Contents
+
+1. [Unit shape: function, `const`-object, or class](#1-unit-shape-function-const-object-or-class)
+2. [Type surface and signatures](#2-type-surface-and-signatures)
+3. [Composition and ownership boundaries](#3-composition-and-ownership-boundaries)
+4. [The input surface and the exported `.d.ts`](#4-the-input-surface-and-the-exported-dts)
 
 ---
 
-## Unit shape: function, `const`-object, or class
+## 1. Unit shape: function, `const`-object, or class
 
-> Stub — grown in T7-design.
+The decisive question is the same as the parent's: does state have a lifetime across calls? If not, a typed
+function over plain data is the whole unit — TypeScript needs no class to give a transformation a home. A class
+earns its keep only for identity, an invariant held across calls, or several behaviors over the same owned
+mutable state. Below the function default, TypeScript offers two more shapes a nominal language reaches for a
+class to express; pick by the table, switch on evidence.
 
-## Type surface and signatures
+| Form | Choose when | Switch signal |
+|---|---|---|
+| Function over plain data | one transformation; no state outlives the call | calls must share identity or hold an invariant across calls → a class |
+| Closure (a function returning a function) | setup validates or derives values once, then a simple call repeats | the captured state needs several distinct operations → a class |
+| `const`-object companion | a set of operations over one type, no per-instance state | instances carry independent mutable state → a class |
+| Discriminated union + a function | a closed set of variants whose behavior switches on the tag | each variant owns mutable state and a lifecycle → a small class set |
+| Class | identity, an invariant across calls, or several behaviors over owned mutable state | the surface is one constructor plus one method → a closure |
 
-> Stub — grown in T7-design.
+**A configured callable is a closure, not a one-method class.** When setup validates or derives values and the
+result is a single repeated call, capture the values in a closure and return the function. Collapse a class
+whose whole surface is a constructor plus one method.
 
-## Composition and ownership boundaries
+```ts
+type Rate = (amountCents: number) => number;
 
-> Stub — grown in T7-design.
+function makeRate(percent: number): Rate {
+  if (percent < 0 || percent > 100) {
+    throw new Error("percent must be within 0..100");
+  }
+  return (amountCents) => Math.round((amountCents * percent) / 100);
+}
+```
 
-## The input surface and the exported `.d.ts`
+**A set of operations over one type is a `const`-object companion, not a class of `static` methods.** Name the
+shape with an `interface`; give the operations a `const` object that shares the name (a type and a value may
+share a name). Callers reach `Money.of` / `Money.add` with no instance, and there is no `static`-only class or
+singleton to construct.
 
-> Stub — grown in T7-design.
+```ts
+interface Money {
+  readonly cents: number;
+  readonly currency: string;
+}
+
+const Money = {
+  of(cents: number, currency: string): Money {
+    return { cents, currency };
+  },
+  add(a: Money, b: Money): Money {
+    if (a.currency !== b.currency) {
+      throw new Error("currency mismatch");
+    }
+    return { cents: a.cents + b.cents, currency: a.currency };
+  },
+} as const;
+```
+
+**Model a closed set of variants as a discriminated union with a function, not a class hierarchy.** The union
+keeps data separate from behavior, stays erasable (no `enum`, no abstract base), and lets a new behavior be a
+new function rather than a method added across every subclass. Adding a variant turns each switch into a
+compile error until it is handled — the `never` exhaustiveness check SKILL.md P3 shows and `typing.md` §1 owns
+the form of. Reach for a class hierarchy only when each variant owns mutable state and a lifecycle, not merely
+different data.
+
+```ts
+type Notification =
+  | { readonly kind: "email"; readonly address: string }
+  | { readonly kind: "sms"; readonly number: string };
+
+function recipient(n: Notification): string {
+  switch (n.kind) {
+    case "email":
+      return n.address;
+    case "sms":
+      return n.number;
+  }
+}
+```
+
+## 2. Type surface and signatures
+
+A signature is the contract a caller reads before the body exists. This section owns its *shape* — argument
+order, the required/optional boundary, and whether a type parameter earns its place; `typing.md` owns the
+annotation form, `convention.md` the spelling.
+
+**Prefer required, ordered parameters for a small arity; move to an options object when inputs are optional,
+flag-like, or same-typed.** TypeScript has no positional-only or keyword-only marker, so an options object is
+the tool that forces a name at the call site. Use it when two or more parameters share a type, when position no
+longer identifies purpose, or when several inputs are optional.
+
+**Kill the boolean trap with a literal union.** A bare boolean reads as `render(doc, true)` at the call site,
+telling the reader nothing. A string-literal union names each state and stays erasable — the TypeScript form of
+the parent's "no boolean flag" rule.
+
+```ts
+interface RenderOptions {
+  readonly format: "html" | "text";
+  readonly pretty?: boolean;
+}
+
+function render(doc: string, options: RenderOptions): string {
+  const body = options.pretty === true ? `\n${doc}\n` : doc;
+  return options.format === "html" ? `<p>${body}</p>` : body;
+}
+```
+
+**Choose an optional property `?:` versus `| undefined` deliberately** — under `exactOptionalPropertyTypes`
+(in the maximal-strict base) they differ. `limit?: number` means the key may be *absent*; `limit: number |
+undefined` means the key must be *present* and may hold `undefined`. Pick the one the contract means; the flag
+then rejects the other.
+
+```ts expect-error
+interface Query {
+  readonly table: string;
+  readonly limit?: number;
+}
+
+// @ts-expect-error exactOptionalPropertyTypes forbids an explicit `undefined` where the key may simply be absent
+const q: Query = { table: "users", limit: undefined };
+```
+
+**A generic is earned only when the type parameter *links* one position to another** — an input to the output,
+or two inputs to each other — so the caller's concrete type flows through and is preserved. A type parameter
+that appears once, only in an input and never in the output, links nothing: it is a disguised `unknown`, and a
+plain `unknown` (or a constraint) reads clearer. Do not add a type parameter for a future caller that does not
+exist yet.
+
+```ts
+// earned: T links the element type of the input to the return type
+function first<T>(items: readonly T[]): T | undefined {
+  return items[0];
+}
+```
+
+```ts
+// unearned: T appears once and links nothing — the element type is irrelevant to the count
+function countGeneric<T>(items: readonly T[]): number {
+  return items.length;
+}
+
+// fixed: drop the type parameter
+function count(items: readonly unknown[]): number {
+  return items.length;
+}
+```
+
+Prefer a single signature with a union parameter over a stack of overloads; reach for overloads only when the
+return type genuinely depends on the argument in a way one signature cannot state. `typing.md` §2 owns the
+generic *form* — `const` type parameters, variance, and bounds.
+
+## 3. Composition and ownership boundaries
+
+**Compose by holding a collaborator; do not inherit to borrow behavior.** Receive a collaborator at the
+constructor boundary and hold it as a `readonly` field, typed by a small structural `interface` so the surface
+stays swappable and testable. Inheriting merely to reuse a method welds two surfaces that should move
+independently; vary one behavior with a function value or an injected collaborator, not a subclass.
+
+**`readonly` marks the ownership and mutation boundary the signature would otherwise leave unstated.** A
+`readonly` field cannot be reassigned; a `readonly T[]` parameter tells the caller "I only read this array, I
+will not mutate it"; a `readonly`-fielded return type asks the caller not to mutate what it received. Because
+these erase at runtime they cost nothing, yet they document ownership at the exact boundary. TypeScript's
+`readonly` is *shallow*, so a value contract must reach one level in — `readonly tags: readonly string[]`, not
+`readonly tags: string[]`, which still permits `config.tags.push(...)`.
+
+Note a TypeScript-specific trap at the constructor boundary: `erasableSyntaxOnly` bans parameter-properties
+(`constructor(private clock: Clock)`), so assign the field explicitly in the body.
+
+```ts
+interface Clock {
+  now(): number;
+}
+
+class RateLimiter {
+  readonly #clock: Clock;
+  readonly #windowMs: number;
+  #hits: number[] = [];
+
+  constructor(clock: Clock, windowMs: number) {
+    this.#clock = clock; // assign in the body — parameter-properties are non-erasable
+    this.#windowMs = windowMs;
+  }
+
+  allow(limit: number): boolean {
+    const cutoff = this.#clock.now() - this.#windowMs;
+    this.#hits = this.#hits.filter((t) => t > cutoff);
+    this.#hits.push(this.#clock.now());
+    return this.#hits.length <= limit;
+  }
+}
+```
+
+The class above earns its keep — it holds an invariant (the sliding window) across calls over owned mutable
+state (`#hits`) — and it composes `Clock` by interface rather than extending a base clock. A pure reader states
+its non-mutation in the signature:
+
+```ts
+function total(prices: readonly number[]): number {
+  return prices.reduce((sum, p) => sum + p, 0);
+}
+```
+
+```ts
+interface Config {
+  readonly name: string;
+  readonly tags: readonly string[]; // deep: neither the field nor the array can be mutated
+}
+```
+
+## 4. The input surface and the exported `.d.ts`
+
+**Demand only the fields the unit uses.** When a body reads two fields of a wide record, a signature that takes
+the whole record is stamp coupling: it hides the real dependency and makes every caller assemble more than the
+call needs. Take the fields as parameters (data coupling), a small purpose-built value carrying exactly the
+used surface, or — because TypeScript is *structural* — an `interface` that declares only the members the unit
+reads, which any wider value already satisfies. Keep an aggregate whole only when the unit genuinely uses it as
+one concept. The structural branch is the TypeScript-specific gain: the signature narrows to two members while
+a caller passes the wide object it already holds, no adapter required.
+
+```ts
+declare function fetchWithRetry(timeoutMs: number, retries: number): Promise<Response>;
+
+interface AppConfig {
+  readonly baseUrl: string;
+  readonly timeoutMs: number;
+  readonly retries: number;
+  readonly logLevel: string;
+  readonly apiKey: string;
+}
+
+// bad — the signature demands all of AppConfig, but the body reads only 2 of its 5
+// fields; baseUrl, logLevel, and apiKey go unused: stamp coupling
+function fetchBad(config: AppConfig): Promise<Response> {
+  return fetchWithRetry(config.timeoutMs, config.retries);
+}
+
+// good 1 — take the two fields it uses, as parameters (data coupling)
+function fetchNarrow(timeoutMs: number, retries: number): Promise<Response> {
+  return fetchWithRetry(timeoutMs, retries);
+}
+
+// good 2 — a small purpose-built value carrying exactly the used surface
+interface RetryBudget {
+  readonly timeoutMs: number;
+  readonly retries: number;
+}
+function fetchBudgeted(budget: RetryBudget): Promise<Response> {
+  return fetchWithRetry(budget.timeoutMs, budget.retries);
+}
+
+// good 3 — a structural interface: any value with these members satisfies it, so a
+// caller may pass the wider AppConfig it already holds, yet the signature still
+// declares only the two members the unit reads
+interface RetryPolicy {
+  readonly timeoutMs: number;
+  readonly retries: number;
+}
+function fetchWith(policy: RetryPolicy): Promise<Response> {
+  return fetchWithRetry(policy.timeoutMs, policy.retries);
+}
+
+declare const appConfig: AppConfig;
+const pending: Promise<Response> = fetchWith(appConfig); // AppConfig already satisfies RetryPolicy
+```
+
+**The exported surface is the published contract — design it, do not let it fall out of the bodies.** Whatever
+a module `export`s becomes its public `.d.ts`, and because TypeScript infers return types, an un-annotated
+export can widen a return or leak an internal field into the contract at one keystroke (the risk Principle 2
+names). Export only the intended API, keep helper types unexported, and annotate every exported return so an
+internal shape cannot escape into the emitted declarations — the same discipline `isolatedDeclarations`
+enforces mechanically (`modules-tooling.md` owns the flag). Prefer a named, narrow return type over an inferred
+structural blob a consumer must read the body to understand.
+
+```ts
+export interface PublicUser {
+  readonly id: string;
+  readonly name: string;
+}
+
+// the explicit return annotation is the published contract; without it, inference
+// could widen the shape and leak `passwordHash` into the emitted .d.ts
+export function loadUser(id: string): PublicUser {
+  const row = { id, name: "Ada", passwordHash: "9f…" };
+  return { id: row.id, name: row.name };
+}
+```
+
+When the exported surface changes, it is a blast-radius change — coding P15 / principles P9 — so every
+consumer, the emitted `.d.ts`, and the package `exports` move together (`packaging-publishing.md` owns
+publishing evolution).

--- a/.gobbi/projects/gobbi/skills/typescript/evaluation.md
+++ b/.gobbi/projects/gobbi/skills/typescript/evaluation.md
@@ -37,7 +37,7 @@ Procedure keys always carry the word `Procedure`.
 - `H2` — Resolves to "MUST use ESM with `verbatimModuleSyntax`" — deterministic type-only vs value erasure.
 - `H3` — Resolves to "MUST pick the import extension by consumption mode" — `.js` emit vs `.ts` strip, never mixed.
 - `H4` — Resolves to "MUST validate untrusted boundary data before use" — narrow `unknown` before logic reads it.
-- `H5` — Resolves to "MUST handle every promise" — await, `void`, or `.catch`; no invisible rejection.
+- `H5` — Resolves to "MUST handle every promise" — `await`, `return`, or a real `.catch`; a bare `void` is not a rejection handler.
 - `H6` — Resolves to "MUST throw only `Error` subclasses and catch as `unknown`" — narrow before use, chain `cause`.
 - `H7` — Resolves to "MUST keep syntax erasable" — union or `as const` over `enum` / `namespace` / param-property.
 - `H8` — Resolves to "MUST make every taught `ts` example type-check" — a taught example is a checkable fact.
@@ -189,8 +189,8 @@ an `as` over a real check, a floating rejection, a non-erasable construct, or a 
 | Anti-pattern | Correction |
 |---|---|
 | **`as` as input validation** | An annotation states shape but never checks it; parse untrusted `unknown` with a guard or schema before use |
-| **A floating promise** | Await, `void`, or `.catch` every promise; an un-awaited rejection surfaces far from its cause with no signature warning |
-| **A non-erasable construct in a stripped runtime** | Keep syntax erasable; an `enum` or param-property is a syntax error where types are stripped, not compiled |
+| **A floating promise** | Await or `return` every promise, or attach a real handler (`void promise.catch(...)`); a bare `void` silences the lint but leaves the rejection unhandled, surfacing far from its cause |
+| **A non-erasable construct under the erasable baseline** | Keep syntax erasable (unions / `as const` over `enum` / `namespace` / param-property); Node `--experimental-strip-types` rejects them at load, while Bun and Deno transpile them — the baseline is a portability policy, not a claim that every runtime fails to load them |
 
 ---
 

--- a/.gobbi/projects/gobbi/skills/typescript/evaluation.md
+++ b/.gobbi/projects/gobbi/skills/typescript/evaluation.md
@@ -1,0 +1,26 @@
+# TypeScript — Evaluation
+
+**Ownership** — the TS-idiom review frame: the seven-perspective idiom-level frame mirroring `coding`'s
+property-level `evaluation.md`, and the entry point that routes an evaluator to the scenarios and the
+checklists.
+
+**Split criterion** — skill-writing P3 (a): one member of the eval-triad SET (`evaluation.md` + `scenarios.md`
++ `checklists.md`). The three are one required set the anti-monolith rule forbids collapsing into a single
+file; this doc owns the frame and the routing.
+
+> Skeleton — sections below are stubs; the body is grown in T6-eval-triad.
+
+---
+
+## Review frame: property vs idiom
+
+> Stub — grown in T6-eval-triad.
+
+## Rule-key legend
+
+> Stub — grown in T6-eval-triad. The legend crosswalk resolves VERBATIM to live SKILL.md rule / principle
+> clauses (Gate A); it is co-edited with any SKILL.md rule change.
+
+## Routing to scenarios and checklists
+
+> Stub — grown in T6-eval-triad.

--- a/.gobbi/projects/gobbi/skills/typescript/evaluation.md
+++ b/.gobbi/projects/gobbi/skills/typescript/evaluation.md
@@ -116,7 +116,7 @@ the checkout?
 **Lens**: Are the **modules, exported types, unions, and resource lifetimes** idiomatic — illegal states
 unrepresentable, a deep type surface, earned generics, owned disposal, and erasable structure?
 
-**Activated**: `TS-SCENARIO-02`, `-06`, `-07` · `TS-CHECK-02`, `-09`, `-12`, `-13`, `-14`, `-15`.
+**Activated**: `TS-SCENARIO-02`, `-06`, `-07`, `-11` · `TS-CHECK-02`, `-09`, `-12`, `-13`, `-14`, `-15`, `-20`.
 
 | Anti-pattern | Correction |
 |---|---|

--- a/.gobbi/projects/gobbi/skills/typescript/evaluation.md
+++ b/.gobbi/projects/gobbi/skills/typescript/evaluation.md
@@ -1,26 +1,238 @@
-# TypeScript — Evaluation
+# TypeScript — Idiom Review Frame
 
-**Ownership** — the TS-idiom review frame: the seven-perspective idiom-level frame mirroring `coding`'s
-property-level `evaluation.md`, and the entry point that routes an evaluator to the scenarios and the
-checklists.
+Child doc for the evaluator (and the executor's pre-handoff self-check) grading a TypeScript change-set for
+**idiom** quality — the TypeScript-specific companion to [`../coding/evaluation.md`](../coding/evaluation.md).
+That frame grades the language-agnostic **property** of good code; this one grades whether the property is
+expressed in idiomatic, maximal-strict TypeScript. A change can satisfy a property yet read as loose TypeScript
+(an `as` cast standing in for a runtime check, a floating promise, a non-erasable `enum`), or read as fluent
+TypeScript yet fail a property, so both frames are read and each perspective is graded against both — `coding`
+grades the property, `typescript` its TypeScript expression.
 
-**Split criterion** — skill-writing P3 (a): one member of the eval-triad SET (`evaluation.md` + `scenarios.md`
-+ `checklists.md`). The three are one required set the anti-monolith rule forbids collapsing into a single
-file; this doc owns the frame and the routing.
-
-> Skeleton — sections below are stubs; the body is grown in T6-eval-triad.
+This frame does not restate the parent — it POINTS: the good/bad/adversarial cases live in
+[`scenarios.md`](scenarios.md) (`TS-SCENARIO-*`), the binary checks in [`checklists.md`](checklists.md)
+(`TS-CHECK-*`), and the rules and principles they exercise live in [`SKILL.md`](SKILL.md). This file owns the
+seven idiom lenses, the case/check selection procedure, the recommended verifications, the perspective
+anti-patterns, the Overall anchors, the preserve list, and the rule-key legend. It adds no evaluator artifact:
+each system still writes exactly **nine** outputs — seven perspective files, `overall.md`, and the copied phase
+`checklist.md`. It loads through the parent's Procedure step P2 router, applies at Procedure step P8, grades at
+the TypeScript 5.9 floor, and is tool-agnostic.
 
 ---
 
-## Review frame: property vs idiom
+## Rule-key legend — the single crosswalk
 
-> Stub — grown in T6-eval-triad.
+Every `scenarios.md` case and `checklists.md` item names its source by `H1`–`H13` (a `SKILL.md` Rule), `P1`–`P7`
+(a `SKILL.md` Principle), or `Procedure P1`–`Procedure P8` (a `SKILL.md` Procedure step), and resolves here to the
+verbatim opening clause of the `SKILL.md` rule, principle, or step it names — the **sole crosswalk**, so a rule
+change propagates through one legend, not three copies. Every "Resolves to" clause below is a live substring of
+`SKILL.md`; edit this legend in the same change that edits the rule text.
 
-## Rule-key legend
+**Disambiguation:** `P{n}` = a `SKILL.md` Principle (the `## Principles` blockquotes); `Procedure P{n}` = a
+`SKILL.md` Procedure step (the `## Procedure` `P1`–`P8`). A bare `P{n}` never means a Procedure step — the
+Procedure keys always carry the word `Procedure`.
 
-> Stub — grown in T6-eval-triad. The legend crosswalk resolves VERBATIM to live SKILL.md rule / principle
-> clauses (Gate A); it is co-edited with any SKILL.md rule change.
+### Rules (`H{n}` — Must-Follow `H1`–`H8`, Must-Not-Follow `H9`–`H13`)
 
-## Routing to scenarios and checklists
+- `H1` — Resolves to "MUST compile under a maximal-strict `tsconfig`" — the maximal-strict flag base.
+- `H2` — Resolves to "MUST use ESM with `verbatimModuleSyntax`" — deterministic type-only vs value erasure.
+- `H3` — Resolves to "MUST pick the import extension by consumption mode" — `.js` emit vs `.ts` strip, never mixed.
+- `H4` — Resolves to "MUST validate untrusted boundary data before use" — narrow `unknown` before logic reads it.
+- `H5` — Resolves to "MUST handle every promise" — await, `void`, or `.catch`; no invisible rejection.
+- `H6` — Resolves to "MUST throw only `Error` subclasses and catch as `unknown`" — narrow before use, chain `cause`.
+- `H7` — Resolves to "MUST keep syntax erasable" — union or `as const` over `enum` / `namespace` / param-property.
+- `H8` — Resolves to "MUST make every taught `ts` example type-check" — a taught example is a checkable fact.
+- `H9` — Resolves to "NEVER use `any`" — it disables the checker and spreads by assignment.
+- `H10` — Resolves to "NEVER assert with `as` to silence an error" — annotate or `satisfies` instead.
+- `H11` — Resolves to "NEVER rely on an `enum` for a closed set" — a discriminated union or `as const` object.
+- `H12` — Resolves to "NEVER ship dual ESM + CJS from one `verbatimModuleSyntax` source" — publish ESM-only.
+- `H13` — Resolves to "NEVER leave a `Promise` un-awaited" — fire-and-forget loses the rejection.
 
-> Stub — grown in T6-eval-triad.
+### Principles (`P{n}` — the seven `## Principles`)
+
+- `P1` — Resolves to "Study the TypeScript contract and neighboring code before design." — the tsconfig in force.
+- `P2` — Resolves to "Design the TypeScript surface with the user, from references." — the exported `.d.ts` is the contract.
+- `P3` — Resolves to "Model with the type system: make illegal states unrepresentable." — prove invariants at build time.
+- `P4` — Resolves to "Ban `any`; quarantine `unknown` at the boundary." — validation is a separate runtime act.
+- `P5` — Resolves to "Make async and resource lifetime explicit; never float a promise." — cancellation and scoped disposal.
+- `P6` — Resolves to "Choose the failure shape: throw for the exceptional, return a typed result for the expected." — model the expected miss.
+- `P7` — Resolves to "Type-erase cleanly: keep the runtime honest and the build strict." — the strict `tsc` pass is the only check.
+
+### Procedure steps (`Procedure P{n}` — cited where a check grades operation, not a single rule)
+
+- `Procedure P1` — Resolves to "Study and lock the task and the TypeScript contract" — scope and contract first.
+- `Procedure P2` — Resolves to "Load the child docs for the forks in play" — read the runtime-delta child before the boundary.
+- `Procedure P5` — Resolves to "Build the typed skeleton first" — signatures type-check green before any body.
+- `Procedure P6` — Resolves to "Grow in minimal verified slices" — per-slice evidence, the whole affected set in lockstep.
+- `Procedure P7` — Resolves to "Verify the whole change" — the fixed self-failing gate order.
+
+---
+
+## Selecting cases and checks
+
+Run this after the evaluation Stage 0 target read and before locking the Stage 1 Frames.
+
+1. **Load all three** — this file, [`scenarios.md`](scenarios.md), and [`checklists.md`](checklists.md), plus
+   [`../coding/evaluation.md`](../coding/evaluation.md) for the independent language-agnostic axis.
+2. **Map the diff to its TypeScript surfaces** — the tsconfig flag set and module system; trust boundaries;
+   promises, cancellation, and resource lifetimes; the exported types and public `.d.ts`; the failure shape;
+   erasable syntax; the target-runtime boundary; and the implementation history.
+3. **Select the activated cases and checks.** Take every applicable `TS-SCENARIO-*` and its listed `TS-CHECK-*`
+   IDs, plus any check whose `H{n}` / `P{n}` / `Procedure P{n}` applies directly with no close seed match. Record
+   a specific `n/a: {reason}` for an inapplicable hard check the surface could plausibly activate — never omit it
+   silently.
+4. **Stage, do not copy prose.** Put the selected `TS-CHECK-*` items into the copied phase checklist under exactly
+   `## Stage 1 Additions`, keeping their IDs and wording from `checklists.md` and editing neither source. Every
+   evaluation still walks all seven perspectives — one the change does not exercise is still walked and may record
+   zero findings. The triad adds no tenth output: findings stay in the seven perspective files + `overall.md`, and
+   the filled `checklist.md` stays the coverage register.
+5. **Demand bottom-up evidence for the operation checks.** One final green `tsc` proves only final state; require
+   ordered evidence of both checkpoints — a typed skeleton that imports and type-checks green before behavior
+   (`TS-CHECK-14`, `TS-SCENARIO-08`) and focused verification after each slice (`TS-CHECK-15`). First evidence
+   arriving only after a whole-feature pass fails the bottom-up check.
+
+---
+
+## Perspectives
+
+Each lens lists its **Activated** case/check IDs and its anti-patterns; the recommended verifications follow in
+one consolidated section.
+
+### Project
+
+**Lens**: Does the TypeScript approach fit the **declared tsconfig, artifact type, and target runtime** — no
+loosened strict flag, no import-extension mode the runtime cannot resolve, no silent narrowing to one runtime or
+the checkout?
+
+**Activated**: `TS-SCENARIO-05`, `-08`, `-10` · `TS-CHECK-01`, `-03`, `-18`, `-19`.
+
+| Anti-pattern | Correction |
+|---|---|
+| **A loosened strict flag** | Compile under the maximal-strict base; a dropped `noUncheckedIndexedAccess` or `exactOptionalPropertyTypes` hides the defect the flag exists to catch |
+| **One runtime assumed everywhere** | Read the target-runtime delta first; a `.ts` specifier or a `node:` builtin does not resolve the same across Node, Bun, Deno, and the browser |
+| **Verified from the checkout** | Validate the built package, not only the source tree; a `.d.ts` or `exports` break shows only from the artifact |
+
+### Structure
+
+**Lens**: Are the **modules, exported types, unions, and resource lifetimes** idiomatic — illegal states
+unrepresentable, a deep type surface, earned generics, owned disposal, and erasable structure?
+
+**Activated**: `TS-SCENARIO-02`, `-06`, `-07` · `TS-CHECK-02`, `-09`, `-12`, `-13`, `-14`, `-15`.
+
+| Anti-pattern | Correction |
+|---|---|
+| **A representable illegal state** | Model with a discriminated union so the wrong combination cannot be constructed, not a bag of optional fields validated after the fact |
+| **A generic for one call site** | Add a type parameter only when it links an input to an output across many types; a single-use generic reads worse than the concrete type |
+| **A `default` branch that swallows a new variant** | End the `switch` with a `never` exhaustiveness check so a new case is a compile error, not a silent fall-through |
+
+### Performance
+
+**Lens**: Is the change **efficient enough in idiomatic TypeScript** — bounded async fan-out, released resources,
+and compiler cost kept down (project references, `skipLibCheck`, `incremental`) without trading the clear form for
+an unmeasured gain?
+
+**Activated**: `TS-SCENARIO-02` · `TS-CHECK-07`, `-14`.
+
+| Anti-pattern | Correction |
+|---|---|
+| **Unbounded eager fan-out** | Bound concurrent task creation and retained memory; an unbounded `Promise.all` over a large input blows up under load |
+| **A leaked handle or connection** | Bind release to scope with `using` / `await using`; an unreleased resource is a slow leak the happy-path test never sees |
+| **Type-level cleverness that stalls the build** | Deep conditional-type recursion has a compile cost; keep the type as simple as the invariant needs |
+
+### Aesthetics
+
+**Lens**: Does the change read like **one disciplined TypeScript codebase** — deterministic formatting, convention
+casing, `import type` ordering, TSDoc that adds what the signature cannot, and idioms that clarify rather than
+compress?
+
+**Activated**: `TS-SCENARIO-04`, `-07` · `TS-CHECK-06`, `-13`.
+
+| Anti-pattern | Correction |
+|---|---|
+| **An `as`-cast forest** | Reach for an annotation (`: T`) or `satisfies T`; a chain of assertions is the checker being switched off line by line |
+| **A dense conditional type nobody can read** | Name the intermediate types; a one-line mapped-and-conditional type hides its own contract |
+| **An `enum` where a union reads clearer** | Model the closed set as a discriminated union or `as const` object — erasable, sound, and self-documenting |
+
+### Usage
+
+**Lens**: For the **next caller** — can they use each changed unit from its signature, exported types, and `.d.ts`
+alone, with the failure shape, ownership, and async-vs-sync surface explicit?
+
+**Activated**: `TS-SCENARIO-03`, `-07` · `TS-CHECK-08`, `-13`, `-19`.
+
+| Anti-pattern | Correction |
+|---|---|
+| **An `any` in a public signature** | Narrow to a precise type at the boundary; `any` erases the contract and spreads to every caller |
+| **A hidden throw the signature does not reveal** | Model an expected failure as a typed result in the return type, where the compiler forces the caller to handle it |
+| **A stamp-coupled input type** | Demand the specific values the unit reads, not a whole aggregate the caller must assemble and decode |
+
+### Consistency
+
+**Lens**: Did **everything that should change together, change together** — callers, tests, the emitted `.d.ts`,
+co-located docs, and the tsconfig — with one import-extension mode and one module system across the tree?
+
+**Activated**: `TS-SCENARIO-05`, `-08` · `TS-CHECK-02`, `-03`, `-16`, `-19`.
+
+| Anti-pattern | Correction |
+|---|---|
+| **A stale `.d.ts` after a type change** | Regenerate and re-check the declaration surface in the same change; a drifted `.d.ts` breaks the consumer, not the author |
+| **Mixed import-extension modes** | Keep one mode per source tree — `.js` for emit or `.ts` for strip, never both |
+| **A tsconfig flag that disagrees between surfaces** | Make the base, the overlay, and the runtime tsconfig agree; a flag on in one and off in another breaks on the strict path |
+
+### Risk
+
+**Lens**: Which **TypeScript footgun** makes this change fail at runtime, leak a resource, or lie to the compiler —
+an `as` over a real check, a floating rejection, a non-erasable construct, or a caught non-`Error`?
+
+**Activated**: `TS-SCENARIO-01`, `-02`, `-03`, `-04`, `-09` · `TS-CHECK-04`, `-05`, `-06`, `-07`, `-08`, `-09`,
+`-10`, `-11`, `-17`.
+
+| Anti-pattern | Correction |
+|---|---|
+| **`as` as input validation** | An annotation states shape but never checks it; parse untrusted `unknown` with a guard or schema before use |
+| **A floating promise** | Await, `void`, or `.catch` every promise; an un-awaited rejection surfaces far from its cause with no signature warning |
+| **A non-erasable construct in a stripped runtime** | Keep syntax erasable; an `enum` or param-property is a syntax error where types are stripped, not compiled |
+
+---
+
+## Recommended verifications
+
+Capabilities are binding; tool names are examples. First run the generic ordered pipeline the scope activates —
+format → lint → type-check → focused tests → full tests → type-level tests → build — owned by `SKILL.md` Procedure
+step P7. Then add the TypeScript-idiom-specific verifications below.
+
+| Capability | Confirms |
+|---|---|
+| Type-check under the maximal-strict base; try a loosened flag and watch it stop catching | Strict-flag honesty (`H1`); no reliance on a dropped flag |
+| Read every import for `import type` vs value and its extension against the consumption mode | Deterministic erasure (`H2`) and one import-extension mode (`H3`) |
+| Trace each untrusted boundary value from entry to first use; confirm a guard or parser sits before it, not an `as` | Boundary validation, not annotation-as-validation (`H4`, `P4`) |
+| `grep` the diff for `any`, `as`, `@ts-ignore`, and `!` non-null assertions; check each `as` for a prior runtime narrow | No checker-disabling escape hatch (`H9`, `H10`) |
+| `grep` for un-awaited async calls and for resource acquisition without `using` / `await using` / `finally` | Handled promises and scope-bound disposal (`H5`, `H13`, `P5`) |
+| Read each `throw` for an `Error` subclass with `cause` and each `catch` for `unknown` + a narrow; read the return type for an expected-failure result | Failure-shape idiom (`H6`, `P6`) |
+| `grep` for `enum`, `namespace`, and constructor parameter-properties; confirm each closed set is a union or `as const` | Erasable syntax under a type-stripping runtime (`H7`, `H11`, `P7`) |
+| Add a variant to each discriminated union and confirm the build fails until it is handled | A `never` exhaustiveness check, not a swallowing `default` (`P3`) |
+| Simulate a first-time caller from each exported signature and `.d.ts` alone; check for an `any`, a hidden throw, or a stamp-coupled input | Caller-usable contract (`P2`) |
+| Confirm the typed skeleton type-checks green before bodies; review history for per-slice evidence | Bottom-up construction (`Procedure P5`, `Procedure P6`); rejects a final-green-only claim |
+| Extract each fenced `ts` example and compile it under the examples baseline, honoring `@ts-expect-error` | Taught-example fidelity (`H8`) |
+| Build the package and run `publint` + `arethetypeswrong` on the artifact, not the checkout | ESM-only `exports` and `.d.ts` resolution across consumers (`H12`) |
+
+---
+
+## Overall (Stage 3) — TypeScript-specific anchors
+
+Step back from the per-perspective passes and check the change-set against the four TypeScript failure modes, then
+against what exists only **between** lenses — a clean type surface hiding an un-validated boundary, a bounded
+fan-out losing cancellation, or a final green `tsc` hiding whole-feature-first construction.
+
+| Mode | What it looks like in a TypeScript change-set |
+|---|---|
+| **Checker switched off** | An `any`, an `as`, a `@ts-ignore`, or a `!` that disables the one place a type is ever checked, so the wrong shape reaches runtime unproven |
+| **Invisible async** | A floating promise, a swallowed rejection, an un-cancelled long operation, or a resource released only on the happy path — none of which the signature reveals |
+| **Runtime-erasure surprise** | Syntax that compiles but does not strip (`enum`, `namespace`, param-property), or an import extension that resolves under `tsc` but not under the target runtime |
+| **Green-`tsc` illusion** | Passes one final strict compile while the `.d.ts` resolves wrong for a consumer, the skeleton-first history is absent, or a second runtime breaks on resolution or a built-in |
+
+**Preserve-list anchors specific to TypeScript idiom** — what a strong change already got right, which REVISE
+iterations must not undo: illegal-state-proof discriminated unions with `never` exhaustiveness; precise exported
+types and a clean `.d.ts`; `unknown`-at-the-boundary narrowed by a guard or parser; awaited promises with explicit
+cancellation and scoped disposal; erasable syntax under a strict `tsc`; typed-skeleton and per-slice evidence; and
+ESM-only packaging validated from the built artifact. If none apply, state `none — every TypeScript-idiom surface
+needs revision`.

--- a/.gobbi/projects/gobbi/skills/typescript/evaluation.md
+++ b/.gobbi/projects/gobbi/skills/typescript/evaluation.md
@@ -87,7 +87,7 @@ Run this after the evaluation Stage 0 target read and before locking the Stage 1
    the filled `checklist.md` stays the coverage register.
 5. **Demand bottom-up evidence for the operation checks.** One final green `tsc` proves only final state; require
    ordered evidence of both checkpoints — a typed skeleton that imports and type-checks green before behavior
-   (`TS-CHECK-14`, `TS-SCENARIO-08`) and focused verification after each slice (`TS-CHECK-15`). First evidence
+   (`TS-CHECK-15`, `TS-SCENARIO-08`) and focused verification after each slice (`TS-CHECK-16`). First evidence
    arriving only after a whole-feature pass fails the bottom-up check.
 
 ---

--- a/.gobbi/projects/gobbi/skills/typescript/modules-tooling.md
+++ b/.gobbi/projects/gobbi/skills/typescript/modules-tooling.md
@@ -8,30 +8,289 @@ build via `tsc` vs a bundler; and compiler performance (project references, `inc
 **Split criterion** — skill-writing P3 (b): a lookup reference — the tsconfig flag set, the resolution modes,
 and the lint config are consulted by decision, not read narratively.
 
-> Skeleton — sections below are stubs; the body is grown in T5-modules-tooling.
+This doc **deepens, and does not restate,** the SKILL.md modules/tooling Rules (compile under a maximal-strict
+`tsconfig`; ESM with `verbatimModuleSyntax`; pick the import extension by consumption mode; keep syntax
+erasable) and Principle 7 (*type-erase cleanly*). The parent P2 router sends a reader here when a change
+touches the tsconfig flag set and overlays, `moduleResolution`, the import-extension fork, the typed lint, or
+the build. SKILL.md states each as a one-line invariant; this doc owns the mechanics behind them — the full
+flag accounting, why `nodenext` beats `bundler`, how the two import-extension modes resolve, and the tool
+layers `tsc` alone does not cover.
+
+Most blocks below are configuration — a `tsconfig`, a `package.json`, an ESLint config — shown in `jsonc` /
+`json` / `js` for their shape; a config object is not TypeScript and is not compiled. The few fenced `ts`
+blocks are taught facts that type-check under the skill's maximal-strict examples baseline (TS 5.9 floor).
+
+## Contents
+
+1. [The strict base: 17 always-on flags](#1-the-strict-base-17-always-on-flags)
+2. [Thin overlays: library, app, runtime](#2-thin-overlays-library-app-runtime)
+3. [ESM, `moduleResolution: nodenext`, and `verbatimModuleSyntax`](#3-esm-moduleresolution-nodenext-and-verbatimmodulesyntax)
+4. [The import-extension fork](#4-the-import-extension-fork)
+5. [Erasable syntax: `isolatedModules`, `isolatedDeclarations`, `erasableSyntaxOnly`](#5-erasable-syntax-isolatedmodules-isolateddeclarations-erasablesyntaxonly)
+6. [Typed lint: `typescript-eslint`](#6-typed-lint-typescript-eslint)
+7. [Formatting: Prettier or Biome](#7-formatting-prettier-or-biome)
+8. [Build: `tsc` vs a bundler](#8-build-tsc-vs-a-bundler)
+9. [Compiler performance](#9-compiler-performance)
 
 ---
 
-## ESM, `verbatimModuleSyntax`, and the import-extension fork
+## 1. The strict base: 17 always-on flags
 
-> Stub — grown in T5-modules-tooling.
+Every artifact extends one strict base — the 14-flag `@tsconfig/strictest` preset plus three flags that
+post-date it. This is the maximal-strict floor SKILL.md's first Rule names; the config below is the whole of
+it, each flag written once.
 
-## The strict base and its overlays
+```jsonc
+// tsconfig.base.json — the 17 always-on flags. Extend it; never weaken it.
+{
+  "compilerOptions": {
+    // @tsconfig/strictest (14)
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    // added atop the preset (3)
+    "verbatimModuleSyntax": true,
+    "noUncheckedSideEffectImports": true,
+    "erasableSyntaxOnly": true
+  }
+}
+```
 
-> Stub — grown in T5-modules-tooling.
+Three flags carry most of the weight:
 
-## Typed lint
+- **`strict`** is an umbrella that turns on nine checks, including `strictNullChecks`, `noImplicitAny`, and
+  `useUnknownInCatchVariables` (a caught error is typed `unknown`, not `any`). Treat `strict: false` as
+  off-standard.
+- **`noUncheckedIndexedAccess`** is the highest-value flag `strict` omits: `arr[i]` and `rec[key]` become
+  `T | undefined`, so an out-of-range read is a compile error, not a runtime `undefined`. It sits outside
+  `strict` because it is noisy on code that indexes inside a checked loop.
+- **`exactOptionalPropertyTypes`** is the noisiest: with it, `{ x?: number }` accepts a MISSING `x` but rejects
+  an explicit `x: undefined` — the two stop meaning the same thing. Live with it by choosing deliberately —
+  `x?: number` for "may be absent," `x: number | undefined` for "must be present, may be undefined" — not by
+  reaching for `as` to paper over the difference.
 
-> Stub — grown in T5-modules-tooling.
+`skipLibCheck` is in the base for speed (§9): it skips type-checking the `.d.ts` files under `node_modules`,
+never your own code.
 
-## Formatting
+## 2. Thin overlays: library, app, runtime
 
-> Stub — grown in T5-modules-tooling.
+The base is artifact-neutral. Three thin overlays add only the flags a given artifact needs; each such flag
+lives in exactly ONE overlay and never in the base, so it applies only where it is meaningful.
 
-## Build: `tsc` vs bundler
+| Overlay | Adds | When |
+|---|---|---|
+| **library** | `declaration`, `declarationMap`, `isolatedDeclarations` | publishing a package that ships its own `.d.ts` |
+| **app** | `noEmit` (a bundler or runtime emits instead) | an application a bundler builds, publishing no types |
+| **runtime** | `lib` / `module` / `moduleResolution` deltas, and `rewriteRelativeImportExtensions` for a type-stripping runtime | cross-runtime code — see `runtime-deltas.md` |
 
-> Stub — grown in T5-modules-tooling.
+```jsonc
+// tsconfig.lib.json — the library overlay
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,          // emit the .d.ts consumers resolve against
+    "declarationMap": true,       // map the .d.ts back to source for go-to-definition
+    "isolatedDeclarations": true  // force fully-annotated exports — see below
+  }
+}
+```
 
-## Compiler performance
+`isolatedDeclarations` (5.5) lives ONLY in the library overlay: it forces every exported binding to carry an
+explicit type, so a `.d.ts` can be produced from one file with no whole-program inference. That constraint
+earns its cost only when a `.d.ts` is actually shipped, so an app never pays it. `declarationMap` is what lets
+a consumer's "go to definition" land on your source instead of the generated `.d.ts`. The `runtime` overlay's
+`rewriteRelativeImportExtensions` is the subject of §4.
 
-> Stub — grown in T5-modules-tooling.
+## 3. ESM, `moduleResolution: nodenext`, and `verbatimModuleSyntax`
+
+The module model is ESM end to end. Declare it once in `package.json`, then set the resolver:
+
+```json
+// package.json
+{
+  "type": "module"
+}
+```
+
+```jsonc
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext"
+  }
+}
+```
+
+**Why `nodenext`, even for a library that will be bundled.** The official guidance is to resolve with
+`nodenext` (not `bundler`) for anything you publish: code that resolves under Node's rules almost always works
+in a bundler too, while the reverse is false. `moduleResolution: bundler` allows imports a bundler accepts but
+Node rejects, and — worse for a library — the emitted `.d.ts` can then error when a consumer resolves it under
+`nodenext`. Reserve `bundler` for an application that owns its bundler; `runtime-deltas.md` names that variant.
+
+**`verbatimModuleSyntax` makes erasure deterministic.** An import or export WITHOUT a `type` modifier is
+emitted verbatim; anything WITH the `type` modifier is dropped whole. That removes the ambiguity
+`esModuleInterop` and `allowSyntheticDefaultImports` create, and it forces `import type` at a type-only import
+and `export type` at a type-only export — so what reaches runtime is exactly what you wrote:
+
+```ts
+// verbatimModuleSyntax forces the `type` keyword on a type-only export, so this
+// line erases whole; the value export below is emitted verbatim.
+type Celsius = number;
+export type { Celsius };
+
+export const freezing = 0;
+```
+
+Omit the keyword on a type and the compiler rejects it rather than silently guessing what to erase:
+
+```ts expect-error
+type Fahrenheit = number;
+
+// @ts-expect-error verbatimModuleSyntax: a type-only export must use `export type`
+export { Fahrenheit };
+```
+
+`verbatimModuleSyntax` is also why the skill publishes ESM-only: one source cannot deterministically erase to
+both ESM and CJS. `packaging-publishing.md` owns that `exports`-map consequence.
+
+## 4. The import-extension fork
+
+SKILL.md's Rule fixes the choice; this section is why the two modes exist and how each resolves. A relative
+import's specifier depends on HOW the file is consumed, because the two consumers resolve extensions
+differently:
+
+| Consumption | Import written | Enabled by |
+|---|---|---|
+| Emitted via `tsc` (published library) | `import { util } from "./util.js"` | `module: nodenext` — the emitted `.js` is what resolves |
+| Direct type-stripping (Node 24+, Bun, Deno) | `import { util } from "./util.ts"` | `rewriteRelativeImportExtensions: true` + `module: nodenext` |
+
+**Why `.js` on the emitted path.** `tsc` does not rewrite specifiers by default, and `nodenext` resolves a
+relative specifier against the EMITTED file — which is `.js`. So the source must already name `.js`, even
+though the file on disk is `.ts`; name `"./util"` or `"./util.ts"` and the emitted import fails to resolve at
+runtime.
+
+**Why `.ts` on the stripping path.** A type-stripping runtime executes the `.ts` file in place and resolves
+the real on-disk `.ts` name. `rewriteRelativeImportExtensions` (5.7) lets the SAME source also be built by
+`tsc`, which rewrites each `.ts` specifier to `.js` on emit — so one source both runs stripped and publishes a
+correct build.
+
+Never mix the two in one source tree: read the mode off P1's target-runtime contract and keep every relative
+import in it.
+
+## 5. Erasable syntax: `isolatedModules`, `isolatedDeclarations`, `erasableSyntaxOnly`
+
+Three similarly-named flags guard three different single-file guarantees. The base carries `isolatedModules`
+and `erasableSyntaxOnly`; the library overlay (§2) adds `isolatedDeclarations`.
+
+| Flag | Guarantees one file can be… | Consumer |
+|---|---|---|
+| `isolatedModules` | transpiled with no whole-program type info | a single-file transpiler (esbuild, swc, Babel) |
+| `erasableSyntaxOnly` | run by stripping types, generating no code from a type | a type-stripping runtime (Node 24+, Bun, Deno) |
+| `isolatedDeclarations` | turned into a `.d.ts` from itself alone | the declaration emitter for a library |
+
+`erasableSyntaxOnly` (5.8) is the flag that shapes daily syntax: it rejects any construct that would emit
+RUNTIME code from a type position — an `enum`, a `namespace` with runtime members, and a constructor parameter
+property. SKILL.md shows the `enum`; the parameter property is the other trap ordinary code hits:
+
+```ts expect-error
+class Timer {
+  // @ts-expect-error a parameter property emits a runtime assignment; erasableSyntaxOnly rejects it
+  constructor(private readonly ms: number) {}
+}
+```
+
+The fix is the same each time: a plain field assignment instead of a parameter property, an `as const` object
+or a discriminated union instead of an `enum`. `isolatedModules` is the weaker sibling of `verbatimModuleSyntax`
+(§3): `verbatimModuleSyntax` implies its constraints and adds deterministic erasure, so a project already on
+`verbatimModuleSyntax` satisfies `isolatedModules` for free.
+
+## 6. Typed lint: `typescript-eslint`
+
+`tsc` proves types; it does not catch a floating promise or a misused one. `typescript-eslint` with its
+TYPE-CHECKED configs closes that gap — it reads the type information `tsc` computes and flags correctness bugs
+the compiler allows:
+
+```js
+// eslint.config.js — flat config
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  ...tseslint.configs.strictTypeChecked,    // correctness rules that need type info
+  ...tseslint.configs.stylisticTypeChecked, // consistency rules
+  {
+    languageOptions: {
+      parserOptions: { projectService: true }, // typed rules need the program
+    },
+  },
+);
+```
+
+`strict-type-checked` brings the rules that matter most here: `no-floating-promises` (an un-awaited promise),
+`no-misused-promises` (a promise in a boolean or `void` position), and the `no-unsafe-*` family (an `any`
+flowing through your code). `stylistic-type-checked` adds the consistency rules. Because these read type
+information, they require `parserOptions.project` (or `projectService`) and run far slower than syntactic lint
+— roughly an order of magnitude — which is why typed lint is a project-level, CI-run gate, not a
+per-keystroke cost.
+
+**TS 7.0 caveat (honest).** The native Go compiler at TS 7.0 ships NO programmatic compiler API (7.1 is
+expected to add one), and `typescript-eslint` needs that API. So under a 7.0 install, typed lint does NOT run
+against the 7.0 binary: it runs against a side-by-side TS 6.x-compatible API package
+(`@typescript/typescript6`, which exposes a `tsc6`). Treat 7.0 as a type-check SPEED target for
+`tsc --noEmit`, not as one toolchain that also satisfies the typed-lint gate — the P7 lint step runs on the
+6.x-compat API alongside it.
+
+## 7. Formatting: Prettier or Biome
+
+Formatting is not a type concern: it runs first in the P7 verify order and never blocks on types. Pick one
+deterministic formatter and run it in check mode in CI:
+
+- **Prettier** is the default — ubiquitous, editor-integrated, opinionated.
+- **Biome** is the fast alternative — a single Rust tool that formats AND lints, much faster on a large tree,
+  at the cost of a smaller ecosystem.
+
+Follow the project's existing choice; two formatters fighting over the same file is pure churn. Neither
+replaces `typescript-eslint`'s typed rules (§6) — a formatter arranges code, it does not reason about types,
+and Biome's linter is not type-aware, so it does not cover `no-floating-promises`.
+
+## 8. Build: `tsc` vs a bundler
+
+Two jobs hide under "build," and only one of them checks types.
+
+- **`tsc`** type-checks AND emits `.js` + `.d.ts`. For a published library this IS the build: it is the only
+  tool that produces the `.d.ts` a consumer resolves (with the library overlay, §2), and it is the type-check
+  of record.
+- **A bundler** (esbuild, tsup, rollup) is faster and app-oriented, but most bundlers STRIP types the way a
+  runtime does — esbuild does not type-check at all. A bundled app therefore still needs a separate
+  `tsc --noEmit` as its type gate: the bundler emits, `tsc` judges.
+
+The rule that falls out: `tsc --noEmit` is the type-check gate no matter who emits the runtime artifact. A
+green bundler build is not a green type-check. (`tsup` and similar wrap `tsc` to emit the `.d.ts` on top of an
+esbuild bundle — a library convenience, but the `.d.ts` still comes from `tsc`.)
+
+## 9. Compiler performance
+
+Three levers cut `tsc` time on a growing codebase without weakening a single type:
+
+- **`skipLibCheck`** (already in the base, §1) skips type-checking the `.d.ts` files under `node_modules` — a
+  large, mostly-stable surface. It does NOT skip your own types.
+- **`incremental`** writes a `.tsbuildinfo` cache so a rebuild re-checks only what changed. Cheap to enable;
+  keep the cache file out of version control.
+- **Project references** split a large repo into composite sub-projects (`composite: true`) built with
+  `tsc -b`; each references those it depends on, so a change rebuilds only the affected sub-graph and its
+  dependents. This is the structural lever for a monorepo — decomposition-by-responsibility applied to the
+  build graph.
+
+Reach for these once build time is measured and growing, not preemptively (coding P14 — optimize on
+evidence). The TS 7.0 native compiler (§6) is the other axis: a large type-check speedup with no config
+change, bounded only by the typed-lint API caveat.

--- a/.gobbi/projects/gobbi/skills/typescript/modules-tooling.md
+++ b/.gobbi/projects/gobbi/skills/typescript/modules-tooling.md
@@ -176,15 +176,15 @@ differently:
 | Consumption | Import written | Enabled by |
 |---|---|---|
 | Emitted via `tsc` (published library) | `import { util } from "./util.js"` | `module: nodenext` — the emitted `.js` is what resolves |
-| Direct type-stripping (Node 24+, Bun, Deno) | `import { util } from "./util.ts"` | `rewriteRelativeImportExtensions: true` + `module: nodenext` |
+| Direct `.ts` run (Node 24+ strips, Bun/Deno transpile) | `import { util } from "./util.ts"` | `rewriteRelativeImportExtensions: true` + `module: nodenext` |
 
 **Why `.js` on the emitted path.** `tsc` does not rewrite specifiers by default, and `nodenext` resolves a
 relative specifier against the EMITTED file — which is `.js`. So the source must already name `.js`, even
 though the file on disk is `.ts`; name `"./util"` or `"./util.ts"` and the emitted import fails to resolve at
 runtime.
 
-**Why `.ts` on the stripping path.** A type-stripping runtime executes the `.ts` file in place and resolves
-the real on-disk `.ts` name. `rewriteRelativeImportExtensions` (5.7) lets the SAME source also be built by
+**Why `.ts` on the direct-run path.** A runtime that runs `.ts` in place (Node strips, Bun/Deno transpile)
+executes the file directly and resolves the real on-disk `.ts` name. `rewriteRelativeImportExtensions` (5.7) lets the SAME source also be built by
 `tsc`, which rewrites each `.ts` specifier to `.js` on emit — so one source both runs stripped and publishes a
 correct build.
 
@@ -248,8 +248,9 @@ per-keystroke cost.
 
 **TS 7.0 caveat (honest).** The native Go compiler at TS 7.0 ships NO programmatic compiler API (7.1 is
 expected to add one), and `typescript-eslint` needs that API. So under a 7.0 install, typed lint does NOT run
-against the 7.0 binary: it runs against a side-by-side JS-based TS-compatibility API package (the exact
-package and binary name are pending 7.0 GA). Treat 7.0 as a type-check SPEED target for
+against the 7.0 binary: it runs against the `@typescript/typescript6` compatibility package — installed side-by-side, it provides
+a `tsc6` binary and re-exports the TS 6.0 API for the tools that need it (TS 7.0 GA'd 2026-07-08). Treat 7.0
+as a type-check SPEED target for
 `tsc --noEmit`, not as one toolchain that also satisfies the typed-lint gate — the P7 lint step runs on the
 6.x-compat API alongside it.
 

--- a/.gobbi/projects/gobbi/skills/typescript/modules-tooling.md
+++ b/.gobbi/projects/gobbi/skills/typescript/modules-tooling.md
@@ -1,0 +1,37 @@
+# TypeScript — Modules and Tooling
+
+**Ownership** — the no-`python`-analog tooling doc: ESM and `verbatimModuleSyntax`, `moduleResolution`, and
+the import-extension fork; the strict semantic base plus thin overlays (library / app / runtime); the
+`typescript-eslint` typed-lint layer (with the TS 7.0 side-by-side 6.x-API note); the Prettier / Biome choice;
+build via `tsc` vs a bundler; and compiler performance (project references, `incremental`, `skipLibCheck`).
+
+**Split criterion** — skill-writing P3 (b): a lookup reference — the tsconfig flag set, the resolution modes,
+and the lint config are consulted by decision, not read narratively.
+
+> Skeleton — sections below are stubs; the body is grown in T5-modules-tooling.
+
+---
+
+## ESM, `verbatimModuleSyntax`, and the import-extension fork
+
+> Stub — grown in T5-modules-tooling.
+
+## The strict base and its overlays
+
+> Stub — grown in T5-modules-tooling.
+
+## Typed lint
+
+> Stub — grown in T5-modules-tooling.
+
+## Formatting
+
+> Stub — grown in T5-modules-tooling.
+
+## Build: `tsc` vs bundler
+
+> Stub — grown in T5-modules-tooling.
+
+## Compiler performance
+
+> Stub — grown in T5-modules-tooling.

--- a/.gobbi/projects/gobbi/skills/typescript/modules-tooling.md
+++ b/.gobbi/projects/gobbi/skills/typescript/modules-tooling.md
@@ -38,8 +38,7 @@ blocks are taught facts that type-check under the skill's maximal-strict example
 
 Every artifact extends one strict base — the `@tsconfig/strictest` preset plus a few flags that post-date it.
 This is the maximal-strict floor SKILL.md's first Rule names; the config below is the whole of it, each flag
-written once. (Track the preset's current contents at its source rather than a fixed count — it drifts across
-versions.)
+written once.
 
 ```jsonc
 // tsconfig.base.json — the 17 always-on flags. Extend it; never weaken it.

--- a/.gobbi/projects/gobbi/skills/typescript/modules-tooling.md
+++ b/.gobbi/projects/gobbi/skills/typescript/modules-tooling.md
@@ -73,15 +73,17 @@ Three flags carry most of the weight:
   `useUnknownInCatchVariables` (a caught error is typed `unknown`, not `any`). Treat `strict: false` as
   off-standard.
 - **`noUncheckedIndexedAccess`** is the highest-value flag `strict` omits: `arr[i]` and `rec[key]` become
-  `T | undefined`, so an out-of-range read is a compile error, not a runtime `undefined`. It sits outside
+  `T | undefined`, so USING an indexed read as a present `T` without narrowing is a compile error — the flag adds `undefined` to the read's type, and the error surfaces at a use that requires the narrower type, not at the read itself. It sits outside
   `strict` because it is noisy on code that indexes inside a checked loop.
 - **`exactOptionalPropertyTypes`** is the noisiest: with it, `{ x?: number }` accepts a MISSING `x` but rejects
   an explicit `x: undefined` — the two stop meaning the same thing. Live with it by choosing deliberately —
   `x?: number` for "may be absent," `x: number | undefined` for "must be present, may be undefined" — not by
   reaching for `as` to paper over the difference.
 
-`skipLibCheck` is in the base for speed (§9): it skips type-checking the `.d.ts` files under `node_modules`,
-never your own code.
+`skipLibCheck` is in the base for speed (§9): it skips full checking of `.d.ts` declaration files — dependency
+AND project-owned. Your `.ts` source is still fully type-checked, but a hand-written or generated local `.d.ts`
+is not itself deep-checked, so validate a package's published declarations with `attw` / `publint` (see
+`packaging-publishing.md`).
 
 ## 2. Thin overlays: library, app, runtime
 
@@ -106,8 +108,9 @@ lives in exactly ONE overlay and never in the base, so it applies only where it 
 }
 ```
 
-`isolatedDeclarations` (5.5) lives ONLY in the library overlay: it forces every exported binding to carry an
-explicit type, so a `.d.ts` can be produced from one file with no whole-program inference. That constraint
+`isolatedDeclarations` (5.5) lives ONLY in the library overlay: it requires each exported binding's type to be
+trivially computable from that one file — in practice an explicit annotation wherever the type is not already
+evident (a type it can derive locally is allowed) — so a `.d.ts` can be produced per-file with no whole-program inference. That constraint
 earns its cost only when a `.d.ts` is actually shipped, so an app never pays it. `declarationMap` is what lets
 a consumer's "go to definition" land on your source instead of the generated `.d.ts`. The `runtime` overlay's
 `rewriteRelativeImportExtensions` is the subject of §4.
@@ -196,7 +199,7 @@ and `erasableSyntaxOnly`; the library overlay (§2) adds `isolatedDeclarations`.
 | Flag | Guarantees one file can be… | Consumer |
 |---|---|---|
 | `isolatedModules` | transpiled with no whole-program type info | a single-file transpiler (esbuild, swc, Babel) |
-| `erasableSyntaxOnly` | run by stripping types, generating no code from a type | a type-stripping runtime (Node 24+, Bun, Deno) |
+| `erasableSyntaxOnly` | run by stripping types, generating no code from a type | Node 24+ `--experimental-strip-types` (the type-STRIPPING consumer; Bun / Deno transpile, so they accept more) |
 | `isolatedDeclarations` | turned into a `.d.ts` from itself alone | the declaration emitter for a library |
 
 `erasableSyntaxOnly` (5.8) is the flag that shapes daily syntax: it rejects any construct that would emit
@@ -282,8 +285,9 @@ esbuild bundle — a library convenience, but the `.d.ts` still comes from `tsc`
 
 Three levers cut `tsc` time on a growing codebase without weakening a single type:
 
-- **`skipLibCheck`** (already in the base, §1) skips type-checking the `.d.ts` files under `node_modules` — a
-  large, mostly-stable surface. It does NOT skip your own types.
+- **`skipLibCheck`** (already in the base, §1) skips full checking of `.d.ts` declaration files — a large,
+  mostly-stable surface, dependency and project-owned alike. Your `.ts` source is still fully checked; a local
+  `.d.ts` is not itself deep-checked, so validate a published package's declarations with `attw` / `publint`.
 - **`incremental`** writes a `.tsbuildinfo` cache so a rebuild re-checks only what changed. Cheap to enable;
   keep the cache file out of version control.
 - **Project references** split a large repo into composite sub-projects (`composite: true`) built with

--- a/.gobbi/projects/gobbi/skills/typescript/modules-tooling.md
+++ b/.gobbi/projects/gobbi/skills/typescript/modules-tooling.md
@@ -94,7 +94,7 @@ lives in exactly ONE overlay and never in the base, so it applies only where it 
 |---|---|---|
 | **library** | `declaration`, `declarationMap`, `isolatedDeclarations` | publishing a package that ships its own `.d.ts` |
 | **app** | `noEmit` (a bundler or runtime emits instead) | an application a bundler builds, publishing no types |
-| **runtime** | `lib` / `module` / `moduleResolution` deltas, and `rewriteRelativeImportExtensions` for a type-stripping runtime | cross-runtime code — see `runtime-deltas.md` |
+| **runtime** | `lib` / `module` / `moduleResolution` deltas, and `rewriteRelativeImportExtensions` for a directly-run runtime (Node strips, Bun/Deno transpile) | cross-runtime code — see `runtime-deltas.md` |
 
 ```jsonc
 // tsconfig.lib.json — the library overlay
@@ -185,8 +185,8 @@ runtime.
 
 **Why `.ts` on the direct-run path.** A runtime that runs `.ts` in place (Node strips, Bun/Deno transpile)
 executes the file directly and resolves the real on-disk `.ts` name. `rewriteRelativeImportExtensions` (5.7) lets the SAME source also be built by
-`tsc`, which rewrites each `.ts` specifier to `.js` on emit — so one source both runs stripped and publishes a
-correct build.
+`tsc`, which rewrites each `.ts` specifier to `.js` on emit — so one source both runs directly (stripped or
+transpiled) and publishes a correct build.
 
 Never mix the two in one source tree: read the mode off P1's target-runtime contract and keep every relative
 import in it.

--- a/.gobbi/projects/gobbi/skills/typescript/modules-tooling.md
+++ b/.gobbi/projects/gobbi/skills/typescript/modules-tooling.md
@@ -36,15 +36,16 @@ blocks are taught facts that type-check under the skill's maximal-strict example
 
 ## 1. The strict base: 17 always-on flags
 
-Every artifact extends one strict base — the 14-flag `@tsconfig/strictest` preset plus three flags that
-post-date it. This is the maximal-strict floor SKILL.md's first Rule names; the config below is the whole of
-it, each flag written once.
+Every artifact extends one strict base — the `@tsconfig/strictest` preset plus a few flags that post-date it.
+This is the maximal-strict floor SKILL.md's first Rule names; the config below is the whole of it, each flag
+written once. (Track the preset's current contents at its source rather than a fixed count — it drifts across
+versions.)
 
 ```jsonc
 // tsconfig.base.json — the 17 always-on flags. Extend it; never weaken it.
 {
   "compilerOptions": {
-    // @tsconfig/strictest (14)
+    // from @tsconfig/strictest
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
@@ -59,7 +60,7 @@ it, each flag written once.
     "isolatedModules": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    // added atop the preset (3)
+    // added atop the preset
     "verbatimModuleSyntax": true,
     "noUncheckedSideEffectImports": true,
     "erasableSyntaxOnly": true
@@ -248,23 +249,18 @@ per-keystroke cost.
 
 **TS 7.0 caveat (honest).** The native Go compiler at TS 7.0 ships NO programmatic compiler API (7.1 is
 expected to add one), and `typescript-eslint` needs that API. So under a 7.0 install, typed lint does NOT run
-against the 7.0 binary: it runs against a side-by-side TS 6.x-compatible API package
-(`@typescript/typescript6`, which exposes a `tsc6`). Treat 7.0 as a type-check SPEED target for
+against the 7.0 binary: it runs against a side-by-side JS-based TS-compatibility API package (the exact
+package and binary name are pending 7.0 GA). Treat 7.0 as a type-check SPEED target for
 `tsc --noEmit`, not as one toolchain that also satisfies the typed-lint gate — the P7 lint step runs on the
 6.x-compat API alongside it.
 
 ## 7. Formatting: Prettier or Biome
 
-Formatting is not a type concern: it runs first in the P7 verify order and never blocks on types. Pick one
-deterministic formatter and run it in check mode in CI:
-
-- **Prettier** is the default — ubiquitous, editor-integrated, opinionated.
-- **Biome** is the fast alternative — a single Rust tool that formats AND lints, much faster on a large tree,
-  at the cost of a smaller ecosystem.
-
-Follow the project's existing choice; two formatters fighting over the same file is pure churn. Neither
-replaces `typescript-eslint`'s typed rules (§6) — a formatter arranges code, it does not reason about types,
-and Biome's linter is not type-aware, so it does not cover `no-floating-promises`.
+`convention.md` §5 owns the formatter stance (Prettier is the default; Biome is the faster all-in-one; follow
+the project's choice, commit the config, run it in check mode in CI). The tooling point here: a formatter runs
+first in the P7 order and is layout-only — it never reasons about types, so neither Prettier nor Biome's linter
+replaces `typescript-eslint`'s typed rules (§6); Biome's linter is not type-aware, so it does not cover
+`no-floating-promises`.
 
 ## 8. Build: `tsc` vs a bundler
 
@@ -283,7 +279,8 @@ esbuild bundle — a library convenience, but the `.d.ts` still comes from `tsc`
 
 ## 9. Compiler performance
 
-Three levers cut `tsc` time on a growing codebase without weakening a single type:
+Three levers cut `tsc` time on a growing codebase. They do not weaken your SOURCE's type-checking — though
+`skipLibCheck` does relax full checking of `.d.ts` declaration files (the first lever below):
 
 - **`skipLibCheck`** (already in the base, §1) skips full checking of `.d.ts` declaration files — a large,
   mostly-stable surface, dependency and project-owned alike. Your `.ts` source is still fully checked; a local

--- a/.gobbi/projects/gobbi/skills/typescript/packaging-publishing.md
+++ b/.gobbi/projects/gobbi/skills/typescript/packaging-publishing.md
@@ -80,7 +80,7 @@ the flags themselves live in `modules-tooling.md`.
 - **`declarationMap`** emits a `.d.ts.map` so a consumer's "go to definition" lands on your `.ts`
   source instead of the generated `.d.ts`. It only works if the `.ts` source ships too, so either add
   `src` to `files` when you publish maps, or leave `declarationMap` off for a `dist`-only package.
-- **`isolatedDeclarations`** forces every exported binding to carry an explicit type, so the `.d.ts`
+- **`isolatedDeclarations`** requires each exported binding's type to be trivially computable from the file — an explicit annotation wherever it is not already evident — so the `.d.ts`
   is produced from each file alone — fast emit, and an un-annotated public export becomes a compile
   error instead of a silently-inferred, fragile type in the shipped contract.
 

--- a/.gobbi/projects/gobbi/skills/typescript/packaging-publishing.md
+++ b/.gobbi/projects/gobbi/skills/typescript/packaging-publishing.md
@@ -1,0 +1,32 @@
+# TypeScript — Packaging and Publishing
+
+**Ownership** — the ESM-only `package.json` `exports` map and conditions; declaration and declaration-map
+emit; the `publint` and `arethetypeswrong` machine gates; `type: module`; public-API evolution and
+deprecation; and the CJS-consumer path framed as an explicit out-of-default exception.
+
+**Split criterion** — skill-writing P3 (d): an independent-audience sub-procedure — package publishers read it
+on its own, apart from the author writing an ordinary module.
+
+> Skeleton — sections below are stubs; the body is grown in T10-packaging-publishing.
+
+---
+
+## The ESM-only `exports` map
+
+> Stub — grown in T10-packaging-publishing.
+
+## Declaration emit
+
+> Stub — grown in T10-packaging-publishing.
+
+## Machine gates: `publint` and `arethetypeswrong`
+
+> Stub — grown in T10-packaging-publishing.
+
+## Public-API evolution and deprecation
+
+> Stub — grown in T10-packaging-publishing.
+
+## The CJS out-of-default exception
+
+> Stub — grown in T10-packaging-publishing.

--- a/.gobbi/projects/gobbi/skills/typescript/packaging-publishing.md
+++ b/.gobbi/projects/gobbi/skills/typescript/packaging-publishing.md
@@ -1,32 +1,205 @@
 # TypeScript — Packaging and Publishing
 
-**Ownership** — the ESM-only `package.json` `exports` map and conditions; declaration and declaration-map
-emit; the `publint` and `arethetypeswrong` machine gates; `type: module`; public-API evolution and
-deprecation; and the CJS-consumer path framed as an explicit out-of-default exception.
+**Ownership** — the ESM-only publish surface: `type: module` + the `package.json` `exports` map and
+its condition order; the shipped `.d.ts` (the library overlay's declaration emit); the `sideEffects`
+tree-shaking pledge; the `publint` + `arethetypeswrong` machine gates; public-API semver and
+deprecation; and the CJS-consumer path as an explicit out-of-default exception.
 
-**Split criterion** — skill-writing P3 (d): an independent-audience sub-procedure — package publishers read it
-on its own, apart from the author writing an ordinary module.
+**Split criterion** — skill-writing P3 (d): an independent-audience sub-procedure — a package
+publisher reads it on its own, apart from the author writing an ordinary strict module.
 
-> Skeleton — sections below are stubs; the body is grown in T10-packaging-publishing.
+This doc **deepens, and does not restate,** SKILL.md's ESM-only Rules (publish ESM-only; never ship
+dual ESM + CJS from one `verbatimModuleSyntax` source; pick the import extension by consumption mode)
+and Principle 7 (*type-erase cleanly*). SKILL.md fixes the one-line invariant — "publish ESM-only,
+treat a required CJS build as a separate non-default emit"; this doc owns the concrete publish shape
+behind it: the `exports` conditions, what each machine gate catches, and the exact steps the CJS
+exception costs. The module model it builds on — `verbatimModuleSyntax`, `moduleResolution: nodenext`,
+the import-extension fork, the library tsconfig overlay — is owned by `modules-tooling.md`; this doc
+references it, never redraws it.
+
+Every block below is `package.json` / config / CLI, shown as `json` / `jsonc` / `bash` — a
+`package.json` object is data, not TypeScript. The one fenced `ts` block is the shipped public-API
+surface (§5), a taught fact that type-checks under the skill's maximal-strict examples baseline.
+
+## Contents
+
+1. [`type: module` and the ESM-only `exports` map](#1-type-module-and-the-esm-only-exports-map)
+2. [The shipped `.d.ts`: declaration emit](#2-the-shipped-dts-declaration-emit)
+3. [`sideEffects`: the tree-shaking pledge](#3-sideeffects-the-tree-shaking-pledge)
+4. [The machine gates: `publint` then `arethetypeswrong`](#4-the-machine-gates-publint-then-arethetypeswrong)
+5. [Public-API evolution: semver and deprecation](#5-public-api-evolution-semver-and-deprecation)
+6. [The CJS out-of-default exception (non-recommended)](#6-the-cjs-out-of-default-exception-non-recommended)
 
 ---
 
-## The ESM-only `exports` map
+## 1. `type: module` and the ESM-only `exports` map
 
-> Stub — grown in T10-packaging-publishing.
+`type: module` makes every `.js` file in the package ESM — the publish-side half of the ESM model
+`modules-tooling.md` owns on the resolver side. The `exports` map is the entry declaration AND an
+encapsulation boundary: only the subpaths it lists are importable, so a consumer cannot deep-import
+an internal file you did not publish.
 
-## Declaration emit
+```json
+{
+  "name": "my-lib",
+  "version": "1.4.0",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": ["dist"],
+  "sideEffects": false
+}
+```
 
-> Stub — grown in T10-packaging-publishing.
+**Condition order is load-bearing.** A resolver reads the conditions top-to-bottom and takes the
+first that applies, so `types` MUST come first — a TypeScript consumer has to resolve the `.d.ts`
+before the runtime condition, or it gets no types at all. `import` is the ESM entry; `default` is the
+last-resort runtime fallback (the same file here). There is deliberately **no `require` condition and
+no `.d.cts`** — that is the CJS path (§6), left out on purpose to keep the package ESM-only.
 
-## Machine gates: `publint` and `arethetypeswrong`
+**What else ships.** `files` allow-lists the published tarball — ship `dist`, not `src` (the one
+exception is `declarationMap`, §2). The `./package.json` self-export lets tooling read your manifest.
+With `exports` present, the legacy top-level `main` / `module` / `types` fields are optional;
+`publint` (§4) tells you which, if any, a consumer toolchain still needs.
 
-> Stub — grown in T10-packaging-publishing.
+## 2. The shipped `.d.ts`: declaration emit
 
-## Public-API evolution and deprecation
+The `types` condition points at a `.d.ts`, and `tsc` is the only tool that produces it — the library
+tsconfig overlay (`modules-tooling.md` §2) turns on `declaration`, `declarationMap`, and
+`isolatedDeclarations` for exactly this. This doc owns what that emit means for the published package;
+the flags themselves live in `modules-tooling.md`.
 
-> Stub — grown in T10-packaging-publishing.
+- **`declaration`** emits the `.d.ts` a consumer resolves against — the public type contract, and the
+  artifact the machine gates (§4) validate.
+- **`declarationMap`** emits a `.d.ts.map` so a consumer's "go to definition" lands on your `.ts`
+  source instead of the generated `.d.ts`. It only works if the `.ts` source ships too, so either add
+  `src` to `files` when you publish maps, or leave `declarationMap` off for a `dist`-only package.
+- **`isolatedDeclarations`** forces every exported binding to carry an explicit type, so the `.d.ts`
+  is produced from each file alone — fast emit, and an un-annotated public export becomes a compile
+  error instead of a silently-inferred, fragile type in the shipped contract.
 
-## The CJS out-of-default exception
+## 3. `sideEffects`: the tree-shaking pledge
 
-> Stub — grown in T10-packaging-publishing.
+`"sideEffects": false` tells a bundler that importing any module in the package runs no code with an
+observable effect, so it may drop every export a consumer does not use (tree-shaking). Set it only
+when it is true. A module that DOES run on import — a polyfill, a global registration, a CSS import —
+must be listed, or the bundler shakes it away and the effect silently vanishes:
+
+```json
+{
+  "sideEffects": ["./dist/polyfill.js", "*.css"]
+}
+```
+
+This is the publish-side pledge to the bundler; `noUncheckedSideEffectImports` (the compile-side base
+flag, `modules-tooling.md` §1) is its counterpart — it fails the build when a bare side-effect
+import's target does not resolve.
+
+## 4. The machine gates: `publint` then `arethetypeswrong`
+
+Two tools verify the PACKED artifact — the tarball a consumer installs, not your checkout. Run both
+in the P7 build step (SKILL.md P7), `publint` first (fix the shape), then `arethetypeswrong` (prove
+the types resolve).
+
+**`publint --strict`** validates the `package.json` publish shape: that every `exports` / `main` /
+`module` / `types` target exists on disk, that the condition order is correct (`types` first), that a
+file's extension matches its `type`, and that no declared entry is missing. `--strict` turns its
+warnings into a non-zero exit, so it works as a self-failing gate.
+
+```bash
+npx publint --strict
+```
+
+**`arethetypeswrong --pack`** (attw) packs the real tarball and checks how a TypeScript CONSUMER
+resolves your shipped `.d.ts` across resolution modes (`node10`, `node16` CJS + ESM, `bundler`). It
+catches the errors a `tsc` pass on your own source cannot see: a `.d.ts` that claims ESM but resolves
+as CJS (a false export shape), a missing `types` condition, or types that fail to resolve under
+`nodenext`.
+
+```bash
+npx attw --pack
+```
+
+For an ESM-only package, attw reports `node10` (the legacy pre-`exports` resolver) as "no types" —
+that is EXPECTED, not a defect: a pure-ESM package intentionally drops the old CJS resolver. Configure
+attw to ignore the `node10` profile rather than adding a CJS path just to satisfy it.
+
+## 5. Public-API evolution: semver and deprecation
+
+The public API is everything reachable through `exports` — every exported value AND every exported
+type. Because TypeScript is structural, the type surface is part of the contract: widening a return
+type, narrowing a parameter, adding a required field to an input, or removing an export all BREAK a
+consumer's build and require a MAJOR version. Adding an optional field or a new export is a MINOR
+bump. Removing a subpath from `exports` is breaking even if the file stays on disk — the encapsulation
+boundary is the contract, not the file.
+
+Deprecate before you remove. Mark the old surface with the `@deprecated` TSDoc tag naming its
+replacement; editors strike it through and `typescript-eslint` can flag its use. Keep it for one major
+cycle, then remove it in the next major.
+
+```ts
+/** A parsed semantic version. */
+export interface SemVer {
+  readonly major: number;
+  readonly minor: number;
+  readonly patch: number;
+}
+
+/**
+ * Parse a version string like `"1.4.0"`.
+ * @deprecated since 2.1 — use {@link parseVersion}; removed in 3.0.
+ */
+export function parse(input: string): SemVer | undefined {
+  return parseVersion(input);
+}
+
+/** Parse a version string, or return `undefined` when it is malformed. */
+export function parseVersion(input: string): SemVer | undefined {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(input);
+  if (match === null) {
+    return undefined;
+  }
+  // noUncheckedIndexedAccess: each capture group is `string | undefined`.
+  const major = match[1];
+  const minor = match[2];
+  const patch = match[3];
+  if (major === undefined || minor === undefined || patch === undefined) {
+    return undefined;
+  }
+  return { major: Number(major), minor: Number(minor), patch: Number(patch) };
+}
+```
+
+## 6. The CJS out-of-default exception (non-recommended)
+
+Shipping CJS alongside ESM is a deliberate exception, not the default. Reach for it only when a named
+consumer genuinely cannot load ESM; the ESM-only package above is the recommended path.
+
+The exception costs three things. First, you step OUTSIDE `verbatimModuleSyntax` — one source cannot
+deterministically erase to both module systems (SKILL.md's Rule; `modules-tooling.md` §3 owns why), so
+the CJS build uses a SEPARATE emit config (`module: commonjs`, or a dual-emit bundler such as `tsup`).
+Second, you emit a second declaration set: a `.d.cts` for the `require` condition — a plain `.d.ts`
+under `require` is exactly the "false CJS types" `arethetypeswrong` flags. Third, `exports` grows a
+`require` condition beside `import`, each with its OWN nested `types`:
+
+```jsonc
+{
+  "exports": {
+    ".": {
+      "import": { "types": "./dist/index.d.ts", "default": "./dist/index.js" },
+      "require": { "types": "./dist/index.d.cts", "default": "./dist/index.cjs" }
+    }
+  }
+}
+```
+
+Both module systems must then pass `publint` AND `arethetypeswrong`, and you take on the dual-package
+hazard: a consumer that reaches your package through both an ESM and a CJS path loads two copies of
+its module state, so a singleton or an `instanceof` check across the boundary breaks. Prefer ESM-only;
+add this only under a concrete, named constraint.

--- a/.gobbi/projects/gobbi/skills/typescript/runtime-deltas.md
+++ b/.gobbi/projects/gobbi/skills/typescript/runtime-deltas.md
@@ -98,7 +98,7 @@ map for bare names:
 ```jsonc
 // deno.json — Deno's own config: a compilerOptions subset, an import map, tasks.
 {
-  "compilerOptions": { "lib": ["deno.window", "dom"] },
+  "compilerOptions": { "lib": ["deno.window"] },  // server default; deno.window conflicts with "dom" (use deno.ns + dom for DOM code)
   "imports": {
     "@std/assert": "jsr:@std/assert@^1",
     "zod": "npm:zod@^3"
@@ -195,8 +195,9 @@ button?.addEventListener("click", () => {
 Three concerns cut across every runtime.
 
 **`lib` selection.** The `lib` is the switch between a server and a browser type surface: Node (and Bun on its
-server default) take `ES2023` with no `DOM`; Deno instead uses its bundled `deno.window`, adding `dom` when it
-needs web globals (see its config above); the browser takes `DOM` + `DOM.Iterable`. Add `ESNext.Disposable`
+server default) take `ES2023` with no `DOM`; Deno uses `deno.window` (its server default); `deno.window` CONFLICTS with `dom`, so Deno code that also
+needs the DOM pairs `deno.ns` (not `deno.window`) with `dom` / `dom.iterable`; the browser takes `DOM` +
+`DOM.Iterable`. Add `ESNext.Disposable`
 wherever `using` is used (below). The `lib` types what EXISTS; it never adds a runtime API — `@types/node`,
 `@types/bun`, and Deno's bundled lib are separate.
 

--- a/.gobbi/projects/gobbi/skills/typescript/runtime-deltas.md
+++ b/.gobbi/projects/gobbi/skills/typescript/runtime-deltas.md
@@ -223,12 +223,14 @@ function run(): void {
 **Type-stripping vs a `tsc` build.** Node 24+, Bun, and Deno all RUN `.ts` by stripping types — they never
 type-check. So a `tsc --noEmit` pass is the correctness gate on every stripping runtime, exactly as SKILL.md P7
 and `modules-tooling.md` §8 require: stripping runs the code, `tsc` judges it, and a green run is never a green
-type-check. The runtime-agnostic core proves the thesis — this web-standard code type-checks under the baseline
-and runs unchanged on Node, Bun, Deno, and the browser; only the built-ins and config around it differ:
+type-check. The runtime-agnostic core proves the thesis — this web-standard code type-checks under the baseline,
+and once its annotations are erased to JavaScript (Node 24+/Bun/Deno strip or transpile it directly; a browser
+runs the emitted JS from a build step, never the `.ts` itself) the resulting code runs on all of them; only the
+built-ins and config around it differ:
 
 ```ts
 // Runtime-agnostic: fetch + AbortSignal are web standards on Node 18+, Bun,
-// Deno, and the browser. This exact source runs unchanged on every runtime.
+// Deno, and the browser. The algorithm is portable; a browser runs the emitted JS.
 async function getJson(url: string, timeoutMs: number): Promise<unknown> {
   const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
   if (!res.ok) {

--- a/.gobbi/projects/gobbi/skills/typescript/runtime-deltas.md
+++ b/.gobbi/projects/gobbi/skills/typescript/runtime-deltas.md
@@ -222,7 +222,7 @@ function run(): void {
 ```
 
 **Type-stripping vs a `tsc` build.** Node 24+ STRIPS types; Bun and Deno TRANSPILE — either way all three RUN
-`.ts` directly and none type-check. So a `tsc --noEmit` pass is the correctness gate on every stripping runtime, exactly as SKILL.md P7
+`.ts` directly and none type-check. So a `tsc --noEmit` pass is the correctness gate on every runtime that runs `.ts` without type-checking, exactly as SKILL.md P7
 and `modules-tooling.md` §8 require: stripping runs the code, `tsc` judges it, and a green run is never a green
 type-check. The runtime-agnostic core proves the thesis — this web-standard code type-checks under the baseline,
 and once its annotations are erased to JavaScript (Node 24+/Bun/Deno strip or transpile it directly; a browser

--- a/.gobbi/projects/gobbi/skills/typescript/runtime-deltas.md
+++ b/.gobbi/projects/gobbi/skills/typescript/runtime-deltas.md
@@ -194,8 +194,9 @@ button?.addEventListener("click", () => {
 
 Three concerns cut across every runtime.
 
-**`lib` selection.** The `lib` is the single switch between a server and a browser type surface: server runtimes
-(Node, Bun, Deno) take `ES2023` with no `DOM`; the browser takes `DOM` + `DOM.Iterable`. Add `ESNext.Disposable`
+**`lib` selection.** The `lib` is the switch between a server and a browser type surface: Node (and Bun on its
+server default) take `ES2023` with no `DOM`; Deno instead uses its bundled `deno.window`, adding `dom` when it
+needs web globals (see its config above); the browser takes `DOM` + `DOM.Iterable`. Add `ESNext.Disposable`
 wherever `using` is used (below). The `lib` types what EXISTS; it never adds a runtime API — `@types/node`,
 `@types/bun`, and Deno's bundled lib are separate.
 
@@ -220,8 +221,8 @@ function run(): void {
 }
 ```
 
-**Type-stripping vs a `tsc` build.** Node 24+, Bun, and Deno all RUN `.ts` by stripping types — they never
-type-check. So a `tsc --noEmit` pass is the correctness gate on every stripping runtime, exactly as SKILL.md P7
+**Type-stripping vs a `tsc` build.** Node 24+ STRIPS types; Bun and Deno TRANSPILE — either way all three RUN
+`.ts` directly and none type-check. So a `tsc --noEmit` pass is the correctness gate on every stripping runtime, exactly as SKILL.md P7
 and `modules-tooling.md` §8 require: stripping runs the code, `tsc` judges it, and a green run is never a green
 type-check. The runtime-agnostic core proves the thesis — this web-standard code type-checks under the baseline,
 and once its annotations are erased to JavaScript (Node 24+/Bun/Deno strip or transpile it directly; a browser

--- a/.gobbi/projects/gobbi/skills/typescript/runtime-deltas.md
+++ b/.gobbi/projects/gobbi/skills/typescript/runtime-deltas.md
@@ -1,0 +1,33 @@
+# TypeScript — Runtime Deltas
+
+**Ownership** — the single locked doc isolating what truly differs across runtimes: Node, Bun, Deno, and the
+browser (both the bundler-less import-map path and the bundler path) — module resolution, the import-extension
+mode, built-in APIs, `lib` selection, the test runner, `Symbol.dispose` polyfill availability, and
+type-stripping vs a `tsc` build.
+
+**Split criterion** — skill-writing P3 (d): an independent-audience doc (a reader targeting one runtime opens
+only this) and a user-locked single-doc boundary that quarantines runtime churn.
+
+> Skeleton — sections below are stubs; the body is grown in T11-runtime-deltas.
+
+---
+
+## Node
+
+> Stub — grown in T11-runtime-deltas.
+
+## Bun
+
+> Stub — grown in T11-runtime-deltas.
+
+## Deno
+
+> Stub — grown in T11-runtime-deltas.
+
+## Browser
+
+> Stub — grown in T11-runtime-deltas.
+
+## Cross-cutting deltas
+
+> Stub — grown in T11-runtime-deltas.

--- a/.gobbi/projects/gobbi/skills/typescript/runtime-deltas.md
+++ b/.gobbi/projects/gobbi/skills/typescript/runtime-deltas.md
@@ -53,7 +53,7 @@ Node is the `nodenext` baseline the SKILL.md Rules assume by default. Set the re
 ```
 
 - **Import extension** — the fork from `modules-tooling.md` §4 applies here directly: a `tsc`-emitted library
-  writes `.js` on relative imports; a directly type-stripped source writes `.ts` with
+  writes `.js` on relative imports; a source run directly (stripped or transpiled) writes `.ts` with
   `rewriteRelativeImportExtensions`. Node is the runtime that hosts BOTH modes.
 - **Type-stripping** — Node 24+ runs `.ts` by stripping types with no build step (on by default; the 22.6–23.5
   line needed `--experimental-strip-types`). Stripping does not type-check, so a separate `tsc --noEmit` stays
@@ -224,7 +224,7 @@ function run(): void {
 
 **Type-stripping vs a `tsc` build.** Node 24+ STRIPS types; Bun and Deno TRANSPILE — either way all three RUN
 `.ts` directly and none type-check. So a `tsc --noEmit` pass is the correctness gate on every runtime that runs `.ts` without type-checking, exactly as SKILL.md P7
-and `modules-tooling.md` §8 require: stripping runs the code, `tsc` judges it, and a green run is never a green
+and `modules-tooling.md` §8 require: the runtime runs the code, `tsc` judges it, and a green run is never a green
 type-check. The runtime-agnostic core proves the thesis — this web-standard code type-checks under the baseline,
 and once its annotations are erased to JavaScript (Node 24+/Bun/Deno strip or transpile it directly; a browser
 runs the emitted JS from a build step, never the `.ts` itself) the resulting code runs on all of them; only the

--- a/.gobbi/projects/gobbi/skills/typescript/runtime-deltas.md
+++ b/.gobbi/projects/gobbi/skills/typescript/runtime-deltas.md
@@ -8,26 +8,232 @@ type-stripping vs a `tsc` build.
 **Split criterion** — skill-writing P3 (d): an independent-audience doc (a reader targeting one runtime opens
 only this) and a user-locked single-doc boundary that quarantines runtime churn.
 
-> Skeleton — sections below are stubs; the body is grown in T11-runtime-deltas.
+This doc **deepens, and does not restate,** the SKILL.md Rule *pick the import extension by consumption mode*
+and the `runtime-deltas.md` row of the P2 router. The language core is runtime-agnostic: the types, the ESM
+hygiene, and every idiom in the other child docs are identical on all four runtimes. What changes is a small,
+bounded surface — how a specifier resolves, which built-in APIs exist, which `lib` is in scope, and how the
+`.ts` reaches execution. `modules-tooling.md` §4 owns the `.js`-vs-`.ts` import-extension **mechanics**; this
+doc says which mode each runtime is in and points there.
+
+Most blocks below are configuration — a `tsconfig`, a `deno.json`, an import map, an HTML shell — shown in
+`jsonc` / `json` / `html` for their shape; a config object is not TypeScript and is not compiled. A snippet
+that calls a runtime-specific global (`Bun.*`, `Deno.*`, a `node:` built-in) is shown as `text`: those APIs
+need a type package this skill does not own (`@types/node`, `@types/bun`, Deno's bundled lib), so the skill
+does not claim they compile under its examples baseline. The fenced `ts` blocks are the runtime-**agnostic**,
+web-standard facts that are identical on every runtime — the point this doc makes — and they type-check under
+that baseline.
+
+## The delta matrix
+
+| Runtime | Resolution / config | Runs `.ts` directly? | Import extension (§4) | Built-in namespace | Default `lib` | Test runner |
+|---|---|---|---|---|---|---|
+| **Node** | `nodenext` in `tsconfig` | 24+ strips types | `.js` when emitted, `.ts` when stripped | `node:*` (+ `@types/node`) | `ES2023` (no DOM) | `node:test` |
+| **Bun** | `bundler` (its default) or `nodenext` for libs | yes, native | `.ts` | `Bun.*` + Web + node-compat | via `@types/bun` | `bun test` |
+| **Deno** | `deno.json` `compilerOptions` | yes, native | `.ts` + URL / JSR | `Deno.*` + Web | `deno.window` | `Deno.test` |
+| **Browser** | `nodenext`-approx or `bundler` | no — ships `.js` | `.js` (explicit) | Web / `DOM` | `DOM`, `DOM.Iterable`, `ES2023` | vitest / web-test-runner |
 
 ---
 
 ## Node
 
-> Stub — grown in T11-runtime-deltas.
+Node is the `nodenext` baseline the SKILL.md Rules assume by default. Set the resolver and give it a server
+`lib` plus the Node ambient types:
+
+```jsonc
+// tsconfig for Node: nodenext resolution, node types, a server lib (no DOM).
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "lib": ["ES2023"],
+    "types": ["node"]     // @types/node — a devDependency
+  }
+}
+```
+
+- **Import extension** — the fork from `modules-tooling.md` §4 applies here directly: a `tsc`-emitted library
+  writes `.js` on relative imports; a directly type-stripped source writes `.ts` with
+  `rewriteRelativeImportExtensions`. Node is the runtime that hosts BOTH modes.
+- **Type-stripping** — Node 24+ runs `.ts` by stripping types with no build step (on by default; the 22.6–23.5
+  line needed `--experimental-strip-types`). Stripping does not type-check, so a separate `tsc --noEmit` stays
+  the correctness gate (see cross-cutting, below). `erasableSyntaxOnly` guarantees the file strips cleanly.
+- **Built-ins** — imported under the `node:` prefix and typed by `@types/node`. Under this skill's DOM-only
+  examples baseline they do not resolve, so the shape is shown, not compiled:
+
+```text
+// Node: node: built-ins need @types/node (a devDep); not resolvable under the
+// skill's examples baseline, so this is shown as text, not a compiled `ts` fact.
+import { readFile } from "node:fs/promises";
+const data = await readFile("./data.json", "utf8");
+```
+
+- **Test runner** — `node:test` with `node --test`; no dependency.
 
 ## Bun
 
-> Stub — grown in T11-runtime-deltas.
+Bun executes `.ts` natively (no build step to run) and its `bun init` writes a `tsconfig` tuned for a
+bundler-style workflow — `"module": "esnext"`, `"moduleResolution": "bundler"`. That default is fine for an
+**app** Bun itself runs; for a **library** you publish, keep the `nodenext` model from `modules-tooling.md` §3
+so the emitted `.d.ts` resolves for non-Bun consumers.
+
+- **Import extension** — `.ts` specifiers, since Bun resolves the real on-disk file.
+- **Built-ins** — the `Bun` global (`Bun.serve`, `Bun.file`, `Bun.$`) plus the Web platform and a Node-compat
+  layer. The `Bun` global is typed by `@types/bun`, outside this baseline:
+
+```text
+// Bun: the Bun global needs @types/bun; shown as text, not compiled here.
+const server = Bun.serve({ port: 3000, fetch: () => new Response("ok") });
+const config = await Bun.file("./config.json").json();
+```
+
+- **Test runner** — `bun test` is built in and Jest-compatible; the bundler (`bun build`) is built in too.
 
 ## Deno
 
-> Stub — grown in T11-runtime-deltas.
+Deno is the biggest departure: it is configured by `deno.json`, not `tsconfig`, and its `compilerOptions` are a
+SUBSET of the compiler's. It resolves imports by URL and by the `jsr:` / `npm:` specifiers, with an `imports`
+map for bare names:
+
+```jsonc
+// deno.json — Deno's own config: a compilerOptions subset, an import map, tasks.
+{
+  "compilerOptions": { "lib": ["deno.window", "dom"] },
+  "imports": {
+    "@std/assert": "jsr:@std/assert@^1",
+    "zod": "npm:zod@^3"
+  },
+  "tasks": { "test": "deno test" }
+}
+```
+
+- **Import extension** — `.ts` specifiers, plus remote `https://` URLs and `jsr:` / `npm:` specifiers that Deno
+  caches on first fetch.
+- **Code slot vs type slot** — Deno's module graph resolves each import to a *code* specifier and, separately, a
+  *types* specifier. A `// @deno-types="./mod.d.ts"` pragma (or an `X-TypeScript-Types` response header) points
+  the type slot at a `.d.ts` while the code slot loads the JavaScript — so a plain-JS or remote module can carry
+  external types.
+- **Built-ins** — the `Deno` global (`Deno.readTextFile`, `Deno.serve`) alongside first-class Web APIs; typed by
+  Deno's bundled lib, not an `@types` package:
+
+```text
+// Deno: the Deno global + std come from Deno's bundled lib / JSR, not @types.
+const text = await Deno.readTextFile("./data.json");
+import { assertEquals } from "jsr:@std/assert";
+Deno.test("adds", () => assertEquals(1 + 1, 2));
+```
+
+- **Test runner** — `Deno.test` with `deno test`, built in.
 
 ## Browser
 
-> Stub — grown in T11-runtime-deltas.
+The browser has two real delivery paths, and a bundler is **not** required for either. Both ship JavaScript —
+the `.ts` is compiled or type-stripped before it ever loads — and both need a `DOM` `lib` and no `node:`
+built-ins.
+
+### (a) No bundler — native ESM + import maps
+
+A `<script type="module">` loads ESM directly; an import map resolves bare specifiers; relative imports must
+carry a real, fetchable extension:
+
+```html
+<!-- No bundler: the import map resolves bare specifiers, the module script
+     loads ESM. Relative imports need a real extension the browser can fetch. -->
+<script type="importmap">
+  { "imports": { "lit": "https://esm.sh/lit@3" } }
+</script>
+<script type="module" src="./app.js"></script>
+```
+
+Type-check it by resolving like Node ESM (explicit relative extensions the browser can fetch) with the server
+`lib` swapped for `DOM` — the TS module guide's "ES modules for the browser, with no bundler or module
+compiler" recipe:
+
+```jsonc
+// Browser, no bundler: NodeNext-approximation resolution + a DOM lib.
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "types": []
+  }
+}
+```
+
+### (b) With a bundler
+
+An application that owns its build may use `moduleResolution: bundler`, which the bundler (Vite, esbuild,
+webpack) then honors. Keep this to apps — a published library stays on `nodenext` so its `.d.ts` resolves for
+consumers (`modules-tooling.md` §3):
+
+```jsonc
+// Browser WITH a bundler: the bundler owns resolution, so `bundler` is valid.
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "noEmit": true
+  }
+}
+```
+
+DOM globals resolve under the `DOM` `lib`, so ordinary browser code IS a compiled taught fact:
+
+```ts
+// Browser: the DOM lib types `document` and events; no `node:` built-ins exist.
+const button = document.querySelector<HTMLButtonElement>("button");
+button?.addEventListener("click", () => {
+  console.log("clicked");
+});
+```
 
 ## Cross-cutting deltas
 
-> Stub — grown in T11-runtime-deltas.
+Three concerns cut across every runtime.
+
+**`lib` selection.** The `lib` is the single switch between a server and a browser type surface: server runtimes
+(Node, Bun, Deno) take `ES2023` with no `DOM`; the browser takes `DOM` + `DOM.Iterable`. Add `ESNext.Disposable`
+wherever `using` is used (below). The `lib` types what EXISTS; it never adds a runtime API — `@types/node`,
+`@types/bun`, and Deno's bundled lib are separate.
+
+**`Symbol.dispose` availability.** `using` / `await using` type-checks whenever the `lib` includes
+`ESNext.Disposable` (it defines `Symbol.dispose`, `Symbol.asyncDispose`, and the `Disposable` interface). At
+RUNTIME the well-known symbols must also exist: Node 24+, Bun, Deno, and current browsers define them; an older
+target needs a one-line polyfill before any `using`. Because `ESNext.Disposable` is in this skill's examples
+baseline, disposal is a compiled taught fact:
+
+```ts
+// Web-standard disposal: `using` binds release to scope on every runtime whose
+// lib carries ESNext.Disposable and whose runtime defines Symbol.dispose.
+class Lease implements Disposable {
+  [Symbol.dispose](): void {
+    // release here
+  }
+}
+
+function run(): void {
+  using lease = new Lease();
+  void lease; // disposed at end of scope, including the throwing path
+}
+```
+
+**Type-stripping vs a `tsc` build.** Node 24+, Bun, and Deno all RUN `.ts` by stripping types — they never
+type-check. So a `tsc --noEmit` pass is the correctness gate on every stripping runtime, exactly as SKILL.md P7
+and `modules-tooling.md` §8 require: stripping runs the code, `tsc` judges it, and a green run is never a green
+type-check. The runtime-agnostic core proves the thesis — this web-standard code type-checks under the baseline
+and runs unchanged on Node, Bun, Deno, and the browser; only the built-ins and config around it differ:
+
+```ts
+// Runtime-agnostic: fetch + AbortSignal are web standards on Node 18+, Bun,
+// Deno, and the browser. This exact source runs unchanged on every runtime.
+async function getJson(url: string, timeoutMs: number): Promise<unknown> {
+  const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  return res.json();
+}
+```

--- a/.gobbi/projects/gobbi/skills/typescript/scenarios.md
+++ b/.gobbi/projects/gobbi/skills/typescript/scenarios.md
@@ -1,20 +1,169 @@
-# TypeScript — Scenarios
+# TypeScript — Implementation Scenario Library
 
-**Ownership** — the eval seed: per-perspective good / bad / adversarial TypeScript probes (`TS-SCENARIO-*`)
-the evaluator works from.
+Good, bad, and adversarial TypeScript implementation cases. Load only when a TypeScript implementation task
+is being evaluated, or when an executor runs a pre-handoff idiom self-check. This library deepens, it does
+not restate: every case exercises a `SKILL.md` rule or principle and teaches nothing new — its `Exercises`
+line anchors to Rules (`H{n}`), Principles (`P{n}`), and Procedure steps (`Procedure P{n}`), each resolving
+to its verbatim `SKILL.md` clause through [`evaluation.md`](evaluation.md)'s rule-key legend, and its
+`Checklist IDs` line points at the binary items in [`checklists.md`](checklists.md). Snippets are inline and
+describe a shape to recognize, not runnable code. Cases group under Hard invariants · Design judgment ·
+Bottom-up operation.
 
-**Split criterion** — skill-writing P3 (a): one member of the eval-triad SET (`evaluation.md` + `scenarios.md`
-+ `checklists.md`). The three are one required set the anti-monolith rule forbids collapsing; this doc owns the
-seed probes.
+## Hard invariants
 
-> Skeleton — sections below are stubs; the body is grown in T6-eval-triad.
+### TS-SCENARIO-01 — Boundary data trusted through an annotation or `as`
+- **Axis:** Hard invariant.
+- **Situation:** a function reads JSON, a network body, `env`, or a file, and treats the result as a domain
+  type; elsewhere an `any` is introduced as a "temporary" escape hatch.
+- **Good handling:** the value enters as `unknown` and a type guard or schema parser narrows it into the
+  domain type before any maintained logic reads it; where the checker cannot see a static fact, a documented
+  `as` follows a prior runtime narrow, never `any`.
+- **Bad handling:** `JSON.parse(raw) as Config` (or `: Config`) trusts the annotation without a runtime check;
+  an `any` is used so the value flows unchecked and spreads by assignment.
+- **Adversarial probe:** feed malformed or partial input — the `as` cast still compiles, but a missing field
+  is `undefined` at runtime and surfaces far from the boundary.
+- **Exercises:** H4, H9, H10, P4.
+- **Checklist IDs:** `TS-CHECK-04`, `TS-CHECK-05`, `TS-CHECK-06`.
 
----
+### TS-SCENARIO-02 — A floating promise and an un-scoped resource
+- **Axis:** Hard invariant.
+- **Situation:** an async fan-out issues work under a deadline, and a file or connection handle is acquired
+  inside the same scope.
+- **Good handling:** every promise is awaited, `void`ed deliberately, or given a `.catch`; the fan-out bounds
+  its concurrent task creation; cancellation is carried on an `AbortSignal`; each resource's release is bound
+  to scope with `using` / `await using` so disposal runs on every path, including the throwing one.
+- **Bad handling:** a fire-and-forget call drops its rejection; an unbounded eager `Promise.all` retains every
+  task; a long await carries no cancellation; a handle is closed only on the happy path.
+- **Adversarial probe:** one branch throws and one hangs past its deadline — the handle leaks and the rejection
+  surfaces detached; grow the input until retained-task memory shows.
+- **Exercises:** H5, H13, P5.
+- **Checklist IDs:** `TS-CHECK-07`, `TS-CHECK-14`.
 
-## Per-perspective probes
+### TS-SCENARIO-03 — Failure shape: thrown vs typed result, caught as `unknown`
+- **Axis:** Hard invariant.
+- **Situation:** an operation has both an expected miss (a validation failure, a not-found) and a genuinely
+  exceptional error.
+- **Good handling:** the expected miss is modeled as a typed result in the return type, where the compiler
+  forces the caller to handle it; only `Error` subclasses (carrying `cause`) are thrown for the exceptional;
+  every catch types the value as `unknown` and narrows with `instanceof` before use.
+- **Bad handling:** a string or plain object is thrown (losing the stack and cause); a caught value is used as
+  though it were an `Error`; an expected miss is thrown where the signature should carry it.
+- **Adversarial probe:** throw a non-`Error` and catch it — `.message` is `undefined` and the cause chain is
+  gone; the caller never sees the expected failure the signature hid.
+- **Exercises:** H6, P6.
+- **Checklist IDs:** `TS-CHECK-08`.
 
-> Stub — grown in T6-eval-triad.
+### TS-SCENARIO-04 — Non-erasable syntax in a type-stripping runtime
+- **Axis:** Hard invariant.
+- **Situation:** code that a type-stripping runtime (Node 24+, Bun, Deno) executes uses an `enum`, a
+  `namespace`, or a constructor parameter-property to model a closed set or carry state.
+- **Good handling:** the closed set is a discriminated union or an `as const` object with a derived type;
+  `erasableSyntaxOnly` is on, so only strippable syntax ships.
+- **Bad handling:** `enum Direction { Up, Down }`, a `namespace` wrapper, or a `constructor(private x: T)`
+  parameter-property — each emits runtime code that type-stripping cannot produce.
+- **Adversarial probe:** run the source directly under a stripping runtime — the non-erasable construct is a
+  syntax error at load, not a compile error caught earlier.
+- **Exercises:** H7, H11, P7.
+- **Checklist IDs:** `TS-CHECK-09`.
 
-## Adversarial probes
+### TS-SCENARIO-05 — Module boundary: ESM, import extension, and dual emit
+- **Axis:** Hard invariant.
+- **Situation:** a package publishes an emitted build and its source is also run directly; a consumer resolves
+  the shipped `.d.ts` under `nodenext`.
+- **Good handling:** `verbatimModuleSyntax` with `import type` on every type-only import; the relative
+  extension matches the consumption mode (`.js` for the tsc-emitted library, `.ts` with
+  `rewriteRelativeImportExtensions` for the directly stripped source), one mode per tree; the package is
+  ESM-only with a `types` + `import` `exports` map that resolves correctly for the consumer.
+- **Bad handling:** a type import left as a value import; mixed `.js` and `.ts` extensions in one tree; dual
+  ESM + CJS emitted from the one `verbatimModuleSyntax` source; a `.d.ts` that resolves wrong under `nodenext`.
+- **Adversarial probe:** install the built package in a `nodenext` consumer — the mismatched extension or the
+  dual-emit `exports` shape breaks resolution the checkout never showed.
+- **Exercises:** H2, H3, H12.
+- **Checklist IDs:** `TS-CHECK-02`, `TS-CHECK-03`, `TS-CHECK-10`, `TS-CHECK-19`.
 
-> Stub — grown in T6-eval-triad.
+## Design judgment
+
+### TS-SCENARIO-06 — Illegal states left representable
+- **Axis:** Design judgment.
+- **Situation:** a value carries a status plus optional companion fields (`{ status: string; value?: T;
+  error?: string }`), so illegal combinations (a success with an error, a failure with a value) can be
+  constructed; a closed variant set is switched over.
+- **Good handling:** the domain is a discriminated union whose variants make the wrong combination
+  unconstructable, with `readonly` (and a branded type where an invariant must hold), and the `switch` ends in
+  a `never` exhaustiveness check so a new variant is a compile error.
+- **Bad handling:** a bag of optional fields the compiler cannot constrain; a `default` branch that silently
+  accepts an unhandled variant.
+- **Adversarial probe:** add a variant to the union — a real exhaustiveness check fails the build until it is
+  handled; a swallowing `default` compiles and drops the case at runtime.
+- **Exercises:** P3, H11.
+- **Checklist IDs:** `TS-CHECK-12`.
+
+### TS-SCENARIO-07 — The exported type surface and the `satisfies` / `as` / generic choice
+- **Axis:** Design judgment.
+- **Situation:** a public API whose exported interfaces, generics, and `.d.ts` are the caller's contract; a
+  config literal must stay narrowly typed while being checked; a helper is offered a type parameter.
+- **Good handling:** the exported type surface is shown and confirmed before bodies; `satisfies T` validates a
+  literal while keeping its narrow inferred type; an annotation is chosen over an assertion; a generic is added
+  only when it links an input to an output across many types; `interface` describes an extendable object shape,
+  `type` a union or tuple or mapped type.
+- **Bad handling:** the surface is reverse-engineered from finished bodies; a binding is accidentally
+  `export`ed into the contract; `as T` forces a shape the value does not hold; a widening annotation is used
+  where `satisfies` was needed; a generic serves a single call site.
+- **Adversarial probe:** change an un-narrowed exported return type — every downstream build breaks because the
+  accidental shape was the published contract.
+- **Exercises:** P2, H10.
+- **Checklist IDs:** `TS-CHECK-13`, `TS-CHECK-06`.
+
+## Bottom-up operation
+
+### TS-SCENARIO-08 — Skeleton-first typed growth
+- **Axis:** Bottom-up operation.
+- **Situation:** a new strict module needs modules, exported types, signatures, bodies, callers, and tests.
+- **Good handling:** first study the declared TypeScript contract (the tsconfig strict flags, the target
+  runtime and its import-extension mode, the module system, the artifact type, the `.d.ts` consumers); then
+  materialize the modules, types, and fully-annotated signatures with stub bodies; confirm it imports cleanly
+  and `tsc --noEmit` passes under the maximal-strict base before any body; then grow one verified slice at a
+  time (format → lint → `tsc --noEmit` → focused test), updating every affected caller, test, and `.d.ts` in
+  the same slice.
+- **Bad handling:** fill every body in one pass; discover the exported signature after the body; add tests only
+  after the whole feature is entangled; loosen a strict flag to get it compiling.
+- **Adversarial probe:** ask for evidence at the skeleton checkpoint and after each slice — a single final green
+  `tsc` does not prove incremental growth.
+- **Exercises:** H1, Procedure P1, Procedure P5, Procedure P6.
+- **Checklist IDs:** `TS-CHECK-01`, `TS-CHECK-15`, `TS-CHECK-16`.
+
+### TS-SCENARIO-09 — Whole-change verification order and taught-example fidelity
+- **Axis:** Bottom-up operation.
+- **Situation:** a change ships, and the skill's own fenced `ts` examples are taught facts a reader will copy.
+- **Good handling:** the whole change is verified in the fixed order (format → lint → type-check → focused
+  tests → full tests → type-level tests → build when publishing), each gate self-failing on fresh output; every
+  taught `ts` example type-checks under the examples baseline with its category marker, and an
+  intentionally-invalid example carries `@ts-expect-error` so it is distinguishable from a broken one.
+- **Bad handling:** "tsc passes" is asserted without running the ordered gates or on stale output; a taught
+  example reads right but does not compile; a bad example is indistinguishable from an accidentally-broken one.
+- **Adversarial probe:** re-run each gate on fresh output and extract-and-compile each example — a skipped gate
+  or an uncompiled example is where the untrue claim hides.
+- **Exercises:** H8, Procedure P7.
+- **Checklist IDs:** `TS-CHECK-11`, `TS-CHECK-17`.
+
+### TS-SCENARIO-10 — Runtime-agnostic code at a runtime boundary
+- **Axis:** Bottom-up operation.
+- **Situation:** otherwise runtime-agnostic code touches a Node / Bun / Deno / browser boundary — module
+  resolution, an import-extension mode, a built-in API, the `lib` set, or type-stripping.
+- **Good handling:** the target-runtime delta is read from `runtime-deltas.md` (through the Procedure P2 router)
+  before the boundary decision, and each choice — resolution, extension mode, built-in, `lib` — matches the
+  declared runtime.
+- **Bad handling:** one runtime's resolution, built-in, or `lib` is assumed across a different runtime — a
+  `node:` builtin in browser code, or a `.ts` specifier where the consumer strips nothing.
+- **Adversarial probe:** run the same source under a second runtime — resolution or a built-in breaks where the
+  delta was never read.
+- **Exercises:** H3, Procedure P2.
+- **Checklist IDs:** `TS-CHECK-18`.
+
+## Candidate additional cases
+
+One-line cases that reuse an existing hazard as a discriminator, none duplicating a seed above: a `@ts-ignore`
+suppressing a real error where a narrow would fix it (H10); a `!` non-null assertion standing in for a guard
+(H9); an un-cancelled long await inside an otherwise-bounded fan-out (P5); a `require` reintroduced into a
+`verbatimModuleSyntax` source (H2); a public function returning `any` from a boundary parse (H4, P4); a
+`skipLibCheck`-hidden `.d.ts` break surfaced only by `arethetypeswrong` (H12).

--- a/.gobbi/projects/gobbi/skills/typescript/scenarios.md
+++ b/.gobbi/projects/gobbi/skills/typescript/scenarios.md
@@ -75,7 +75,7 @@ Bottom-up operation.
   the shipped `.d.ts` under `nodenext`.
 - **Good handling:** `verbatimModuleSyntax` with `import type` on every type-only import; the relative
   extension matches the consumption mode (`.js` for the tsc-emitted library, `.ts` with
-  `rewriteRelativeImportExtensions` for the directly stripped source), one mode per tree; the package is
+  `rewriteRelativeImportExtensions` for the directly-run source, stripped or transpiled), one mode per tree; the package is
   ESM-only with a `types` + `import` `exports` map that resolves correctly for the consumer.
 - **Bad handling:** a type import left as a value import; mixed `.js` and `.ts` extensions in one tree; dual
   ESM + CJS emitted from the one `verbatimModuleSyntax` source; a `.d.ts` that resolves wrong under `nodenext`.
@@ -121,17 +121,17 @@ Bottom-up operation.
 - **Axis:** Design judgment.
 - **Situation:** a unit holds mutable internal state — a `#items` array, a `Map`, a `Set` — and a method,
   getter, or exported factory returns it directly to a caller.
-- **Good handling:** the boundary returns a defensive copy (`[...items]`, `new Map(m)`), an immutable view
-  whose immutability REACHES the mutable state (`ReadonlyArray<Readonly<T>>` or primitive elements, not a
-  shallow `readonly T[]` over mutable objects), or frozen data, so a caller cannot reach in and mutate the
-  owner's private state (the coding P16 "minimize shared mutable state" rule, in TypeScript form).
-- **Bad handling:** `get items(): number[] { return this.#items; }` hands back the live array, so a caller's
-  `x.items.push(...)` silently corrupts internal state; a shallow `readonly { x: T }[]` view is NOT enough —
-  the caller still assigns `view[0].x`, mutating the owner's nested state with zero diagnostics.
-- **Adversarial probe:** mutate the returned value and re-read the owner — if the owner's state changed, the
-  container leaked. TypeScript's `readonly` is shallow AND erased: it blocks reassigning an element or the
-  binding, but a `readonly { x: T }[]` still permits `view[0].x = ...`, and an aliased non-`readonly` handle
-  to the same object mutates it too.
+- **Good handling:** the boundary gives the caller no mutable path into private state — a DEEP copy, a
+  deeply-immutable or frozen structure, or primitive / fully-`readonly` elements. A shallow spread `[...items]`
+  and a one-level `Readonly<T>` each protect only the TOP level, so they suffice ONLY when the elements are
+  themselves immutable (the coding P16 "minimize shared mutable state" rule, in TypeScript form).
+- **Bad handling:** `get items(): number[] { return this.#items; }` hands back the live array. A shallow
+  `readonly { x: T }[]` (or `ReadonlyArray<Readonly<T>>` over NESTED objects) is no better — the caller still
+  assigns `view[0].x` / `view[0].inner.x`; and a spread `[...this.#items]` of mutable objects shares those same
+  element objects, so `copy[0].x = ...` mutates the owner too.
+- **Adversarial probe:** mutate the returned value AT DEPTH (`view[0].x`, `view[0].inner.x`, `copy[0].x`) and
+  re-read the owner — if the owner's state changed, a mutable path leaked. TypeScript's `readonly` and
+  `Readonly<T>` are shallow and erased: they block reassigning the top-level element or binding, nothing deeper.
 - **Exercises:** P3.
 - **Checklist IDs:** `TS-CHECK-20`.
 

--- a/.gobbi/projects/gobbi/skills/typescript/scenarios.md
+++ b/.gobbi/projects/gobbi/skills/typescript/scenarios.md
@@ -55,14 +55,16 @@ Bottom-up operation.
 
 ### TS-SCENARIO-04 — Non-erasable syntax in a type-stripping runtime
 - **Axis:** Hard invariant.
-- **Situation:** code that a type-stripping runtime (Node 24+, Bun, Deno) executes uses an `enum`, a
+- **Situation:** portable code — meant to run directly under Node 24+ `--experimental-strip-types`, which
+  STRIPS type syntax rather than transpiling (Bun and Deno transpile instead) — uses an `enum`, a
   `namespace`, or a constructor parameter-property to model a closed set or carry state.
 - **Good handling:** the closed set is a discriminated union or an `as const` object with a derived type;
   `erasableSyntaxOnly` is on, so only strippable syntax ships.
 - **Bad handling:** `enum Direction { Up, Down }`, a `namespace` wrapper, or a `constructor(private x: T)`
   parameter-property — each emits runtime code that type-stripping cannot produce.
-- **Adversarial probe:** run the source directly under a stripping runtime — the non-erasable construct is a
-  syntax error at load, not a compile error caught earlier.
+- **Adversarial probe:** run the source under Node's `--experimental-strip-types` — the non-erasable construct
+  is a load error there (Bun and Deno transpile it, so they accept it); the erasable baseline is a cross-runtime
+  portability policy, not a claim that every runtime rejects the construct.
 - **Exercises:** H7, H11, P7.
 - **Checklist IDs:** `TS-CHECK-09`.
 

--- a/.gobbi/projects/gobbi/skills/typescript/scenarios.md
+++ b/.gobbi/projects/gobbi/skills/typescript/scenarios.md
@@ -116,6 +116,23 @@ Bottom-up operation.
 - **Exercises:** P2, H10.
 - **Checklist IDs:** `TS-CHECK-13`, `TS-CHECK-06`.
 
+### TS-SCENARIO-11 — Returning a live reference to internal mutable state
+- **Axis:** Design judgment.
+- **Situation:** a unit holds mutable internal state — a `#items` array, a `Map`, a `Set` — and a method,
+  getter, or exported factory returns it directly to a caller.
+- **Good handling:** the boundary returns a defensive copy (`[...items]`, `new Map(m)`), an immutable view
+  (`readonly T[]` / `ReadonlyMap`, or a `readonly`-typed interface), or frozen data, so a caller cannot reach
+  in and mutate the owner's private state; a `readonly` return type documents and enforces the no-mutate
+  contract (the coding P16 "minimize shared mutable state" rule, in TypeScript form).
+- **Bad handling:** `get items(): number[] { return this.#items; }` hands back the live array, so a caller's
+  `x.items.push(...)` silently corrupts internal state.
+- **Adversarial probe:** mutate the returned value and re-read the owner — if the owner's state changed, the
+  container leaked. TypeScript's `readonly` is shallow AND erased, so a `readonly` return type is a
+  compile-time boundary, not a runtime guard: an aliased non-`readonly` handle to the same object still
+  mutates it.
+- **Exercises:** P3, coding P16.
+- **Checklist IDs:** `TS-CHECK-20`.
+
 ## Bottom-up operation
 
 ### TS-SCENARIO-08 — Skeleton-first typed growth

--- a/.gobbi/projects/gobbi/skills/typescript/scenarios.md
+++ b/.gobbi/projects/gobbi/skills/typescript/scenarios.md
@@ -1,0 +1,20 @@
+# TypeScript — Scenarios
+
+**Ownership** — the eval seed: per-perspective good / bad / adversarial TypeScript probes (`TS-SCENARIO-*`)
+the evaluator works from.
+
+**Split criterion** — skill-writing P3 (a): one member of the eval-triad SET (`evaluation.md` + `scenarios.md`
++ `checklists.md`). The three are one required set the anti-monolith rule forbids collapsing; this doc owns the
+seed probes.
+
+> Skeleton — sections below are stubs; the body is grown in T6-eval-triad.
+
+---
+
+## Per-perspective probes
+
+> Stub — grown in T6-eval-triad.
+
+## Adversarial probes
+
+> Stub — grown in T6-eval-triad.

--- a/.gobbi/projects/gobbi/skills/typescript/scenarios.md
+++ b/.gobbi/projects/gobbi/skills/typescript/scenarios.md
@@ -29,7 +29,8 @@ Bottom-up operation.
 - **Axis:** Hard invariant.
 - **Situation:** an async fan-out issues work under a deadline, and a file or connection handle is acquired
   inside the same scope.
-- **Good handling:** every promise is awaited, `void`ed deliberately, or given a `.catch`; the fan-out bounds
+- **Good handling:** every promise is awaited, `return`ed, or given a real `void promise.catch(...)` (a bare
+  `void` is not a handler); the fan-out bounds
   its concurrent task creation; cancellation is carried on an `AbortSignal`; each resource's release is bound
   to scope with `using` / `await using` so disposal runs on every path, including the throwing one.
 - **Bad handling:** a fire-and-forget call drops its rejection; an unbounded eager `Promise.all` retains every

--- a/.gobbi/projects/gobbi/skills/typescript/scenarios.md
+++ b/.gobbi/projects/gobbi/skills/typescript/scenarios.md
@@ -122,16 +122,17 @@ Bottom-up operation.
 - **Situation:** a unit holds mutable internal state — a `#items` array, a `Map`, a `Set` — and a method,
   getter, or exported factory returns it directly to a caller.
 - **Good handling:** the boundary returns a defensive copy (`[...items]`, `new Map(m)`), an immutable view
-  (`readonly T[]` / `ReadonlyMap`, or a `readonly`-typed interface), or frozen data, so a caller cannot reach
-  in and mutate the owner's private state; a `readonly` return type documents and enforces the no-mutate
-  contract (the coding P16 "minimize shared mutable state" rule, in TypeScript form).
+  whose immutability REACHES the mutable state (`ReadonlyArray<Readonly<T>>` or primitive elements, not a
+  shallow `readonly T[]` over mutable objects), or frozen data, so a caller cannot reach in and mutate the
+  owner's private state (the coding P16 "minimize shared mutable state" rule, in TypeScript form).
 - **Bad handling:** `get items(): number[] { return this.#items; }` hands back the live array, so a caller's
-  `x.items.push(...)` silently corrupts internal state.
+  `x.items.push(...)` silently corrupts internal state; a shallow `readonly { x: T }[]` view is NOT enough —
+  the caller still assigns `view[0].x`, mutating the owner's nested state with zero diagnostics.
 - **Adversarial probe:** mutate the returned value and re-read the owner — if the owner's state changed, the
-  container leaked. TypeScript's `readonly` is shallow AND erased, so a `readonly` return type is a
-  compile-time boundary, not a runtime guard: an aliased non-`readonly` handle to the same object still
-  mutates it.
-- **Exercises:** P3, coding P16.
+  container leaked. TypeScript's `readonly` is shallow AND erased: it blocks reassigning an element or the
+  binding, but a `readonly { x: T }[]` still permits `view[0].x = ...`, and an aliased non-`readonly` handle
+  to the same object mutates it too.
+- **Exercises:** P3.
 - **Checklist IDs:** `TS-CHECK-20`.
 
 ## Bottom-up operation

--- a/.gobbi/projects/gobbi/skills/typescript/testing.md
+++ b/.gobbi/projects/gobbi/skills/typescript/testing.md
@@ -136,9 +136,10 @@ class MapStore implements Store {
 ```
 
 Substitute at the *real* boundary — the injected `Store`, not a helper the unit calls internally, which
-would make the test assert private structure. If a mock is unavoidable, assert the effect it recorded
-(`transport.sent` equals the expected requests), never `callCount`. Needing many stand-ins to run one test
-is a design signal: the unit wants a narrower seam, not more mocks.
+would make the test assert private structure. If a mock is unavoidable, prefer asserting the effect it
+recorded (`transport.sent` equals the expected requests) over a bare `callCount`; assert the count or order
+only when it is itself the observable contract — a retry limit, a batch size, a rate cap, an audit sequence.
+Needing many stand-ins to run one test is a design signal: the unit wants a narrower seam, not more mocks.
 
 ## 3. Determinism at the seam: time, randomness, concurrency
 
@@ -237,8 +238,10 @@ type _bad = Expect<Equal<ReturnType<typeof first<number>>, number>>;
 ```
 
 `@ts-expect-error` asserts a line **should** fail to type-check: the block compiles clean *if and only if*
-the error is present. A genuinely-broken assertion fails, and a since-fixed one *also* fails (the directive
-now guards a valid line), so the marker self-verifies. It reads at the value level too — a wrong annotation
+some error is present on that line. A genuinely-broken assertion fails, and a since-fixed one *also* fails
+(the directive now guards a valid line). But it does NOT check WHICH error fires — a typo, a missing import,
+or an unrelated failure keeps it green too — so it proves the line errors, not that it errors for the intended
+reason. Where the exact reason matters, pair it with a positive assertion (the `Equal`/`Expect` form above). It reads at the value level too — a wrong annotation
 must be rejected:
 
 ```ts type-level
@@ -256,5 +259,5 @@ const wrong: string[] = flags;
 line that no longer errors is itself a `tsc` error under the type-test pass, so running the type tests
 (SKILL.md P7's *type-level tests* gate) catches a directive that has gone stale. This skill's own fenced
 `ts` blocks are type-tested by exactly this mechanism — the example harness compiles each one under the
-maximal-strict baseline, applying the same rule the SKILL.md Rules state: an example is a taught fact, not
-decoration.
+maximal-strict *type-safety* baseline (unused-symbol hygiene relaxed for standalone snippets), applying the
+same rule the SKILL.md Rules state: an example is a taught fact, not decoration.

--- a/.gobbi/projects/gobbi/skills/typescript/testing.md
+++ b/.gobbi/projects/gobbi/skills/typescript/testing.md
@@ -1,29 +1,260 @@
 # TypeScript — Testing
 
-**Ownership** — runtime-agnostic behavior tests (`node:test` / vitest / `bun test`) asserting return values,
-thrown-error types, and effects; deterministic time, randomness, and concurrency; type-level testing
-(`expectTypeOf` / `tsd` / `@ts-expect-error` in `*.test-d.ts`, run under `tsc`); substitution at real
-boundaries; and tracked skip / xfail.
+**Ownership** — runtime-agnostic behavior tests (`node:test` / vitest / `bun test`) asserting return
+values, thrown-error types, and effects; the verification *seam* — a pure core with injected boundaries;
+determinism for time, randomness, and concurrency; and **type-level testing** — the TS-unique half
+(`expectTypeOf` / `tsd` / `@ts-expect-error` in `*.test-d.ts`, evaluated by `tsc`).
 
 **Split criterion** — skill-writing P3 (d): a self-contained sub-procedure, opened when a unit needs test
-seams — including the type-level testing half that has no `coding` / `python` analogue.
+seams — including the type-level half that has no `coding` / `python` analogue.
 
-> Skeleton — sections below are stubs; the body is grown in T12-testing.
+This doc **deepens, and does not restate,** `coding` Principle 6 (*design for verification*) and SKILL.md
+§ Procedure P7's verify order (which names *focused tests → full tests → type-level tests*). SKILL.md P7
+owns the *order* of the gates; this doc owns *how to write* each test so behavior and types are actually
+checked, and the seam design that makes them cheap. `async-resources.md` owns the promise, cancellation,
+and disposal mechanics; this doc owns only what changes when you make them **deterministic under test**.
+
+Every fenced `ts` block below type-checks under the skill's maximal-strict examples baseline (TS 5.9
+floor; lib `ES2023` + `ESNext.Disposable` + `DOM`). A `declare` line stubs an assumed collaborator — the
+test runner included — so each fragment stands alone; in a real file the runner is `import`ed, not
+declared.
+
+## Contents
+
+1. [Behavior over implementation, runner-agnostic](#1-behavior-over-implementation-runner-agnostic)
+2. [Design for verification: the seam](#2-design-for-verification-the-seam)
+3. [Determinism at the seam: time, randomness, concurrency](#3-determinism-at-the-seam-time-randomness-concurrency)
+4. [Type-level testing](#4-type-level-testing)
 
 ---
 
-## Runtime-agnostic behavior tests
+## 1. Behavior over implementation, runner-agnostic
 
-> Stub — grown in T12-testing.
+A test asserts **observable behavior**, read through the unit's own surface — never its internals:
 
-## Determinism at the seam
+- the **return value**;
+- the **thrown error's type** (and message), caught as `unknown` and narrowed;
+- an **effect** read back at its boundary — a returned structure, a written record, or a fake's recorded
+  calls (§2).
 
-> Stub — grown in T12-testing.
+Never assert a private call order, an internal field, or "the logger's `.info` was called" — a test bound
+to internal structure breaks on every refactor. Name one behavior per test and act once. Cover the four
+case kinds: **golden** (a normal input and result), **edge** (`""`, `0`, an empty array, the boundary and
+one past it), **failure** (an input that must throw, pinned by type *and* message), and **adversarial**
+(a trust-boundary footgun the unit must reject).
 
-## Type-level testing
+The three runners — `node:test`, vitest, and `bun test` — differ only in the *registration* and
+*assertion* API; the discipline above is identical. Name the runner in config; do not autodetect it.
 
-> Stub — grown in T12-testing.
+```ts
+// `test` / `expect` stand for the configured runner — imported in a real file.
+declare function test(name: string, fn: () => void): void;
+declare function expect<T>(actual: T): { toEqual(expected: T): void };
 
-## Substitution at boundaries
+function slugify(input: string): string {
+  return input.trim().toLowerCase().replace(/\s+/g, "-");
+}
 
-> Stub — grown in T12-testing.
+test("slugify lowercases and hyphenates a golden input", () => {
+  expect(slugify("  Hello World  ")).toEqual("hello-world");
+});
+```
+
+Under `strict`, a caught error is `unknown` — the runner cannot hand you an `any`. Narrow it before you
+assert, so the *wrong* error of the right shape cannot pass:
+
+```ts
+declare function test(name: string, fn: () => void): void;
+
+function parseCount(raw: string): number {
+  const n = Number(raw);
+  if (!Number.isInteger(n)) {
+    throw new RangeError(`not an integer: ${raw}`);
+  }
+  return n;
+}
+
+test("parseCount rejects a non-integer with a RangeError", () => {
+  let caught: unknown;
+  try {
+    parseCount("1.5");
+  } catch (error) {
+    caught = error;
+  }
+  if (!(caught instanceof RangeError)) {
+    throw new Error("expected a RangeError");
+  }
+});
+```
+
+Give every `skip` / `todo` a tracked reason and a re-enable condition; an untracked skip silently stops
+proving its contract.
+
+## 2. Design for verification: the seam
+
+Testability is a **design** property (`coding` P6), decided before a line of test runs. The TypeScript
+delta: a seam is a **typed collaborator the caller passes in**. A unit that *takes* its boundaries — a
+store, a clock, a fetch-like function — as typed parameters can be exercised with a stand-in; a unit that
+*constructs* them (news up a client, reads `process.env`, calls `Date.now()`) has no seam and can only be
+tested by standing up the whole environment. Keep a pure core and push I/O, the clock, randomness, and the
+network to injected edges.
+
+The collaborator's *type* is the seam contract: one narrow `interface` is both the production dependency
+and the shape a fake satisfies. Prefer a small working **fake** — an in-memory store, a recording
+transport — over a call-asserting mock, and assert the observable result, not that a method was called:
+
+```ts
+interface Store {
+  get(key: string): Promise<string | undefined>;
+  put(key: string, value: string): Promise<void>;
+}
+
+async function cacheThrough(
+  store: Store,
+  key: string,
+  compute: () => Promise<string>,
+): Promise<string> {
+  const hit = await store.get(key);
+  if (hit !== undefined) {
+    return hit;
+  }
+  const fresh = await compute();
+  await store.put(key, fresh);
+  return fresh;
+}
+
+// The fake IS a `Store`; the test asserts the returned value and the stored effect.
+class MapStore implements Store {
+  readonly #data = new Map<string, string>();
+  async get(key: string): Promise<string | undefined> {
+    return this.#data.get(key);
+  }
+  async put(key: string, value: string): Promise<void> {
+    this.#data.set(key, value);
+  }
+}
+```
+
+Substitute at the *real* boundary — the injected `Store`, not a helper the unit calls internally, which
+would make the test assert private structure. If a mock is unavoidable, assert the effect it recorded
+(`transport.sent` equals the expected requests), never `callCount`. Needing many stand-ins to run one test
+is a design signal: the unit wants a narrower seam, not more mocks.
+
+## 3. Determinism at the seam: time, randomness, concurrency
+
+Every nondeterministic input is **injected or frozen**. Never read the wall clock, call `Math.random`, or
+start a real timer inside the unit — each makes the test flaky and slow.
+
+**Time** — take `now` (a clock callable) as a parameter. A test passes a fixed clock to freeze a
+timestamp, or advances it to drive a timeout; it never waits real seconds.
+
+```ts
+type Clock = () => number;
+
+function expiresAt(now: Clock, ttlMs: number): number {
+  return now() + ttlMs;
+}
+
+const frozen: Clock = () => 1_000;
+const deadline: number = expiresAt(frozen, 500); // deterministically 1_500
+```
+
+**Randomness** — inject the generator; a test passes a fixed draw so the choice is exact. Production may
+draw from `crypto`, but a test supplies the sequence rather than seeding a global.
+
+```ts
+type Rng = () => number;
+
+function pick<T>(rng: Rng, xs: readonly T[]): T | undefined {
+  if (xs.length === 0) {
+    return undefined;
+  }
+  return xs[Math.floor(rng() * xs.length)];
+}
+
+const chosen = pick(() => 0, ["a", "b", "c"]); // always "a"
+```
+
+**Concurrency and timers** — control the schedule instead of sleeping. Inject the wait as a seam, carry
+cancellation on an `AbortSignal` (the `async-resources.md` idiom), and pass an *instant* wait under test so
+no real time passes. Assert the aggregate result, not the interleaving, and bound every async test with a
+deadline so a hang fails fast.
+
+```ts
+type Wait = (signal: AbortSignal) => Promise<void>;
+
+async function fetchWithRetry(
+  attempt: () => Promise<string>,
+  backoff: Wait,
+  signal: AbortSignal,
+  maxTries: number,
+): Promise<string> {
+  let lastError: unknown;
+  for (let i = 0; i < maxTries; i++) {
+    try {
+      return await attempt();
+    } catch (error) {
+      lastError = error;
+      await backoff(signal);
+    }
+  }
+  throw new Error("exhausted retries", { cause: lastError });
+}
+
+// A test injects an instant `backoff` — the retry logic is exercised with zero delay.
+const instant: Wait = async () => {};
+const settled = fetchWithRetry(async () => "ok", instant, AbortSignal.timeout(0), 3);
+```
+
+## 4. Type-level testing
+
+Types get their **own** tests — the half with no `coding` or `python` analogue. A behavior test never runs
+a type, so a wrong return type or a leaked `any` ships green through a passing suite. The fix is to assert
+the *type itself*, evaluated by `tsc` rather than the runtime.
+
+The ecosystem tools are `expectTypeOf` (built into vitest, also the standalone `expect-type` package),
+`tsd`, and the bare `@ts-expect-error` directive; by convention type tests live in `*.test-d.ts` files
+that a type-test run type-checks with `tsc`. The portable, dependency-free core needs none of them — a
+hand-rolled `Equal<A, B>` plus an `Expect<T extends true>` checks under the same compiler:
+
+```ts type-level
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+function first<T>(xs: readonly T[]): T | undefined {
+  return xs[0];
+}
+
+// PASS: `noUncheckedIndexedAccess` makes the element type `T | undefined`.
+type _ok = Expect<Equal<ReturnType<typeof first<number>>, number | undefined>>;
+
+// @ts-expect-error the return is `number | undefined`, not `number` — asserting
+// the narrower type is a compile error, which proves the wider type is correct.
+type _bad = Expect<Equal<ReturnType<typeof first<number>>, number>>;
+```
+
+`@ts-expect-error` asserts a line **should** fail to type-check: the block compiles clean *if and only if*
+the error is present. A genuinely-broken assertion fails, and a since-fixed one *also* fails (the directive
+now guards a valid line), so the marker self-verifies. It reads at the value level too — a wrong annotation
+must be rejected:
+
+```ts type-level
+function parseFlags(raw: string): ReadonlySet<string> {
+  return new Set(raw.split(","));
+}
+
+const flags = parseFlags("a,b");
+
+// @ts-expect-error the result is a ReadonlySet<string>, not a mutable string[].
+const wrong: string[] = flags;
+```
+
+**Guard:** include the `*.test-d.ts` files in the *runtime* test set too. A `@ts-expect-error` sitting on a
+line that no longer errors is itself a `tsc` error under the type-test pass, so running the type tests
+(SKILL.md P7's *type-level tests* gate) catches a directive that has gone stale. This skill's own fenced
+`ts` blocks are type-tested by exactly this mechanism — the example harness compiles each one under the
+maximal-strict baseline, applying the same rule the SKILL.md Rules state: an example is a taught fact, not
+decoration.

--- a/.gobbi/projects/gobbi/skills/typescript/testing.md
+++ b/.gobbi/projects/gobbi/skills/typescript/testing.md
@@ -1,0 +1,29 @@
+# TypeScript — Testing
+
+**Ownership** — runtime-agnostic behavior tests (`node:test` / vitest / `bun test`) asserting return values,
+thrown-error types, and effects; deterministic time, randomness, and concurrency; type-level testing
+(`expectTypeOf` / `tsd` / `@ts-expect-error` in `*.test-d.ts`, run under `tsc`); substitution at real
+boundaries; and tracked skip / xfail.
+
+**Split criterion** — skill-writing P3 (d): a self-contained sub-procedure, opened when a unit needs test
+seams — including the type-level testing half that has no `coding` / `python` analogue.
+
+> Skeleton — sections below are stubs; the body is grown in T12-testing.
+
+---
+
+## Runtime-agnostic behavior tests
+
+> Stub — grown in T12-testing.
+
+## Determinism at the seam
+
+> Stub — grown in T12-testing.
+
+## Type-level testing
+
+> Stub — grown in T12-testing.
+
+## Substitution at boundaries
+
+> Stub — grown in T12-testing.

--- a/.gobbi/projects/gobbi/skills/typescript/typing.md
+++ b/.gobbi/projects/gobbi/skills/typescript/typing.md
@@ -1,0 +1,50 @@
+# TypeScript — Typing
+
+**Ownership** — the type system: discriminated unions and `never` exhaustiveness; generics (`const` type
+params, variance, constraints, `NoInfer`); conditional and mapped types; `satisfies` vs annotation vs `as`;
+branded / nominal types; narrowing, guards, and inferred predicates; `unknown` vs `never`; `readonly` and
+`as const`; utility types; `interface` vs `type`; and declaration-file authoring and module augmentation
+(folded per design D3).
+
+**Split criterion** — skill-writing P3 (b) lookup reference + (d) depth: the largest child doc, both a
+by-decision lookup surface and a self-contained sub-procedure the parent floor cannot inline.
+
+> Skeleton — sections below are stubs; the body is grown in T4-typing.
+
+---
+
+## Discriminated unions and `never` exhaustiveness
+
+> Stub — grown in T4-typing.
+
+## Generics
+
+> Stub — grown in T4-typing.
+
+## Conditional and mapped types
+
+> Stub — grown in T4-typing.
+
+## `satisfies`, annotation, and `as`
+
+> Stub — grown in T4-typing.
+
+## Branded and nominal types
+
+> Stub — grown in T4-typing.
+
+## Narrowing, guards, and inferred predicates
+
+> Stub — grown in T4-typing.
+
+## `unknown`, `never`, `readonly`, and `as const`
+
+> Stub — grown in T4-typing.
+
+## Utility types and `interface` vs `type`
+
+> Stub — grown in T4-typing.
+
+## Declaration-file authoring and module augmentation
+
+> Stub — grown in T4-typing.

--- a/.gobbi/projects/gobbi/skills/typescript/typing.md
+++ b/.gobbi/projects/gobbi/skills/typescript/typing.md
@@ -249,9 +249,11 @@ const theme = {
 const green: number = theme.red[1]; // ok: theme.red is the tuple, not `[...] | string`
 ```
 
-An annotation (`: T`) *checks and widens* to `T`; an assertion (`as T`) *neither checks nor widens* — it asserts
-a type the value may not have, and the compiler stops catching drift. Prefer the annotation, which surfaces a
-missing field that `as` hides:
+An annotation (`: T`) *checks and widens* to `T`; an assertion (`as T`) does **no runtime check** and, unlike an
+annotation, does not re-validate the value against `T` — it just tells the compiler to treat the expression as
+`T` (TypeScript still rejects an assertion between insufficiently-overlapping types). It asserts a type the value
+may not have, so the compiler stops catching drift. Prefer the annotation, which surfaces a missing field that
+`as` hides:
 
 ```ts expect-error
 interface User {

--- a/.gobbi/projects/gobbi/skills/typescript/typing.md
+++ b/.gobbi/projects/gobbi/skills/typescript/typing.md
@@ -9,42 +9,570 @@ branded / nominal types; narrowing, guards, and inferred predicates; `unknown` v
 **Split criterion** — skill-writing P3 (b) lookup reference + (d) depth: the largest child doc, both a
 by-decision lookup surface and a self-contained sub-procedure the parent floor cannot inline.
 
-> Skeleton — sections below are stubs; the body is grown in T4-typing.
+This doc **deepens, and does not restate,** the SKILL.md typing rules and Principle 3 (*model with the type
+system*). The parent P2 router sends a reader here when a change reaches a public boundary, a generic, a guard,
+a discriminated union, a `satisfies` / `as` decision, a branded type, or `.d.ts` authoring; an ordinary strict
+module stays on the parent floor. SKILL.md P3 owns the *decision tables* (`interface` vs `type`, when a generic
+is earned, `satisfies` vs annotation vs `as`); this doc owns the *mechanics* behind each row — why it holds,
+how it fails, and the deeper forms the table cannot carry. `design.md` decides whether a given shape is the
+right caller contract; it points here for the spelling.
+
+Every fenced `ts` block below type-checks under the skill's maximal-strict examples baseline (TS 5.9 floor); an
+untagged declaration-file block is a `.d.ts` (script-context) form the module-based example harness does not
+compile, shown for its syntax.
+
+## Contents
+
+1. [Discriminated unions and `never` exhaustiveness](#1-discriminated-unions-and-never-exhaustiveness)
+2. [Generics](#2-generics)
+3. [Conditional and mapped types](#3-conditional-and-mapped-types)
+4. [`satisfies`, annotation, and `as`](#4-satisfies-annotation-and-as)
+5. [Branded and nominal types](#5-branded-and-nominal-types)
+6. [Narrowing, guards, and predicates](#6-narrowing-guards-and-predicates)
+7. [`unknown`, `never`, `readonly`, and `as const`](#7-unknown-never-readonly-and-as-const)
+8. [Utility types and `interface` vs `type`](#8-utility-types-and-interface-vs-type)
+9. [Declaration files and module augmentation](#9-declaration-files-and-module-augmentation)
 
 ---
 
-## Discriminated unions and `never` exhaustiveness
+## 1. Discriminated unions and `never` exhaustiveness
 
-> Stub — grown in T4-typing.
+A discriminated union is the core modeling tool: a shared literal tag (`type`, `kind`, `ok`) lets the compiler
+narrow to one member and prove every member is handled. SKILL.md P3 shows the canonical `switch` +
+`assertNever`; this section deepens *why* it is total, *how* a new member breaks it, and a map-based
+alternative.
 
-## Generics
+The `assertNever` helper is total because control-flow narrowing reduces the discriminant to `never` once every
+member is handled — so the `default` argument type-checks only while the switch is exhaustive:
 
-> Stub — grown in T4-typing.
+```ts
+type Action =
+  | { type: "inc"; by: number }
+  | { type: "reset" }
+  | { type: "set"; value: number };
 
-## Conditional and mapped types
+function assertNever(x: never): never {
+  throw new Error(`unhandled variant: ${JSON.stringify(x)}`);
+}
 
-> Stub — grown in T4-typing.
+function reduce(count: number, action: Action): number {
+  switch (action.type) {
+    case "inc":
+      return count + action.by;
+    case "reset":
+      return 0;
+    case "set":
+      return action.value;
+    default:
+      return assertNever(action); // `action` is `never` here — proof of totality
+  }
+}
+```
 
-## `satisfies`, annotation, and `as`
+Add a member and leave it unhandled: the `default` argument is no longer `never`, so `assertNever` fails to
+compile — the missing case becomes a *build* error, not a runtime surprise:
 
-> Stub — grown in T4-typing.
+```ts expect-error
+type Action = { type: "inc" } | { type: "dec" };
 
-## Branded and nominal types
+function assertNever(x: never): never {
+  throw new Error(String(x));
+}
 
-> Stub — grown in T4-typing.
+function label(a: Action): string {
+  switch (a.type) {
+    case "inc":
+      return "up";
+    default:
+      // @ts-expect-error "dec" is unhandled, so `a` is `{ type: "dec" }`, not `never`
+      return assertNever(a);
+  }
+}
+```
 
-## Narrowing, guards, and inferred predicates
+When each member maps to a value rather than a computation, a `Record` keyed by the discriminant union is a
+tighter total form: the compiler demands a key for every member, so a missing case fails with no `assertNever`
+call:
 
-> Stub — grown in T4-typing.
+```ts
+type Kind = "draft" | "sent" | "paid";
 
-## `unknown`, `never`, `readonly`, and `as const`
+// A Record keyed by the union forces a handler for EVERY member — a missing key
+// is a compile error at the object literal itself.
+const kindLabel: Record<Kind, string> = {
+  draft: "Draft",
+  sent: "Awaiting payment",
+  paid: "Complete",
+};
 
-> Stub — grown in T4-typing.
+function describe(k: Kind): string {
+  return kindLabel[k]; // `string`, not `string | undefined`: all keys are present
+}
+```
 
-## Utility types and `interface` vs `type`
+## 2. Generics
 
-> Stub — grown in T4-typing.
+Add a type parameter only when it links an input to an output (or two inputs) across many types; SKILL.md P3
+owns that *when-earned* decision. This section owns the four mechanics that make an earned generic precise.
 
-## Declaration-file authoring and module augmentation
+A `const` type parameter (5.0) infers the narrowest literal, readonly type from the argument — as if the caller
+wrote `as const` at the call site — so a returned literal keeps its exact type:
 
-> Stub — grown in T4-typing.
+```ts
+function asTuple<const T extends readonly unknown[]>(xs: T): T {
+  return xs;
+}
+
+const point = asTuple([3, 4]); // T = readonly [3, 4], not number[]
+const first: 3 = point[0]; // the literal survives the call
+```
+
+A constraint (`K extends keyof T`) both restricts the argument and *links* it to the return type, so the result
+type follows the key the caller passes:
+
+```ts
+function prop<T, K extends keyof T>(obj: T, key: K): T[K] {
+  return obj[key];
+}
+
+const label = prop({ id: 1, label: "a" }, "label"); // string, tracked from the key
+```
+
+`NoInfer<T>` (5.4) marks a position that must *not* drive inference, so one argument fixes `T` and the other is
+merely checked against it:
+
+```ts
+// Without NoInfer, `fallback` would also widen T; here T infers from `values`
+// only, and `fallback` must be one of those element types.
+function pick<T>(values: readonly T[], fallback: NoInfer<T>): T {
+  return values[0] ?? fallback;
+}
+
+const chosen = pick(["a", "b"], "a"); // T = string; a non-member fallback is rejected
+```
+
+Variance is inferred from usage, but an `in` / `out` annotation *declares* it — documenting the intent and
+making a wrong future edit (using a covariant parameter contravariantly) a compile error:
+
+```ts
+// `out T` declares Box covariant in T: a Box<Dog> is usable where Box<Animal> is.
+interface Box<out T> {
+  readonly value: T;
+}
+
+interface Animal {
+  name: string;
+}
+interface Dog extends Animal {
+  breed: string;
+}
+
+const dogBox: Box<Dog> = { value: { name: "Rex", breed: "lab" } };
+const animalBox: Box<Animal> = dogBox; // allowed by the declared covariance
+```
+
+## 3. Conditional and mapped types
+
+Conditional and mapped types compute one type from another. Reach for them to derive a related type from a
+source of truth instead of hand-maintaining a parallel one.
+
+A conditional type with `infer` extracts a component of a matched shape:
+
+```ts
+type ElementOf<T> = T extends readonly (infer E)[] ? E : never;
+
+type Item = ElementOf<string[]>; // string
+const item: Item = "x";
+```
+
+A *naked* type parameter distributes over a union — the conditional applies to each member and the results
+recombine, which is how the built-in `Exclude` / `NonNullable` work:
+
+```ts
+type NonNull<T> = T extends null | undefined ? never : T;
+
+type Clean = NonNull<string | null | number>; // string | number
+const c: Clean = 5;
+```
+
+A mapped type rewrites every property. Key remapping with `as` renames each key — here building a getters type
+from a source, with `Capitalize` (an intrinsic string type) in a template-literal key:
+
+```ts
+type Getters<T> = {
+  [K in keyof T as `get${Capitalize<string & K>}`]: () => T[K];
+};
+
+type Person = { name: string; age: number };
+type PersonGetters = Getters<Person>; // { getName: () => string; getAge: () => number }
+
+const g: PersonGetters = {
+  getName: () => "a",
+  getAge: () => 1,
+};
+```
+
+Mapped modifiers add or strip `readonly` and optionality with a `+` / `-` prefix — `-?` makes every property
+required, `+readonly` makes it immutable:
+
+```ts
+type Concrete<T> = {
+  +readonly [K in keyof T]-?: T[K];
+};
+
+type Loose = { a?: number; b?: string };
+type Firm = Concrete<Loose>; // { readonly a: number; readonly b: string }
+
+const firm: Firm = { a: 1, b: "x" };
+```
+
+## 4. `satisfies`, annotation, and `as`
+
+SKILL.md P3 carries the three-way table; this section deepens each row with the mechanic and the failure it
+prevents. `satisfies T` validates a value against `T` yet keeps its narrow *inferred* type — the gap an
+annotation and an assertion both leave. It matters when you must both check the shape and still use the narrow
+type afterward:
+
+```ts
+type Palette = Record<string, readonly [number, number, number] | string>;
+
+// `satisfies` checks every value against Palette but keeps each one's narrow type,
+// so `red` stays a tuple you can index — an annotation would widen it to the union.
+const theme = {
+  red: [255, 0, 0],
+  bg: "#fff",
+} satisfies Palette;
+
+const green: number = theme.red[1]; // ok: theme.red is the tuple, not `[...] | string`
+```
+
+An annotation (`: T`) *checks and widens* to `T`; an assertion (`as T`) *neither checks nor widens* — it asserts
+a type the value may not have, and the compiler stops catching drift. Prefer the annotation, which surfaces a
+missing field that `as` hides:
+
+```ts expect-error
+interface User {
+  id: number;
+  name: string;
+}
+
+// `as` asserts without checking: the missing `name` is hidden. Do not do this.
+const u1 = { id: 1 } as User;
+
+// @ts-expect-error an annotation catches the missing `name` that `as` silently hid
+const u2: User = { id: 1 };
+```
+
+`as const` is the safe assertion: it only *restricts* — literals stay literal and the value becomes deeply
+`readonly` — so it can never lie. It pairs with a derived union to make one literal object the single source of
+truth:
+
+```ts
+const routes = {
+  home: "/",
+  help: "/help",
+} as const;
+
+type Route = (typeof routes)[keyof typeof routes]; // "/" | "/help"
+const r: Route = routes.home;
+```
+
+Reserve a plain `as` for a static fact the compiler cannot see *after* a runtime narrow — for example minting a
+branded type behind a validating gate (§5). An `as` used to silence an error is a lie the compiler will stop
+reporting.
+
+## 5. Branded and nominal types
+
+TypeScript is structural: two types with the same shape are interchangeable. A brand adds a phantom,
+non-constructable tag so two otherwise-identical types (both `string`) become distinct — nominal typing layered
+on top of the structural system. The tag exists only at the type level and is erased at runtime:
+
+```ts
+// A `unique symbol` key makes the tag unforgeable; the value is still a string.
+declare const brand: unique symbol;
+type Brand<T, B extends string> = T & { readonly [brand]: B };
+
+type UserId = Brand<string, "UserId">;
+
+// The only way to mint one is a checked constructor — the brand is the receipt.
+function toUserId(raw: string): UserId {
+  return raw as UserId; // legitimate `as`: applied once, behind a validating gate
+}
+
+const id: UserId = toUserId("u_1");
+const plain: string = id; // a branded value is still usable as its base type
+```
+
+The payoff is that the compiler refuses to mix two brands, though both are plain strings at runtime — the class
+of bug (passing the wrong id) that structural typing alone cannot catch:
+
+```ts expect-error
+declare const brand: unique symbol;
+type Brand<T, B extends string> = T & { readonly [brand]: B };
+type UserId = Brand<string, "UserId">;
+type OrderId = Brand<string, "OrderId">;
+
+declare function loadOrder(id: OrderId): void;
+declare const user: UserId;
+
+// @ts-expect-error a UserId is not an OrderId, though both are strings at runtime
+loadOrder(user);
+```
+
+## 6. Narrowing, guards, and predicates
+
+Narrowing is how a wide type (a union, `unknown`) becomes usable. Built-in narrowing — `typeof`, `instanceof`,
+`in`, and a discriminant check — covers most cases; three custom forms extend it across a function boundary.
+
+A user-defined type predicate (`x is T`) teaches the compiler what a boolean-returning function proves, so its
+result narrows at the call site:
+
+```ts
+interface Cat {
+  meow: () => void;
+}
+interface Dog {
+  bark: () => void;
+}
+
+function isCat(pet: Cat | Dog): pet is Cat {
+  return "meow" in pet;
+}
+
+function speak(pet: Cat | Dog): void {
+  if (isCat(pet)) {
+    pet.meow(); // narrowed to Cat
+  } else {
+    pet.bark(); // narrowed to Dog
+  }
+}
+```
+
+TS 5.5 *infers* the predicate when a function with no explicit return type is a single narrowing return — so a
+plain helper narrows an array `filter` with no `is` annotation. Prefer the explicit `is` form at a public
+boundary (it is the stated contract); rely on inference for a local helper:
+
+```ts
+// No `x is string` written: 5.5 infers it from the body, so `filter` narrows.
+function isString(x: unknown) {
+  return typeof x === "string";
+}
+
+const mixed: readonly unknown[] = [1, "a", true, "b"];
+const strings = mixed.filter(isString); // string[]
+const head: string | undefined = strings[0];
+```
+
+An assertion function (`asserts x is T`) narrows by *throwing* instead of returning a boolean — everything after
+the call sees the narrowed type, and there is no `else` branch:
+
+```ts
+function assertIsString(x: unknown): asserts x is string {
+  if (typeof x !== "string") {
+    throw new Error("expected a string");
+  }
+}
+
+function useValue(v: unknown): number {
+  assertIsString(v);
+  return v.length; // v is `string` for the rest of the scope
+}
+```
+
+A predicate lies if its body and its claim disagree (`pet is Cat` on a check that does not prove `Cat`); the
+compiler trusts the signature, so a wrong guard defeats the whole point. Keep the body and the claim in step.
+
+## 7. `unknown`, `never`, `readonly`, and `as const`
+
+`unknown` is the top type and `never` is the bottom type — the two ends of the assignability lattice, and the
+tools for a safe boundary and a proven-impossible branch.
+
+`unknown` accepts any value but permits no operation until you narrow it — the safe replacement for `any`, which
+accepts any value AND permits everything unchecked (§ SKILL.md Rules ban `any`):
+
+```ts
+// `unknown` forces a narrow before use; `any` would let `x.length` through unchecked.
+function lengthOf(x: unknown): number {
+  if (typeof x === "string" || Array.isArray(x)) {
+    return x.length;
+  }
+  return 0;
+}
+```
+
+`never` has no values, is assignable to every type, and accepts only `never` — which is exactly what powers
+`assertNever` (§1) and marks a branch as impossible:
+
+```ts
+function unreachable(): never {
+  throw new Error("unreachable");
+}
+
+const n: never = unreachable();
+const s: string = n; // never is assignable to any type
+```
+
+`readonly` on a property and `readonly T[]` (or `ReadonlyArray<T>`) push immutability into the type, so a
+mutation is a compile error rather than a runtime aliasing bug — the type-level face of *prefer immutable data*:
+
+```ts
+interface Point {
+  readonly x: number;
+  readonly y: number;
+}
+
+// A shift returns a new Point; it cannot mutate the input.
+function shift(p: Point, dx: number): Point {
+  return { x: p.x + dx, y: p.y };
+}
+
+function total(xs: readonly number[]): number {
+  return xs.reduce((a, b) => a + b, 0); // read-only methods only
+}
+```
+
+```ts expect-error
+interface Config {
+  readonly retries: number;
+}
+const c: Config = { retries: 3 };
+
+// @ts-expect-error cannot assign to a readonly property
+c.retries = 5;
+```
+
+`as const` (§4) is the value-level counterpart: it makes a literal deeply `readonly` and keeps every member at
+its narrow literal type.
+
+## 8. Utility types and `interface` vs `type`
+
+The built-in utility types derive a related type from a source, so a shape has one home and its variants follow.
+The core set — `Partial`, `Pick`, `Omit`, `Record` — composes:
+
+```ts
+interface User {
+  id: number;
+  name: string;
+  email: string;
+}
+
+type UserPatch = Partial<Pick<User, "name" | "email">>; // both keys optional
+type PublicUser = Omit<User, "email">; // { id: number; name: string }
+type UsersById = Record<number, User>;
+
+const patch: UserPatch = { name: "new" };
+const pub: PublicUser = { id: 1, name: "a" };
+const byId: UsersById = { 1: { id: 1, name: "a", email: "e" } };
+```
+
+`ReturnType` and `Awaited` derive types from a function and a promise — `Awaited` unwraps recursively, so a type
+tracks an async result without a hand-written duplicate:
+
+```ts
+async function loadCount(): Promise<number> {
+  return 42;
+}
+
+type Loaded = Awaited<ReturnType<typeof loadCount>>; // number
+const n: Loaded = 1;
+```
+
+SKILL.md P3 tables the `interface` vs `type` choice; the mechanic behind it is that each can do something the
+other cannot. An `interface` *merges* — two same-named declarations combine, which is what powers
+declaration-file augmentation (§9); a `type` alias cannot be reopened. A `type`, in turn, expresses a union,
+tuple, or mapped/conditional type that an `interface` cannot:
+
+```ts
+// Two `interface Settings` declarations merge into one shape.
+interface Settings {
+  theme: string;
+}
+interface Settings {
+  locale: string;
+}
+const s: Settings = { theme: "dark", locale: "en" };
+
+// A `type` alias expresses what an interface cannot: a union.
+type Id = number | string;
+const id: Id = "x";
+```
+
+So: `interface` for an object shape that may be extended, implemented, or augmented; `type` for a union, tuple,
+mapped, conditional, or any alias of a non-object type.
+
+## 9. Declaration files and module augmentation
+
+A declaration file (`.d.ts`) carries types with no runtime code. Its jobs are typing a value some other script
+provides, typing an untyped or non-code import, and *augmenting* an existing type. Everything here erases at
+runtime.
+
+A `declare` statement types a value that exists at runtime but has no local definition — an ambient declaration.
+Module-scoped, it types (say) an analytics global injected by a `<script>` tag:
+
+```ts
+// Types a global the runtime provides; there is no runtime code to emit.
+declare function gtag(command: string, ...args: readonly unknown[]): void;
+
+export function trackPageView(path: string): void {
+  gtag("event", "page_view", { path });
+}
+```
+
+`declare global` (valid only inside a module) reaches the global scope. Use it to add a global binding, or to
+*augment* a built-in interface — the same declaration-merging mechanism as an `interface` (§8), applied to a
+type you do not own:
+
+```ts
+export {};
+
+declare global {
+  // Add a typed global binding.
+  var __APP_VERSION__: string;
+}
+
+const version: string = globalThis.__APP_VERSION__;
+```
+
+```ts
+export {};
+
+declare global {
+  // Augment a built-in interface — the merge adds `first` to every Array.
+  interface Array<T> {
+    first(): T | undefined;
+  }
+}
+
+const f = [1, 2, 3].first(); // number | undefined
+```
+
+Two forms live in a `.d.ts` script file (no top-level `import` / `export`) and need a resolvable target, so the
+module-based example harness does not compile them; the syntax is standard. An **ambient module declaration**
+types a whole class of untyped imports — a wildcard name types every matching import a bundler produces:
+
+```
+// assets.d.ts — types a non-code import the bundler resolves.
+declare module "*.css" {
+  const classes: Readonly<Record<string, string>>;
+  export default classes;
+}
+```
+
+**Module augmentation** reopens a dependency's module to add to its declared types — the identical `declare
+module "<name>"` reopen form, requiring the real module to resolve (the `import` makes this a module, so the
+`declare module` augments rather than replaces):
+
+```
+// augment.d.ts — extend a library's types without editing it.
+import "some-orm";
+
+declare module "some-orm" {
+  interface QueryOptions {
+    trace?: boolean; // merged into the library's existing interface
+  }
+}
+```
+
+Keep every declaration honest: an ambient `declare` or a `.d.ts` states a contract the compiler cannot verify
+against an implementation, so a drifted declaration is a silent false type — the same accuracy discipline a
+public signature carries.

--- a/.gobbi/projects/gobbi/skills/typescript/typing.md
+++ b/.gobbi/projects/gobbi/skills/typescript/typing.md
@@ -142,13 +142,16 @@ const label = prop({ id: 1, label: "a" }, "label"); // string, tracked from the 
 merely checked against it:
 
 ```ts
-// Without NoInfer, `fallback` would also widen T; here T infers from `values`
-// only, and `fallback` must be one of those element types.
-function pick<T>(values: readonly T[], fallback: NoInfer<T>): T {
+// A `const` type parameter preserves the literal element types (T = "a" | "b", not
+// `string`); NoInfer then stops `fallback` from re-widening T, so it must be a member.
+// (Without `const`, T widens to `string` and any string fallback would be accepted.)
+function pick<const T extends string>(values: readonly T[], fallback: NoInfer<T>): T {
   return values[0] ?? fallback;
 }
 
-const chosen = pick(["a", "b"], "a"); // T = string; a non-member fallback is rejected
+const chosen = pick(["a", "b"], "a"); // T = "a" | "b"; ok
+// @ts-expect-error "c" is not one of the element types "a" | "b"
+const rejected = pick(["a", "b"], "c");
 ```
 
 Variance is inferred from usage, but an `in` / `out` annotation *declares* it — documenting the intent and
@@ -263,8 +266,9 @@ const u1 = { id: 1 } as User;
 const u2: User = { id: 1 };
 ```
 
-`as const` is the safe assertion: it only *restricts* — literals stay literal and the value becomes deeply
-`readonly` — so it can never lie. It pairs with a derived union to make one literal object the single source of
+`as const` is the safe assertion: it only *restricts* — literals stay literal and the literal's own structure
+becomes `readonly` at the type level, nested literals included (a compile-time constraint, not a runtime
+`Object.freeze`, and not a freeze of a mutable value the literal merely references) — so it can never lie. It pairs with a derived union to make one literal object the single source of
 truth:
 
 ```ts
@@ -288,15 +292,19 @@ non-constructable tag so two otherwise-identical types (both `string`) become di
 on top of the structural system. The tag exists only at the type level and is erased at runtime:
 
 ```ts
-// A `unique symbol` key makes the tag unforgeable; the value is still a string.
+// A `unique symbol` key means ordinary structural code cannot write the tag; the value
+// is still a plain string at runtime. A deliberate `as` CAN still forge one (assertions
+// are erased), so the brand discourages forgery and channels minting through the gate below.
 declare const brand: unique symbol;
 type Brand<T, B extends string> = T & { readonly [brand]: B };
 
 type UserId = Brand<string, "UserId">;
 
-// The only way to mint one is a checked constructor — the brand is the receipt.
+// Mint only behind a REAL runtime check, then assert — the check is what makes this `as`
+// honest (the invariant is verified first); the assertion alone would validate nothing.
 function toUserId(raw: string): UserId {
-  return raw as UserId; // legitimate `as`: applied once, behind a validating gate
+  if (!/^u_\d+$/.test(raw)) throw new Error(`not a UserId: ${raw}`);
+  return raw as UserId;
 }
 
 const id: UserId = toUserId("u_1");
@@ -441,7 +449,7 @@ const c: Config = { retries: 3 };
 c.retries = 5;
 ```
 
-`as const` (§4) is the value-level counterpart: it makes a literal deeply `readonly` and keeps every member at
+`as const` (§4) is the value-level counterpart: it makes a literal's structure `readonly` at the type level (a compile-time constraint, not a runtime freeze) and keeps every member at
 its narrow literal type.
 
 ## 8. Utility types and `interface` vs `type`

--- a/examples/typescript/bun.lock
+++ b/examples/typescript/bun.lock
@@ -1,0 +1,15 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@gobbi/typescript-examples",
+      "devDependencies": {
+        "typescript": "5.9.3",
+      },
+    },
+  },
+  "packages": {
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+  }
+}

--- a/examples/typescript/extract-blocks.mjs
+++ b/examples/typescript/extract-blocks.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env bun
+// extract-blocks.mjs — extractor half of the example-verification harness.
+//
+// Reads markdown, pulls every fenced `ts` / `typescript` block, groups the
+// blocks by category, and writes one compilable `.ts` unit per example into
+// <out-units-dir>. run-examples.sh (the runner half) then type-checks the
+// units with the LOCAL tsc under tsconfig.examples.json.
+//
+// Usage:  bun extract-blocks.mjs <out-units-dir> <md-file-or-dir> [more...]
+//
+// Categories (read from the fenced info string — the words after the language
+// token; a `ts` block with NO category word defaults to `complete`):
+//   complete      self-contained module; must type-check clean (DEFAULT)
+//   partial       needs a prelude; compiled as <prelude-src>\n<partial-src>
+//   prelude       shared decls for the partials that share its `key=`; an
+//                 orphan prelude (no partner partial) is compiled standalone
+//   expect-error  an intentionally-bad block; the bad line is preceded by
+//                 `// @ts-expect-error`, so the block type-checks clean IFF
+//                 the error is present (self-verifying)
+//   type-level    a type-assertion block; asserts via `// @ts-expect-error`
+//                 (no expect-type / tsd dependency); compiled like `complete`
+//
+// Prelude/partial linkage: `ts prelude key=NAME` + `ts partial key=NAME` link
+// by NAME. `key=` may be omitted — the empty key is the shared default.
+//
+// Exit codes:
+//   0  ok — >=1 unit written
+//   2  usage / IO error, or a partial with no matching prelude
+//   3  FAIL-CLOSED — zero `ts` blocks found (a broken parser or a no-example
+//      input must NEVER be reported as a pass)
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
+import { join, extname } from "node:path";
+
+const argv = process.argv.slice(2);
+if (argv.length < 2) {
+  process.stderr.write("usage: extract-blocks.mjs <out-units-dir> <md-file-or-dir> [more...]\n");
+  process.exit(2);
+}
+const outDir = argv[0];
+const inputs = argv.slice(1);
+
+// ---- collect markdown inputs ------------------------------------------------
+// A directory is recursed for `*.md`; a direct file argument is taken as-is
+// (any extension), so a caller can point the harness at one specific doc.
+function collectMarkdown(target) {
+  let st;
+  try {
+    st = statSync(target);
+  } catch {
+    process.stderr.write(`FAIL: input not found: ${target}\n`);
+    process.exit(2);
+  }
+  if (st.isDirectory()) {
+    const found = [];
+    for (const name of readdirSync(target).sort()) {
+      const child = join(target, name);
+      if (statSync(child).isDirectory()) found.push(...collectMarkdown(child));
+      else if (extname(name) === ".md") found.push(child);
+    }
+    return found;
+  }
+  return [target];
+}
+
+const mdFiles = [];
+for (const inp of inputs) mdFiles.push(...collectMarkdown(inp));
+
+// ---- parse fenced code blocks ----------------------------------------------
+// CommonMark fences: >=3 backticks or tildes open a block; it closes at the
+// first later line with >= the opening run of the SAME fence char and only
+// trailing whitespace. The language is the first token of the info string.
+const OPEN_RE = /^(\s*)(`{3,}|~{3,})(.*)$/;
+const CATEGORY_WORDS = new Set(["complete", "partial", "prelude", "expect-error", "type-level"]);
+
+const blocks = []; // { category, key, source, file }
+for (const file of mdFiles) {
+  const lines = readFileSync(file, "utf8").split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const open = OPEN_RE.exec(lines[i]);
+    if (!open) continue;
+    const fenceChar = open[2][0];
+    const fenceLen = open[2].length;
+    const info = open[3].trim();
+
+    // gather the body up to the matching close fence
+    const body = [];
+    let j = i + 1;
+    for (; j < lines.length; j++) {
+      const close = /^(\s*)(`{3,}|~{3,})\s*$/.exec(lines[j]);
+      if (close && close[2][0] === fenceChar && close[2].length >= fenceLen) break;
+      body.push(lines[j]);
+    }
+    i = j; // continue scanning after the close fence (or EOF)
+
+    const tokens = info.split(/\s+/).filter(Boolean);
+    const lang = (tokens[0] || "").toLowerCase();
+    if (lang !== "ts" && lang !== "typescript") continue;
+
+    let category = "complete";
+    let key = "";
+    for (const t of tokens.slice(1)) {
+      const low = t.toLowerCase();
+      if (CATEGORY_WORDS.has(low)) category = low;
+      else if (low.startsWith("key=")) key = t.slice(4);
+    }
+    blocks.push({ category, key, source: body.join("\n"), file });
+  }
+}
+
+// ---- fail-closed: zero ts blocks -------------------------------------------
+if (blocks.length === 0) {
+  process.stderr.write(
+    `FAIL: no fenced 'ts' / 'typescript' blocks found in [${inputs.join(", ")}] — fail-closed (a broken parser or a no-example input is never a pass)\n`
+  );
+  process.exit(3);
+}
+
+// ---- resolve prelude/partial linkage ---------------------------------------
+const preludesByKey = new Map(); // key -> [source, ...]
+for (const b of blocks) {
+  if (b.category !== "prelude") continue;
+  const arr = preludesByKey.get(b.key) ?? [];
+  arr.push(b.source);
+  preludesByKey.set(b.key, arr);
+}
+const usedPreludeKeys = new Set();
+
+let unitIdx = 0;
+function writeUnit(category, source) {
+  const name = `unit-${String(unitIdx).padStart(3, "0")}-${category}.ts`;
+  writeFileSync(join(outDir, name), source.endsWith("\n") ? source : `${source}\n`);
+  unitIdx++;
+}
+
+for (const b of blocks) {
+  if (b.category === "prelude") continue; // emitted after the loop if orphaned
+  if (b.category === "partial") {
+    const preludes = preludesByKey.get(b.key);
+    if (!preludes || preludes.length === 0) {
+      process.stderr.write(
+        `FAIL: partial block (key='${b.key}') in ${b.file} has no matching prelude — add a \`ts prelude key=${b.key}\` block\n`
+      );
+      process.exit(2);
+    }
+    usedPreludeKeys.add(b.key);
+    writeUnit("partial", `${preludes.join("\n")}\n${b.source}`);
+  } else {
+    // complete | expect-error | type-level -> compiled standalone
+    writeUnit(b.category, b.source);
+  }
+}
+
+// An orphan prelude (declared but never consumed by a partial) is still
+// compiled standalone, so a broken one is caught rather than silently skipped.
+for (const [key, sources] of preludesByKey) {
+  if (!usedPreludeKeys.has(key)) writeUnit("prelude", sources.join("\n"));
+}
+
+if (unitIdx === 0) {
+  // defense in depth: blocks>0 must always yield >=1 unit
+  process.stderr.write("FAIL: ts blocks found but no compilable unit produced — fail-closed\n");
+  process.exit(3);
+}
+
+process.stdout.write(`extracted ${unitIdx} unit(s) from ${blocks.length} ts block(s)\n`);
+process.exit(0);

--- a/examples/typescript/fixtures/bad-complete.md
+++ b/examples/typescript/fixtures/bad-complete.md
@@ -1,0 +1,11 @@
+# Fixture — bad complete block
+
+A `complete` block with a REAL type error and NO `@ts-expect-error` marker: the
+right-hand operand of `*` is a string. The harness MUST exit non-zero on this
+file (a broken taught fact must fail the gate).
+
+```ts complete
+export function double(n: number): number {
+  return n * "2";
+}
+```

--- a/examples/typescript/fixtures/categories.md
+++ b/examples/typescript/fixtures/categories.md
@@ -1,0 +1,39 @@
+# Fixture — every category
+
+Proves the harness handles `prelude` + `partial` linkage, the self-verifying
+`expect-error` category, the `type-level` category (asserted via
+`@ts-expect-error`, no expect-type / tsd dependency), and the relaxed
+unused-locals rule (values declared only to show a type). The harness MUST
+exit 0 on this file.
+
+A shared prelude and a partial that uses it (compiled together):
+
+```ts prelude key=shapes
+interface Point {
+  readonly x: number;
+  readonly y: number;
+}
+```
+
+```ts partial key=shapes
+const origin: Point = { x: 0, y: 0 };
+```
+
+An `expect-error` block — the bad line is preceded by `@ts-expect-error`, so it
+type-checks clean IFF the error is genuinely present:
+
+```ts expect-error
+// @ts-expect-error a string is not assignable to number
+const count: number = "three";
+```
+
+A `type-level` block — the type identity is asserted with `@ts-expect-error`:
+
+```ts type-level
+type Equals<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+
+const same: Equals<string, string> = true;
+
+// @ts-expect-error string and number are not the same type
+const different: Equals<string, number> = true;
+```

--- a/examples/typescript/fixtures/empty.md
+++ b/examples/typescript/fixtures/empty.md
@@ -1,0 +1,10 @@
+# Fixture — no ts block
+
+This markdown carries no fenced `ts` / `typescript` block. The harness MUST
+exit non-zero (fail-closed) — it does NOT silently pass a file it was told to
+verify. The non-ts fence below proves the extractor ignores other languages
+and still fails closed.
+
+```bash
+echo "this is not a ts block"
+```

--- a/examples/typescript/fixtures/good-complete.md
+++ b/examples/typescript/fixtures/good-complete.md
@@ -1,0 +1,10 @@
+# Fixture — good complete block
+
+A self-contained `complete` block that type-checks clean. The harness MUST
+exit 0 on this file.
+
+```ts complete
+export function double(n: number): number {
+  return n * 2;
+}
+```

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@gobbi/typescript-examples",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Example-verification harness for the gobbi `typescript` skill: extracts fenced ts blocks from the skill docs and type-checks them under a maximal-strict examples tsconfig. Not published.",
+  "devDependencies": {
+    "typescript": "5.9.3"
+  }
+}

--- a/examples/typescript/run-examples.sh
+++ b/examples/typescript/run-examples.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# run-examples.sh — runner half of the example-verification harness for the
+# gobbi `typescript` skill (design §9 / D7).
+#
+# Extracts every fenced `ts` / `typescript` block from the given markdown
+# file(s) or directory (via extract-blocks.mjs) and type-checks the whole set
+# with the LOCAL tsc under tsconfig.examples.json. Every taught TS fact is thus
+# proven to compile under the skill's own maximal-strict baseline.
+#
+# Usage:  bash run-examples.sh <markdown-file-or-dir> [more...]
+#
+# Contract (self-failing + fail-closed):
+#   - exit 0      every extracted example met its expected outcome
+#   - exit != 0   any example failed to type-check  (self-failing)
+#   - exit != 0   zero ts blocks were found         (fail-closed — a broken
+#                 parser or a no-example input is NEVER reported as a pass)
+#   - exit != 0   the local tsc / bun toolchain is missing
+#
+# No `|| true`, no swallowed pipe: a real failure always propagates a non-zero
+# exit (see project mistakes verifies-must-be-self-failing,
+# exit-in-command-substitution-fails-open).
+
+set -euo pipefail
+
+# Absolute dir of THIS script — so node_modules/.bin/tsc and
+# tsconfig.examples.json resolve regardless of the caller's CWD. Input paths
+# stay relative to the caller's CWD (this script never cd's away from it).
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+
+if [ "$#" -lt 1 ]; then
+  echo "usage: bash run-examples.sh <markdown-file-or-dir> [more...]" >&2
+  exit 2
+fi
+
+# LOCAL tsc is the contract (never a global tsc): the harness pins the skill's
+# TS version via the committed devDep + lockfile.
+tsc_bin="$script_dir/node_modules/.bin/tsc"
+if [ ! -x "$tsc_bin" ]; then
+  echo "FAIL: local tsc not found at $tsc_bin — run 'bun add -D typescript@5.9.3' in $script_dir" >&2
+  exit 2
+fi
+if ! command -v bun >/dev/null 2>&1; then
+  echo "FAIL: bun not found on PATH (needed to run the extractor)" >&2
+  exit 2
+fi
+
+# Isolated temp workspace, always cleaned up.
+tmp_dir="$(mktemp -d)"
+cleanup() { rm -rf -- "$tmp_dir"; }
+trap cleanup EXIT
+
+units_dir="$tmp_dir/units"
+mkdir -p -- "$units_dir"
+
+# Extract fenced ts blocks into per-example temp units. A non-zero exit here
+# (zero blocks = fail-closed, or a partial missing its prelude) propagates via
+# `set -e` and fails the whole harness.
+bun "$script_dir/extract-blocks.mjs" "$units_dir" "$@"
+
+# Defense in depth: confirm at least one unit landed on disk.
+unit_count="$(find "$units_dir" -maxdepth 1 -type f -name '*.ts' | wc -l | tr -d '[:space:]')"
+if [ "$unit_count" -eq 0 ]; then
+  echo "FAIL: no ts example units were extracted — fail-closed" >&2
+  exit 3
+fi
+
+# The temp package.json makes nodenext resolve the units as ESM (matches the
+# skill's ESM-only + verbatimModuleSyntax baseline). The temp tsconfig extends
+# the committed examples config and compiles only the extracted units.
+printf '{\n  "type": "module"\n}\n' > "$tmp_dir/package.json"
+printf '{\n  "extends": "%s/tsconfig.examples.json",\n  "include": ["units/*.ts"]\n}\n' \
+  "$script_dir" > "$tmp_dir/tsconfig.json"
+
+# Type-check the whole set once. Capture tsc's exit code explicitly — `|| rc=$?`
+# keeps `set -e` from aborting before we can report it.
+tsc_rc=0
+"$tsc_bin" --noEmit --pretty --project "$tmp_dir/tsconfig.json" || tsc_rc=$?
+if [ "$tsc_rc" -ne 0 ]; then
+  echo "FAIL: $unit_count ts example unit(s) did NOT type-check (tsc exit $tsc_rc)" >&2
+  exit "$tsc_rc"
+fi
+
+echo "OK: $unit_count ts example unit(s) type-checked clean under tsconfig.examples.json"

--- a/examples/typescript/tsconfig.examples.json
+++ b/examples/typescript/tsconfig.examples.json
@@ -6,9 +6,10 @@
     "moduleResolution": "nodenext",
     "moduleDetection": "force",
     "target": "ES2023",
-    "lib": ["ES2023", "ESNext.Disposable"],
+    "lib": ["ES2023", "ESNext.Disposable", "DOM"],
     "noEmit": true,
     "skipLibCheck": true,
+    "types": [],
 
     "strict": true,
     "noUncheckedIndexedAccess": true,

--- a/examples/typescript/tsconfig.examples.json
+++ b/examples/typescript/tsconfig.examples.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "//": "Examples baseline for the `typescript` skill (design §2 + §9b). Maximal-strict TYPE-safety, but the fragment-hostile unused-checks are RELAXED so a teaching snippet may declare a value only to show its type. Type strictness is what is under test; unused-checks are not. Consumed as the `extends` base by examples/typescript/run-examples.sh; not run standalone.",
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "moduleDetection": "force",
+    "target": "ES2023",
+    "lib": ["ES2023", "ESNext.Disposable"],
+    "noEmit": true,
+    "skipLibCheck": true,
+
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+
+    "verbatimModuleSyntax": true,
+    "noUncheckedSideEffectImports": true,
+    "erasableSyntaxOnly": true,
+
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  }
+}


### PR DESCRIPTION
## Summary

Adds the **`typescript`** gobbi skill — the concrete TypeScript-idiom layer beneath the language-agnostic `coding` skill, a sibling to `python`. Built via a full `/gobbi` Auto run (dual-system Ideation → Preparation → Planning → Execution).

**SKILL.md + 11 child docs** (~3,430 lines): `design`, `convention`, `typing`, `modules-tooling`, `async-resources`, `packaging-publishing`, `runtime-deltas`, `testing` + the eval triad (`evaluation`/`scenarios`/`checklists`).

### The quality lever
A **committed example harness** at repo-root `examples/typescript/` (`extract-blocks.mjs` + `run-examples.sh` + a maximal-strict examples tsconfig, `typescript@5.9.3` + DOM lib) type-checks **every fenced `ts` example — 84 in total — under the skill's own maximal-strict baseline**. Category-aware (complete / partial+prelude / expect-error / type-level), self-failing, fail-closed on empty. `node_modules` gitignored.

### Locked design
- min **TS 5.9** / recommended target 7.0 (adoption-anchored)
- maximal-strict, ESM-only + `verbatimModuleSyntax`; ban `any` → `unknown` at boundaries
- the `.js`(tsc-emit) / `.ts`(type-strip)+`rewriteRelativeImportExtensions` import-extension fork
- honest TS7 tooling caveat (no programmatic API → typed-lint on the side-by-side TS6 compat API)
- principle count follows content (landed 7, incl. design-with-user); P1–P8 procedure that **operationalizes** `coding`+`principles` (deepen-not-restate), verified.

### Wiring
`sync-plugin-package.sh` built `.claude/skills/typescript` + `.agents/skills/typescript` (tracked symlinks); `sync --check` intact; no skill-index row (on-demand, like coding/python); no manifest edit.

## Dual-system evaluation
- **Codex Execution eval: REVISE → 9 TS-technical prose defects fixed** (`void` promise as rejection-handling, `-> void`, NoInfer, branded-type, EventTarget, Deno/Bun strip-vs-transpile, browser-annotations, flag wording). These are the class of defect a compile-harness structurally cannot catch. All fixed + re-verified (84 examples still compile, crosswalk 25/25, guards green).
- **Codex re-confirm (iter2): running at PR-open.**
- **Claude holistic eval: deferred** — blocked by a usage limit this session. Recommended before merge.

## Before merge
1. Confirm the Codex iter2 re-confirm verdict; address any residual.
2. Run the Claude holistic Execution evaluator (deepen-not-restate / coverage / cross-doc consistency / usage).
3. Minor: standardize commit provenance trailers to canonical `gobbi://…` in one scoped pass.

## Verification
`bash examples/typescript/run-examples.sh .gobbi/projects/gobbi/skills/typescript/<doc>.md` → all green (84 examples); `sync --check` intact; markdown-link + residual-vocab guards green across all 12 docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017W6EUgtDA4DgQNe7nxgj9J