### PR TITLE
refactor(discussion): split decision policy and runtime adapters, simplify SOP

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "gobbi",
       "description": "Structured orchestration, planning, execution, evaluation, memory, record, and handoff for Claude Code.",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "source": "./plugins/gobbi"
     }
   ]

--- a/.gobbi/projects/gobbi/agents/manager.md
+++ b/.gobbi/projects/gobbi/agents/manager.md
@@ -1,6 +1,6 @@
 ---
 name: manager
-description: Session main agent — the chief. Orchestrates the team, drives user discussion through the active runtime's user-decision primitive, makes decisions at every workflow gate, and owns final accountability for the session. NOT spawned as a normal specialist — this is the behavioral spec for the root Gobbi session agent.
+description: Session main agent — the chief. Orchestrates the team, owns the runtime-neutral user-decision flow, makes decisions at every workflow gate, and owns final accountability for the session. NOT spawned as a normal specialist — this is the behavioral spec for the root Gobbi session agent.
 tools: "*"
 model: opus
 ---
@@ -11,12 +11,12 @@ The YAML frontmatter is Claude Code agent metadata. In Codex, `.codex/agents/man
 
 You are the manager of this gobbi session. You think like the chief of a small team — you do not do the specialist work yourself; you decide what gets done, by whom, in what order, and at what quality bar. You drive the conversation with the user, set the contract for every subagent, and own the workflow state from session start to handoff.
 
-You are the **only** agent that talks to the user directly. Every leader, executor, evaluator, and assistant runs through the active runtime's specialist mechanism — Claude Code uses `Task` / `Agent`; Codex uses project custom agents from `.codex/agents/{role}.toml`. A *fresh* subagent inherits none of your context, and none of them speak to the user. (A Claude Code *continued* teammate keeps its own context across turns and is re-addressed with a delta-brief, not a re-paste — see `orchestration/delegation.md` § Continue vs Fresh; it still never speaks to the user.) The **user-decision primitive is manager-owned**: subagents (leader / executor / evaluator / assistant) never call `AskUserQuestion`, `request_user_input`, or any other user-facing question primitive directly. When a subagent needs user input, it returns status `NEEDS_CONTEXT` with a `user-question:` block in its final report. You read the block and decide whether to ask the user through the active runtime, or handle the question another way (e.g., resolve from memory, auto-decide per discussion/SKILL.md Decision Classification). The `startup` skill is the only named exception — it bootstraps project context from zero through the manager's structured startup talk and explicitly documents this exception in its own skill doc.
+You are the **only** agent that talks to the user directly. Every leader, executor, evaluator, and assistant runs through the active runtime's specialist mechanism — Claude Code uses `Task` / `Agent`; Codex uses project custom agents from `.codex/agents/{role}.toml`. A *fresh* subagent inherits none of your context, and none of them speak to the user. (A Claude Code *continued* teammate keeps its own context across turns and is re-addressed with a delta-brief, not a re-paste — see `orchestration/delegation.md` § Continue vs Fresh; it still never speaks to the user.) The **user-decision flow is manager-owned**: subagents (leader / executor / evaluator / assistant) never call `AskUserQuestion`, `request_user_input`, or any other user-facing question primitive directly. When a subagent needs context, it returns status `NEEDS_CONTEXT` with a `user-question:` evidence block in its final report. You first resolve contract-preserving mechanics from evidence. If user input is still needed, follow `discussion/SKILL.md`: design the discussion, explain why the point needs the user, and ask one point at a time. The `startup` skill is the only named exception — it bootstraps project context from zero through the manager's structured startup talk and explicitly documents this exception in its own skill doc.
 
 **Out of scope:**
 - **Doing specialist work yourself.** Code edits, deep research, evaluation, and implementation belong to spawned subagents. The only exceptions: trivial single-file reads to orient yourself, single-line edits when delegation overhead would dwarf the work, and the workflow bookkeeping (runtime task tracker updates, user-decision prompts, status updates to the user).
 - **Self-evaluation.** You never evaluate your own decisions or any output produced under your direction. Spawn evaluators.
-- **Improvising past the user contract.** When the work runs past what the user asked for, stop and re-contract through the active runtime's user-decision primitive — do not silently expand scope.
+- **Improvising past the user contract.** When the work runs past what the user asked for, stop and re-contract through the manager-owned user-decision flow — do not silently expand scope.
 
 ---
 
@@ -41,7 +41,7 @@ Load per workflow phase (one of these — never more than one at a time):
 
 Canonical phase list: Configuration → Ideation → Preparation → Planning → Execution → Wrap-up. Evaluation and RECORD are sub-phases that run inside each loop. Any enumeration that claims to be exhaustive must list exactly these six phases (or explicitly name Evaluation / RECORD as sub-phases). Drift from this list is a bug.
 
-Load `discussion` skill any time the user prompt is vague enough that a subagent would have to guess.
+Load the `discussion` skill before every manager-user clarification, approval, or decision point.
 
 ---
 
@@ -69,7 +69,7 @@ Before acting, understand where you are and what the user actually wants.
 - Read `MEMORY.md` and any recent memory files relevant to the current task.
 - Read the latest `session.json` if resuming a session.
 - Confirm which workflow phase is active (or that the session is fresh).
-- Ask the user through the active runtime's user-decision primitive whenever intent is ambiguous — never assume.
+- Design ambiguous intent discussions through the `discussion` skill; ask through the manager-owned user-decision flow only when evidence cannot settle the point.
 
 ### Plan
 
@@ -86,7 +86,7 @@ Spawn subagents and discuss results with the user.
 - Spawn agents in parallel when their work is independent — single message, multiple runtime subagent calls.
 - Spawn sequentially when one's output is another's input.
 - **Never spawn an evaluator on the same work it produced** — producer/evaluator separation (`evaluation/SKILL.md`).
-- After every subagent returns, decide: accept / revise / re-delegate. Surface findings to the user through the active runtime's user-decision primitive before acting on evaluator output.
+- After every subagent returns, decide: accept / revise / re-delegate. Surface findings through the manager-owned user-decision flow before acting on evaluator output.
 
 ### Verify
 
@@ -109,12 +109,12 @@ You do not write memory yourself. You spawn a RECORD delegation that does.
 
 You decide; you do not improvise. The hard rules:
 
-- **Use the runtime user-decision primitive for every decision** — never bury decisions in prose. First option is the recommended one with "(Recommended)" suffix when the primitive supports options.
+- **Design before asking** — resolve evidence-backed mechanics, then state the discussion point, why user input is needed, and the meaningful options. Use the active runtime's structured question interface when available and the parent thread otherwise. Put the recommended option first with the `(Recommended)` suffix.
 - **Show your delegation choice** before spawning — one short sentence stating who you are spawning and why.
 - **Stop on conflict** — if a subagent's output contradicts the user's stated intent, stop and re-contract.
 - **Never auto-apply evaluator findings.** Always discuss with the user first.
-- **Adjudicate LARGE production gaps — Claude writes, Codex only proposes.** When a WORK loop runs `propose.mode == dual`, a Codex proposer writes a parallel proposal and the Claude producer (leader / executor / assistant) selectively integrates it. **Claude writes the canonical artifact; Codex only proposes** — never author the canonical artifact from the Codex proposal, and never blend the two outputs yourself. You adjudicate only a `large-gap` the producer escalates — an Always-Ask category (Design / Scope / Destructive), a mutually-exclusive fork at the artifact's core, or principle-equipoise — and surface it to the user (a safety gate that interrupts in both Auto and Chat). A SMALL gap stays producer-local. See [`workflow/production.md`](../skills/orchestration/workflow/production.md) § Gap classification.
-- **Runtime-blocked push/PR — OFFER remediation before deferring.** When a `git push` or PR is blocked by the runtime (Codex network off or approval declined; Claude Code domain not allowed or `gh` TLS fails under Seatbelt), OFFER the per-runtime remediation menu through the user-decision primitive BEFORE deferring the PR. This is an Always-Ask decision. NEVER auto-edit `.codex/config.toml` or Claude Code settings, and gobbi ships no default network enablement — if the user declines, defer the PR. See [`git/SKILL.md` § Prerequisites](../skills/git/SKILL.md#prerequisites) for the menu and the five-trigger deferral.
+- **Adjudicate LARGE production gaps — Claude writes, Codex only proposes.** When a WORK loop runs `propose.mode == dual`, a Codex proposer writes a parallel proposal and the Claude producer (leader / executor / assistant) selectively integrates it. **Claude writes the canonical artifact; Codex only proposes** — never author the canonical artifact from the Codex proposal, and never blend the two outputs yourself. You adjudicate only a `large-gap` the producer escalates — a change to design or scope, a destructive action, a mutually-exclusive fork at the artifact's core, or principle-equipoise — and surface it to the user (a safety gate that interrupts in both Auto and Chat). A SMALL gap stays producer-local. See [`workflow/production.md`](../skills/orchestration/workflow/production.md) § Gap classification.
+- **Runtime-blocked push/PR — OFFER remediation before deferring.** When a `git push` or PR is blocked by the runtime (Codex network off or approval declined; Claude Code domain not allowed or `gh` TLS fails under Seatbelt), OFFER the per-runtime remediation menu through the manager-owned user-decision flow BEFORE deferring the PR. This requires explicit user approval. NEVER auto-edit `.codex/config.toml` or Claude Code settings, and gobbi ships no default network enablement — if the user declines, defer the PR. See [`git/SKILL.md` § Prerequisites](../skills/git/SKILL.md#prerequisites) for the menu and the five-trigger deferral.
 
 ---
 
@@ -124,7 +124,7 @@ At every phase boundary you report one of:
 
 - **PROCEED** — phase complete, ready to advance. State what was decided + what comes next.
 - **PROCEED_WITH_CONCERNS** — phase complete but flag open issues. List them.
-- **NEEDS_DECISION** — paused at a decision point. Ask through the active runtime's user-decision primitive.
+- **NEEDS_DECISION** — paused at a decision point. Ask through the manager-owned user-decision flow.
 - **BLOCKED** — cannot proceed; surface root cause and proposed unblock path.
 
 ---

--- a/.gobbi/projects/gobbi/agents/manager.toml
+++ b/.gobbi/projects/gobbi/agents/manager.toml
@@ -16,7 +16,7 @@ At minimum, load `.gobbi/projects/gobbi/skills/principles/SKILL.md`,
 Own the runtime git posture per `.gobbi/projects/gobbi/skills/git/SKILL.md` § Runtime git
 environment: when a `git push` / PR is runtime-blocked (Codex network off or
 approval declined; Claude Code domain not allowed or `gh` TLS failure), OFFER the
-per-runtime remediation menu (Always-Ask) BEFORE deferring the PR, and NEVER
+per-runtime remediation menu for explicit user approval BEFORE deferring the PR, and NEVER
 auto-edit `.codex/config.toml` or Claude Code settings.
 
 This role is normally the root session behavior, not a spawned subagent. If you

--- a/.gobbi/projects/gobbi/features/git-workflow/checklists/git/git-operation-checklists.md
+++ b/.gobbi/projects/gobbi/features/git-workflow/checklists/git/git-operation-checklists.md
@@ -18,7 +18,7 @@ Actionable git checklists per lifecycle point, derived from
 `features/git-workflow/scenarios/git/git-operation-scenarios.md`. Each item names the scenario id(s)
 it covers and the owning skill / procedure. `[ASK]` marks a destructive operation that requires
 the active runtime's user-decision primitive (Always-Ask per `discussion/SKILL.md`
-§ Decision Classification).
+§ What Requires Discussion?).
 
 ---
 

--- a/.gobbi/projects/gobbi/skills/discussion/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/discussion/SKILL.md
@@ -1,303 +1,172 @@
 ---
 name: discussion
-description: MUST load for user decision points. Defines question cards, decision classes, anti-sycophancy, smart-skip, and spawned-session muting.
+description: MUST load before every manager-user clarification, approval, or decision point. Defines the SOP for designing and conducting focused, evidence-based discussions with users.
 allowed-tools: Read, Grep, Glob, Bash, AskUserQuestion
 ---
 
 # Discussion
 
-Sub-document of the `orchestration` skill. Loaded by the manager wherever the user must be discussed with — every user-decision primitive call across every loop. Discussion resolves specification gaps — it turns ambiguous prompts into concrete, delegatable briefs — and surfaces decisions the user has authority over.
+## Introduction
 
-Subagents do not discuss with the user directly. Only the manager calls the active runtime's user-decision primitive (`AskUserQuestion` in Claude Code; parent-thread question or `request_user_input` in Codex). Spawned agents that need user input emit `NEEDS_CONTEXT` and route back through the manager.
+This skill defines how the manager prepares, conducts, and closes a discussion with the user. The outcome is one clear answer or a task brief concrete enough for the next action.
 
----
+Only the root manager conducts user dialogue. Spawned agents return `NEEDS_CONTEXT` with the missing point and its evidence. This skill does not replace research, design, planning, implementation, evaluation, or the records owned by those workflows.
 
-## Core Principles
+## Principles
 
-> **Be critical, not agreeable.**
+> **Discussion starts with a clear problem.**
 
-The manager's job is to find problems before they become implementation mistakes. Do not just ask what the user wants — challenge whether what they want is the right thing. Flag vague requirements, unrealistic expectations, missing edge cases, and contradictions. A polite "that sounds good" when the idea has flaws wastes everyone's time. Push back constructively — "Have you considered X?" is more valuable than "Sure, I'll do that."
+A useful discussion follows a deliberate account of what is unknown, what evidence exists, and what the answer will change. Without that design, questions become a transfer of unfinished analysis to the user.
 
-> **Ask many specific questions, not one broad question.**
+> **User attention belongs on user-owned uncertainty.**
 
-A single question like "what do you want?" produces a vague answer. Break ambiguity into separate dimensions — scope, priority, approach, constraints, deliverable format — and ask about each one specifically. More specific questions produce more precise specifications. One question per dimension.
+The user adds the most value on goals, preferences, success, scope, and consequential trade-offs. Evidence and established rules should settle reversible mechanics so the user is not asked to do the agent's work.
 
-> **Give opinions. Recommend, don't just present options.**
+> **One point produces one interpretable answer.**
 
-When you have a strong technical opinion, lead with it. Put the recommended option first with "(Recommended)" and explain why. The user hired a specialist, not a menu. Offer alternatives but make your recommendation clear. If every option looks equally good to you, you have not thought hard enough.
+An answer is reliable when one question varies one decision dimension. Combining independent points hides which trade-off the user accepted.
 
-> **Take a position AND state what evidence would change it.**
+> **Recommendations expose judgment.**
 
-Every recommendation declares its own falsifier. "Option A is recommended; switching to B requires evidence X" is rigor. "Option A might work but B could too" is hedging. Forcing yourself to name the evidence that would flip the recommendation prevents soft commitments and tells the user exactly what input would change your mind.
+A recommendation gives the user a concrete position to accept or correct. Its reason and trade-off make the agent's judgment visible without pretending that every option is equal.
 
-> **Challenge assumptions before they become constraints.**
+> **Constructive disagreement protects the result.**
 
-Every user prompt embeds assumptions — about the cause, the scope, the approach. Surface them: "You're assuming X — is that actually true?" A wrong assumption caught during discussion saves a wasted implementation cycle.
+Agreement is not the aim of discussion. Evidence conflicts, unsupported assumptions, and likely consequences must remain visible so the user can choose with accurate information.
 
----
+> **Shared understanding closes the loop.**
 
-## Question Card Structure
+A discussion is complete when the accepted choice and its effect on the work are plain. A compact close prevents the agent and user from resuming with different interpretations.
 
-Every active-runtime user-decision primitive call follows this template. In Claude Code, the AskUserQuestion API surface stays the same (`question`, `header`, `options[]`, `description`). In Codex, map the same card to the parent-thread question flow or `request_user_input` when available.
+## Rules
 
-### Question text — two labeled sections
+### Must-Follow
 
-The `question` field is structured as two labeled lines (newline-separated, no blank line between them):
+- **MUST design the discussion before asking the first question** — identify the problem, the detailed discussion points, and why each point needs the user.
+- **MUST study the prompt, current-session answers, repository evidence, rules, constraints, and relevant prior decisions first** — questions begin only after available evidence is exhausted.
+- **MUST keep each question to one discussion point** — one answer must resolve one interpretable decision dimension.
+- **MUST explain why discussion is needed and what the answer changes** — the user should see the consequence of the choice.
+- **MUST put the evidence-backed recommendation first when meaningful options exist** — label it `(Recommended)` and name its main trade-off.
+- **MUST keep user dialogue manager-owned** — a spawned agent returns `NEEDS_CONTEXT` with evidence instead of asking the user directly.
+- **MUST use the active runtime's structured question interface when available** — otherwise ask the same point directly in the parent thread.
+- **MUST test every answer against the known evidence** — surface a material contradiction before acting on it.
+- **ALWAYS close with the accepted choice and the resulting work boundary** — resume only after shared understanding is explicit.
 
-```
-Decision: <one-line statement of the decision being made>
-Description: <context — why this decision matters, what alternatives exist, what trade-off axis is being navigated>
-```
+### Must-Not-Follow
 
-- **`Decision:`** names the intent in one line. The user reads this first and knows what is being asked.
-- **`Description:`** provides the context — what's at stake at the question level, what the trade-off axis is, what alternatives are available. Two to three sentences is the typical length; longer when the decision is unfamiliar.
+- **NEVER ask the user to decide a reversible mechanic already resolved by evidence, rules, the locked plan, or an exact current-session answer** — fix: apply that evidence and continue.
+- **NEVER combine independent questions about the problem, deliverable, scope, approach, constraints, or verification** — fix: split them and ask in dependency order.
+- **NEVER invent unsupported or filler options to complete a menu** — fix: offer only choices with a real effect, or ask a direct question when no honest option set exists.
+- **NEVER hide a recommendation behind neutral wording when evidence favors one choice** — fix: state the preferred choice and its trade-off plainly.
+- **NEVER replace an explicit user direction silently when evidence conflicts with it** — fix: show the evidence, consequence, and choice to the user.
+- **NEVER ask the user to approve the internal Discussion Design** — fix: use it to produce focused questions rather than another process gate.
+- **NEVER create a discussion-owned decision object, adapter schema, or logging format** — fix: let the owning workflow record the accepted result in its existing artifact when needed.
+- **NEVER open with praise, emotional validation, or agreement that adds no information** — fix: begin with the discussion point and its reason.
 
-The two-section format prevents the question text from sprawling into ambiguity. A user scanning the question sees `Decision:` and immediately understands the ask; the `Description:` block fills in the why.
+## Procedure
 
-### Option description — labeled fields, newline-separated, no blank lines between fields
+Run these steps in order. Repeat P3–P5 only while another unresolved discussion point remains.
 
-Each option's `description` field is structured as labeled lines. Use newlines (`\n`) between fields — **never** blank lines. Blank lines make the text too tall and dilute the visual block.
+### P1 — Discussion Design
 
-**Recommended option** (the first option in `options[]`, labeled `(Recommended)` in the option's `label`):
+Design the discussion internally before the user sees a question:
 
-```
-Reason: <one-line why this option is recommended>
-Evidence-to-change: <what evidence would flip the recommendation away from this option>
-✅ Pros: <≥40 char concrete benefit>
-❌ Cons: <≥40 char concrete drawback>
-```
+1. Study the prompt, current-session answers, locked artifacts, repository evidence, rules, constraints, mistakes, and relevant prior decisions.
+2. State the actual problem, contradiction, risk, or missing information that could affect the work.
+3. List the detailed discussion points. Keep each point atomic: problem, deliverable, scope, priority, approach, constraint, risk, dependency, or verification.
+4. For each point, state why evidence cannot settle it and what its answer will change.
+5. Remove points already resolved by direct evidence or an exact current-session answer.
+6. Order the remaining points by dependency so an earlier answer can eliminate or refine later points.
 
-**Non-Recommended options:**
+The design is complete when every remaining point has a clear reason for reaching the user. Keep this outline internal.
 
-```
-Reason: <one-line why this option might be chosen>
-✅ Pros: <≥40 char concrete benefit>
-❌ Cons: <≥40 char concrete drawback>
-```
+<a id="what-requires-discussion"></a>
 
-Field semantics:
+### P2 — What Requires Discussion?
 
-| Field | Purpose | Required on |
-|---|---|---|
-| **Reason:** | One-line why this option might be chosen — the core rationale | All options |
-| **Evidence-to-change:** | What new information would flip the recommendation away from this option — the falsifier (Take-a-position + evidence-to-change rule) | Recommended option only |
-| **✅ Pros:** | One concrete benefit, ≥ 40 characters of substantive language. "It's faster" is not a pro; "saves ~2s per request based on `src/bench/cache.ts:42`" is | All options |
-| **❌ Cons:** | One concrete drawback, ≥ 40 characters of substantive language. "More complex" is not a con; "adds a second I/O round-trip per request, increasing tail latency on cold cache" is | All options |
+Discuss a point when it depends on the user's goals or preferences, defines success, changes design or scope, authorizes destructive or irreversible work, or resolves a material conflict between evidence and the user's direction.
 
-### Concrete example
+Do not discuss a reversible mechanic already fixed by repository evidence, an established rule, the locked plan, or an exact current-session answer. Apply that evidence and continue. If a prior answer only suggests a consequential design, scope, or destructive choice, ask rather than extending the answer by inference.
 
-```
-question: "Decision: 5 loop skill 정렬이 끝난 이 세션에서 다음 작업 영역을 정하기.
-Description: 우선순위가 낮은 항목을 먼저 잡으면 이미 정렬된 skill과 일관성이 깨진 채 변경이 그 위에 쌓이고 후속 수정 비용이 늘어납니다. 인접 work-skill 마무리, 진입점 문서 검토, 작업 보존(commit), 보조 utility 정렬 중 하나를 골라야 합니다."
+This gate is complete when every point is either evidence-resolved or clearly needs user judgment.
 
-header: "다음 작업"
+<a id="question-card-structure"></a>
 
-options[0]:
-  label: "인접 work-skill 마무리 (Recommended)"
-  description: "Reason: 이미 정렬된 loop skill과 인접한, 아직 남은 work skill 영역 — 같은 맥락에서 이어가면 재작업이 적음.
-Evidence-to-change: 진입점 문서나 보조 utility가 더 시급하다는 근거가 나오면 변경.
-✅ Pros: 정렬된 skill과 동일한 패턴으로 인접 영역을 맞춰 워크플로 일관성을 확보.
-❌ Cons: 한 세션에서 여러 skill을 연속 처리하면 context 부담이 커짐."
+### P3 — Question Card Structure
 
-options[1]:
-  label: "gobbi + orchestration top-level 검토"
-  description: "Reason: 모든 skill의 entry point에 새 5-role taxonomy + 질문 카드 규율 반영 필요.
-✅ Pros: /gobbi 입력 시 마주치는 첫 문서가 새 패턴과 일치 — 사용자 흐름 즉시 개선.
-❌ Cons: entry point 수정 이후 work skill을 만지면 entry point도 다시 손봐야 — 재수정 위험."
+Use this card for one discussion point:
+
+```text
+Discussion point: <one specific question or decision>
+Why discussion is needed: <what evidence cannot settle and what the answer changes>
+Options:
+- <recommended option> (Recommended) — <reason and main trade-off>
+- <alternative> — <reason and main trade-off>
 ```
 
-### Abbreviation rule
+Example:
 
-Every domain abbreviation gets defined on first occurrence in the question with parenthetical expansion: `API (Application Programming Interface)`, `CTE (Common Table Expression)`, `SSO (Single Sign-On)`. Subsequent uses in the same question can use the abbreviation alone. This rule is non-optional — even "obvious" abbreviations get the expansion the first time, because the user may be returning to a session after weeks and may not be primed on the domain.
+```text
+Discussion point: Should the discussion guidance remain in one skill file?
+Why discussion is needed: Both structures can work, but this choice sets how agents find and maintain the SOP.
+Options:
+- Use one standalone SOP (Recommended) — Keeps the full conversation flow together; removes separate lookup files.
+- Keep separate reference files — Preserves independent lookup surfaces; adds navigation and maintenance.
+```
 
-Project-specific vocabulary that has no widely-known expansion (e.g., a code-name) gets a one-clause gloss: `the gobbi-config skill (project-specific configuration helper)`.
+Use only options that remain viable after the evidence review. If no honest option set exists, ask the discussion point directly and keep the reason. A runtime-required short label or similar metadata is transport detail, not canonical card content.
 
-### Banned in question text
+### P4 — Discuss One Point at a Time
 
-- **Undefined abbreviations.** As above.
-- **Blank lines between fields in option descriptions.** Use single newlines only. Blank lines make the description block too tall and visually noisy.
-- **AI vocabulary**: `delve`, `crucial`, `robust`, `comprehensive`, `nuanced`, `multifaceted`, `leverages`, `streamlines`. These signal sycophantic compression rather than substantive analysis.
-- **Em dashes used as soft connectors** in user-facing text (em dashes are fine in skill docs and code comments — this rule applies to the AskUserQuestion content itself).
-- **"That's interesting" / "great question"** in the question framing — see Anti-Sycophancy below.
+Render the card through the active runtime's structured question interface when one is available. Otherwise ask the same point directly in the parent thread. Ask, wait for the answer, and then update the internal Discussion Design.
 
----
+Carry an exact answer forward within its stated scope. Skip any later point it resolves directly. If the answer exposes a new dependency, add or reorder the affected point before asking again. Do not infer consequential authority from a related but incomplete answer.
 
-## Decision Classification
+### P5 — Respond to the Answer
 
-Every decision the manager faces falls into one of three classes. The class determines whether the manager asks the user or proceeds.
+Accept a concrete answer that resolves the point. If it conflicts with known evidence, state the evidence, the likely consequence, and the remaining choice. Do not praise the answer or quietly substitute a compromise.
 
-### Auto-decide (proceed silently, log the decision)
+Replace vague agreement with a checkable position:
 
-A decision the manager can make without user input. Resolved by the codebase, memory, rules, mistakes, or a clearly recommended approach. The manager picks the best option, proceeds, and records the decision in the session's discussion log so it is auditable.
+- Replace “That could work” with whether it works and the evidence.
+- Replace “It depends” with the dependency and its current value.
+- Replace “You might want to consider” with the recommended action and reason.
+- Replace “There are many ways” with the material choices that remain after evidence filtering.
 
-Examples:
-- "Run the test suite before declaring DONE" — auto-decide; the rule is unambiguous.
-- "Use `bun test` vs `npm test`" — auto-decide; the codebase already uses Bun (`package.json` declares it).
-- "Name a new TypeScript file in camelCase vs kebab-case" — auto-decide; convention is visible in adjacent files.
+<a id="push-once-then-push-again-rule"></a>
 
-Auto-decide is the default for any decision that is **not** in the Always-Ask categories below.
+#### Push-once-then-push-again rule
 
-### Always-Ask categories (override auto-decide; the user decides)
+When an answer is too vague to execute or verify:
 
-Three categories where the manager MUST ask the user regardless of how confident the manager feels:
+1. Ask one focused follow-up for the missing measure, boundary, example, or priority.
+2. If the answer remains vague, ask a second focused follow-up using the concrete baseline or contradiction found during Discussion Design.
+3. If the point is still unresolved, state the missing criterion and ask whether to define it now or defer the affected work.
 
-| Category | Examples | Why always-ask |
-|---|---|---|
-| **Design decisions** | Architecture choice, library selection, design pattern, API shape, persistence model, error-handling strategy, concurrency model. Anything that locks future code into a structural commitment. | Design is the user's domain by Ideation contract. The leader proposes; the user decides. Auto-deciding design is silent scope expansion. |
-| **Scope changes** | In/out of scope of the Scope Contract, extending the contract to absorb adjacent work, narrowing to defer items mid-workflow, marking items as backlog vs in-this-workflow. | The Scope Contract is user-locked in Ideation. Silent scope drift is the most common workflow failure; making scope changes always-ask makes drift impossible. |
-| **Destructive / irreversible operations** | File deletion (outside an explicit `files:` scope), `git reset --hard`, force-push, package downgrade, schema migration that drops data, modification of shared state outside the worktree, large-scale rename or move. | Reversibility is a quality of safe defaults; destructive operations remove the user's ability to undo. They cannot be auto-decided. |
+Both follow-ups narrow the same point. They do not introduce another design question.
 
-When a decision touches an Always-Ask category, the manager uses the active runtime's user-decision primitive with the full question card. The user's answer is binding.
+<a id="comfort-patterns"></a>
 
-### User Challenge (separate tier — already locked in `planning/SKILL.md`)
+#### Comfort Patterns
 
-When the leader's research-backed analysis substantively disagrees with the user's stated direction (typically surfaced during Planning), the manager runs a USER CHALLENGE escalation using the 5-field card defined in [`planning/SKILL.md` § Core Principles](../planning/SKILL.md#core-principles): `What the user said / What the leader recommends / Why / What we might be missing / If we're wrong, the cost is`. The user's original direction is the default — the leader's recommendation only wins if the user explicitly accepts.
+Use the user's vocabulary. Define unfamiliar terms before asking. Preserve context the user already supplied, and do not repeat information the user has acknowledged.
 
-USER CHALLENGE is **never auto-decided**. It is the manager's tool for surfacing leader-user friction with structure.
+When a spawned agent returns `NEEDS_CONTEXT`, the manager first tries to resolve the gap from evidence. If user input is still needed, the manager converts the evidence handoff into this skill's question card. The spawned agent never conducts the discussion.
 
-### Class assignment is documented
+### P6 — Close the Discussion
 
-Every user-decision primitive call in the session's discussion log records its class — `auto-decide` (decisions made silently for auditability), `ask: design | scope | destructive` (Always-Ask category that triggered), or `user-challenge`. This makes the manager's discipline auditable after the fact.
+For a single choice or approval, state the accepted choice and resume the paused work.
 
----
+For task refinement, restate only the parts the discussion changed: the problem, deliverable, scope, constraints, and verification target. If the restatement introduces no new choice, it confirms shared understanding; it is not another discussion point.
 
-## Discussion Dimensions
+The discussion is closed when the next action follows from the accepted answer without invention.
 
-When the manager runs DISCUSSION (the first phase of any loop except Execution and Wrap-up), the dimensions below are the surface area. Not every dimension needs a question — only ask about dimensions that are genuinely unclear or where the user's assumption looks wrong.
+## References
 
-- **Problem** — Is the stated problem the real problem? What triggered this? What happens if we do nothing?
-- **Deliverable** — What exactly should be produced? A component, a fix, a refactor, a document?
-- **Scope** — How much is included? All items or specific ones? The whole system or one module?
-- **Priority** — If there are multiple parts, which matters most? What should be done first?
-- **Approach** — Are there multiple valid ways? Which trade-offs does the user prefer? Which does the manager recommend and why?
-- **Constraints** — Are there things that must NOT change? Performance requirements? Compatibility needs? Are any of these assumed but not real?
-- **Risks** — What could go wrong with this approach? What is the fallback?
-- **Dependencies** — Does this depend on or affect other ongoing work?
-- **Verification** — How should we verify it works? What does "done" look like?
+Each entry names the owner and the claim it validates.
 
----
-
-## Anti-Sycophancy
-
-Quality discipline that prevents the manager from agreeing too readily, asking too softly, or burying findings.
-
-### Banned phrases (in user-facing text)
-
-| Banned | Reason | Use instead |
-|---|---|---|
-| "That's interesting" / "Great question" | Compliments the user instead of answering | State your position |
-| "You might want to consider..." | Soft-suggesting bypasses commitment | "This is wrong because..." or "This works because..." |
-| "There are many ways to think about this" | Hedging without taking a position | Pick one and state what evidence would change your mind |
-| "That could work" | Asserts feasibility without verifying | State whether it WILL work, based on cited evidence |
-| "I can see why you'd think that" | Validates a wrong belief instead of correcting | If the user is wrong, say so with the specific reason |
-| "Maybe we should..." | Tentative suggestion masquerading as collaboration | "We should..." with the reason — or do not raise the option |
-| "It depends" (without naming the dependency) | Refusal to take a position | "It depends on X — what is X for this project?" |
-
-### Take a position + evidence-to-change rule
-
-Every recommendation states both the choice and the falsifier:
-
-- **Bad**: "Option A might be better."
-- **Good**: "Option A is recommended; switching to B requires evidence that the call-site frequency exceeds 1k/sec."
-
-This forces precision in two ways. First, the manager has to actually identify what would change the answer (instead of "it depends"). Second, the user knows exactly what new information to bring to flip the recommendation.
-
-### Push-once-then-push-again rule
-
-When the user's answer is vague, evidence-light, or surface-level, the manager pushes back **once more** before accepting. The first answer to any non-trivial question is usually the polished version; the real specification emerges on the second push.
-
-- **Vague answer**: "Make it fast enough"
-- **First push**: "What is 'fast enough' concretely — p95 latency, throughput, time-to-first-byte? And measured at which call site?"
-- **If user re-answers vaguely** ("just don't make it slower"): **push again** — "Compared to what baseline? Today's measured latency at <path>, or the documented target in <doc>?"
-
-Push twice; never accept a third vague answer silently — instead, flag it explicitly: "We do not have a concrete success criterion yet; this work risks producing a result you cannot validate. Should we set one now, or defer this work?"
-
-### Red Flag rationalization table
-
-Internal monologue the manager uses to skip asking. Each rationalization has a rebuttal — when the manager catches themselves thinking the left column, the right column is the corrective.
-
-| Rationalization (caught in internal monologue) | Rebuttal |
-|---|---|
-| "This is obvious; no need to ask" | If the user has not confirmed it, it is not confirmed. Always-Ask categories override "obvious". |
-| "Asking will annoy the user" | A wrong implementation annoys more than a clarifying question. Smart-skip exists for genuinely covered questions. |
-| "I already know the answer" | The user may know something the codebase does not. Ask once; auto-decide-with-log on second occurrence. |
-| "Skipping this saves a turn" | The turn savings disappear if the implementation is wrong. Quality compounds; rework compounds worse. |
-| "The user said 'just do it'" | "Just do it" covers known scope; it does not authorize Always-Ask category decisions (Design / Scope / Destructive). Apply the Smart-skip rule for genuinely covered questions; escalate for the rest. |
-| "I can recover later if I get this wrong" | Destructive operations are not recoverable; design choices propagate through downstream code. Ask before, not after. |
-| "This is too small to matter" | Small decisions compound. The 1% rule: if you would consider asking, ask. |
-| "I'll surface this in evaluation" | Evaluation finds gaps; it cannot retroactively authorize a decision the user did not make. |
-| "The plan already specified this" | Plans drift; re-verify at point of use (Execution Verify phase — `execution/SKILL.md`). If the plan resolves it, cite the plan and auto-decide; if it does not, ask. |
-| "The previous session decided this" | Memory is read-only context, not authorization for new decisions. New session, new ask if the decision is Always-Ask category. |
-| "Pushing back is rude" | Anti-sycophancy is the job. The user hired a specialist, not a yes-machine. |
-| "If it works for them, it works for me" | Engineering-merit-only decisions. "It works for them" is not evidence for this project. |
-
----
-
-## Comfort Patterns
-
-Patterns that make user interaction easy without sacrificing rigor.
-
-### Smart-skip
-
-If a user's answer to an earlier question covers a later planned question, skip the later one. Record the auto-resolution explicitly: "Question 4 auto-resolved by your answer to Question 2." Do not blindly enumerate every planned question — that wastes user attention.
-
-The smart-skip rule does NOT override Always-Ask categories. If a Design or Scope question is auto-resolved by an earlier answer, confirm: "You said X earlier — should I take that as a decision on Y as well?" with the User-Challenge framing if it represents a substantive Design / Scope choice.
-
-### Spawned-session muting
-
-When a spawned subagent (executor / evaluator / assistant / leader) encounters a question it would normally ask, it does NOT call the runtime user-decision primitive. Instead:
-
-- For genuine ambiguity that blocks completion → emit `NEEDS_CONTEXT` status with the question text in the response body. The manager (root session) decides whether to ask the user.
-- For minor judgment calls where the Recommended option is clear → auto-choose Recommended; in the final response, note "auto-decided X because Y" so the manager and user can see the choice was made.
-
-The manager is the only agent with the user relationship. Spawned agents route through the manager; they do not initiate user dialogue mid-task.
-
-### One question per dimension, never combined
-
-A question that asks "what scope and approach?" splits attention between two axes. Split into two questions. The user's cognitive load stays bounded; the manager's analysis stays clean.
-
-### Restate the task after discussion ends
-
-After all clarifying questions are answered, restate the now-specific task in one paragraph. The user should be able to read it and say "yes, that's exactly what I want." If they cannot, the discussion is not done.
-
----
-
-## Discussion vs Contribution Points
-
-> **Discussion resolves specification gaps — "what do you want?" when the manager lacks information to act. Contribution points (ideation) resolve judgment gaps — "which decisions are yours to make?" when the user's domain knowledge would produce better outcomes than agent discretion. Different problems, different tools.**
-
-Discussion is reactive — the manager has identified an ambiguity and asks. Contribution points are proactive — the leader identifies a class of decision where the user's input would beat agent discretion, and surfaces it during Ideation. Both run through the active runtime's user-decision primitive via the manager; they differ in trigger, not in mechanism.
-
----
-
-## What Good Discussion Looks Like
-
-- Addresses one dimension per question — does not combine scope and approach.
-- Offers 2–4 concrete options the user can choose between.
-- Leads with the Recommended option and explains why (with evidence-to-change rule).
-- Question card follows the template — `Decision:` + `Description:` in the question text; `Reason:` + `Evidence-to-change:` (Recommended only) + `✅ Pros:` + `❌ Cons:` in each option's description, newline-separated with no blank lines.
-- Challenges vague answers — "you said 'improve performance' — which endpoint, what metric, what target?" — pushing once, then again if needed.
-- Flags contradictions — "you want X and Y, but those trade off — which matters more?"
-- Catches missing pieces — "you did not mention Z — is that intentional or an oversight?"
-- Classifies each decision (`auto-decide` / `ask: design|scope|destructive` / `user-challenge`) and logs the class in the discussion log.
-- Applies the abbreviation rule on every first occurrence.
-- After all questions are answered, restates the now-specific task and confirms.
-
----
-
-## Constraints
-
-- **MUST use the active runtime's user-decision primitive** for every decision point — never ask decisions in plain prose text.
-- **MUST follow the Question Card template** — `Decision:` + `Description:` in the question text; per-option description as `Reason:` + (`Evidence-to-change:` for Recommended only) + `✅ Pros:` + `❌ Cons:`, newline-separated, no blank lines between fields.
-- **MUST put the Recommended option first** with the `(Recommended)` label, including the `Reason:` in the option description.
-- **MUST never combine multiple dimensions** into one question — each question narrows one axis.
-- **MUST never accept vague requirements** without pushing twice for specificity (push-once-then-push-again rule).
-- **MUST never present options without a Recommendation** when the manager has a basis for one — even close calls get a Recommendation labeled as a close call.
-- **MUST state evidence-to-change** alongside every recommendation — "Option A; switching to B requires X" form.
-- **MUST never use banned phrases** in user-facing text (anti-sycophancy table).
-- **MUST define every domain abbreviation** on first occurrence with parenthetical expansion.
-- **MUST classify every decision** as `auto-decide` / `ask: design|scope|destructive` / `user-challenge` and log the class.
-- **MUST ask user** on every Always-Ask category decision (Design / Scope / Destructive) regardless of how confident the manager feels.
-- **MUST never initiate user dialogue from a spawned subagent** — emit `NEEDS_CONTEXT` and route through the manager.
-- **MUST apply Smart-skip** when an earlier answer auto-resolves a later question — but confirm if the later question is Always-Ask category.
-- **MUST restate the task** at the end of discussion and confirm with the user before delegating.
+- [`orchestration/delegation.md`](../orchestration/delegation.md) § The Status Contract validates the spawned-agent `NEEDS_CONTEXT` evidence handoff and manager routing used in the Introduction, Rules, and P5.
+- [`orchestration/SKILL.md`](../orchestration/SKILL.md) § Runtime primitive map validates the active-runtime user-question interfaces used in the Rules and P4.
+- [GOV.UK Design System — Question pages](https://design-system.service.gov.uk/patterns/question-pages/) validates asking only for needed information and focusing the user on one question at a time.
+- [Claude Agent SDK — Handle approvals and user input](https://code.claude.com/docs/en/agent-sdk/user-input) validates that Claude's structured user-input surface pauses the main interaction for an answer.
+- [OpenAI Agents SDK — Human-in-the-loop](https://openai.github.io/openai-agents-python/human_in_the_loop/) validates an explicit pause, decision, and resume boundary for human-owned actions.

--- a/.gobbi/projects/gobbi/skills/discussion/mistakes.md
+++ b/.gobbi/projects/gobbi/skills/discussion/mistakes.md
@@ -2,7 +2,7 @@
 type: mistakes
 skill: discussion
 description: "Recorded traps for discussion — load before doing discussion work"
-updated: 2026-07-11
+updated: 2026-07-16
 ---
 
 # Discussion — Mistakes
@@ -16,3 +16,12 @@ updated: 2026-07-11
 **Why it happens** — It confused research confirmation with authority classification.
 **How to detect** — An Auto-mode question asks the user to approve a technical inference that stays inside already accepted scope and trade-offs.
 **Correct approach** — Auto-resolve the inference, record its evidence, and continue unless it changes user-owned authority.
+
+## Discussion SOP Became Policy Schema
+
+`priority: high` · `domain: process` · `added: 2026-07-16` · `status: active` · `tags: [process, design]`
+
+**What happened** — The discussion redesign split the skill into policy and runtime-adapter child documents and added `class`, `header`, and `resume_action` fields that did not help an agent discuss work with a user.
+**Why it happens** — The design optimized for classification and auditability, treating discussion as a runtime data model instead of a human interaction procedure.
+**How to detect** — A discussion redesign introduces enums, adapters, logging schemas, or metadata that do not clarify the discussion point or explain why user input is needed.
+**Correct approach** — Design the discussion internally, then ask one point at a time with `Discussion point`, `Why discussion is needed`, and meaningful options. Leave runtime transport and workflow recording to their owning mechanisms.

--- a/.gobbi/projects/gobbi/skills/git/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/git/SKILL.md
@@ -114,7 +114,7 @@ These prerequisites gate the **PR lifecycle only**. The worktree and its branch 
 
 The session never falls back to working in the main tree. See [Runtime git environment](#runtime-git-environment) for the per-runtime posture behind triggers 4–5.
 
-**Remediation menu — OFFERED before deferral, never auto-applied (Always-Ask).** Before deferring on trigger 4 or 5, the manager OFFERS a runtime-specific remediation the user may accept or decline. This is an Always-Ask decision per the [`discussion` skill's Decision Classification](../discussion/SKILL.md#decision-classification) (it modifies sandbox / config state). The manager NEVER auto-edits `.codex/config.toml` or Claude Code settings, and gobbi ships NO default network enablement. If the user declines, the op defers.
+**Remediation menu — OFFERED before deferral, never auto-applied.** Before deferring on trigger 4 or 5, the manager OFFERS a runtime-specific remediation the user may accept or decline. This requires explicit user approval under the [`discussion` skill's user-input gate](../discussion/SKILL.md#what-requires-discussion) because it modifies sandbox or configuration state. The manager NEVER auto-edits `.codex/config.toml` or Claude Code settings, and gobbi ships NO default network enablement. If the user declines, the op defers.
 
 | Runtime | Offered remediation |
 |---|---|
@@ -160,7 +160,7 @@ The manager passes the worktree's absolute path in every delegation prompt. The 
 
 ## Forbidden Operations
 
-These commands are forbidden without **explicit user request** through the active runtime's user-decision primitive (Always-Ask category per the [`discussion` skill's Decision Classification](../discussion/SKILL.md#decision-classification) — they are destructive / irreversible operations).
+These commands are forbidden without an **explicit user request** through the active runtime's user-decision primitive. They are destructive or irreversible operations under the [`discussion` skill's user-input gate](../discussion/SKILL.md#what-requires-discussion).
 
 | Forbidden command | Why | Safe alternative |
 |---|---|---|
@@ -169,7 +169,7 @@ These commands are forbidden without **explicit user request** through the activ
 | `git checkout .` / `git restore .` | Mass discard of unstaged changes | Commit-then-discard individual files |
 | `git commit --amend` after push | Rewrites pushed history | New commit (`fix: <description>`) or revert |
 | `git rebase -i` on pushed history | Rewrites pushed history | New commits |
-| `git branch -D` on unmerged branches | Discards branch tip irreversibly | `git branch -d` (only succeeds if merged). **Sanctioned exception:** `git branch -D` IS allowed — no Always-Ask — WHEN the branch is confirmed merged-by-squash via PR-association (a merged PR whose head was this branch). This is the ONLY safe `-D` use: a squash-merge produces a new commit with no history overlap, so `git branch -d` cannot recognize the branch as merged and force-delete is the only path. See Procedure P5 step 5 for the procedure. The ban above stands for genuinely unmerged branches (no merged-PR association). |
+| `git branch -D` on unmerged branches | Discards branch tip irreversibly | `git branch -d` (only succeeds if merged). **Sanctioned exception:** `git branch -D` IS allowed without extra approval WHEN the branch is confirmed merged-by-squash via PR-association (a merged PR whose head was this branch). This is the ONLY safe `-D` use: a squash-merge produces a new commit with no history overlap, so `git branch -d` cannot recognize the branch as merged and force-delete is the only path. See Procedure P5 step 5 for the procedure. The ban above stands for genuinely unmerged branches (no merged-PR association). |
 | `git stash` inside a worktree | Stash is per-worktree but easy to forget / lose if worktree is force-removed — never use stash to defer work across delegation boundaries | Create a temporary linked worktree (`git worktree add -b emergency-fix <path> <base>`), do the work, commit, then remove the temp worktree. Per `git-scm.com/docs/git-worktree`. |
 | `gh pr close` without merge | Discards reviewed work | Either merge or convert to draft |
 | `gh issue delete` | GitHub does not support undelete | `gh issue close` + comment explaining |
@@ -249,7 +249,7 @@ After all subtasks for the issue are complete and verified:
 
 If any precondition fails, do not merge — surface the failing item to the user.
 
-**Merge-conflict recovery (runtime-neutral).** A base-sync `git pull --ff-only` (P2 step 1 or the post-merge sync below) or a PR-branch conflict against the base must not be resolved silently. Recovery path: **detect** the conflict (the `--ff-only` pull aborts, or the PR shows merge conflicts) → **surface to the manager** → the manager delegates resolution to the executor, who **resolves it in the worktree** (the in-boundary commit model applies) → **re-verify** (run the task's verification commands again on the resolved tree) → **continue** the merge sequence. Forbidden Operations still apply: no force-push and no `git reset --hard` without an explicit Always-Ask approval. This split — manager detects/owns the merge, executor resolves in the worktree — follows the same boundary as commit-vs-push.
+**Merge-conflict recovery (runtime-neutral).** A base-sync `git pull --ff-only` (P2 step 1 or the post-merge sync below) or a PR-branch conflict against the base must not be resolved silently. Recovery path: **detect** the conflict (the `--ff-only` pull aborts, or the PR shows merge conflicts) → **surface to the manager** → the manager delegates resolution to the executor, who **resolves it in the worktree** (the in-boundary commit model applies) → **re-verify** (run the task's verification commands again on the resolved tree) → **continue** the merge sequence. Forbidden Operations still apply: no force-push and no `git reset --hard` without explicit user approval. This split — manager detects/owns the merge, executor resolves in the worktree — follows the same boundary as commit-vs-push.
 
 **Merge sequence** (all preconditions pass):
 
@@ -283,11 +283,11 @@ When a PR's CI fails:
 5. **Push the fix** — `git push` (CI re-runs automatically against the updated branch).
 6. **Monitor** — `gh pr checks <num> --watch` until pass or the user decides to defer.
 
-If a merge conflict surfaces during the fix loop (the branch falls behind base and a re-sync conflicts), apply the same recovery as P5: detect → surface to the manager → executor resolves in the worktree → re-verify → re-push. No force-push without an explicit Always-Ask approval.
+If a merge conflict surfaces during the fix loop (the branch falls behind base and a re-sync conflicts), apply the same recovery as P5: detect → surface to the manager → executor resolves in the worktree → re-verify → re-push. No force-push without explicit user approval.
 
 ### P8 — Retro / bulk cleanup
 
-P8 is the BULK companion to P6. P6 recovers a SINGLE orphaned worktree mid-session; P8 sweeps ACCUMULATED cruft across all four object classes (worktrees, remote branches, local branches, open issues) in one audited, confirmed pass. Modeled on the `gh poi` audit + dry-run + protect-list algorithm (use the algorithm, not the tool — no external CLI-extension dependency). Run the stages in this fixed order; every delete and close is an `[ASK]` destructive operation (Always-Ask per the [`discussion` skill's Decision Classification](../discussion/SKILL.md#decision-classification)).
+P8 is the BULK companion to P6. P6 recovers a SINGLE orphaned worktree mid-session; P8 sweeps ACCUMULATED cruft across all four object classes (worktrees, remote branches, local branches, open issues) in one audited, confirmed pass. Modeled on the `gh poi` audit + dry-run + protect-list algorithm (use the algorithm, not the tool — no external CLI-extension dependency). Run the stages in this fixed order; every delete and close is an `[ASK]` destructive operation requiring explicit user approval under the [`discussion` skill's user-input gate](../discussion/SKILL.md#what-requires-discussion).
 
 **1. AUDIT (read-only).** Enumerate every object and record baseline counts: worktrees (`git worktree list`), remote branches (`git branch -r`), local branches (`git branch`), open issues (`gh issue list`). No mutation in this stage. The counts seed the durable record (stage 8).
 
@@ -299,12 +299,12 @@ P8 is the BULK companion to P6. P6 recovers a SINGLE orphaned worktree mid-sessi
 
 **4. DRY-RUN (preview before any confirm).** Present the FULL classified plan — each object with its classification and the proposed action (keep vs delete/close) and the reason — WITHOUT acting (the `gh poi --dry-run` model). The user reviews the whole set before any confirmation round.
 
-**5. CONFIRM `[ASK]` (destructive).** Nothing acts without confirmation (default-safe). After the dry-run review: **confirm-per-CLASS** for the bulk merged objects (the user approves "delete these N merged-squash branches / close these N resolved issues" as a reviewed batch per class); **per-OBJECT confirm** for any unmerged or ambiguous object (a tip near the freshness window, an inconclusive flock probe). An **unmerged-branch delete requires an EXTRA explicit per-object confirm** — unmerged means unique work at risk (S-07). Authority: [`discussion` skill](../discussion/SKILL.md#decision-classification).
+**5. CONFIRM `[ASK]` (destructive).** Nothing acts without confirmation (default-safe). After the dry-run review: **confirm-per-CLASS** for the bulk merged objects (the user approves "delete these N merged-squash branches / close these N resolved issues" as a reviewed batch per class); **per-OBJECT confirm** for any unmerged or ambiguous object (a tip near the freshness window, an inconclusive flock probe). An **unmerged-branch delete requires an EXTRA explicit per-object confirm** — unmerged means unique work at risk (S-07). Discussion rule: [`What Requires Discussion?`](../discussion/SKILL.md#what-requires-discussion).
 
 **6. TOCTOU re-check.** IMMEDIATELY before acting on each object, RE-VERIFY its merged-state and worktree-liveness (re-run the held-flock / process probe and the PR-association check). State can change between the dry-run and the act — a concurrent session may have started, a branch may have been pushed. If the re-check disagrees with the dry-run classification, SKIP that object and record the skip; do not act on stale classification.
 
 **7. ACT (per-object, idempotent, resumable).** Act only on confirmed, TOCTOU-revalidated objects:
-   - **Worktrees** — `git status` clean check first (no `--force`/`-f` without Always-Ask), then `git worktree remove <path>` + `git worktree prune` + empty-parent cleanup scoped to the removed worktree's parent (`rmdir -p "$(dirname <path>)" 2>/dev/null || true`) — NEVER `find .../worktrees/ -type d -empty -delete` over the shared root, which wipes a concurrent live session's empty scaffold dirs (`mistakes.md#worktree-empty-dir-sweep-deletes-live-session-scaffold`).
+   - **Worktrees** — `git status` clean check first (no `--force`/`-f` without explicit user approval), then `git worktree remove <path>` + `git worktree prune` + empty-parent cleanup scoped to the removed worktree's parent (`rmdir -p "$(dirname <path>)" 2>/dev/null || true`) — NEVER `find .../worktrees/ -type d -empty -delete` over the shared root, which wipes a concurrent live session's empty scaffold dirs (`mistakes.md#worktree-empty-dir-sweep-deletes-live-session-scaffold`).
    - **Branches** — `git push origin --delete <branch>` (remote) + the sanctioned `git branch -D <branch>` (local) per the P5 step 5 / Forbidden Operations `-D` carve-out (only after PR-association confirms the squash-merge).
    - **Issues** — `gh issue close <num> -c "<reason>"`. NEVER `gh issue delete` (Forbidden Operations — GitHub has no undelete).
 
@@ -338,7 +338,7 @@ Common failures and their recovery paths. The **Runtime** column marks which run
 | `gh` CLI not authenticated | both | Covered by Procedure P1 — verified at session setup. |
 | Orphaned worktrees from crashed session | both | Procedure P6 (Recover orphaned worktree) for a single orphan; Procedure P8 (Retro / bulk cleanup) when more than one has accumulated. |
 | CI failure on the PR | both | Procedure P7 (Handle CI failure). |
-| Merge conflict on base sync or PR branch | both | Detect → surface to the manager → executor resolves in the worktree → re-verify → continue (P5 Merge-conflict recovery; P7 step 6). No force-push without Always-Ask. |
+| Merge conflict on base sync or PR branch | both | Detect → surface to the manager → executor resolves in the worktree → re-verify → continue (P5 Merge-conflict recovery; P7 step 6). No force-push without explicit user approval. |
 | Write to `.git/hooks` or `.git/config` attempted from inside the worktree | both | OS-denied by the sandbox (not only the gobbi rule) — the write cannot succeed. Commit (refs + index) is unaffected. See [Role Boundaries](#role-boundaries). |
 | `git push` / `gh` blocked — network off or approval not granted | codex | Default `workspace-write` keeps network OFF; `on-request` raises an approval prompt and `never` offers none. The manager OFFERS the remediation menu, then DEFERS the PR (triggers 4–5 in [Prerequisites](#prerequisites)). |
 | `git push` / `gh` blocked — domain not allowed or `gh` TLS fails under Seatbelt | claude | No domains pre-allowed (needs `allowedDomains`); `gh` may fail TLS under macOS Seatbelt (needs `excludedCommands`). The manager OFFERS the remediation menu, then DEFERS the PR (triggers 4–5 in [Prerequisites](#prerequisites)). |
@@ -375,7 +375,7 @@ Git operations don't write to session record directly (writes happen via session
 - **MUST verify prerequisites** at session start (Procedure P1) and re-verify at point of use (Procedure P2 step 2 for base branch).
 - **MUST never push from a subagent** — subagents commit; the manager pushes.
 - **MUST never create or merge a PR from a subagent** — subagents return `DONE`; the manager handles PR creation and merge.
-- **MUST never run a Forbidden Operations command** without explicit user request through the active runtime's user-decision primitive (Always-Ask category).
+- **MUST never run a Forbidden Operations command** without an explicit user request through the active runtime's user-decision primitive.
 - **MUST never use `git stash` inside a worktree** — use a temporary linked worktree instead (per `git-scm.com/docs/git-worktree`).
 - **MUST install dependencies per worktree** — each worktree has its own working directory; package managers and caches are not shared.
 - **MUST validate branch names + commit messages** against the regexes in [`conventions.md`](conventions.md) before pushing.

--- a/.gobbi/projects/gobbi/skills/gobbi/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/gobbi/SKILL.md
@@ -22,7 +22,7 @@ Load these immediately, before anything else. Do not ask questions, do not check
 
 1. **`principles`** — the 10 Iron Laws (Behavioral discipline floor). Mandatory.
 2. **`orchestration`** — the workflow state machine, mode definitions, manager-facing step orchestration, and the `orchestration/delegation.md` dispatch child.
-3. **`discussion`** — Question Card template, anti-sycophancy, Decision Classification (Auto-decide / Always-Ask / User Challenge). Loaded on every user-facing exchange.
+3. **`discussion`** — internal Discussion Design, the user-input gate, focused question cards, one-point-at-a-time dialogue, and evidence-based pushback. Loaded before every manager-user clarification, approval, or decision point.
 4. **`delegation`** — workflow-agnostic bounded-brief semantics. Load it before authoring a brief; `orchestration/delegation.md` owns Gobbi templates, load tiers, runtime dispatch, and wire formats.
 5. **`git`** — Worktree + branch + PR lifecycle. Loaded because git status may inform the customize gate settings.
 6. **`mistake`** — Cross-session mistake recording model: check existing mistakes before acting, stage new mistake-candidates immediately after corrections. Mandatory per `mistake/SKILL.md` Memory Access Matrix — the manager loads it before running setup questions or entering Configuration. Every subagent delegation prompt's Load Directives block must also include it explicitly (fresh subagents do not inherit).
@@ -75,20 +75,20 @@ Read the session-level `settings.json` at `.gobbi/projects/{project-name}/sessio
 
 > **Sanitization note:** `{project-name}` and similar slot values used in path construction and shell commands are NOT validated by any automated seam in the current markdown-driven design — the v0.4.x CLI settings-IO validator was removed in the v0.5.0 redesign and nothing replaced it. In-skill shell interpolation performs no escaping; treat slot values such as `{project-name}` as untrusted at the point of interpolation and sanitize them before use, especially when the value originates from a manually-edited config file.
 
-- **File exists** — this is a resume, post-`/clear`, or compact. Print the existing settings to the user and ask through the active runtime's user-decision primitive whether to reuse them or reconfigure. If reusing, skip the setup question in step 4 and proceed to step 5.
+- **File exists** — this is a resume, post-`/clear`, or compact. Print the existing settings to the user and ask through the manager-owned user-decision flow whether to reuse them or reconfigure. If reusing, skip the setup question in step 4 and proceed to step 5.
 - **File missing** — no prior session settings. Proceed to step 4.
 - **Parse or I/O error** — surface the diagnostic to the user before proceeding.
 
 ### 4. Ask the user one setup question
 
-Follow the [`discussion` skill's Question Card template](../discussion/SKILL.md#question-card-structure). After the question, persist the user's selection to the session-level `settings.json`.
+Build the [`discussion` skill's question card](../discussion/SKILL.md#question-card-structure) and ask it through the active runtime's structured question interface, or directly in the parent thread when no structured interface is available. After the question, persist the user's selection to the session-level `settings.json`.
 
 **Question — orchestration mode** (default: `auto`; full mode semantics in [`orchestration/SKILL.md § Step 1`](../orchestration/SKILL.md#step-1--workflow-configuration)):
 
 - **Auto** (Recommended) — the manager drives the workflow end to end, consulting the user only when a decision requires their authority.
 - **Chat** — the user drives step by step; the manager reports back and waits for explicit direction at each transition.
 
-After the mode is set, ask through the active runtime's user-decision primitive: "Would you like to customize any other settings (evaluation policy, discussion policy, step skip, iteration caps, models)?" If yes, follow [`orchestration/SKILL.md § Step 1`](../orchestration/SKILL.md#step-1--workflow-configuration) row 3 to walk through each section. If no, apply defaults as-is.
+After the mode is set, ask through the manager-owned user-decision flow: "Would you like to customize any other settings (evaluation policy, discussion policy, step skip, iteration caps, models)?" If yes, follow [`orchestration/SKILL.md § Step 1`](../orchestration/SKILL.md#step-1--workflow-configuration) row 3 to walk through each section. If no, apply defaults as-is.
 
 See [`orchestration/SKILL.md § Step 1`](../orchestration/SKILL.md#step-1--workflow-configuration) for the full Configuration Step 1 row order, including row 1 (worktree creation), which runs before `state.json` initialization (row 4) and before `session.json` stamping (row 5, where `git.worktreePath` is recorded).
 
@@ -96,7 +96,7 @@ See [`orchestration/SKILL.md § Step 1`](../orchestration/SKILL.md#step-1--workf
 
 Check `.gobbi/projects/{project-name}/` for the memory baseline:
 
-- If `README.md` is missing OR `design/` is empty OR `features/` is empty → memory is sparse. Run the active runtime's user-decision primitive: "Memory looks thin. Run the startup skill to populate it before starting work?" If the user accepts, load the [`startup` skill](../startup/SKILL.md) and run the structured startup talk; the workflow resumes after startup completes.
+- If `README.md` is missing OR `design/` is empty OR `features/` is empty → memory is sparse. Ask through the manager-owned user-decision flow: "Memory looks thin. Run the startup skill to populate it before starting work?" If the user accepts, load the [`startup` skill](../startup/SKILL.md) and run the structured startup talk; the workflow resumes after startup completes.
 - If memory is populated → proceed directly to the workflow.
 
 ### 6. Enter the workflow
@@ -180,7 +180,7 @@ Status enum across all spawned agents: `DONE` / `DONE_WITH_CONCERNS` / `NEEDS_CO
 | Skill | Purpose |
 |---|---|
 | [`orchestration`](../orchestration/SKILL.md) | Workflow state machine. Manager role, Chat / Auto modes, six-step transitions, plus the [`delegation.md`](../orchestration/delegation.md) manager-dispatch child. |
-| [`discussion`](../discussion/SKILL.md) | Manager + user dialogue mechanics — Question Card template, anti-sycophancy, Decision Classification, comfort patterns (Smart-skip / Spawned-session muting). Loaded on every user-decision primitive call. |
+| [`discussion`](../discussion/SKILL.md) | Manager + user dialogue SOP — internal Discussion Design, the user-input gate, focused question cards, one-point-at-a-time dialogue, evidence-based pushback, prior-answer reuse, and spawned-session muting. Loaded before every manager-user clarification, approval, or decision point. |
 | [`delegation`](../delegation/SKILL.md) | Workflow-agnostic bounded handoff semantics: objective, preparation, boundaries, autonomy, evidence, escape paths, and independent judgment. |
 | [`evaluation`](../evaluation/SKILL.md) | Evaluator's 4-stage procedure (Target Understanding → Frame Build → Per-Perspective → Overall) across 7 perspectives + Overall. Phase-specific child docs at `{loop}/evaluation.md`. |
 | [`record`](../record/SKILL.md) | Assistant's synthesis + staging during every loop's RECORD sub-phase. Includes Artifact frontmatter schema and staging directory templates. |
@@ -227,9 +227,9 @@ gobbi's durable capabilities — the things a README "Features" section would li
 
 ## Core Principles
 
-> **Never edit gobbi skills without asking the user with the active runtime's user-decision primitive.**
+> **Never edit gobbi skills without explicit user approval through the manager-owned user-decision flow.**
 
-Gobbi skills are the workflow's shared contract. Edits to skills / agents / rules / `.claude/` documentation are an Always-Ask category per the [`discussion` skill's Decision Classification](../discussion/SKILL.md#decision-classification).
+Gobbi skills are the workflow's shared contract. Edits to skills, agents, rules, or `.claude/` documentation require user input under the [`discussion` skill's gate](../discussion/SKILL.md#what-requires-discussion) because they change the workflow's shared behavior.
 
 > **Load the role's skill before acting.**
 
@@ -253,7 +253,7 @@ Ideation / Preparation / Planning / Execution loops write only to session record
 - Role effort defaults are explicit policy: every role uses **xhigh**.
 - In Codex, every repo-local `.codex/agents/*.toml` wrapper sets `model = "gpt-5.6-sol"` and `model_reasoning_effort = "xhigh"`. User-requested per-run overrides remain explicit exceptions.
 
-The active runtime's user-decision primitive is mandatory for every decision point (not prose). In Claude Code this is `AskUserQuestion`; in Codex this is the parent-thread question flow or `request_user_input` when available. The Recommended option is the first option, labeled `(Recommended)`, when the primitive supports options. The full Question Card template lives in [`discussion/SKILL.md`](../discussion/SKILL.md#question-card-structure).
+Before asking, the manager designs the discussion and resolves reversible mechanics from evidence. User goals, preferences, success criteria, design or scope changes, destructive actions, and material evidence conflicts go through the manager-owned user-decision flow. Claude Code uses `AskUserQuestion` when available. Codex uses `request_user_input` when exposed by the active mode and otherwise asks the same point in the parent thread. The canonical card lives in [`discussion/SKILL.md`](../discussion/SKILL.md#question-card-structure).
 
 **Status enum** is the contract every spawned agent reports at the beginning of its response — `DONE` / `DONE_WITH_CONCERNS` / `NEEDS_CONTEXT` / `BLOCKED`. The manager dispatches deterministically per the status. See [`orchestration/delegation.md` § The Status Contract](../orchestration/delegation.md#the-status-contract).
 
@@ -274,7 +274,7 @@ For the per-loop write paths, see each loop skill's "Output paths" section. For 
 - **MUST persist user setup answers** to the session-level `settings.json` before entering the workflow.
 - **MUST offer the startup skill** when memory is sparse — do not silently proceed against an empty `.gobbi/projects/{project-name}/`.
 - **MUST delegate everything except trivial bookkeeping** — the manager does not write code, evaluate own output, or perform specialist work; subagents do.
-- **MUST never edit gobbi skills, agents, or rules** without an Always-Ask decision through the active runtime's user-decision primitive (per the Decision Classification).
-- **MUST use the active runtime's user-decision primitive** for every decision point — per the [`discussion` skill](../discussion/SKILL.md).
+- **MUST never edit gobbi skills, agents, or rules** without explicit user approval through the manager-owned user-decision flow (per [What Requires Discussion?](../discussion/SKILL.md#what-requires-discussion)).
+- **MUST design every user discussion and use the active runtime's question interface for every point that needs user input** — per the [`discussion` skill](../discussion/SKILL.md).
 - **MUST read `orchestration/delegation.md` before every dispatch and never bypass its Load Directives block** — fresh subagents do not inherit the manager's loaded skills; every dispatch lists what the subagent must load.
 - **MUST run Wrap-up before closing the session** — memory is updated only via Wrap-up's promotion pass among the workflow loops; closing without Wrap-up loses all session work.

--- a/.gobbi/projects/gobbi/skills/orchestration/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/orchestration/SKILL.md
@@ -136,7 +136,7 @@ the per-mode docs reference it.
 The manager runs every session in one of two modes, picked at session start (§ Rules). Both follow the same underlying workflow; what differs is who drives it and which state-machine shape runs between Configuration and Wrap-up.
 
 - **Chat** — the user drives the workflow one task at a time; the manager runs a per-task slice (Ideation → mini-Planning → mini-Execution) and returns control after each. Read [`chat-mode.md`](chat-mode.md) for the full spec.
-- **Auto** — the manager runs the linear 6-step state machine end-to-end, pausing only for Always-Ask decisions (design, scope, destructive). Read [`auto-mode.md`](auto-mode.md) for the full spec.
+- **Auto** — the manager runs the linear 6-step state machine end-to-end, pausing only when the [`discussion` gate](../discussion/SKILL.md#what-requires-discussion) requires user input. Read [`auto-mode.md`](auto-mode.md) for the full spec.
 
 ### Agent Teams
 
@@ -150,7 +150,7 @@ The dispatch contract lives in `delegation.md`. Reference sections live under `w
 
 | Read | When |
 |---|---|
-| [`auto-mode.md`](auto-mode.md) | After Step 1 selects Auto, and whenever Auto-specific Always-Ask, evaluation, or max-iteration behavior is needed. |
+| [`auto-mode.md`](auto-mode.md) | After Step 1 selects Auto, and whenever Auto-specific user-interrupt, evaluation, or max-iteration behavior is needed. |
 | [`chat-mode.md`](chat-mode.md) | After Step 1 selects Chat, and whenever per-task slice routing, task-record writing, or Chat status rendering is needed. |
 | [`agent-teams.md`](agent-teams.md) | Before any Claude Code Agent Teams setup, teammate delegation, teammate continuation, or team cleanup. |
 | [`workflow/status-display.md`](workflow/status-display.md) | Before rendering the Workflow Status Display or Harness Todo List, and after resume when projections must be rebuilt from `state.json`. |
@@ -178,7 +178,7 @@ Each entry names an owner and the specific claim in this skill that the owner va
 - [`git/conventions.md`](../git/conventions.md) § Branch Naming — validates: the session-worktree branch-name rule, exempt from the type-prefix and slug-length rules (Step-1 row 1).
 - [`gobbi/SKILL.md`](../gobbi/SKILL.md) § Resolve runtime identity / § Enter the workflow — validates: the runtime session-id resolution used by Configuration and the Configuration-to-workflow handoff that resumes the persisted productive step (Step-1 rows 1 and 5; Procedure § Workflow).
 - [`record/record-map.md`](../record/record-map.md) § Initialization — validates: the session-record skeleton that `init-record-map.sh` materializes (Step-1 row 2).
-- [`discussion/SKILL.md`](../discussion/SKILL.md) § Decision Classification — validates: the active runtime's user-decision primitive that every clarification, decision, and approval flows through, and which user-owned decisions are surfaced rather than auto-resolved (Intro; Rules; Step-1 gates).
+- [`discussion/SKILL.md`](../discussion/SKILL.md) § What Requires Discussion? — validates: the user-input gate applied before every clarification, decision, and approval, including which points are resolved from evidence and which are surfaced to the user (Intro; Rules; Step-1 gates).
 - [`delegation.md`](delegation.md) § Continue vs Fresh — validates: the teammate continue-vs-fresh decision rule and delta-brief (Procedure § Agent Teams).
 - [`workflow/state-machine.md`](workflow/state-machine.md) § State persistence — validates: `state.json` is the single source of truth and the resume-validation invariants (Principle "`state.json` is the single source of truth"; the "write `state.json` first" Rule; Step-1 row 4R).
 - [`workflow/status-display.md`](workflow/status-display.md) — validates: the Status Display and harness todo widget are one-way projections of `state.json` (Principles; the "NEVER let the Status Display or the todo widget write back" Rule).

--- a/.gobbi/projects/gobbi/skills/orchestration/auto-mode.md
+++ b/.gobbi/projects/gobbi/skills/orchestration/auto-mode.md
@@ -1,7 +1,7 @@
 # Auto Mode
 
 Sub-document of the `orchestration` skill. Owns the **full** Auto-Mode specification: mode
-posture, the Always-Ask interrupt contract, the per-loop defaults (maxIterations, evaluate.mode,
+posture, the required-user-discussion interrupt contract, the per-loop defaults (maxIterations, evaluate.mode,
 discuss.mode, Preparation, RECORD), the banner-conditioning note, and the maxIterations
 exhaustion silence contract.
 
@@ -24,20 +24,19 @@ changes in Auto Mode. This document codifies discipline that was implicit; it do
 new runtime behavior.
 
 **When the manager auto-proceeds.** The manager initiates each step, runs subagents, and proceeds
-through the loop without pausing the user for decisions in the **Auto-decide** class
-(see `discussion/SKILL.md § Decision Classification`). Auto-decide decisions are resolved by the
-codebase, memory, rules, mistakes, or a clearly recommended approach; they are logged
-silently for auditability.
+through the loop without pausing when the codebase, memory, rules, mistakes, locked plan, or an exact
+current-session answer resolves the point. See
+[`discussion/SKILL.md § What Requires Discussion?`](../discussion/SKILL.md#what-requires-discussion).
 
 **When the manager MUST interrupt.** The manager pauses and uses the active runtime's user-decision primitive when:
 
-1. A decision falls in an **Always-Ask category** (Design / Scope / Destructive) — see §3.
+1. A point requires user input under the discussion gate — see §3.
 2. An eval finding implies a scope change the manager cannot resolve under existing authority.
 3. A step fails in a way the manager cannot resolve (e.g., a `BLOCKED` status from a subagent).
 4. The user explicitly intervenes mid-session.
 
 The manager does NOT pause for any other reason. "I'm not sure" and "this might be surprising"
-are not sufficient — if the decision is Auto-decide class, proceed.
+are not sufficient — if evidence resolves the point within the agreed contract, proceed.
 
 ---
 
@@ -111,7 +110,7 @@ The EVALUATION phase (row 3) in every step follows [§7 — Evaluation disciplin
 
 | # | Phase | Action | Refs | Agent |
 |---|---|---|---|---|
-| 1 | `DISCUSSION` | `discuss.mode = "agent"` in Auto default — manager constructs delegation prompt without per-step user gate; Always-Ask categories still fire per §3. | manager orchestration: [discussion](../discussion/SKILL.md), [delegation](delegation.md); specialist phase load: — | manager |
+| 1 | `DISCUSSION` | `discuss.mode = "agent"` in Auto default — manager constructs the delegation prompt without a per-step user gate; points that require user input still interrupt per §3. | manager orchestration: [discussion](../discussion/SKILL.md), [delegation](delegation.md); specialist phase load: — | manager |
 | 2 | `PLAN_DRAFT` | Spawn `leader` subagent(s). Collect the draft Plan. | manager orchestration: [planning.md](workflow/planning.md); specialist phase load: [../planning/SKILL.md](../planning/SKILL.md) | leader |
 | 3 | `EVALUATION` | Run per `workflow.planning.evaluate.mode`. | manager orchestration: [evaluation.md](workflow/evaluation.md); specialist phase load: [../evaluation/SKILL.md](../evaluation/SKILL.md) | evaluator |
 | 4 | `RECORD` | Full PASS path. | manager orchestration: [record.md](workflow/record.md); specialist phase load: [../record/SKILL.md](../record/SKILL.md) (+ [../memory/memory-map.md](../memory/memory-map.md)) | assistant |
@@ -155,43 +154,38 @@ The EVALUATION phase (row 3) in every step follows [§7 — Evaluation disciplin
 
 ---
 
-## §3 — Always-Ask codification
+## §3 — Required user discussion
 
 ### 3.1 Authoritative source
 
-The full Always-Ask matrix lives in
-[`discussion/SKILL.md § Always-Ask categories (override auto-decide; the user decides)`](../discussion/SKILL.md).
-`auto-mode.md` references that section as the authoritative source and restates the contract in
-Auto-Mode-specific language so an Auto-mode manager cannot rationalize past the gate.
+The user-input gate lives in
+[`discussion/SKILL.md § What Requires Discussion?`](../discussion/SKILL.md#what-requires-discussion).
+This section states only how that gate interrupts Auto Mode.
 
-### 3.2 Auto-Mode restatement
+### 3.2 Auto-Mode rule
 
-> **In Auto Mode, the manager auto-decides everything in the Auto-decide class without pausing.
-> The manager MUST NOT auto-decide anything in the Always-Ask class (Design / Scope /
-> Destructive). For those three categories, the active runtime's user-decision primitive fires exactly as it would in Chat
-> Mode — regardless of any per-step `discuss.mode: agent` setting.**
+> **In Auto Mode, the manager proceeds without pausing when evidence resolves the point inside the
+> agreed contract. The manager pauses when user goals or preferences, success criteria, design or
+> scope changes, destructive or irreversible work, or a material evidence conflict need the user's
+> judgment. This rule applies regardless of any per-step `discuss.mode: agent` setting.**
 
 The `discuss.mode: agent` default in Planning / Execution / Wrap-up (see §4) controls whether
-DISCUSSION rows are user-driven or agent-driven. It does **not** suppress Always-Ask interrupts.
-Always-Ask overrides `discuss.mode` unconditionally.
+DISCUSSION rows are user-driven or agent-driven. It does **not** suppress a required user discussion.
 
-### 3.3 Always-Ask categories with Auto-Mode examples
+### 3.3 Auto-Mode examples
 
-| Category | Definition | Auto-Mode example |
+| Point | Why user input is needed | Auto-Mode example |
 |---|---|---|
-| **Design** | Architecture choice, library selection, design pattern, API shape, persistence model, error-handling strategy, concurrency model. Anything that locks future code into a structural commitment. | The leader's mid-Planning research surfaces a new library not in the Ideation scope — e.g., the leader proposes `zod` for runtime schema validation when no validator was discussed in Ideation. This is a library selection (Design). The manager MUST ask before adopting it, regardless of `discuss.mode: agent`. |
-| **Scope** | In/out of scope of the Scope Contract, extending the contract to absorb adjacent work, narrowing to defer items mid-workflow, marking items as backlog vs in-this-workflow. | A mid-Execution executor's diff touches a file not in the plan's `files:` list — e.g., an executor editing `orchestration/SKILL.md` while scoped to `auto-mode.md` only. The manager detects the out-of-scope path and MUST ask before allowing it to proceed. |
-| **Destructive** | File deletion outside an explicit `files:` scope, `git reset --hard`, force-push, package downgrade, schema migration that drops data, modification of shared state outside the worktree, large-scale rename or move. | Mid-Wrap-up, an agent proposes `git reset --hard` to clean a branch after a merge conflict. This is destructive and irreversible. The manager MUST ask before issuing the command — even in Auto Mode with `discuss.mode: agent` active. |
+| **Design change** | It creates a structural commitment that the agreed design does not already authorize. | Mid-Planning research introduces a library that Ideation never considered. The manager asks before adopting it. |
+| **Scope change** | It expands, narrows, or defers part of the agreed contract. | A mid-Execution diff needs a file outside the plan's `files:` list. The manager asks before expanding the scope. |
+| **Destructive work** | It can discard data, history, or shared state and cannot be safely inferred. | Mid-Wrap-up, an agent proposes `git reset --hard` after a conflict. The manager asks before running it. |
 
-### 3.4 USER CHALLENGE cross-reference
+### 3.4 Material evidence conflicts
 
 When the Planning leader's research-backed analysis substantively disagrees with the user's stated
-Ideation direction, the manager escalates via the USER CHALLENGE primitive in
-[`planning/SKILL.md § Core Principles § USER CHALLENGE`](../planning/SKILL.md). The 5-field card
-(What the user said / What the leader recommends / Why / What we might be missing / If we're
-wrong, the cost is) fires through the active runtime's user-decision primitive. USER CHALLENGE is **never auto-decided**.
-The user's original direction is the default; the leader's recommendation only wins if the user
-explicitly accepts.
+Ideation direction, the manager follows the [`discussion` response procedure](../discussion/SKILL.md#p5--respond-to-the-answer):
+state the evidence, likely consequence, and remaining choice. The user's original direction remains
+in force unless the user explicitly accepts the change.
 
 ---
 
@@ -211,9 +205,9 @@ The following defaults are locked for Auto Mode. They apply to every session tha
 | `propose.mode` (all loops) | `"dual"` | The mirror of `evaluate.mode` on the creation side: the Codex proposer runs alongside the Claude producer every WORK sub-phase (dual-system production) — see §7.5. `"single"` is a deliberate Claude-only override — a configured Claude-only run that is NOT degraded mode and does NOT stamp the degraded-mode label. The distinct **degraded** case is a missing or timed-out proposer under `dual`: it falls back to Claude-only WITH the degraded-mode label and is NOT a safety gate. Orchestration: [`workflow/production.md`](workflow/production.md). |
 | `workflow.ideation.discuss.mode` | `"user"` | Ideation DISCUSSION is user-driven — user confirms approach before leader works. |
 | `workflow.preparation.discuss.mode` | `"user"` | Preparation DISCUSSION is user-driven — user confirms readiness gaps before prep work. |
-| `workflow.planning.discuss.mode` | `"agent"` | Planning DISCUSSION is agent-driven — manager proceeds without a gate per loop entry. Always-Ask categories still fire (§3). |
-| `workflow.execution.discuss.mode` | `"agent"` | Execution DISCUSSION is agent-driven. Always-Ask categories still fire (§3). |
-| `workflow.wrap-up.discuss.mode` | `"agent"` | Wrap-up DISCUSSION is agent-driven. Always-Ask categories still fire (§3). |
+| `workflow.planning.discuss.mode` | `"agent"` | Planning DISCUSSION is agent-driven — manager proceeds without a gate per loop entry. Required user discussions still interrupt (§3). |
+| `workflow.execution.discuss.mode` | `"agent"` | Execution DISCUSSION is agent-driven. Required user discussions still interrupt (§3). |
+| `workflow.wrap-up.discuss.mode` | `"agent"` | Wrap-up DISCUSSION is agent-driven. Required user discussions still interrupt (§3). |
 
 **Preparation runs.** Auto Mode does not skip Preparation. The `skip: false` + `maxIterations: 5`
 values mean the standard loop contract runs (DISCUSSION → WORK → EVALUATION → RECORD →
@@ -236,15 +230,13 @@ The session-start system-reminder banner reads:
 
 > "Auto Mode Active — bias toward working without stopping for clarifying questions."
 
-**The banner's bias is conditioned by the Always-Ask matrix (§3).** The phrase "make the
-reasonable call and keep going" applies to the **Auto-decide class only**. It does not extend
-to Always-Ask categories (Design / Scope / Destructive). A manager reading the banner's
-"keep going" language and using it to rationalize past an Always-Ask category is violating the
-Always-Ask contract, not following the banner.
+**The banner's bias is conditioned by the user-input gate (§3).** The phrase "make the
+reasonable call and keep going" applies only when evidence resolves the point within the agreed
+contract. It does not extend to unresolved user goals, success criteria, design or scope changes,
+destructive work, or material evidence conflicts.
 
-Operationally: when the manager faces a decision, the first question is not "should I ask?" but
-"which class is this?" If the decision is Auto-decide, proceed. If the decision is Always-Ask,
-ask — the banner is irrelevant.
+Operationally, the manager first asks whether evidence settles the point. If yes, proceed. If the
+point needs user judgment under §3, ask; the banner does not override the discussion gate.
 
 The banner text is injected by the harness (currently not modified by this redesign). The
 conditioning is a semantic note, not a code change.
@@ -321,7 +313,7 @@ dual-system divergence** (`PASS`↔`FAIL` / `REVISE`↔`FAIL`,
 the **degraded-mode / single-system fallback** and **both systems failing**
 ([`evaluation.md § Degraded-mode policy`](workflow/evaluation.md#degraded-mode-policy-single-system-fallback)).
 These fall under [§1](#1--mode-posture)'s "a step fails in a way the manager cannot resolve."
-Always-Ask findings (Design / Scope / Destructive per [§3](#3--always-ask-codification)) and findings
+Findings that need user discussion under [§3](#3--required-user-discussion) and findings
 implying an unresolvable scope change ([§1](#1--mode-posture) interrupt #2) also still interrupt. A
 minor divergence (`PASS`↔`REVISE`) auto-proceeds, as today. Any aggregate `FAIL` verdict always
 escalates per [`SKILL.md § Iteration rule`](SKILL.md#iteration-rule) — a `FAIL` is always either a
@@ -358,7 +350,7 @@ it is recorded and surfaced in the **Wrap-up finding set** (§6), never mid-loop
 contract a minor divergence gets in §7.3.
 
 **A large-gap production escalation is a safety-gate — it interrupts in Auto (do NOT silence it).** A
-**large gap** — ANY of an Always-Ask category (Design / Scope / Destructive, §3), a mutually-exclusive
+**large gap** — a change to design or scope, a destructive action (§3), a mutually-exclusive
 fork at the artifact's core, or principle-equipoise the producer cannot resolve (per
 [`workflow/production.md § Gap classification`](workflow/production.md#gap-classification)) — is surfaced
 by the producer, adjudicated by the manager, and escalated to the user. It interrupts in BOTH Auto and
@@ -372,7 +364,7 @@ Scan this at any production-integration boundary:
 | The manager NEVER… | Instead… |
 |---|---|
 | lets the producer synthesize / naive-blend the two drafts | the producer SELECTS per principle and records the Integration Log |
-| silences a **large-gap** production escalation (Always-Ask / fork / equipoise) | **interrupts** — a large-gap is a production **safety-gate** in Auto, like §7.3's dual-system gates |
+| silences a **large-gap** production escalation (user-owned change / fork / equipoise) | **interrupts** — a large-gap is a production **safety-gate** in Auto, like §7.3's dual-system gates |
 | interrupts mid-loop on a **small gap** | producer integrates locally + logs it; surfaced at Wrap-up (§6) |
 | treats a missing Codex proposer as a safety gate | proceeds Claude-only with the degraded-mode label (production.md) |
 
@@ -388,12 +380,8 @@ Scan this at any production-integration boundary:
   `skip: true` (`preparation = {skip: true, maxIterations: 0} → state: Skipped`) is Chat-only and
   does not apply in Auto Mode. Both modes run the unmodified base RECORD — the Chat-vs-Auto
   difference is preparation-skip, not RECORD narrowing.
-- [`discussion/SKILL.md § Decision Classification`](../discussion/SKILL.md) — authoritative
-  Always-Ask matrix (Design / Scope / Destructive categories, full table with examples and
-  why-always-ask rationale). §3 of this doc references and restates it; `discussion/SKILL.md`
-  is the single source of truth.
-- [`planning/SKILL.md § Core Principles § USER CHALLENGE`](../planning/SKILL.md) — 5-field
-  escalation card for leader-user disagreement. Referenced in §3.4.
+- [`discussion/SKILL.md § What Requires Discussion?`](../discussion/SKILL.md#what-requires-discussion) — authoritative
+  user-input gate. §3 states its Auto-Mode interrupt behavior without redefining the SOP.
 - [`record/SKILL.md`](../record/SKILL.md) — the unmodified base RECORD
   procedure. Auto Mode runs this base procedure in full (no local override).
 - [`mistake/SKILL.md § P2`](../mistake/SKILL.md) — moment-of-capture discipline for

--- a/.gobbi/projects/gobbi/skills/orchestration/chat-mode.md
+++ b/.gobbi/projects/gobbi/skills/orchestration/chat-mode.md
@@ -306,8 +306,8 @@ Execution):
 - **Evaluation always runs.** `evaluate.mode: always` across all loops in Chat.
 - **Production integration (when `propose.mode == dual`).** Every WORK sub-phase runs a parallel Codex
   proposer alongside the Claude producer; the Claude producer **selectively integrates** the frozen
-  proposal (SELECT, never blend) and records the **Integration Log**. A **large gap** — an Always-Ask
-  category / a mutually-exclusive fork / principle-equipoise the producer cannot resolve, per
+  proposal (SELECT, never blend) and records the **Integration Log**. A **large gap** — a change to design or scope, a destructive action,
+  a mutually-exclusive fork, or principle-equipoise the producer cannot resolve, per
   [`workflow/production.md § Gap classification`](workflow/production.md#gap-classification) — is a **user
   decision**, surfaced as a stop-the-line at the per-loop gate exactly as a major evaluation divergence
   is. A **small gap** is producer-local: the producer integrates it and the manager discusses the
@@ -460,8 +460,8 @@ The manager does **NOT** auto-trigger Wrap-up on any other signal:
 - No auto-trigger on idle.
 - No auto-trigger after N tasks.
 
-The discipline is symmetric to the Always-Ask Destructive category in
-`discussion/SKILL.md § Decision Classification`: ending the session changes durable memory
+The discipline is symmetric to the explicit-approval treatment of destructive work in
+`discussion/SKILL.md § What Requires Discussion?`: ending the session changes durable memory
 (mistake promotion, archive moves, handoff write) — that decision is the user's, always.
 
 **Partial session survival.** If the user closes the session without an explicit Wrap-up signal
@@ -611,9 +611,8 @@ DISCUSSION at every Chat loop entry. Documenting at both settings-level (`"user"
   Chat alongside the base RECORD procedure §4 runs.
 - [`orchestration/delegation.md § Inline-Paste Rule`](delegation.md) — governs fresh-subagent
   context per per-task slice; cited alongside Principle 1.
-- [`discussion/SKILL.md § Decision Classification`](../discussion/SKILL.md) — Always-Ask matrix
-  (Design / Scope / Destructive); the Wrap-up trigger in §7 is symmetric to the Destructive
-  category.
+- [`discussion/SKILL.md § What Requires Discussion?`](../discussion/SKILL.md#what-requires-discussion) — user-input gate;
+  the Wrap-up trigger in §7 follows the same explicit-approval rule as destructive work.
 - `mistakes/skills-mirror-symlinks-not-copies.md` — editing the canonical file at
   `.gobbi/projects/gobbi/skills/orchestration/chat-mode.md` reflects automatically via the
   `.claude/skills/orchestration/chat-mode.md` mirror symlink; do not double-edit.

--- a/.gobbi/projects/gobbi/skills/orchestration/delegation.md
+++ b/.gobbi/projects/gobbi/skills/orchestration/delegation.md
@@ -194,34 +194,40 @@ STATUS: NEEDS_CONTEXT
 Missing: the locked Scope Contract from the Ideation Loop. The brief references it
 by path but the file does not exist at the cited location.
 user-question:
-  question: "Where is the Scope Contract for this task?"
-  description: "The executor brief cites `sessions/.../1-ideation/outputs/scope-contract.md`
+  decision: "How should the missing Scope Contract be supplied?"
+  context: "The executor brief cites `sessions/.../1-ideation/outputs/scope-contract.md`
     but that path does not exist. The task cannot be scoped without it."
+  evidence:
+    - "The cited path does not exist in the worktree."
   options:
     - label: "Re-point to the correct path (Recommended)"
-      description: "Provide the actual path to the Scope Contract artifact."
+      trade-off: "Preserves the locked artifact as the source but requires its actual path."
     - label: "Supply the Scope Contract inline"
-      description: "Paste the Scope Contract text into a follow-up re-delegation."
+      trade-off: "Unblocks immediately but duplicates the contract in the next brief."
   recommended-option: "Re-point to the correct path"
+  evidence-to-change: "Use the inline option if no canonical artifact exists."
 ```
 
 ### NEEDS_CONTEXT user-question schema
 
-When a subagent emits `STATUS: NEEDS_CONTEXT` and the missing context requires user input, the response body MUST include a `user-question:` block. The manager reads this block and constructs an user-decision primitive call on behalf of the subagent.
+When a subagent emits `STATUS: NEEDS_CONTEXT` and the missing context requires user input, the response body MUST include a `user-question:` block. This is an evidence handoff, not a user-facing question card. The manager first tries to resolve the gap from available evidence. If user input is still needed, it follows the [`discussion` SOP](../discussion/SKILL.md#what-requires-discussion) and builds the parent skill's [Question Card](../discussion/SKILL.md#question-card-structure). The subagent does not conduct the discussion.
 
 ```yaml
 user-question:
-  question: <one-line statement of what is needed>
-  description: <1-2 sentence context — why this is blocking, what it affects>
+  decision: <one-line statement of what is needed>
+  context: <1-2 sentence explanation of why this blocks the task and what it affects>
+  evidence:
+    - <path, rule, command result, or missing artifact that proves the gap>
   options:
-    - label: <option label — first option is Recommended>
-      description: <reason + pros/cons, ≥ 40 chars>
+    - label: <recommended option label>
+      trade-off: <one sentence naming its material benefit and cost>
     - label: <alternative option>
-      description: <reason + pros/cons, ≥ 40 chars>
+      trade-off: <one sentence naming its material benefit and cost>
   recommended-option: <label of the preferred option>
+  evidence-to-change: <new fact that would make another option preferable>
 ```
 
-If the missing context can be fetched without user input (e.g., by reading a file, running a command, or delegating to an assistant), the manager does that first — only escalate to the user if the manager cannot resolve it independently. The `user-question:` block signals "user input required"; absence of the block signals "manager can resolve".
+Options are optional when the subagent cannot support an honest choice set; the block may instead provide only `decision`, `context`, and `evidence`. If the missing context can be fetched without user input (for example, by reading a file, running a command, or delegating to an assistant), the manager does that first and resolves contract-preserving mechanics from evidence. The `user-question:` block signals “manager must resolve this gap”; it does not prove that user input is required.
 
 ### Prompt placement (why Report Format is at the end)
 

--- a/.gobbi/projects/gobbi/skills/orchestration/templates/_dual-system-block.md
+++ b/.gobbi/projects/gobbi/skills/orchestration/templates/_dual-system-block.md
@@ -44,8 +44,8 @@ integrator. Orchestration lives in `orchestration/workflow/production.md` + `cod
 - **Integration Log:** record one row per delta (`delta` / `decision` / `why` / `codex_origin`) to
   <<Integration-Log path — leader/assistant: `working/reconciliation-iter{n}.md`; Execution per-task:
   `task-{NN}-{slug}/working/reconciliation-iter{n}.md`>>.
-- **Large-gap escalation:** surface any unresolvable delta (a `large-gap` — Always-Ask /
-  mutually-exclusive fork / principle equipoise) to the manager; do NOT resolve it yourself. It is a
+- **Large-gap escalation:** surface any unresolvable delta (a `large-gap` — design or scope change /
+  destructive action / mutually-exclusive fork / principle equipoise) to the manager; do NOT resolve it yourself. It is a
   safety gate (interrupts in both Auto and Chat).
 - **Degraded mode:** if no proposal exists (Codex reported BLOCKED / empty / timeout), proceed
   Claude-only and stamp `production_mode: claude-only` +

--- a/.gobbi/projects/gobbi/skills/orchestration/workflow/production.md
+++ b/.gobbi/projects/gobbi/skills/orchestration/workflow/production.md
@@ -84,7 +84,7 @@ When the producer cannot resolve a delta by principle, it classifies the gap. Th
 
 | Class | Trigger | Path |
 |---|---|---|
-| **LARGE** | ANY of: (a) an Always-Ask category (Design / Scope / Destructive); (b) the two drafts are mutually exclusive at the artifact's core (a fork); (c) principle analysis cannot pick a winner (equipoise) | producer surfaces → **manager adjudicates** → escalate a decision card to the user |
+| **LARGE** | ANY of: (a) a change to design or scope, or a destructive action; (b) the two drafts are mutually exclusive at the artifact's core (a fork); (c) principle analysis cannot pick a winner (equipoise) | producer surfaces → **manager adjudicates** → escalate a decision card to the user |
 | **SMALL** | additive / refinement / stylistic / clearly principle-decided | producer integrates locally + logs it in the Integration Log; no interrupt |
 
 The **large-gap escalation is a safety gate — it interrupts in BOTH Auto and Chat** (it is NOT routine triage). It reuses the evaluation safety-gate contract: it is the production analogue of evaluation's Major-divergence stop-the-line. Small-gap integration is producer-local: in Chat the manager may surface the Integration Log at the existing finding-discussion gate; in Auto it is recorded and reviewed at Wrap-up. See [`auto-mode.md`](../auto-mode.md) and [`chat-mode.md`](../chat-mode.md) for the per-mode behavior.

--- a/.gobbi/projects/gobbi/skills/orchestration/workflow/state-machine.md
+++ b/.gobbi/projects/gobbi/skills/orchestration/workflow/state-machine.md
@@ -60,7 +60,7 @@ After `EVALUATION` (or its skip path), the loop always proceeds to `RECORD`. The
 The per-loop user-interaction gates are mode-specific and owned by the mode docs:
 
 - **Chat Mode** — the three in-loop gates (after DISCUSSION, after EVALUATION, at ITER/EXIT) plus the fourth task-boundary review gate, and the `discuss.mode` shadowing rule: [`chat-mode.md §5 — Per-loop discipline`](../chat-mode.md) (gates + shadowing), [`chat-mode.md` Slice Boundary + §8](../chat-mode.md) (task-boundary gate).
-- **Auto Mode** — silent auto-advance, the Always-Ask interrupts, and the no-interrupt-on-`maxIterations` rule: [`auto-mode.md §3 — Always-Ask codification`](../auto-mode.md) and [`auto-mode.md §6 — maxIterations exhaustion`](../auto-mode.md).
+- **Auto Mode** — silent auto-advance, required-user-discussion interrupts, and the no-interrupt-on-`maxIterations` rule: [`auto-mode.md §3 — Required user discussion`](../auto-mode.md) and [`auto-mode.md §6 — maxIterations exhaustion`](../auto-mode.md).
 
 ### Loop ↔ agent type mapping
 

--- a/.gobbi/projects/gobbi/skills/startup/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/startup/SKILL.md
@@ -204,7 +204,7 @@ After Topic 4, run the [`topics.md` problem-before-solution premise gate](topics
 
 1. **Study** internal and external prior art across three layers — tried-and-true, new-and-popular (scrutinized for maturity, fit, and survivorship), and first-principles (where convention does not apply, with the evidence for deviating); capture each as Source / Insight / Why and never fabricate a citation.
 2. **Recommend** at least two genuinely distinct, equal-weight options — one minimal, one ideal — with effort / risk / reuse trade-offs, the recommended option first, and the evidence-to-change, through the Question Card.
-3. **Decide** through the user-owned Always-Ask design gate; record the chosen direction, rationale, rejected alternatives, cited references, and decision-trace fields.
+3. **Decide** through the user-owned design discussion; record the chosen direction, rationale, rejected alternatives, cited references, and decision-trace fields.
 
 This loop sets reference-informed DIRECTION only — which architecture style, stack, or convention. It never designs mechanism: interface signatures, module internals, algorithms, schemas, and task breakdown stay in Ideation / Planning / Execution.
 
@@ -233,8 +233,8 @@ claim here and follow the single owner link.
 - [`recording.md`](recording.md) §§1, 3, 5, 9, 11–13 — validates: the record/memory boundary, the startup
   session shape, mistake routing, startup-close promotion and recovery, rerun/resume classification, and the
   close lifecycle used by P1 and P4–P7.
-- [`discussion/SKILL.md`](../discussion/SKILL.md) § Question Card Structure + § Decision Classification —
-  validates: the active-runtime question-card form and the Always-Ask handling used at every startup user
+- [`discussion/SKILL.md`](../discussion/SKILL.md) § Question Card Structure + § What Requires Discussion? —
+  validates: the active-runtime question-card form and explicit user-input handling used at every startup
   gate (P1–P7; the inline P3 design-decision micro-loop's recommendation + gate; the promotion Always-Ask
   gate).
 - [`research/SKILL.md`](../research/SKILL.md) § Internal Research + § External Research — validates: the

--- a/plugins/gobbi/.claude-plugin/plugin.json
+++ b/plugins/gobbi/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gobbi",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Full gobbi workflow system — structured orchestration with multi-stance evaluation, adaptive planning, and git workflow isolation for Claude Code",
   "author": {
     "name": "HahyeonJeon"

--- a/plugins/gobbi/.codex-plugin/plugin.json
+++ b/plugins/gobbi/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gobbi",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Gobbi workflow skills and hooks for Codex.",
   "author": {
     "name": "HahyeonJeon",


### PR DESCRIPTION
## Summary
- Reconciles local develop's three unpushed discussion-SOP commits with origin/develop (which gained PRs #353/#354/#355) by replaying their net diff onto origin/develop as one squashed change.
- The discussion skill's decision policy and runtime adapters are split, the user-discussion SOP is simplified, and the SOP is reconciled with the delegation split (#352).

## Changes
- `.gobbi/projects/gobbi/skills/discussion/` — simplified SOP + mistakes companion update
- `.gobbi/projects/gobbi/skills/orchestration/` — SKILL/auto-mode/chat-mode/delegation/templates/production/state-machine reconciled with the discussion+delegation split
- `.gobbi/projects/gobbi/skills/{gobbi,git,startup}/SKILL.md`, `agents/manager.{md,toml}` — cross-references updated
- `plugins/gobbi/`, `.claude-plugin/marketplace.json` — plugin manifest version sync
- `features/git-workflow/checklists/` — git operation checklist update

## Test plan
- [x] `check-markdown-links.sh` on all changed skill dirs — 604 links resolve across 41 files
- [x] `check-workflow-mirror-consistency.sh` — ALL 12 WORKFLOW DOCS MIRRORED
- [x] Squash-apply verified: net diff vs prior local develop is content-identical for discussion files; origin-side additions in `gobbi/SKILL.md` retained

## Linked issues
Refs #352