### PR TITLE
feat(ui-ux): add cross-surface design skills

### DIFF
--- a/.agents/skills/ui
+++ b/.agents/skills/ui
@@ -1,0 +1,1 @@
+../../.gobbi/projects/gobbi/skills/ui

--- a/.agents/skills/ux
+++ b/.agents/skills/ux
@@ -1,0 +1,1 @@
+../../.gobbi/projects/gobbi/skills/ux

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "gobbi",
       "description": "Structured orchestration, planning, execution, evaluation, memory, record, and handoff for Claude Code.",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "source": "./plugins/gobbi"
     }
   ]

--- a/.claude/skills/ui/SKILL.md
+++ b/.claude/skills/ui/SKILL.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/ui/SKILL.md

--- a/.claude/skills/ui/checklists.md
+++ b/.claude/skills/ui/checklists.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/ui/checklists.md

--- a/.claude/skills/ui/evaluation.md
+++ b/.claude/skills/ui/evaluation.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/ui/evaluation.md

--- a/.claude/skills/ui/ideation.md
+++ b/.claude/skills/ui/ideation.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/ui/ideation.md

--- a/.claude/skills/ui/scenarios.md
+++ b/.claude/skills/ui/scenarios.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/ui/scenarios.md

--- a/.claude/skills/ux/SKILL.md
+++ b/.claude/skills/ux/SKILL.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/ux/SKILL.md

--- a/.claude/skills/ux/checklists.md
+++ b/.claude/skills/ux/checklists.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/ux/checklists.md

--- a/.claude/skills/ux/evaluation.md
+++ b/.claude/skills/ux/evaluation.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/ux/evaluation.md

--- a/.claude/skills/ux/ideation.md
+++ b/.claude/skills/ux/ideation.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/ux/ideation.md

--- a/.claude/skills/ux/scenarios.md
+++ b/.claude/skills/ux/scenarios.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/ux/scenarios.md

--- a/.gobbi/projects/gobbi/skills/claude-plugin/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/claude-plugin/SKILL.md
@@ -238,10 +238,10 @@ Do not collapse the two registrations into one — the dev registration must use
 The Claude Code manifest remains metadata-only. Claude Code auto-loads components from conventional directories:
 
 - `plugins/gobbi/agents/` — 5 agent files (manager, leader, executor, evaluator, assistant) auto-loaded by convention
-- `plugins/gobbi/skills/` — all 25 canonical skill directories auto-loaded by convention; merged with the user's existing skills (ADDS-TO semantics)
+- `plugins/gobbi/skills/` — all 27 canonical skill directories auto-loaded by convention; merged with the user's existing skills (ADDS-TO semantics)
 - `plugins/gobbi/hooks/hooks.json` — hook registrations (4 event groups) auto-loaded by convention
 
-Verified on CLI v2.1.159: `claude plugin details gobbi` historically reported `Skills (19), Agents (5), Hooks (3)`; the current canonical package tree contains 25 skills after subsequent additions and retirement of Preparation. Re-verify the installed count on the next CLI compatibility check. Adding `skills`/`agents`/`hooks` keys to the Claude manifest previously produced `Status: failed to load` and `Agents (0)` — those keys stay out of `plugins/gobbi/.claude-plugin/plugin.json`.
+Verified on CLI v2.1.159: `claude plugin details gobbi` historically reported `Skills (19), Agents (5), Hooks (3)`; the current canonical package tree contains 27 skills after subsequent additions and retirement of Preparation. Re-verify the installed count on the next CLI compatibility check. Adding `skills`/`agents`/`hooks` keys to the Claude manifest previously produced `Status: failed to load` and `Agents (0)` — those keys stay out of `plugins/gobbi/.claude-plugin/plugin.json`.
 
 The Codex manifest is explicit where Codex needs it:
 
@@ -250,13 +250,13 @@ The Codex manifest is explicit where Codex needs it:
 
 Codex custom agents remain repo-local under `.codex/agents/*.toml`; the plugin package includes `agents/` as a shared distribution snapshot, not as the native Codex custom-agent discovery path.
 
-### Skills shipped by the package (25 total)
+### Skills shipped by the package (27 total)
 
-The package ships all 25 canonical skills:
+The package ships all 27 canonical skills:
 
-`agent-writing`, `checklist`, `claude-plugin`, `codex`, `coding`, `delegation`, `discussion`, `evaluation`, `execution`, `git`, `gobbi`, `ideation`, `memory`, `mistake`, `orchestration`, `planning`, `principles`, `python`, `record`, `research`, `scenario`, `skill-writing`, `startup`, `typescript`, `wrap-up`
+`agent-writing`, `checklist`, `claude-plugin`, `codex`, `coding`, `delegation`, `discussion`, `evaluation`, `execution`, `git`, `gobbi`, `ideation`, `memory`, `mistake`, `orchestration`, `planning`, `principles`, `python`, `record`, `research`, `scenario`, `skill-writing`, `startup`, `typescript`, `ui`, `ux`, `wrap-up`
 
-The `claude-plugin` skill (this file) is one of the 25. The canonical source lives at `.gobbi/projects/gobbi/skills/claude-plugin/SKILL.md`; the workspace-visible mirror is `.claude/skills/claude-plugin/SKILL.md` (a symlink). The package path `plugins/gobbi/skills/claude-plugin/SKILL.md` resolves through the package symlink.
+The `claude-plugin` skill (this file) is one of the 27. The canonical source lives at `.gobbi/projects/gobbi/skills/claude-plugin/SKILL.md`; the workspace-visible mirror is `.claude/skills/claude-plugin/SKILL.md` (a symlink). The package path `plugins/gobbi/skills/claude-plugin/SKILL.md` resolves through the package symlink.
 
 ### Pointer to the claude-plugin skill
 

--- a/.gobbi/projects/gobbi/skills/ui/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/ui/SKILL.md
@@ -1,0 +1,368 @@
+---
+name: ui
+description: Use when designing one complete observable interface outcome across web, command-line, desktop, mobile, voice, or future surfaces, from an evidence-bound interface specification through direct-user testing of a disposable prototype.
+allowed-tools: Read, Grep, Glob, Bash, Write, Edit, AskUserQuestion, WebSearch, WebFetch
+skill-type: operation
+---
+
+# User Interface Design
+
+Operation skill for designing one complete observable interface outcome across web, command-line, desktop,
+mobile, voice, and future surfaces. A run binds the outcome and evidence, establishes the project and platform
+foundation, creates a surface-neutral interface skeleton, grows a complete specification one meaningful unit
+at a time, and only then tests a disposable prototype with representative users. Load it when hierarchy,
+composition, controls or commands, interaction, feedback, state representation, adaptive behavior, modality
+equivalence, or detailed aesthetic decisions must be designed.
+
+This skill is independently loadable. It does not require or outrank a `ux` skill. When both are loaded, UI
+owns surface realization and preserves the co-loaded outcome, content, state, recovery, evidence, and risk
+contract. Neither skill wins by load order.
+
+---
+
+## Principles
+
+> **Design one complete interface outcome, not an isolated artifact.**
+
+A screen, page, command, component, prompt, or happy path is only one possible part of an interface outcome.
+Design from entry through observable completion. Include every required actor, state, alternative, failure,
+feedback, recovery, handoff, support step, and adaptation. Keep adjacent outcomes outside the run.
+
+> **Set the whole skeleton from the top, then grow the interface from the bottom.**
+
+Start with a surface-neutral hierarchy and state model so every local choice has a place. Then begin with the
+smallest meaningful interface unit and connect one complete interaction at a time. A control or command that
+works alone but breaks the hierarchy, path, state model, or another required surface is wrong.
+
+> **Project identity constrains from the foundation; detailed aesthetics come last.**
+
+Identity shapes the product's promise, character, voice, recognizable patterns, and allowed expression from
+the start. Detailed typography, color, density, spacing, shape, imagery, motion, tone, and expressive finish
+wait until structure, behavior, content, feedback, failure, recovery, adaptation, and accessibility are
+complete. Polish can strengthen a sound contract; it cannot repair a missing one.
+
+> **Finish and approve the whole specification before prototyping.**
+
+Early prototypes anchor attention on the first visible solution and hide unsolved states. Complete the entire
+interface specification and obtain explicit user approval first. The prototype then tests named uncertainties
+in that approved contract. It never substitutes for the contract.
+
+> **Direct use is the acceptance evidence.**
+
+Standards, expert review, prior UX research, analytics, and stakeholder approval help shape an interface.
+None proves that representative users can perceive, understand, operate, complete, and recover through this
+run's design. Acceptance needs direct prototype testing with people representative of the claims.
+
+> **Surface-neutral obligations and surface-specific mechanics are different layers.**
+
+Every interface needs understandable structure, perceivable status, operable actions, coherent states,
+feedback, recovery, and completion evidence. A graphical form, command-line command, voice prompt, and future
+surface realize those obligations differently. This parent owns the shared outcome discipline. Future child
+skills own exact platform mechanics, technical standards, and platform examples without weakening parent
+invariants.
+
+---
+
+## Rules
+
+### Must-Follow
+
+- **UI-R1 — MUST bind one complete observable interface outcome per run.** Name the primary actor, necessary
+  supporting actors, trigger, entry, completion evidence, normal and alternative paths, applicable states,
+  errors, feedback, recovery, handoffs, support, adaptation, scope, and non-goals. A screen, page, command,
+  component, artifact, isolated state, or happy path is not the outcome. An adjacent outcome enters only after
+  the user changes the scope contract.
+- **UI-R2 — MUST decide surface scope from the outcome and evidence.** One run may include multiple surfaces
+  only when they realize the same outcome and share one interface skeleton. Each surface must still have
+  separately specifiable and testable mechanics, accessibility or modality equivalence, prototype coverage,
+  and evidence. Split the run when the outcome or skeleton differs, or when a surface cannot be specified and
+  tested separately.
+- **UI-R3 — MUST obtain direct representative-user prototype testing before the interface design is locked.**
+  Prior UX research, earlier UI tests, analytics, expert review, and standards may frame the work but never
+  replace this run's test. A project owner counts only when evidence shows that person is genuinely
+  representative of the relevant user context. Choose method, sample, and claim boundaries from the question,
+  diversity, uncertainty, impact, and risk; this skill sets no fixed participant count.
+- **UI-R4 — MUST protect participants and evidence and fail closed on missing conditions.** Obtain informed
+  consent, provide needed accommodations, minimize and protect collected data, separate observations from
+  interpretations, and state evidence limits. Missing access to representative users, consent,
+  accommodations, or required evidence yields `NEEDS_CONTEXT`. The run may record assumptions and a test plan,
+  but no final UI design may be accepted.
+- **UI-R5 — MUST establish project identity through one authority chain.** Use, in order: explicit
+  `DESIGN.md`, brand, product, or design-system documents; the live product, system, and tokens; then a
+  user-confirmed temporary identity brief. If governing material is missing, ask the kinds of questions such a
+  document would answer and capture the run-scoped brief in the feature design document. Do not create or
+  prescribe a universal project-wide `DESIGN.md`.
+- **UI-R6 — MUST follow the construction order without skipping or rearranging it.** Bind outcome, surfaces,
+  users, context, and evidence; establish the reference, platform-system, and identity foundation; create the
+  top-down surface-neutral interface skeleton; grow the specification bottom-up; compare concepts; complete
+  and obtain approval for the whole specification; then prototype; test; revise the specification first and
+  prototype second; retest; and hand off. A prototype before whole-specification approval fails the run.
+- **UI-R7 — MUST stop at each user gate.** Obtain an explicit decision after the foundation and identity, the
+  skeleton, the core unit and path, the accumulated specification, the final whole specification including
+  final aesthetics, and the post-test revision. Silence, continued work, an earlier decision, or stakeholder
+  enthusiasm is not approval.
+- **UI-R8 — MUST make user discussion adaptively complete.** Read [`ideation.md`](ideation.md) and default to
+  its full decision tree. Ask one decision axis per turn. Smart-skip only when current evidence answers the axis
+  and the user has already locked that answer for this run. Research before recommending. When meaningful
+  alternatives exist, present two evidence-backed options, recommend one, state what evidence would change the
+  recommendation, and let the user lock the choice. Ask project-specific follow-ups beyond the tree, and keep
+  stakeholder decisions separate from representative-user test evidence.
+- **UI-R9 — MUST compare at least two materially different interface concepts by default.** Concepts must
+  differ in structure, action model, information flow, interaction strategy, state communication, or another
+  consequential property. Cosmetic variants are one concept. A single-concept exception requires real
+  constraints plus direct evidence, and its constraints, evidence, and rationale must be recorded.
+- **UI-R10 — MUST complete one evidence-bearing feature design document before prototyping.** The active
+  project or workflow owns its path. The document uses the schema in Procedure and records evidence,
+  alternatives, decisions, rejected options, deviations, limitations, the whole specification, and remaining
+  uncertainty. Headings without resolved content do not satisfy this rule.
+- **UI-R11 — MUST finish structure and behavior before detailed aesthetics.** Complete hierarchy,
+  composition, controls or commands, interaction, content, feedback, failure, recovery, adaptation,
+  accessibility, and modality equivalence first. Then specify typography or character rendering, color where
+  present, density, spacing, rhythm, shape, imagery, iconography or symbols, motion or transitions, tone, and
+  expressive detail as applicable. Aesthetics must improve hierarchy, state recognition, affordance, trust,
+  and identity fit; they cannot hide inaccessible behavior or missing structure.
+- **UI-R12 — MUST make every required action, state, and meaning accessible across applicable modalities.**
+  Specify perception, operation, focus or cursor flow, reading or announcement order, input alternatives,
+  status, error identification, recovery, timing, motion, contrast or non-color cues, language, locale, and
+  adaptation as the surfaces require. When identity conflicts with accessibility, safety, direct user
+  evidence, or platform convention, present the evidence and ask the user. The accessibility and safety floor
+  cannot be waived.
+- **UI-R13 — MUST make prototypes disposable, post-specification test artifacts.** Size fidelity to the named
+  uncertainty. Trace the artifact to the approved whole specification and mark simulated behavior and data.
+  For a multi-surface run, provide separately testable variants and evidence for every surface. Production
+  implementation and production-ready code are out of scope.
+- **UI-R14 — MUST revise the specification before revising the prototype.** Every supported test finding first
+  changes the owning hierarchy, component, command, interaction, content, state, feedback, recovery,
+  accessibility, aesthetic rule, or decision. Bring the prototype back into agreement second, then retest
+  every affected assumption and regression before the post-test gate.
+- **UI-R15 — MUST preserve the parent contract across handoff and specialization.** The handoff states the
+  outcome, surfaces, evidence and limits, skeleton, interface units, complete paths and states, content,
+  feedback, recovery, adaptation, accessibility, aesthetic system, prototype status, decisions, deviations,
+  and reopen conditions. Future web, command-line, desktop, mobile, voice, or other child skills may own exact
+  mechanics, standards, and examples. A child convention cannot waive a parent obligation; any material
+  deviation returns to the user.
+- **UI-R16 — MUST resolve co-loaded UI and UX conflicts with evidence and user authority.** UI owns hierarchy,
+  composition, controls or commands, interaction, feedback, state representation, adaptive behavior, modality
+  equivalence, and detailed aesthetic decisions. Preserve any co-loaded UX outcome, content, state, recovery,
+  accessibility, evidence, and risk contract. If clauses conflict, identify the concrete conflict, show the
+  evidence and trade-offs, and ask the user. Never invent precedence or use load order.
+
+### Must-Not-Follow
+
+- **NEVER produce a polished interface in one big pass.** Fix: establish the foundation and skeleton, then grow
+  one meaningful unit and path at a time through the required gates.
+- **NEVER treat a screen, page, command, component, prompt, or output as a complete outcome by itself.** Fix:
+  bind observable completion and include every required state, failure, recovery, support step, and actor.
+- **NEVER combine surfaces because they look related.** Fix: prove one outcome and skeleton, then keep each
+  surface's mechanics, accessibility, prototype, and evidence separate; otherwise split the run.
+- **NEVER use prior UX or UI evidence, standards compliance, expert judgment, or an unrepresentative owner as
+  a replacement for this run's direct prototype testing.** Fix: meet UI-R3 and UI-R4 or return
+  `NEEDS_CONTEXT` without accepting the design.
+- **NEVER create a prototype before the whole specification is complete and explicitly approved.** Fix: finish
+  every specification section and pass the final whole-specification gate first.
+- **NEVER start detailed aesthetics while structure, behavior, content, feedback, recovery, adaptation, or
+  accessibility remains unresolved.** Fix: return to the earliest incomplete layer, then perform UI-R11 last.
+- **NEVER accept a component or command that works alone but breaks the skeleton or another required surface.**
+  Fix: repair the unit or the approved skeleton and recheck the complete outcome.
+- **NEVER use visual polish, matching labels, a familiar design-system component, or a present artifact as
+  proof of operable, accessible, safe behavior.** Fix: inspect behavior and direct-user evidence against the
+  failure oracle.
+- **NEVER apply a prototype finding only to the mockup.** Fix: revise the specification first, update the
+  prototype second, and retest affected evidence.
+- **NEVER let a child convention waive this parent or resolve co-loaded UI and UX by precedence.** Fix: preserve
+  the invariant, or surface the concrete conflict for an evidence-led user decision.
+
+---
+
+## Procedure
+
+Run nine phases in order. Read [`ideation.md`](ideation.md) before the first user discussion. Use the active
+project's own feature-document and workflow locations. The skill defines the design contract, not where a
+project stores it.
+
+### P1 — Bind the outcome, surfaces, authority, and evidence conditions
+
+Write one sentence naming the actor's observable interface outcome. Expand it into the primary actor,
+supporting actors, trigger, context, entry, completion and false-completion evidence, normal and alternative
+paths, applicable states, failures, feedback, recovery, support, handoffs, adaptation, scope, and explicit
+non-goals. Decide which surfaces the run needs under UI-R2. Identify who can lock product intent and who is
+representative enough to supply test evidence. Inventory user access, consent, accommodations, prior evidence,
+platform dependencies, and constraints. Return `NEEDS_CONTEXT` on a UI-R4 gate failure.
+
+**Evidence:** user-locked outcome and surface contract, actor/context map, evidence conditions, and adjacent-
+outcome list.
+
+### P2 — Establish references, governing systems, and project identity
+
+Read the identity authority chain in UI-R5. Inspect the live interface, governing product and design-system
+material, platform conventions, tokens, content, support evidence, and applicable standards. Research external
+prior art for the outcome and each selected surface. Distinguish transferable abstract obligations from
+surface-specific mechanics. If identity is incomplete, elicit and confirm a temporary brief covering product
+promise, users, values, voice, character, recognizable patterns, constraints, anti-patterns, and permissible
+expression. Record known conflicts and evidence limits.
+
+At the **foundation and identity gate**, present the sources, governing systems, brief, surface assumptions,
+risks, conflicts, and recommended foundation. The user explicitly approves or reopens it.
+
+**Evidence:** approved reference and identity register, platform-system map, temporary brief when needed,
+conflict register, and explicit user decision.
+
+### P3 — Create the top-down surface-neutral interface skeleton
+
+Map the outcome before designing local detail. Define hierarchy, regions or stages, navigation or command
+structure, action priority, information flow, system status, state relationships, decision points, failure
+zones, recovery routes, handoffs, adaptation, and completion evidence without assuming a graphical layout.
+Then map how each selected surface realizes the skeleton without choosing detailed mechanics too early. Prove
+that all surfaces still serve one outcome and share the same skeleton.
+
+At the **skeleton gate**, show the whole hierarchy and state map, surface mappings, scope boundary, and open
+questions. The user explicitly approves it or reopens the foundation.
+
+**Evidence:** approved interface skeleton with state, path, surface, and uncertainty annotations.
+
+### P4 — Grow the core unit and shortest complete path bottom-up
+
+Choose the smallest meaningful interface unit that advances the outcome: a component, control, command,
+prompt, output, feedback message, or state. Specify its purpose, preconditions, input, output, affordance,
+content, feedback, states, errors, recovery, accessibility, modality equivalence, adaptation, and evidence.
+Connect it to the next unit. Grow the shortest complete core path and continuously reconcile it with the
+skeleton and every selected surface.
+
+At the **core unit and path gate**, demonstrate the unit and complete path in the skeleton, including one
+applicable failure and recovery route and each surface's distinct realization. State the failure oracle.
+
+**Evidence:** approved unit records, surface mappings, and one complete core path.
+
+### P5 — Grow the accumulated complete interface specification
+
+Extend the core path one meaningful unit at a time until every applicable normal, alternative, empty, loading,
+progress, success, boundary, failure, interruption, timeout, partial, recovery, support, adaptation, and
+completion state is specified. Add complete content, feedback, focus or cursor movement, announcement or
+reading order, commands and shortcuts, destructive-action handling, permissions, responsive or environmental
+adaptation, locale, and modality equivalence as applicable. Reconcile each increment with the skeleton, earlier
+units, and every selected surface. Do not begin the detailed aesthetics pass.
+
+At the **accumulated-specification gate**, present the complete unit, path, state, content, feedback, recovery,
+adaptation, and accessibility inventory plus the gap register. An applicable unresolved requirement prevents
+the final gate.
+
+**Evidence:** accumulated specification, bidirectional trace, cross-surface matrix, and resolved-or-open gap
+register.
+
+### P6 — Compare concepts, finish aesthetics, and approve the whole specification
+
+Create at least two materially different interface concepts that satisfy the accumulated obligations. Compare
+their hierarchy, action model, information flow, interaction strategy, state communication, accessibility,
+adaptation, recovery, trust, identity fit, implementation implications, and evidence. Recommend one and state
+what evidence would change the recommendation. If UI-R9's exception applies, record it instead of presenting a
+cosmetic second concept.
+
+Integrate the user-locked concept. Only now perform the detailed aesthetics pass in UI-R11 for each selected
+surface. Resolve contradictions and recheck the outcome, skeleton, units, paths, states, content, feedback,
+failure, recovery, adaptation, accessibility, modality equivalence, aesthetics, decisions, deviations, and
+non-goals. At the **final whole-specification gate**, show the complete feature design document and obtain
+explicit approval. No prototype may exist before this gate passes.
+
+**Evidence:** material concept comparison or valid exception, aesthetic system, rejected options, decision
+trace, complete whole specification, and explicit approval.
+
+### P7 — Create a disposable prototype after whole-specification approval
+
+Name the remaining uncertainties and test questions. Select the lowest fidelity that can answer them. Trace
+the prototype to the approved specification, represent every path and state the questions need, and mark
+simulated data or behavior. For a multi-surface run, create separately testable surface variants while keeping
+their shared skeleton explicit. Do not turn the artifact into production implementation.
+
+**Evidence:** post-approval prototype plan, fidelity rationale, specification trace, simulated-behavior marks,
+and separately testable artifacts per surface.
+
+### P8 — Test directly, revise the specification first, and retest
+
+Test the prototype with representative users under UI-R3 and UI-R4. Observe perception, comprehension,
+operation, completion, alternatives, errors, recovery, feedback, status recognition, trust, accessibility,
+adaptation, workarounds, and unintended harm as applicable. Test each surface separately enough to support its
+claims. Separate observation from interpretation and bound claims to the evidence.
+
+For every supported finding, revise the owning specification clause first. Revise the prototype second. Retest
+affected assumptions and regressions. At the **post-test revision gate**, present the evidence, ordered changes,
+remaining limits, and recommendation. Acceptance requires this gate and every applicable evidence obligation
+to pass.
+
+**Evidence:** direct-test record, findings, specification-first revision trace, updated prototype, per-surface
+and regression evidence, and explicit user decision.
+
+### P9 — Hand off the interface contract
+
+Publish the approved feature design document, prototype status, evidence limits, decision and deviation log,
+implementation questions, child-skill boundaries, no-silent-change contract, and reopen conditions. Map each
+surface-specific mechanic to its future owner without treating one platform's convention as universal. If UX
+is co-loaded, show that the UI handoff preserves its outcome, content, state, recovery, accessibility, evidence,
+and risk contract.
+
+A run is complete only when the whole specification is coherent, direct prototype evidence supports its
+claims, every required user gate is explicit, and a cold reader can realize the interface without hidden
+session context or waived parent obligations.
+
+**Evidence:** handed-off document, trace and owner maps, cold-reader result, prototype/test status, and reopen
+conditions.
+
+### Feature design document schema
+
+The skill defines the schema, not a universal filesystem path. The active project or workflow owns the actual
+document location.
+
+1. **Project Identity and References**
+2. **Outcome, Users, Context, Surface Scope, Non-Goals**
+3. **Evidence and Governing Design/Platform Systems**
+4. **Top-Down Interface Skeleton**
+5. **Bottom-Up Components, Commands, Interactions, States**
+6. **Content, Feedback, Failure, Recovery, Adaptation**
+7. **Accessibility and Modality Equivalence**
+8. **Aesthetic System and Identity Fit**
+9. **Concepts, Decisions, Complete Specification, Deviations**
+10. **Prototype, Direct-User Test Evidence, Revisions, Handoff**
+
+### Cross-surface boundary example
+
+For a login/authentication run, the outcome is “an eligible returning user securely reaches the intended
+authenticated destination and can understand and recover from any failure on that attempt.” A graphical
+surface may realize the skeleton through a form, labeled controls, focus order, inline and summary errors,
+progress, and a signed-in destination. A command-line realization may use `tool auth login`, flags or prompts,
+clear stdout/stderr and exit-status behavior, an external authorization handoff, cancellation, timeout,
+recovery guidance, and a verified authenticated terminal state. They share abstract obligations for action,
+status, error, recovery, accessibility, and completion, but their exact mechanics belong to different future
+surface children and need separate prototypes and evidence. Registration, password reset, account
+administration, and onboarding are adjacent outcomes and remain out of scope unless the user changes the
+contract.
+
+---
+
+## References
+
+- [ISO 9241-210: Human-centred design for interactive systems](https://www.iso.org/standard/77520.html)
+  validates iterative human-centred work grounded in users, tasks, and environments.
+- [ISO 9241-11: Usability definitions and concepts](https://www.iso.org/standard/63500.html) validates the
+  outcome-and-context framing for effectiveness, efficiency, and satisfaction.
+- [GOV.UK Government Design Principles](https://www.gov.uk/guidance/government-design-principles) validates
+  starting with user needs, iterating, and making services understandable and inclusive.
+- [U.S. Web Design System Design Principles](https://designsystem.digital.gov/design-principles/) validates
+  accessible, user-centred, consistent interface decisions within a governing system.
+- [W3C Web Content Accessibility Guidelines 2.2](https://www.w3.org/TR/WCAG22/) validates testable web
+  accessibility outcomes. It is web-specific and is not a universal substitute for a future surface child.
+- [WAI-ARIA Authoring Practices: Developing a Keyboard Interface](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/)
+  validates keyboard interaction and focus design for applicable web widgets. It is surface-specific.
+- [W3C WAI: Involving Users in Evaluating Web Accessibility](https://www.w3.org/WAI/test-evaluate/involving-users/)
+  validates direct involvement of people with disabilities alongside standards and expert evaluation.
+- [Apple Human Interface Guidelines: Design principles](https://developer.apple.com/design/human-interface-guidelines/design-principles),
+  [Microsoft Windows design guidance](https://learn.microsoft.com/en-us/windows/apps/design/guidelines-overview),
+  and [Android accessibility design guidance](https://developer.android.com/design/ui/mobile/guides/foundations/accessibility)
+  validate platform-aware interface design. Each is a platform reference, not a universal parent policy or a
+  substitute for future child skills.
+- [GNU Coding Standards: Command-Line Interfaces](https://www.gnu.org/prep/standards/standards.html) and
+  [POSIX Utility Syntax Guidelines](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html)
+  validate conventions for applicable command-line realizations. They do not define all CLI experience or
+  future surface mechanics.
+- [`ideation.md`](ideation.md) owns the complete user-decision procedure used by P1–P9.
+- [`scenarios.md`](scenarios.md) exercises this parent contract without adding policy.
+- [`checklists.md`](checklists.md) provides the unchecked operational evidence gates for this parent contract.
+- [`evaluation.md`](evaluation.md) extends active Gobbi evaluation with UI-specific selection and lenses.

--- a/.gobbi/projects/gobbi/skills/ui/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/ui/SKILL.md
@@ -299,12 +299,25 @@ surface-specific mechanic to its future owner without treating one platform's co
 is co-loaded, show that the UI handoff preserves its outcome, content, state, recovery, accessibility, evidence,
 and risk contract.
 
-A run is complete only when the whole specification is coherent, direct prototype evidence supports its
-claims, every required user gate is explicit, and a cold reader can realize the interface without hidden
-session context or waived parent obligations.
+Every applicable gate and required item must be `PASS` for acceptance, with one bounded exception: exactly one
+valid authorized waiver may substitute for `PASS` on at most one non-protected operational gate. The waiver is
+an acceptance exception, not `PASS`. The named authority's mandate must cover that item's stated consequence
+and stop action, and the authorization evidence and rationale must be recorded.
 
-**Evidence:** handed-off document, trace and owner maps, cold-reader result, prototype/test status, and reopen
-conditions.
+Accessibility and safety in every applicable item are protected and non-waivable. Current direct
+representative-user prototype testing through `UI-CHECK-13` is protected and non-waivable. Complete
+whole-specification approval before every prototype, including document closure and chronology through
+`UI-CHECK-11`, is protected and non-waivable. A waiver token on a protected item is invalid and closes neither
+coverage nor acceptance. `FAIL` or `recorded-open` on any applicable item closes coverage only, never
+acceptance. A child convention, platform authority, co-loaded contract, precedence rule, or load order cannot
+authorize or widen the bounded exception.
+
+A run is complete only when the whole specification is coherent, direct prototype evidence supports its
+claims, every required user gate is explicit, a cold reader can realize the interface without hidden session
+context, and every applicable item satisfies this acceptance rule.
+
+**Evidence:** handed-off document, trace and owner maps, cold-reader result, prototype/test status, any bounded
+waiver's authority/evidence/rationale record, and reopen conditions.
 
 ### Feature design document schema
 

--- a/.gobbi/projects/gobbi/skills/ui/checklists.md
+++ b/.gobbi/projects/gobbi/skills/ui/checklists.md
@@ -1,0 +1,259 @@
+# UI Design — Operational Checklist
+
+Unchecked source for running and evaluating one complete UI outcome. Each run works a fresh filled copy,
+identifies this source and the run, and declares the actual use style at each pause point. Never mark this
+source. Mode: **operational**. Default use style is **read-do** at pause points A–D and **do-confirm** at pause
+point E.
+
+Coverage closure means every applicable gate and required item has a terminal resolution. Acceptance is a
+separate result: every applicable gate and required item must be `PASS`. The one operational waiver permitted
+by the checklist state machine may substitute for `PASS` on one item only when named authority covers that
+item's consequence and stop action and the authorization evidence and rationale are recorded. It never counts
+as `PASS`. Accessibility, safety, direct representative-user testing, and the whole-specification-before-
+prototype order cannot be waived. A failed, recorded-open, or waived item can close coverage without accepting
+the UI design.
+
+## Resolution legend
+
+- `PASS` — the pass condition was verified from the named, inspected evidence.
+- `FAIL:<finding-id>` — the pass condition was verified false and the finding or action is cited.
+- `n/a:<property>` — inspected evidence proves the applicability predicate false.
+- `recorded-open:<owner+resolution-method>` — operational coverage is closed but acceptance is not granted.
+- `waived/exception-authorized:<authority+rationale>` — allowed only within the bounded operational rule above;
+  it never counts as `PASS`.
+
+## Pause point A — Before the skeleton: outcome, surfaces, evidence, identity
+
+- [ ] **UI-CHECK-01 [GATE, read-do] — One complete observable interface outcome is bound.**
+  - Applicability: unconditional.
+  - Pass: one user-locked contract names the trigger/context, primary actor, supporting actors, observable and
+    false completion, entry, normal and alternative paths, applicable states, errors, feedback, recovery,
+    handoffs, support, adaptation, scope, and explicit non-goals; independent adjacent outcomes are excluded.
+  - Evidence: outcome contract, path/state inventory, and adjacent-outcome list.
+  - On fail: halt before the skeleton and return to P1; otherwise every later artifact may solve an incomplete
+    or expanded outcome.
+  - Source: `SKILL.md` UI-R1, P1; `UI-SCENARIO-01`–`03`.
+- [ ] **UI-CHECK-02 [GATE, read-do] — Surface scope satisfies the shared-and-separate rule.**
+  - Applicability: every run; a single-surface run proves one surface and records the others out.
+  - Pass: every included surface realizes the same outcome and shared interface skeleton, while mechanics,
+    accessibility or modality equivalence, prototype coverage, and evidence are separately specifiable and
+    testable; any surface that fails either half is split into another run.
+  - Evidence: user-locked surface contract, shared skeleton map, per-surface matrix, and split decisions.
+  - On fail: stop the combined run and return to P1/P3; otherwise one surface's design or evidence can conceal
+    another's incompatible outcome or missing proof.
+  - Source: `SKILL.md` UI-R2, P1/P3; `UI-SCENARIO-02`, `14`, `15`.
+- [ ] **UI-CHECK-03 [GATE, read-do] — Representative-user access and ethical test conditions are supportable.**
+  - Applicability: unconditional for a final UI claim.
+  - Pass: representative access, informed consent, required accommodations, data minimization and protection,
+    method, sample logic, and claim boundary are evidenced from the question, diversity, uncertainty, impact,
+    and risk; no stakeholder status or fixed participant count substitutes; missing conditions produce
+    `NEEDS_CONTEXT` and no accepted design.
+  - Evidence: actor/context map, recruitment rationale, consent/accommodation record, data plan, and evidence-
+    conditions register.
+  - On fail: halt acceptance and return to P1/P8 or `NEEDS_CONTEXT`; otherwise unsupported or unethically
+    collected evidence can be treated as user proof.
+  - Source: `SKILL.md` UI-R3, UI-R4, P1/P8; `UI-SCENARIO-04`–`06`, `21`.
+- [ ] **UI-CHECK-04 [REQUIRED, read-do] — Project identity follows the evidence authority chain.**
+  - Applicability: unconditional.
+  - Pass: identity traces in order to explicit `DESIGN.md`/brand/product/design-system material, then live
+    product/system/tokens, then a user-confirmed temporary run brief; missing material triggered identity
+    questions and feature-document capture rather than an invented or universal project-wide `DESIGN.md`.
+  - Evidence: identity/reference register, inspected live sources, decision record, and run-scoped brief where
+    needed.
+  - On fail: return to P2 before skeleton approval and repair the authority chain.
+  - Source: `SKILL.md` UI-R5, P2; `UI-SCENARIO-19`, `20`, `28`.
+
+## Pause point B — Before accumulated growth: skeleton and core unit/path
+
+- [ ] **UI-CHECK-05 [GATE, read-do] — The top-down surface-neutral skeleton is complete and approved.**
+  - Applicability: unconditional.
+  - Pass: an explicit pre-unit artifact defines hierarchy, regions or stages, navigation or command structure,
+    action priority, information flow, system status, state relationships, failures, recovery, handoffs,
+    adaptation, completion, and surface mappings without assuming a GUI; G2 approval is recorded.
+  - Evidence: versioned skeleton, state/path map, surface mapping, open-question register, and explicit G2
+    decision.
+  - On fail: halt bottom-up growth and return to P3; otherwise local units have no approved whole to preserve.
+  - Source: `SKILL.md` UI-R6, UI-R7, P3; `UI-SCENARIO-07`, `09`.
+- [ ] **UI-CHECK-06 [GATE, read-do] — The smallest meaningful unit grows one complete core path without breaking the skeleton.**
+  - Applicability: unconditional.
+  - Pass: the core component/control/command/prompt/output/feedback/state names purpose, preconditions, input,
+    output, affordance, content, feedback, states, error, recovery, access, adaptation, and surface realization;
+    its shortest complete path, failure oracle, and G3 approval are evidenced and fit the skeleton.
+  - Evidence: unit record, unit-to-skeleton trace, core path, per-surface realization, failure injection, and G3
+    decision.
+  - On fail: stop accumulated growth and return to P3/P4; otherwise an isolated success can create whole-path
+    or cross-surface failure.
+  - Source: `SKILL.md` UI-R6, UI-R7, P4; `UI-SCENARIO-02`, `07`, `09`.
+
+## Pause point C — Before final whole-specification approval: complete behavior, concepts, access, aesthetics
+
+- [ ] **UI-CHECK-07 [GATE, read-do] — The accumulated specification covers all applicable interactions and states in order.**
+  - Applicability: unconditional.
+  - Pass: dated/versioned evidence shows foundation then skeleton then core then bottom-up growth; every
+    applicable normal, alternative, empty, loading, progress, boundary, failure, interruption, partial,
+    recovery, support, adaptation, success, and completion state has content, feedback, allowed actions,
+    transition, and surface trace; G4 approval is explicit.
+  - Evidence: artifact chronology, complete unit/path/state matrix, cross-surface trace, gap register, and G4
+    decision.
+  - On fail: halt finalization and return to the earliest incomplete P2–P5 layer; otherwise hidden states or
+    reordered construction can survive into polish.
+  - Source: `SKILL.md` UI-R1, UI-R6, UI-R7, P2–P5; `UI-SCENARIO-03`, `07`, `08`, `10`, `17`.
+- [ ] **UI-CHECK-08 [REQUIRED, read-do] — Concepts are materially different or the one-concept exception is proved.**
+  - Applicability: unconditional before selecting the final direction.
+  - Pass: at least two concepts differ in hierarchy, action model, information flow, interaction strategy, state
+    communication, or another consequential property and are compared against the same obligations; otherwise
+    real constraints plus direct evidence prove and record the one-concept exception. Cosmetic variants do not
+    count.
+  - Evidence: concept diff, obligation comparison, recommendation with evidence-to-change, user decision, or
+    recorded exception with constraints and direct evidence.
+  - On fail: return to P6 and create material alternatives or prove the exception.
+  - Source: `SKILL.md` UI-R8, UI-R9, P6; `UI-SCENARIO-31`.
+- [ ] **UI-CHECK-09 [REQUIRED, read-do] — Detailed aesthetics occur last and improve the completed contract.**
+  - Applicability: every applicable aesthetic dimension; a non-visual surface still addresses character
+    rendering, density, rhythm, symbols, tone, and feedback expression where relevant.
+  - Pass: artifact chronology places the detailed typography/character, color, density, spacing, rhythm, shape,
+    imagery/iconography/symbol, motion/transition, tone, and expressive pass after complete structure,
+    behavior, content, feedback, recovery, adaptation, and accessibility; each choice improves hierarchy, state
+    recognition, affordance, trust, or identity fit without hiding a defect.
+  - Evidence: chronology, aesthetics-to-obligation map, identity trace, and before/after behavioral review.
+  - On fail: remove premature polish from approval and return to the earliest incomplete structural or
+    behavioral layer, then redo the aesthetics pass.
+  - Source: `SKILL.md` UI-R5, UI-R11, P5–P6; `UI-SCENARIO-18`–`20`, `23`, `24`.
+- [ ] **UI-CHECK-10 [GATE, read-do] — Required actions, states, and meaning are accessible across applicable modalities.**
+  - Applicability: unconditional; exact modality set is surface/context-specific.
+  - Pass: direct behavior and the specification prove applicable perception, operation, focus/cursor flow,
+    reading/announcement order, alternative input, status, error identification, recovery, timing, motion,
+    contrast or non-color meaning, language/locale, and adaptation; identity or child convention does not waive
+    accessibility or safety.
+  - Evidence: modality matrix, behavioral task results, state comparison, direct-user evidence plan/results,
+    and conflict decisions.
+  - On fail: halt final approval or acceptance and return to P4–P6/P8; otherwise people can be excluded or
+    misled despite cosmetic compliance.
+  - Source: `SKILL.md` UI-R11, UI-R12, P4–P8; `UI-SCENARIO-16`, `18`–`24`, `26`.
+- [ ] **UI-CHECK-19 [GATE, read-do] — The user-decision tree is adaptively complete and every gate is explicit.**
+  - Applicability: unconditional; a D-node may smart-skip only under its evidence predicate.
+  - Pass: each D0–D16 axis has one explicit user decision or a recorded smart-skip with both current evidence
+    and a prior user lock; design-bearing axes show research, two meaningful options when applicable, one
+    recommendation, evidence-to-change, and the user's lock; project-specific follow-ups are recorded; G1–G6
+    each has an explicit decision and none is inferred from silence or continued work.
+  - Evidence: question/decision history, D-node coverage audit, smart-skip evidence/lock pairs, recommendation
+    records, follow-ups, and explicit G1–G6 decisions.
+  - On fail: halt at the earliest undecided axis or gate and return to `ideation.md`; otherwise construction,
+    prototyping, acceptance, or handoff can proceed without user authority.
+  - Source: `SKILL.md` UI-R7, UI-R8, P1–P9; `UI-SCENARIO-30`, `32`.
+
+## Pause point D — Before any prototype and before direct testing
+
+- [ ] **UI-CHECK-11 [GATE, read-do] — The whole UI specification is complete and explicitly approved before every prototype.**
+  - Applicability: unconditional before prototype creation.
+  - Pass: all ten feature-document sections contain resolved, traceable content; outcome, skeleton, units,
+    paths, states, content, feedback, recovery, adaptation, access, concept decision, aesthetics, deviations,
+    evidence limits, and non-goals agree; G5 approval is explicit; repository/artifact history proves no mockup,
+    wireframe, coded demo, command stub, or other prototype predates it.
+  - Evidence: complete feature design document, gap/contradiction audit, explicit G5 decision, and dated/versioned
+    artifact history.
+  - On fail: stop and remove prototype status from the run, return to the earliest incomplete specification
+    layer, and re-establish chronology; otherwise premature artifacts anchor and conceal missing obligations.
+  - Source: `SKILL.md` UI-R6, UI-R7, UI-R10, UI-R13, P6; `UI-SCENARIO-10`, `11`.
+- [ ] **UI-CHECK-12 [REQUIRED, read-do] — The post-approval prototype is disposable, uncertainty-sized, and separately testable by surface.**
+  - Applicability: every prototype; per-surface clauses apply to multi-surface runs.
+  - Pass: the artifact follows G5, traces to the approved specification, represents only paths/states needed by
+    named questions, marks simulated behavior/data, uses the lowest sufficient fidelity, remains outside
+    production, and supplies separately testable variants for each included surface.
+  - Evidence: prototype plan, creation history, fidelity/question rationale, spec trace, simulation marks,
+    per-surface artifacts, and production-boundary statement.
+  - On fail: return to P7 and resize, separate, or clearly mark the artifact before direct testing.
+  - Source: `SKILL.md` UI-R2, UI-R13, P7; `UI-SCENARIO-10`, `11`, `13`–`15`.
+
+## Pause point E — Before acceptance and handoff: direct evidence, revision, recovery, compatibility, trace
+
+- [ ] **UI-CHECK-13 [GATE, do-confirm] — This run has direct representative-user prototype evidence for every claimed surface.**
+  - Applicability: unconditional for final acceptance.
+  - Pass: under UI-CHECK-03 conditions, representative users directly used each claimed surface's post-G5
+    prototype; observations cover perception, comprehension, operation, completion, alternatives, errors,
+    recovery, status, trust, accessibility, adaptation, workarounds, and harm as applicable; claims remain
+    bounded; prior UX/UI evidence, standards, experts, and stakeholders are context only.
+  - Evidence: dated prototype/test record, participant-context rationale, consent/accommodations, per-surface
+    tasks and observations, interpretations, limits, and claim trace.
+  - On fail: block acceptance and return `NEEDS_CONTEXT` or rerun P8; otherwise human-outcome claims have no
+    current direct evidence.
+  - Source: `SKILL.md` UI-R3, UI-R4, P8; `UI-SCENARIO-04`–`06`, `14`, `21`, `22`, `24`, `29`.
+- [ ] **UI-CHECK-14 [GATE, do-confirm] — Supported findings revise specification first, prototype second, then affected evidence.**
+  - Applicability: every supported direct-test finding.
+  - Pass: each finding first changes its owning specification clause, then the prototype is brought into
+    agreement, then every affected assumption, surface, path, and regression is directly retested; G6 records
+    an explicit decision.
+  - Evidence: ordered finding → specification revision → prototype revision → retest → G6 decision trace.
+  - On fail: block acceptance and return to P8; otherwise the durable handoff remains wrong even when the
+    mockup appears fixed.
+  - Source: `SKILL.md` UI-R7, UI-R14, P8; `UI-SCENARIO-12`, `30`.
+- [ ] **UI-CHECK-15 [REQUIRED, do-confirm] — Handoff preserves parent obligations while assigning exact mechanics to children.**
+  - Applicability: unconditional at handoff; child diff applies when a future specialization exists.
+  - Pass: the handoff carries the full UI-R15 contract, assigns exact platform mechanics/standards/examples to
+    future children, and a parent/child clause diff shows no waived outcome, order, recovery, access, evidence,
+    aesthetics, testing, or revision obligation.
+  - Evidence: cold-reader handoff, owner map, parent/child crosswalk or future-owner placeholders, deviation
+    log, and reopen conditions.
+  - On fail: return to P9 and repair the handoff or route a material deviation to the user.
+  - Source: `SKILL.md` UI-R15, P9; `UI-SCENARIO-25`, `26`.
+- [ ] **UI-CHECK-16 [GATE, do-confirm] — Co-loaded UI/UX conflict is an evidence-led user decision, never precedence.**
+  - Applicability: a co-loaded UX clause or another parent contract materially conflicts with the UI direction.
+  - Pass: exact clauses, evidence, trade-offs, and affected traces are presented to the user; the explicit
+    resolution propagates through the specification/prototype/handoff; no precedence or load-order rule is
+    invented; accessibility and safety remain intact.
+  - Evidence: conflict record, cited clauses and evidence, user decision, updated traces, and regression check.
+  - On fail: stop the conflicting change and reopen its owning gate; otherwise one independently valid parent
+    can silently erase the other.
+  - Source: `SKILL.md` UI-R16, P9; `UI-SCENARIO-27`.
+- [ ] **UI-CHECK-17 [GATE, do-confirm] — Failure, feedback, recovery, and completion are behaviorally truthful.**
+  - Applicability: every applicable failure, pending, timeout, interruption, partial, or completion state.
+  - Pass: injected cases on each surface expose one truthful state, surface-appropriate feedback, safe allowed
+    actions, containment, retry/cancel/support/recovery, late-result handling where needed, and no false success;
+    visual labels or component presence alone cannot pass.
+  - Evidence: state table, injected before/at/after transitions, direct modality behavior, system-state
+    comparison, and recovery-to-completion trace.
+  - On fail: block acceptance and return to P3–P5/P8; otherwise users may be stranded, misled, or cause duplicate
+    effects.
+  - Source: `SKILL.md` UI-R1, UI-R6, UI-R11, UI-R12; `UI-SCENARIO-01`, `08`, `16`–`18`, `24`.
+- [ ] **UI-CHECK-18 [REQUIRED, do-confirm] — The complete evidence and decision trace is bidirectional and cold-readable.**
+  - Applicability: unconditional at handoff.
+  - Pass: every load-bearing parent rule resolves to scenarios, checks, feature-document clauses, evidence, and
+    decisions; each delivered clause resolves back to its source and owner; identity fallback, concept
+    decision, G1–G6 approvals, prototype chronology, test evidence, revisions, deviations, and reopen conditions
+    require no hidden session context.
+  - Evidence: two-way orphan sweep, cold-reader result, chronology, decision/evidence register, and complete
+    feature-document schema audit.
+  - On fail: return to the owning P-step and repair the missing parent policy, artifact, or trace before handoff.
+  - Source: `SKILL.md` UI-R1–UI-R16, P1–P9; `UI-SCENARIO-10`, `12`, `25`, `28`–`30`.
+
+## Guaranteed coverage map
+
+| Check | Scenario source |
+|---|---|
+| `UI-CHECK-01` | `UI-SCENARIO-01`–`03` |
+| `UI-CHECK-02` | `UI-SCENARIO-02`, `14`, `15` |
+| `UI-CHECK-03` | `UI-SCENARIO-04`–`06`, `21` |
+| `UI-CHECK-04` | `UI-SCENARIO-19`, `20`, `28` |
+| `UI-CHECK-05` | `UI-SCENARIO-07`, `09` |
+| `UI-CHECK-06` | `UI-SCENARIO-02`, `07`, `09` |
+| `UI-CHECK-07` | `UI-SCENARIO-03`, `07`, `08`, `10`, `17` |
+| `UI-CHECK-08` | `UI-SCENARIO-31` |
+| `UI-CHECK-09` | `UI-SCENARIO-18`–`20`, `23`, `24` |
+| `UI-CHECK-10` | `UI-SCENARIO-16`, `18`–`24`, `26` |
+| `UI-CHECK-11` | `UI-SCENARIO-10`, `11` |
+| `UI-CHECK-12` | `UI-SCENARIO-10`, `11`, `13`–`15` |
+| `UI-CHECK-13` | `UI-SCENARIO-04`–`06`, `14`, `21`, `22`, `24`, `29` |
+| `UI-CHECK-14` | `UI-SCENARIO-12`, `30` |
+| `UI-CHECK-15` | `UI-SCENARIO-25`, `26` |
+| `UI-CHECK-16` | `UI-SCENARIO-27` |
+| `UI-CHECK-17` | `UI-SCENARIO-01`, `08`, `16`–`18`, `24` |
+| `UI-CHECK-18` | `UI-SCENARIO-10`, `12`, `25`, `28`–`32` |
+| `UI-CHECK-19` | `UI-SCENARIO-30`, `32` |
+
+## Filled-copy close
+
+In a run-specific copy, inspect the named evidence before resolving each row. Record coverage closure and
+acceptance separately. Acceptance requires `PASS` on every applicable gate and required item. Pilot the source
+against a passing complete run, a single-surface `n/a` disposition, the timeout/recovery boundary, the
+big-bang/premature-prototype/cosmetic-access adversarial cases, and a failed direct-evidence gate. A label,
+heading, component name, visual match, or present-but-empty artifact must never earn `PASS`.

--- a/.gobbi/projects/gobbi/skills/ui/checklists.md
+++ b/.gobbi/projects/gobbi/skills/ui/checklists.md
@@ -8,13 +8,19 @@ run identity identifies the execution, not the source revision. The filled copy 
 style at each pause point. Mode: **operational**. Default use style is **read-do** at pause points A–D and
 **do-confirm** at pause point E.
 
-Coverage closure means every applicable gate and required item has a terminal resolution. Acceptance is a
-separate result: every applicable gate and required item must be `PASS`. The one operational waiver permitted
-by the checklist state machine may substitute for `PASS` on one item only when named authority covers that
-item's consequence and stop action and the authorization evidence and rationale are recorded. It never counts
-as `PASS`. Accessibility, safety, direct representative-user testing, and the whole-specification-before-
-prototype order cannot be waived. A failed, recorded-open, or waived item can close coverage without accepting
-the UI design.
+Coverage closure means every applicable gate and required item has a valid terminal resolution. Acceptance is a
+separate result: every applicable gate and required item must be `PASS`, except that the checklist owner's
+bounded operational waiver may substitute on at most one **non-protected operational gate** when named authority
+covers that item's consequence and stop action and the authorization evidence and rationale are recorded. A
+valid waiver is an acceptance exception and never counts as `PASS`.
+
+Four protected mandatory classes are explicitly non-waivable: (1) accessibility in any applicable item's claim
+or pass condition; (2) safety in any applicable item's claim or pass condition; (3) current direct
+representative-user prototype testing (`UI-CHECK-13`); and (4) complete whole-specification approval before
+every prototype, including both document closure and chronology (`UI-CHECK-11`). A waiver token on a protected
+item is invalid: it closes neither coverage nor acceptance. Resolve that item with a permitted terminal;
+`FAIL` or `recorded-open` can close coverage but cannot accept the run. A failed or recorded-open non-protected
+item likewise closes coverage without acceptance.
 
 ## Resolution legend
 
@@ -22,8 +28,24 @@ the UI design.
 - `FAIL:<finding-id>` — the pass condition was verified false and the finding or action is cited.
 - `n/a:<property>` — inspected evidence proves the applicability predicate false.
 - `recorded-open:<owner+resolution-method>` — operational coverage is closed but acceptance is not granted.
-- `waived/exception-authorized:<authority+rationale>` — allowed only within the bounded operational rule above;
-  it never counts as `PASS`.
+- `waived/exception-authorized:<authority+rationale>` — permitted only for one non-protected operational gate
+  when the named authority covers its stated consequence and stop action and evidence plus rationale are
+  recorded; it does not count as `PASS`. It is invalid for accessibility, safety, `UI-CHECK-13`, or
+  `UI-CHECK-11` document closure or chronology.
+
+## Protected-waiver acceptance truth table
+
+Each adversarial row holds every other applicable gate and required item at `PASS`. Coverage closure and
+acceptance are evaluated separately.
+
+| Protected class or control | Attempted item resolution | All other applicable items | Coverage closed? | Accepted? |
+|---|---|---|---|---|
+| Accessibility in any applicable item | `waived/exception-authorized:<authority+rationale>` | `PASS` | No — invalid token | No |
+| Safety in any applicable item | `waived/exception-authorized:<authority+rationale>` | `PASS` | No — invalid token | No |
+| Current direct representative-user prototype testing (`UI-CHECK-13`) | `waived/exception-authorized:<authority+rationale>` | `PASS` | No — invalid token | No |
+| Whole-specification-before-prototype document closure or chronology (`UI-CHECK-11`) | `waived/exception-authorized:<authority+rationale>` | `PASS` | No — invalid token | No |
+| Coverage/acceptance separation control | one applicable protected or non-protected item is `FAIL:<finding-id>` or `recorded-open:<owner+resolution-method>` | `PASS` | Yes | No |
+| Bounded-waiver accepting control | every protected item is `PASS`; non-protected `UI-CHECK-05` has one valid authorized waiver whose named authority covers its halt-and-return-to-P3 consequence and stop action | `PASS` | Yes | Yes, only under the bounded exception |
 
 ## Pause point A — Before the skeleton: outcome, surfaces, evidence, identity
 
@@ -259,7 +281,10 @@ In a run-specific copy, first record the reusable checklist source identity/path
 version/revision, and the distinct run identity. At close, repeat those three values with the result so another
 reader can reconstruct both the rules used and the execution that applied them. Inspect the named evidence
 before resolving each row. Record coverage closure and acceptance separately. Acceptance requires `PASS` on
-every applicable gate and required item. Pilot the source against a passing complete run, a single-surface
-`n/a` disposition, the timeout/recovery boundary, the big-bang/premature-prototype/cosmetic-access adversarial
-cases, and a failed direct-evidence gate. A label, heading, component name, visual match, or present-but-empty
-artifact must never earn `PASS`.
+every applicable gate and required item, except that one valid authorized waiver may substitute on at most one
+non-protected operational gate under the bounded rule above; the waiver remains an exception and never becomes
+`PASS`. A protected waiver is invalid and closes neither result. A `FAIL` or `recorded-open` closes coverage but
+never acceptance, whether its item is protected or non-protected. Pilot the source against all six truth-table
+rows, a passing complete run, a single-surface `n/a` disposition, the timeout/recovery boundary, the big-bang/
+premature-prototype/cosmetic-access adversarial cases, and a failed direct-evidence gate. A label, heading,
+component name, visual match, or present-but-empty artifact must never earn `PASS`.

--- a/.gobbi/projects/gobbi/skills/ui/checklists.md
+++ b/.gobbi/projects/gobbi/skills/ui/checklists.md
@@ -1,9 +1,12 @@
 # UI Design — Operational Checklist
 
-Unchecked source for running and evaluating one complete UI outcome. Each run works a fresh filled copy,
-identifies this source and the run, and declares the actual use style at each pause point. Never mark this
-source. Mode: **operational**. Default use style is **read-do** at pause points A–D and **do-confirm** at pause
-point E.
+Unchecked reusable source for running and evaluating one complete UI outcome. Never mark this source. Each run
+works a fresh filled copy that records three distinct provenance fields: this source's identity/path, its
+immutable source version or revision (for example a commit SHA, release tag, or content hash), and the run
+identity (for example session plus task/evaluation ID). Stable item IDs identify checks, not source bytes; the
+run identity identifies the execution, not the source revision. The filled copy also declares the actual use
+style at each pause point. Mode: **operational**. Default use style is **read-do** at pause points A–D and
+**do-confirm** at pause point E.
 
 Coverage closure means every applicable gate and required item has a terminal resolution. Acceptance is a
 separate result: every applicable gate and required item must be `PASS`. The one operational waiver permitted
@@ -252,8 +255,11 @@ the UI design.
 
 ## Filled-copy close
 
-In a run-specific copy, inspect the named evidence before resolving each row. Record coverage closure and
-acceptance separately. Acceptance requires `PASS` on every applicable gate and required item. Pilot the source
-against a passing complete run, a single-surface `n/a` disposition, the timeout/recovery boundary, the
-big-bang/premature-prototype/cosmetic-access adversarial cases, and a failed direct-evidence gate. A label,
-heading, component name, visual match, or present-but-empty artifact must never earn `PASS`.
+In a run-specific copy, first record the reusable checklist source identity/path, the exact immutable source
+version/revision, and the distinct run identity. At close, repeat those three values with the result so another
+reader can reconstruct both the rules used and the execution that applied them. Inspect the named evidence
+before resolving each row. Record coverage closure and acceptance separately. Acceptance requires `PASS` on
+every applicable gate and required item. Pilot the source against a passing complete run, a single-surface
+`n/a` disposition, the timeout/recovery boundary, the big-bang/premature-prototype/cosmetic-access adversarial
+cases, and a failed direct-evidence gate. A label, heading, component name, visual match, or present-but-empty
+artifact must never earn `PASS`.

--- a/.gobbi/projects/gobbi/skills/ui/checklists.md
+++ b/.gobbi/projects/gobbi/skills/ui/checklists.md
@@ -9,7 +9,7 @@ style at each pause point. Mode: **operational**. Default use style is **read-do
 **do-confirm** at pause point E.
 
 Coverage closure means every applicable gate and required item has a valid terminal resolution. Acceptance is a
-separate result: every applicable gate and required item must be `PASS`, except that the checklist owner's
+separate result: every applicable gate and required item must be `PASS`, except that parent `SKILL.md` P9's
 bounded operational waiver may substitute on at most one **non-protected operational gate** when named authority
 covers that item's consequence and stop action and the authorization evidence and rationale are recorded. A
 valid waiver is an acceptance exception and never counts as `PASS`.
@@ -35,8 +35,8 @@ item likewise closes coverage without acceptance.
 
 ## Protected-waiver acceptance truth table
 
-Each adversarial row holds every other applicable gate and required item at `PASS`. Coverage closure and
-acceptance are evaluated separately.
+This six-row table directly replays parent `SKILL.md` P9. Each adversarial row holds every other applicable
+gate and required item at `PASS`. Coverage closure and acceptance are evaluated separately.
 
 | Protected class or control | Attempted item resolution | All other applicable items | Coverage closed? | Accepted? |
 |---|---|---|---|---|
@@ -282,9 +282,9 @@ version/revision, and the distinct run identity. At close, repeat those three va
 reader can reconstruct both the rules used and the execution that applied them. Inspect the named evidence
 before resolving each row. Record coverage closure and acceptance separately. Acceptance requires `PASS` on
 every applicable gate and required item, except that one valid authorized waiver may substitute on at most one
-non-protected operational gate under the bounded rule above; the waiver remains an exception and never becomes
-`PASS`. A protected waiver is invalid and closes neither result. A `FAIL` or `recorded-open` closes coverage but
-never acceptance, whether its item is protected or non-protected. Pilot the source against all six truth-table
-rows, a passing complete run, a single-surface `n/a` disposition, the timeout/recovery boundary, the big-bang/
-premature-prototype/cosmetic-access adversarial cases, and a failed direct-evidence gate. A label, heading,
-component name, visual match, or present-but-empty artifact must never earn `PASS`.
+non-protected operational gate under parent `SKILL.md` P9's bounded rule above; the waiver remains an exception
+and never becomes `PASS`. A protected waiver is invalid and closes neither result. A `FAIL` or `recorded-open`
+closes coverage but never acceptance, whether its item is protected or non-protected. Pilot the source against
+all six truth-table rows, a passing complete run, a single-surface `n/a` disposition, the timeout/recovery
+boundary, the big-bang/premature-prototype/cosmetic-access adversarial cases, and a failed direct-evidence gate.
+A label, heading, component name, visual match, or present-but-empty artifact must never earn `PASS`.

--- a/.gobbi/projects/gobbi/skills/ui/evaluation.md
+++ b/.gobbi/projects/gobbi/skills/ui/evaluation.md
@@ -1,0 +1,253 @@
+# UI Design — Evaluation Entry
+
+Evaluator entrypoint for grading one complete UI design run. It extends the active Gobbi phase evaluation with
+the UI scenario and checklist sources. It does not replace the active phase's four stages, seven-perspective
+order, finding metadata, scoring, verdict thresholds, output paths, or nine-output contract.
+
+At Stage 0, load and read the complete UI bundle:
+
+1. [`SKILL.md`](SKILL.md) — sole UI policy owner.
+2. [`ideation.md`](ideation.md) — user-decision procedure and gate trace.
+3. [`scenarios.md`](scenarios.md) — coverage frame and fail-able cases.
+4. [`checklists.md`](checklists.md) — unchecked operational evidence source.
+5. This `evaluation.md` entry — selection, UI perspective lenses, verification, and Overall anchors.
+
+Also load the active phase's own `scenario.md`, `checklist.md`, and `evaluation.md` bundle. At Stage 1, reconcile
+its seed frame with the applicable UI cases and copy selected `UI-CHECK-*` items into the active evaluator's
+filled checklist under `## Stage 1 Additions`. Never edit or tick the shipped UI source. Record findings only
+through the active Gobbi schema and destinations.
+
+## Parent-clause crosswalk
+
+| Parent clause | Scenario evidence | Checklist evidence |
+|---|---|---|
+| UI-R1 — one complete observable outcome | `UI-SCENARIO-01`–`03`, `07`, `08`, `16`–`18` | `UI-CHECK-01`, `06`, `07`, `17` |
+| UI-R2 — shared skeleton plus separate surface proof | `UI-SCENARIO-02`, `14`, `15` | `UI-CHECK-02`, `12` |
+| UI-R3 — direct representative-user prototype testing | `UI-SCENARIO-04`–`06`, `13`, `14`, `22`, `24`, `29` | `UI-CHECK-03`, `13` |
+| UI-R4 — ethical evidence conditions / `NEEDS_CONTEXT` | `UI-SCENARIO-04`, `06`, `21` | `UI-CHECK-03`, `13` |
+| UI-R5 — identity authority chain and bounded fallback | `UI-SCENARIO-19`, `20`, `28` | `UI-CHECK-04`, `09` |
+| UI-R6 — exact construction and revision order | `UI-SCENARIO-03`, `07`–`12`, `17`, `30` | `UI-CHECK-05`–`07`, `11`, `14` |
+| UI-R7 — explicit user gates | `UI-SCENARIO-10`–`12`, `30`, `32` | `UI-CHECK-05`–`07`, `11`, `14`, `18`, `19` |
+| UI-R8 — adaptively complete evidence-led discussion | `UI-SCENARIO-19`, `27`, `28`, `30`, `32` | `UI-CHECK-04`, `08`, `16`, `18`, `19` |
+| UI-R9 — material concepts or proved exception | `UI-SCENARIO-31` | `UI-CHECK-08` |
+| UI-R10 — complete feature design document before prototype | `UI-SCENARIO-10`, `11`, `28`, `30` | `UI-CHECK-07`, `11`, `18` |
+| UI-R11 — detailed aesthetics last and substantive | `UI-SCENARIO-18`–`20`, `23`, `24` | `UI-CHECK-09`, `10`, `17` |
+| UI-R12 — accessible modality equivalence and protected floor | `UI-SCENARIO-16`, `18`–`24`, `26` | `UI-CHECK-10`, `17` |
+| UI-R13 — post-approval disposable per-surface prototype | `UI-SCENARIO-10`, `11`, `13`–`15` | `UI-CHECK-11`, `12` |
+| UI-R14 — specification-first revision and retest | `UI-SCENARIO-12`, `30` | `UI-CHECK-14`, `18` |
+| UI-R15 — parent-preserving handoff and child boundary | `UI-SCENARIO-25`, `26` | `UI-CHECK-15`, `18` |
+| UI-R16 — evidence-led UI/UX conflict resolution | `UI-SCENARIO-27` | `UI-CHECK-16`, `18` |
+
+## Selecting scenarios and checks
+
+Run this selection after Stage 0 target understanding and before each Stage 1 perspective frame is frozen.
+
+1. **Confirm target and status.** Extract the one observable outcome, actor/context map, selected surfaces,
+   current UI phase, feature design document, decision/evidence records, prototype status, and acceptance claim.
+   If What, Why, or How is missing, use the active evaluation's Stage 0 gate.
+2. **Activate the invariant core.** Always select `UI-SCENARIO-01`, `03`–`13`, `16`–`24`, and `28`–`32`, plus
+   every `UI-CHECK-*` item except conditional `UI-CHECK-16`. These cases distinguish a substantive run from
+   big-bang polish, missing evidence, premature prototyping, local-unit breakage, aesthetics-first work,
+   cosmetic concepts/access, mockup-only fixes, and hidden trace gaps.
+3. **Activate surface cases.** Select `UI-SCENARIO-02`, `14`, and `15` when multiple surfaces are included, an
+   alternative surface is proposed, or a surface boundary is disputed. Keep `UI-CHECK-02` active even for a
+   single-surface run so inspected scope proves other surfaces are out. Apply `UI-CHECK-12` to each included
+   surface.
+4. **Activate child and co-load cases.** Select `UI-SCENARIO-25`, `26`, and `UI-CHECK-15` when an existing or
+   future child/surface handoff is in the target; otherwise inspect the parent-preserving generic handoff. Select
+   `UI-SCENARIO-27` and `UI-CHECK-16` when UI and UX or another parent materially conflict.
+5. **Disposition non-selected cases with evidence.** Use `n/a:<property>` only when inspected target evidence
+   proves the trigger false. Never omit an inconvenient surface, child, actor, failure, access mode, or conflict.
+6. **Copy exact checks.** Copy activated `UI-CHECK-*` records into the active filled checklist without changing
+   ID, claim, pass condition, evidence, or on-fail route. Resolve them through the active checklist/evaluation
+   state machine.
+7. **Extend only the run copy.** A newly discovered UI scenario or check becomes a `scenario_gap` or
+   `checklist_gap` finding plus a Stage 1 addition in the active run. Evaluators never edit the shipped UI
+   bundle. A missing policy obligation is a parent-policy finding; do not repair it in a companion.
+
+## Perspectives
+
+Apply these UI lenses inside Gobbi's canonical order: Project → Structure → Performance → Aesthetics → Usage →
+Consistency → Risk, then Overall. Each perspective independently inspects the target, selected cases, checks,
+prototype, direct-user evidence, and current repository evidence. A perspective records no UI finding only
+after its lens and all applicable dispositions are evidenced.
+
+### Project
+
+**Lens:** Does the run realize one right, observable interface outcome for the intended users without
+substituting a screen, command, component, prototype, or related product area for the outcome?
+
+**Activate:** `UI-SCENARIO-01`–`06`, `10`, `11`, `13`–`15`, `28`, `29`, `31`, `32`; `UI-CHECK-01`–`04`, `08`, `11`–`13`, `19`.
+
+**Verify:** compare the user-locked outcome, surface contract, scope, non-goals, evidence conditions, feature
+document, prototype questions, and acceptance claim. Check that login recovery remains in while registration,
+password reset, account administration, and onboarding stay out. Confirm multi-surface scope rests on one
+outcome and skeleton rather than a shared product label.
+
+**Anti-patterns:** a page or command called the outcome; breadth called completeness; a project owner called
+representative by title; prior evidence called the current direct test; cosmetic options called concepts.
+
+### Structure
+
+**Lens:** Do foundation, skeleton, bottom-up units, complete interactions/states, concepts, aesthetics, whole
+approval, prototype, revision, and handoff form one dependency-correct and traceable interface contract?
+
+**Activate:** `UI-SCENARIO-02`, `07`–`12`, `14`–`18`, `25`, `26`, `30`; `UI-CHECK-02`, `05`–`07`, `11`, `12`,
+`14`, `15`, `17`, `18`.
+
+**Verify:** reconstruct artifact chronology and both trace directions. Inject one local-unit mismatch, exact
+state transition, failure/recovery break, and cross-surface mismatch. Prove no prototype artifact predates the
+complete aesthetics-inclusive G5 approval. Trace one test finding through specification first, prototype
+second, and direct retest third.
+
+**Anti-patterns:** component works alone but breaks the skeleton; headings stand in for a specification;
+milestone prototypes; mockup repaired while the handoff stays stale; a child supplies policy the parent lacks.
+
+### Performance
+
+**Lens:** Are surface count, specification depth, prototype fidelity, direct-test method/sample, and evidence
+claims proportionate to the question, diversity, uncertainty, impact, and risk?
+
+**Activate:** `UI-SCENARIO-04`–`06`, `13`–`15`, `21`, `22`, `29`; `UI-CHECK-02`, `03`, `08`, `12`, `13`.
+
+**Verify:** compare each included surface and prototype element with a named uncertainty and claim. Look for
+production-like fidelity that does not reduce uncertainty, fixed participant counts, underpowered evidence,
+and multi-surface bundling that avoids separate prototypes or tests. Confirm a smaller artifact would not
+answer equally well and a broader claim is not made than the evidence supports.
+
+**Anti-patterns:** “five users” as universal proof; high fidelity by default; every platform in one run; one
+surface test generalized to another; collecting more data without a decision it can change.
+
+### Aesthetics
+
+**Lens:** Does final expression fit project identity and strengthen hierarchy, state recognition, affordance,
+trust, and clarity only after the complete behavioral/access contract exists?
+
+**Activate:** `UI-SCENARIO-03`, `18`–`20`, `23`, `24`, `28`, `31`; `UI-CHECK-04`, `08`–`10`, `17`–`19`.
+
+**Verify:** inspect identity authority and fallback, detailed-aesthetics chronology, typography or character
+rendering, color where present, density, spacing, rhythm, shape, imagery/iconography/symbols, motion/transitions,
+tone, and expressive detail on each surface. Remove visual resemblance and confirm hierarchy, meaning, action,
+status, access, recovery, and identity still hold. Check that aesthetics exposed a defect by reopening its
+owner rather than hiding it.
+
+**Anti-patterns:** identity as unsupported adjectives; color/type variants called concepts; token compliance as
+behavior proof; aesthetics begun before access/recovery; “minimal” used to remove status or labels.
+
+### Usage
+
+**Lens:** Can representative people in their real contexts perceive, understand, operate, complete, recover,
+adapt, and recognize truthful state through every claimed surface and applicable modality?
+
+**Activate:** `UI-SCENARIO-01`, `02`, `04`–`09`, `14`, `16`–`24`; `UI-CHECK-01`–`03`, `06`, `07`, `10`, `12`,
+`13`, `17`.
+
+**Verify:** inspect direct observations rather than summary claims. Perform the normal, alternative, exact
+transition, error, timeout, recovery, access, locale, terminal, and completion tasks. Compare visible/spoken/
+announced/output state with system state. Confirm participants had representative context, consent, and needed
+accommodations and that each included surface has direct evidence.
+
+**Anti-patterns:** coached participants; project owner assumed representative; screenshot-only access review;
+color-only or visually present status; GUI assumptions copied into CLI; false success output.
+
+### Consistency
+
+**Lens:** Do identity, governing systems, skeleton, units, surfaces, states, content, feedback, aesthetics,
+decisions, whole specification, prototype, findings, UI/UX clauses, child specializations, and handoff agree?
+
+**Activate:** `UI-SCENARIO-02`, `07`–`12`, `14`, `15`, `19`, `23`, `25`–`32`; `UI-CHECK-02`, `04`–`09`,
+`11`, `12`, `14`–`19`.
+
+**Verify:** compare all approved/revised versions. Check shared skeleton against each surface and the prototype
+against the exact current specification. Inspect identity conflict propagation, concept/aesthetic coherence,
+UI/UX conflict decisions, child diffs, and reopen conditions. Confirm load order never decides a clause and a
+revision never updates only one artifact.
+
+**Anti-patterns:** web and CLI claim different completion; prototype and specification disagree; identity
+decision appears on one surface only; last-loaded parent wins; child convention silently deletes an obligation.
+
+### Risk
+
+**Lens:** Does the run fail closed on missing outcome evidence, representative users, consent, accommodations,
+accessibility, safety, trust, truthful status, recovery, artifact chronology, conflicts, and unsupported
+acceptance claims?
+
+**Activate:** `UI-SCENARIO-03`, `05`, `06`, `09`, `11`, `12`, `15`, `17`–`21`, `24`, `26`, `27`, `29`–`32`;
+`UI-CHECK-01`–`03`, `05`–`19`.
+
+**Verify:** run every required adversarial probe. Inject timeout, partial/late result, false completion,
+inaccessible operation, misleading output, identity pressure, child waiver, co-load conflict, prior-evidence
+replacement, premature prototype, cosmetic concept, and mockup-only revision. Inspect final status when any
+direct-evidence condition is missing and confirm safety/accessibility cannot be waived.
+
+**Anti-patterns:** evidence theater; consent assumed; `NEEDS_CONTEXT` relabeled accepted; familiar component or
+standard treated as proof; brand/platform authority waives access; polished big-bang artifact passes.
+
+## Recommended verification
+
+Use the strongest evidence the artifact admits. Run safe tools for file, chronology, ID, trace, and wiring
+claims. Use close reading, cross-reference, direct task observation, and evidence-record inspection for design
+claims.
+
+1. Parse `SKILL.md` frontmatter and confirm exact key order: `name`, `description`, `allowed-tools`,
+   `skill-type`; confirm `name: ui`, the declared tool list, and `skill-type: operation`.
+2. Confirm exactly `SKILL.md`, `ideation.md`, `scenarios.md`, `checklists.md`, and `evaluation.md` form the
+   canonical bundle, with no singular `scenario.md` substitute.
+3. Extract `UI-R*`, `UI-SCENARIO-*`, and `UI-CHECK-*` IDs. Prove every load-bearing parent rule has scenarios
+   and checks; every scenario points to a live parent clause and check; every check points to live scenarios and
+   parent clauses; and this entry selects every applicable check.
+4. Confirm the scenario coverage register dispositions all ten categories. Verify the positive floor,
+   triggered minima, one adversarial face per family, observable failure oracle, evidence tuple, and cosmetic-
+   compliance failure.
+5. Confirm the checklist source has exactly 19 unchecked items and no checked source box. In the active filled
+   copy, require named inspected evidence and record coverage closure separately from acceptance.
+6. Inspect feature-document content against all ten schema sections. Headings, placeholders, a design-system
+   component name, or a present prototype do not satisfy missing content.
+7. Reconstruct dated/versioned chronology: foundation/G1 → skeleton/G2 → core/G3 → accumulated complete
+   interactions/access/G4 → concepts and detailed aesthetics → whole-spec G5 → first prototype. Fail on any
+   prototype-like artifact before G5.
+8. Inspect direct-test provenance. Confirm representative context, consent, accommodations, data handling,
+   questions, method/sample logic, direct behavior, per-surface tasks, observations, interpretations, claim
+   limits, and G6 decision. Fail acceptance on missing conditions even when prior UX/UI evidence or stakeholder
+   approval exists.
+9. Trace one supported finding through specification revision first, prototype revision second, and affected
+   assumption/surface/regression retest third.
+10. Run missing-identity fallback and identity/accessibility conflict probes. Confirm the fallback stays in the
+    feature document and the access/safety floor is not waived.
+11. Run the login GUI/CLI boundary, invalid multi-surface merge, local-unit/skeleton, timeout, visually
+    compliant but behaviorally inaccessible/misleading, cosmetic-concept, child-waiver, and co-load-conflict
+    probes.
+12. Run the project markdown-link and residual-vocabulary guards against the canonical directory. Inspect live
+    runtime wiring through its owning sync mechanism; evaluators remain read-only and never repair mirrors.
+
+Tool evidence is required for chronology, file, path, ID, link, trace, and wiring findings at confidence 75 or
+100. Human-outcome claims require the actual bounded direct-use record; prose saying “tested with users” is not
+proof. Apply the active evaluation's side-effect preflight before any prototype interaction or external call.
+
+## Overall anchors
+
+The Overall pass must answer:
+
+- Is this exactly one complete observable interface outcome, including required actors, states, feedback,
+  failure, recovery, handoffs, support, adaptation, and completion, while adjacent outcomes stay out?
+- Does every included surface share the outcome and one surface-neutral skeleton while retaining separately
+  specifiable and testable mechanics, accessibility/modality equivalence, prototype, and evidence?
+- Did project identity follow the authority chain, and did conflicts preserve the accessibility/safety floor?
+- Was the top-down skeleton approved before bottom-up growth, with every local unit reconciled to the whole?
+- Were two material concepts compared or was the one-concept exception genuinely proved with constraints and
+  direct evidence?
+- Did detailed aesthetics occur only after structure, behavior, content, feedback, recovery, adaptation, and
+  accessibility were complete, and do they improve rather than hide the contract?
+- Was the entire ten-section specification, including final aesthetics, complete and explicitly approved at G5
+  before every prototype-like artifact?
+- Did representative users directly use every claimed surface's prototype under valid consent, accommodation,
+  and evidence conditions, with claims bounded to the test?
+- Did each supported finding revise the specification first, prototype second, and affected evidence third?
+- Does the handoff preserve parent invariants across UI/UX co-loading and future surface children without
+  precedence, load-order override, or platform-convention waiver?
+- Would a polished big-bang design, present-but-empty document, familiar component, or visually compliant but
+  behaviorally broken interface fail the selected cases and checks?
+
+The preserve list should name the outcome/surface boundary, identity and reference chain, approved skeleton,
+coherent bottom-up state model, non-waivable access/safety floor, whole-spec-before-prototype chronology,
+representative direct-use evidence, and specification-first revision traces that later work must not weaken.

--- a/.gobbi/projects/gobbi/skills/ui/evaluation.md
+++ b/.gobbi/projects/gobbi/skills/ui/evaluation.md
@@ -49,21 +49,41 @@ Run this selection after Stage 0 target understanding and before each Stage 1 pe
    every `UI-CHECK-*` item except conditional `UI-CHECK-16`. These cases distinguish a substantive run from
    big-bang polish, missing evidence, premature prototyping, local-unit breakage, aesthetics-first work,
    cosmetic concepts/access, mockup-only fixes, and hidden trace gaps.
-3. **Activate surface cases.** Select `UI-SCENARIO-02`, `14`, and `15` when multiple surfaces are included, an
+3. **Activate protected-waiver probes.** Copy the protected-waiver truth table below into the filled evaluation
+   checklist. Attempt an authorized waiver separately on accessibility, safety, current direct
+   representative-user prototype testing, and whole-specification-before-prototype document closure/chronology
+   while every other applicable item is `PASS`. Each protected waiver must remain invalid and leave coverage
+   open and the run not accepted. Also replay the coverage-without-acceptance control and the valid bounded
+   non-protected `UI-CHECK-05` waiver control.
+4. **Activate surface cases.** Select `UI-SCENARIO-02`, `14`, and `15` when multiple surfaces are included, an
    alternative surface is proposed, or a surface boundary is disputed. Keep `UI-CHECK-02` active even for a
    single-surface run so inspected scope proves other surfaces are out. Apply `UI-CHECK-12` to each included
    surface.
-4. **Activate child and co-load cases.** Select `UI-SCENARIO-25`, `26`, and `UI-CHECK-15` when an existing or
+5. **Activate child and co-load cases.** Select `UI-SCENARIO-25`, `26`, and `UI-CHECK-15` when an existing or
    future child/surface handoff is in the target; otherwise inspect the parent-preserving generic handoff. Select
    `UI-SCENARIO-27` and `UI-CHECK-16` when UI and UX or another parent materially conflict.
-5. **Disposition non-selected cases with evidence.** Use `n/a:<property>` only when inspected target evidence
+6. **Disposition non-selected cases with evidence.** Use `n/a:<property>` only when inspected target evidence
    proves the trigger false. Never omit an inconvenient surface, child, actor, failure, access mode, or conflict.
-6. **Copy exact checks.** Copy activated `UI-CHECK-*` records into the active filled checklist without changing
+7. **Copy exact checks.** Copy activated `UI-CHECK-*` records into the active filled checklist without changing
    ID, claim, pass condition, evidence, or on-fail route. Resolve them through the active checklist/evaluation
    state machine.
-7. **Extend only the run copy.** A newly discovered UI scenario or check becomes a `scenario_gap` or
+8. **Extend only the run copy.** A newly discovered UI scenario or check becomes a `scenario_gap` or
    `checklist_gap` finding plus a Stage 1 addition in the active run. Evaluators never edit the shipped UI
    bundle. A missing policy obligation is a parent-policy finding; do not repair it in a companion.
+
+## Protected-waiver adversarial truth table
+
+This is an evaluation copy of the acceptance probe owned by [`checklists.md`](checklists.md). Hold every other
+applicable gate and required item at `PASS`; do not infer acceptance from coverage closure.
+
+| Protected class or control | Attempted resolution | Coverage result | Acceptance result | Required scenario/check evidence |
+|---|---|---|---|---|
+| Accessibility in any applicable item | authorized waiver | invalid / not closed | not accepted | `UI-SCENARIO-20`, `24`; `UI-CHECK-10` |
+| Safety in any applicable item | authorized waiver | invalid / not closed | not accepted | `UI-SCENARIO-19`, `20`; `UI-CHECK-10` |
+| Current direct representative-user prototype testing (`UI-CHECK-13`) | authorized waiver | invalid / not closed | not accepted | `UI-SCENARIO-05`, `06`, `29`; `UI-CHECK-13` |
+| Whole-specification-before-prototype document closure or chronology (`UI-CHECK-11`) | authorized waiver | invalid / not closed | not accepted | `UI-SCENARIO-10`, `11`; `UI-CHECK-11` |
+| Coverage/acceptance control | one applicable protected or non-protected item is `FAIL` or `recorded-open` | closed | not accepted | `UI-SCENARIO-06`, `21`; applicable check |
+| Bounded-waiver control | protected items `PASS`; one valid waiver on non-protected `UI-CHECK-05`, with authority covering its halt-and-return-to-P3 consequence and stop action | closed | accepted only under the bounded exception | `UI-SCENARIO-07`, `09`; `UI-CHECK-05` |
 
 ## Perspectives
 
@@ -82,7 +102,9 @@ substituting a screen, command, component, prototype, or related product area fo
 **Verify:** compare the user-locked outcome, surface contract, scope, non-goals, evidence conditions, feature
 document, prototype questions, and acceptance claim. Check that login recovery remains in while registration,
 password reset, account administration, and onboarding stay out. Confirm multi-surface scope rests on one
-outcome and skeleton rather than a shared product label.
+outcome and skeleton rather than a shared product label. Replay the four protected-waiver attempts plus both
+controls with every other applicable item at `PASS`; only the one valid non-protected bounded-waiver control may
+accept by exception.
 
 **Anti-patterns:** a page or command called the outcome; breadth called completeness; a project owner called
 representative by title; prior evidence called the current direct test; cosmetic options called concepts.
@@ -178,7 +200,10 @@ acceptance claims?
 **Verify:** run every required adversarial probe. Inject timeout, partial/late result, false completion,
 inaccessible operation, misleading output, identity pressure, child waiver, co-load conflict, prior-evidence
 replacement, premature prototype, cosmetic concept, and mockup-only revision. Inspect final status when any
-direct-evidence condition is missing and confirm safety/accessibility cannot be waived.
+direct-evidence condition is missing. Replay the complete protected-waiver truth table: four protected waiver
+tokens stay invalid and close neither result; protected or non-protected `FAIL`/`recorded-open` closes coverage
+without acceptance; and one valid non-protected `UI-CHECK-05` waiver accepts only under the bounded exception
+with every protected item `PASS`.
 
 **Anti-patterns:** evidence theater; consent assumed; `NEEDS_CONTEXT` relabeled accepted; familiar component or
 standard treated as proof; brand/platform authority waives access; polished big-bang artifact passes.
@@ -200,7 +225,9 @@ claims.
    triggered minima, one adversarial face per family, observable failure oracle, evidence tuple, and cosmetic-
    compliance failure.
 5. Confirm the checklist source has exactly 19 unchecked items and no checked source box. In the active filled
-   copy, require named inspected evidence and record coverage closure separately from acceptance.
+   copy, require named inspected evidence and record coverage closure separately from acceptance. Replay all
+   four protected-waiver attempts, the `FAIL`/`recorded-open` coverage control, and the valid non-protected
+   `UI-CHECK-05` bounded-waiver accepting control with every other applicable item at `PASS`.
 6. Inspect feature-document content against all ten schema sections. Headings, placeholders, a design-system
    component name, or a present prototype do not satisfy missing content.
 7. Reconstruct dated/versioned chronology: foundation/G1 → skeleton/G2 → core/G3 → accumulated complete
@@ -243,6 +270,8 @@ The Overall pass must answer:
 - Did representative users directly use every claimed surface's prototype under valid consent, accommodation,
   and evidence conditions, with claims bounded to the test?
 - Did each supported finding revise the specification first, prototype second, and affected evidence third?
+- Do the four protected classes reject waiver tokens without closing coverage, while exactly one valid
+  non-protected operational-gate waiver can accept only as the recorded bounded exception?
 - Does the handoff preserve parent invariants across UI/UX co-loading and future surface children without
   precedence, load-order override, or platform-convention waiver?
 - Would a polished big-bang design, present-but-empty document, familiar component, or visually compliant but

--- a/.gobbi/projects/gobbi/skills/ui/evaluation.md
+++ b/.gobbi/projects/gobbi/skills/ui/evaluation.md
@@ -37,6 +37,7 @@ through the active Gobbi schema and destinations.
 | UI-R14 — specification-first revision and retest | `UI-SCENARIO-12`, `30` | `UI-CHECK-14`, `18` |
 | UI-R15 — parent-preserving handoff and child boundary | `UI-SCENARIO-25`, `26` | `UI-CHECK-15`, `18` |
 | UI-R16 — evidence-led UI/UX conflict resolution | `UI-SCENARIO-27` | `UI-CHECK-16`, `18` |
+| P9 — bounded acceptance, protected floors, and coverage separation | `UI-SCENARIO-05`–`07`, `09`–`11`, `19`–`21`, `24`, `29` | `UI-CHECK-03`, `05`, `10`, `11`, `13` |
 
 ## Selecting scenarios and checks
 
@@ -49,8 +50,8 @@ Run this selection after Stage 0 target understanding and before each Stage 1 pe
    every `UI-CHECK-*` item except conditional `UI-CHECK-16`. These cases distinguish a substantive run from
    big-bang polish, missing evidence, premature prototyping, local-unit breakage, aesthetics-first work,
    cosmetic concepts/access, mockup-only fixes, and hidden trace gaps.
-3. **Activate protected-waiver probes.** Copy the protected-waiver truth table below into the filled evaluation
-   checklist. Attempt an authorized waiver separately on accessibility, safety, current direct
+3. **Activate protected-waiver probes.** Copy the parent-P9 protected-waiver truth table below into the filled
+   evaluation checklist. Attempt an authorized waiver separately on accessibility, safety, current direct
    representative-user prototype testing, and whole-specification-before-prototype document closure/chronology
    while every other applicable item is `PASS`. Each protected waiver must remain invalid and leave coverage
    open and the run not accepted. Also replay the coverage-without-acceptance control and the valid bounded
@@ -73,8 +74,9 @@ Run this selection after Stage 0 target understanding and before each Stage 1 pe
 
 ## Protected-waiver adversarial truth table
 
-This is an evaluation copy of the acceptance probe owned by [`checklists.md`](checklists.md). Hold every other
-applicable gate and required item at `PASS`; do not infer acceptance from coverage closure.
+This is an evaluation replay of the six-row acceptance probe that [`checklists.md`](checklists.md)
+operationalizes from parent [`SKILL.md`](SKILL.md) P9. Hold every other applicable gate and required item at
+`PASS`; do not infer acceptance from coverage closure.
 
 | Protected class or control | Attempted resolution | Coverage result | Acceptance result | Required scenario/check evidence |
 |---|---|---|---|---|

--- a/.gobbi/projects/gobbi/skills/ui/ideation.md
+++ b/.gobbi/projects/gobbi/skills/ui/ideation.md
@@ -1,0 +1,439 @@
+# UI Ideation — User Decision Tree
+
+Decision procedure for discussing and deciding one UI run with the user. Load it from `SKILL.md` P1 before
+asking the first design question. It deepens the parent procedure. It does not change the parent outcome,
+surface rule, evidence gates, construction order, aesthetics-last rule, or acceptance standard.
+
+Here, **the user** means the project owner or stakeholder with authority to lock product intent, scope, and
+design decisions. **Representative users** are test participants whose behavior supplies interface evidence.
+Stakeholder approval cannot substitute for direct prototype-test evidence. A participant observation does not
+itself make a product decision. Record each on its own trace.
+
+## Interview conduct
+
+Default to the full tree. Adapt only when the run remains complete.
+
+1. Ask one decision axis per turn.
+2. Smart-skip an elicitation question only when current evidence answers it and the user has already locked
+   that answer for this run. Record both the evidence and the earlier decision.
+3. Never smart-skip a parent user gate. Restate the accumulated decision and obtain explicit approval.
+4. Research internal evidence and applicable external prior art before a design-bearing recommendation.
+5. When meaningful alternatives exist, present two evidence-backed options. Recommend one and state what
+   evidence would change the recommendation. The user locks the choice.
+6. Ask project-specific follow-ups about evidence, constraints, conflicts, and earlier answers. This tree is a
+   coverage floor, not a script ceiling.
+7. Treat silence, continuation, a polished artifact, or an earlier adjacent decision as no decision.
+8. When an answer is vague, contradicted, or unsupported, show the conflict and ask a narrower follow-up.
+   Never turn an evidence gap into an unmarked assumption.
+9. Keep concepts materially different. Changes limited to color, type, spacing, icon style, wording, or other
+   surface polish are not two concepts.
+10. Do not create, request, or accept any prototype artifact before Gate G5 approves the complete whole
+    specification, including final aesthetics.
+
+These conduct steps apply UI-R3, UI-R4, UI-R7, UI-R8, UI-R9, and UI-R13.
+
+## Decision record
+
+For each axis, keep a compact record:
+
+- **Axis:** the single question being decided.
+- **Evidence:** representative-user evidence, internal evidence, external reference, or named constraint.
+- **Options:** materially different choices when alternatives exist.
+- **Recommendation:** one position and the evidence that would change it.
+- **User decision:** explicit lock, rejection, or request to investigate further.
+- **Representative-user evidence:** separate observations, participant context, and limits.
+- **Effects:** parent rule, document section, skeleton, unit, path, state, surface, or earlier branch affected.
+
+## Dependency-ordered tree
+
+Walk D0–D16 in order. A later answer that invalidates an earlier one reopens the earliest affected node. Do not
+repair an unresolved foundation with more visual detail. Do not repair a wrong specification only in the
+prototype.
+
+### D0 — Confirm the run can proceed
+
+**Discuss with the user**
+
+- What triggered this UI design run now?
+- Who owns product intent, scope, identity, and design decisions?
+- Which representative users can be reached after whole-specification approval for direct prototype testing?
+- What consent, privacy, accessibility, language, scheduling, compensation, data-handling, and accommodation
+  conditions apply?
+- Which prior UX research, UI evidence, analytics, support data, standards, and platform guidance are current?
+  Which are context only?
+
+**Decision**
+
+Lock authority, representative-user access, ethical conditions, accommodations, and the evidence inventory.
+If representative-user access, consent, accommodations, or required evidence is unavailable, return
+`NEEDS_CONTEXT` under UI-R4. The user may approve an assumptions register and test plan, but cannot approve the
+missing evidence into existence or accept a final design.
+
+**Trace:** UI-R3, UI-R4, UI-R8; `SKILL.md` P1.
+
+### D1 — Define the observable interface outcome
+
+**Discuss with the user**
+
+- Who is trying to achieve what observable result, in which triggering situation?
+- What will that person perceive, and what system evidence confirms completion?
+- What would look complete while leaving the outcome unfinished or unsafe?
+- Is the requested object a complete outcome or only a screen, page, command, component, prompt, state,
+  artifact, or happy path?
+
+**Decision**
+
+Lock one sentence in the form: “When `<trigger/context>` occurs, `<primary actor>` can `<complete observable
+outcome>`, evidenced by `<user-visible and system completion signals>`.” Split independent outcomes into other
+runs.
+
+**Trace:** UI-R1; `SKILL.md` P1.
+
+### D2 — Identify actors and use contexts
+
+**Discuss with the user**
+
+- Which primary actor operates the interface?
+- Which supporting actors approve, assist, operate, receive, monitor, or are affected?
+- Which device, terminal, channel, environment, connectivity, time pressure, language, locale, ability,
+  knowledge, privacy, safety, or emotional conditions change interface needs?
+- Which claimed user contexts are not represented by current evidence?
+
+**Decision**
+
+Lock the actor/context map. Distinguish supporting actors needed for completion from stakeholders who only need
+information. Mark evidence limits for each claimed context.
+
+**Trace:** UI-R1, UI-R3, UI-R4; `SKILL.md` P1.
+
+### D3 — Decide the surface contract
+
+**Discuss with the user**
+
+- Which surfaces must realize this outcome: web, command-line, desktop, mobile, voice, or another mode?
+- Do those surfaces share one outcome and one abstract hierarchy, action flow, state model, and completion
+  contract?
+- Can each surface's mechanics, accessibility or modality equivalence, prototype, and evidence be specified and
+  tested separately?
+- Is a surface a necessary realization, a supporting handoff, an existing dependency, or an adjacent outcome?
+
+**Decision**
+
+Lock one or more surfaces only under UI-R2. Split surfaces into different runs if their outcome or skeleton
+differs or separate evidence cannot be obtained. Record shared obligations and separate test/evidence columns.
+
+**Trace:** UI-R2; `SKILL.md` P1.
+
+### D4 — Lock scope and adjacent outcomes
+
+**Discuss with the user**
+
+- Which entry conditions, paths, states, errors, feedback, recovery, handoffs, support steps, adaptations, and
+  completion states are necessary for this one outcome?
+- Which tempting neighboring outcomes are independent?
+- Which systems, teams, platforms, and design systems constrain the work but remain outside design scope?
+- What existing behavior must remain unchanged?
+
+**Decision**
+
+Lock scope and explicit non-goals. For login/authentication, registration, password reset, account
+administration, and onboarding remain adjacent. Recovery needed for the bounded login attempt remains in scope
+even when another system supplies part of it.
+
+**Trace:** UI-R1, UI-R2; `SKILL.md` P1.
+
+### D5 — Bound evidence and the future prototype test
+
+**Discuss with the user**
+
+- Which interface assumptions must direct prototype testing answer before the design can be locked?
+- Who is representative of each claim, including people likely to face perception, input, language, recovery,
+  trust, or environmental barriers?
+- Which test method and sample match the question, diversity, uncertainty, impact, and risk without claiming
+  more than the evidence supports?
+- What consent, accommodations, data minimization, retention, and stop conditions apply?
+- How will observations be kept separate from interpretations and stakeholder decisions?
+
+**Decision**
+
+Lock a test-evidence contract, not a prototype solution: questions, recruitment logic, method, claim boundary,
+ethical conditions, accommodations, and evidence limits. Reconfirm that prior evidence cannot replace the
+future direct test and that no fixed participant count applies.
+
+**Trace:** UI-R3, UI-R4; `SKILL.md` P1 and P8.
+
+### D6 — Select governing references and platform systems
+
+**Discuss with the user**
+
+- Which product, design-system, content, platform, accessibility, safety, or regulatory sources govern this
+  outcome and each surface?
+- Which live patterns and tokens are intentional, and which are inherited defects?
+- Which obligations transfer across surfaces, and which mechanics belong only to a web, graphical,
+  command-line, voice, or other child?
+- Where do governing sources disagree or fail to cover the target context?
+
+**Options and decision**
+
+For a disputed pattern, research current internal evidence and applicable official guidance. Present two real
+directions when alternatives exist, recommend one, and state the evidence that would change it. Lock the
+reference set, applicability limits, and open conflicts. Do not turn WCAG, ARIA APG, a platform HIG, GNU, or
+POSIX guidance into a universal cross-surface mechanic.
+
+**Trace:** UI-R5, UI-R8, UI-R12, UI-R15; `SKILL.md` P2.
+
+### D7 — Establish project identity
+
+**Discuss with the user**
+
+- Which `DESIGN.md`, brand, product, or design-system material expresses the product's identity?
+- What do the live product, interface language, tokens, symbols, motion, density, and recognizable patterns
+  already teach users?
+- What promise does the product make, to whom, in what voice and character, with which values?
+- Which traits must this interface express, and which tones, symbols, interactions, or aesthetic patterns must
+  never appear?
+- Where does identity conflict with accessibility, safety, direct evidence, or platform convention?
+
+**Decision**
+
+Apply UI-R5's authority chain. When sources are insufficient, lock a temporary run-scoped brief covering
+promise, users, values, voice, character, recognizable patterns, constraints, anti-patterns, and allowed
+expression. Record conflicts for explicit decision. Do not waive the accessibility or safety floor, and do not
+create a project-wide `DESIGN.md`.
+
+**Trace:** UI-R5, UI-R12; `SKILL.md` P2.
+
+### Gate G1 — Foundation and identity
+
+Present D0–D7 as one foundation: outcome, actors, contexts, surfaces, scope, evidence/test conditions,
+references, platform systems, identity brief, conflicts, risks, and open questions. Recommend the foundation
+and name evidence that would reopen it. The user explicitly approves or reopens the earliest owning node.
+
+**Trace:** UI-R7; `SKILL.md` P2.
+
+### D8 — Design the top-down surface-neutral skeleton
+
+**Discuss with the user**
+
+- What hierarchy, regions or stages, navigation or command structure, and action priority lead from entry to
+  completion?
+- How do information, control, focus or attention, system status, and state move through the outcome?
+- Where are decisions, waits, failures, recovery, support, handoffs, adaptations, and completion signals?
+- Which parts are shared abstract obligations, and how does each surface map them without copying another
+  surface's mechanics?
+- Where could a locally useful component or command break the whole skeleton?
+
+**Options and decision**
+
+When the macro structure permits alternatives, show two materially different surface-neutral skeletons.
+Recommend one from the foundation evidence. Lock the skeleton and surface mappings without detailed controls,
+commands, or aesthetics.
+
+**Trace:** UI-R2, UI-R6, UI-R8; `SKILL.md` P3.
+
+### Gate G2 — Skeleton
+
+Show the whole hierarchy, action/information flow, state relationships, failure/recovery zones, surface
+mappings, scope boundary, and unresolved questions. The user explicitly approves it or reopens the foundation.
+
+**Trace:** UI-R7; `SKILL.md` P3.
+
+### D9 — Choose the smallest meaningful interface unit
+
+**Discuss with the user**
+
+- What is the smallest component, control, command, prompt, output, feedback, or state that makes real progress?
+- What must the user perceive, understand, decide, provide, control, or receive at this unit?
+- What are its preconditions, inputs, outputs, content, affordance, feedback, states, errors, recovery,
+  accessibility, modality equivalence, adaptation, and evidence?
+- How does each surface realize the obligation without breaking the skeleton?
+- What observable result distinguishes a working unit from cosmetic compliance?
+
+**Decision**
+
+Lock the core unit and grow the shortest complete path from it. Reject a unit that works alone but introduces
+inconsistent priority, hidden state, inaccessible operation, a dead end, or cross-surface breakage.
+
+**Trace:** UI-R6, UI-R11, UI-R12; `SKILL.md` P4.
+
+### Gate G3 — Core unit and path
+
+Demonstrate the unit and shortest complete path within the skeleton. Include one applicable failure and
+recovery route, each surface's realization, and a failure oracle that visual or textual resemblance alone
+cannot pass. The user explicitly approves or reopens D8/D9.
+
+**Trace:** UI-R7; `SKILL.md` P4.
+
+### D10 — Grow all interactions, states, feedback, and recovery
+
+**Discuss with the user as the specification grows**
+
+- Which materially different valid paths arise from actor, context, input, permission, mode, or surface?
+- What occurs at empty, one, many, first, last, limit, loading, progress, timeout, interruption, dependency
+  failure, partial completion, cancellation, resumption, success, and stale states where applicable?
+- What content, feedback, status, confirmation, error identification, prevention, recovery, and support is
+  needed at each unit?
+- How do focus, cursor, reading, announcement, shortcut, command, voice, gesture, and alternative-input flows
+  work where applicable?
+- How does the interface adapt to size, device, terminal, connection, locale, environment, user preference, and
+  assistive technology without changing meaning or completion?
+- Does each increment still fit the skeleton and all selected surfaces?
+
+**Decision**
+
+Lock each increment only after reconciling it with the skeleton and prior units. Keep detailed aesthetics out.
+Keep unresolved requirements and evidence visible; do not hide them behind a component library or platform
+convention.
+
+**Trace:** UI-R1, UI-R2, UI-R6, UI-R10, UI-R11, UI-R12; `SKILL.md` P5.
+
+### Gate G4 — Accumulated specification
+
+Present the complete unit, interaction, path, state, content, feedback, failure, recovery, adaptation,
+accessibility, and cross-surface inventory plus the trace and gap registers. The user explicitly approves or
+reopens the earliest owning node. An applicable unresolved requirement blocks final approval.
+
+**Trace:** UI-R7, UI-R10; `SKILL.md` P5.
+
+### D11 — Compare material interface concepts
+
+**Discuss with the user**
+
+- Which two approaches differ in hierarchy, action model, information flow, interaction strategy, state
+  communication, or another consequential property?
+- How does each concept satisfy the same accumulated obligations, skeleton, accessibility floor, and surface
+  contract?
+- What changes in effort, clarity, recovery, adaptation, trust, identity fit, implementation implications, and
+  test uncertainty?
+- Which evidence would disconfirm the recommendation?
+
+**Decision**
+
+Present at least two material concepts, recommend one, and let the user lock it. If only one is possible,
+record the real constraints plus direct evidence that make divergence false. Do not count cosmetic variants.
+
+**Trace:** UI-R8, UI-R9; `SKILL.md` P6.
+
+### D12 — Specify the aesthetic system last
+
+**Discuss with the user**
+
+- After selecting the concept, how should typography or character rendering, color where present, density,
+  spacing, rhythm, shape, imagery, iconography or symbols, motion or transitions, tone, and expressive detail
+  apply on each surface?
+- How does each choice improve hierarchy, state recognition, affordance, trust, and identity fit?
+- Does meaning remain available without color, animation, imagery, symbol familiarity, sound, pointer input, or
+  a particular terminal capability where applicable?
+- Which identity traits are expressed through behavior and content as well as appearance?
+- Does any aesthetic choice hide feedback, reduce access, mislead priority, imply a false state, or conflict
+  with direct evidence or platform convention?
+
+**Options and decision**
+
+Show evidence-backed aesthetic directions only after D10 and D11. Recommend one and state what evidence would
+change it. Lock each surface's coherent aesthetic system and record intentional deviations. Reopen the owning
+structural or behavioral node if aesthetics expose a missing obligation; do not style around it.
+
+**Trace:** UI-R5, UI-R8, UI-R11, UI-R12; `SKILL.md` P6.
+
+### D13 — Reconcile the complete whole specification
+
+**Discuss with the user**
+
+- Does every document section contain resolved, traceable content rather than headings or placeholders?
+- Does the chosen concept agree with the skeleton, units, paths, states, content, feedback, recovery,
+  adaptation, accessibility, modalities, and aesthetics on every surface?
+- Are decisions, rejected options, deviations, evidence limits, non-goals, and implementation questions clear?
+- Can a cold reader tell what must be built and tested without hidden session context?
+- Does any artifact that could be called a prototype already exist? If yes, the sequence failed and must be
+  corrected before approval.
+
+**Decision**
+
+Resolve contradictions and close every applicable requirement. Record real unknowns only when they do not
+prevent a complete, testable specification. Confirm that no prototype has been created.
+
+**Trace:** UI-R6, UI-R10, UI-R11, UI-R15, UI-R16; `SKILL.md` P6.
+
+### Gate G5 — Final whole specification, including aesthetics
+
+Present the complete feature design document, material concept decision, detailed aesthetic system, evidence
+limits, deviations, and all surface specifications. The user explicitly approves or reopens the earliest
+owning node. Only this approval permits prototype creation.
+
+**Trace:** UI-R6, UI-R7, UI-R10, UI-R11, UI-R13; `SKILL.md` P6.
+
+### D14 — Choose the disposable prototype and test design
+
+**Discuss with the user after G5 passes**
+
+- Which remaining uncertainties and failure risks must the prototype answer?
+- What is the lowest fidelity that can answer each question without resembling production unnecessarily?
+- Which approved paths, states, errors, recovery, adaptations, and accessibility behaviors must be represented?
+- For multiple surfaces, how will each variant remain separately operable, testable, and evidenced while
+  preserving the shared skeleton?
+- Which behavior or data is simulated, and how will participants be told?
+
+**Decision**
+
+Lock a disposable prototype plan, specification trace, per-surface variants, test tasks, observation plan,
+claim boundary, and stop conditions. Production implementation remains outside scope.
+
+**Trace:** UI-R2, UI-R3, UI-R4, UI-R13; `SKILL.md` P7–P8.
+
+### D15 — Interpret findings and revise in the required order
+
+**Discuss with the user after direct testing**
+
+- What was directly observed, and what is interpretation?
+- Which finding is supported strongly enough to change a specification clause?
+- Which hierarchy, unit, interaction, content, state, feedback, recovery, accessibility, aesthetic rule, or
+  decision owns the finding?
+- What prototype change follows that specification revision?
+- Which assumptions, surfaces, paths, and regressions require direct retest?
+- What evidence remains limited, conflicting, or missing?
+
+**Decision**
+
+For each supported finding, lock the specification revision first, prototype revision second, and retest plan
+third. Do not accept mockup-only fixes. Keep participant evidence separate from the stakeholder's product
+decision.
+
+**Trace:** UI-R3, UI-R4, UI-R14; `SKILL.md` P8.
+
+### Gate G6 — Post-test revision
+
+Present direct observations, bounded interpretations, ordered specification/prototype changes, per-surface and
+regression retest evidence, unresolved limits, and the acceptance recommendation. The user explicitly accepts,
+reopens an owning node, or records `NEEDS_CONTEXT`. Acceptance is unavailable while UI-R3 or UI-R4 is unmet.
+
+**Trace:** UI-R7, UI-R14; `SKILL.md` P8.
+
+### D16 — Lock the handoff and change contract
+
+**Discuss with the user**
+
+- Which team or future child skill owns each exact surface mechanic and technical standard?
+- Which parent outcome, skeleton, state, recovery, accessibility, safety, evidence, and aesthetic obligations
+  must remain unchanged?
+- If UX is co-loaded, where is its outcome, content, state, recovery, evidence, and risk contract preserved?
+- What implementation question needs evidence rather than an invented answer?
+- Which later evidence or deviation reopens which decision?
+
+**Decision**
+
+Lock the owner map, no-silent-change rule, cold-reader handoff, open implementation questions, and reopen
+conditions. A child convention or load order cannot approve a deviation. Route a concrete conflict back to the
+user with evidence.
+
+**Trace:** UI-R15, UI-R16; `SKILL.md` P9.
+
+## Completion audit
+
+Before leaving ideation, confirm that every D-node is either explicitly decided or smart-skipped with current
+evidence plus a user-locked answer. Confirm that G1–G6 each has an explicit user decision. Confirm that the
+decision record separates stakeholder locks from representative-user observations. Confirm that prototype
+creation occurred only after G5, and that any supported finding changed the specification before the prototype.
+
+The feature design document uses the schema in `SKILL.md`. This decision tree never assigns a universal file
+path and never creates a project-wide `DESIGN.md`.

--- a/.gobbi/projects/gobbi/skills/ui/scenarios.md
+++ b/.gobbi/projects/gobbi/skills/ui/scenarios.md
@@ -35,22 +35,22 @@ category carriers; no concern is delegated through `covered-elsewhere`.
 Each selected category has a positive case and each family has an adversarial face. Other minima appear when
 the family's properties trigger them. An `n/a` cell names the property that makes that minimum inapplicable.
 
-| Family | Good | Alternative-valid | Boundary | Failure/recovery | Adversarial | Change | Counterfactual |
-|---|---|---|---|---|---|---|---|
-| `UI-FAMILY-01` | `01` | `02` | n/a: no numeric or finite limit | n/a: failure owned by family 06 | `03` | n/a: no version event | n/a: outcome premise is directly locked |
-| `UI-FAMILY-02` | `04` | n/a: one actor-evidence class per claim | n/a: sample is risk-based, not a numeric threshold | `06` | `05` | n/a: no version event | n/a: representativeness is inspected, not assumed |
-| `UI-FAMILY-03` | `07` | n/a: alternative surface is exercised in `02` | `08` | n/a: injected failure owned by family 06 | `09` | n/a: no version event | n/a: state inventory is inspected directly |
-| `UI-FAMILY-04` | `10` | n/a: parent order has one valid chronology | n/a: stage transition is audited chronologically | `12` | `11` | n/a: no version event | n/a: chronology is evidenced, not premised |
-| `UI-FAMILY-05` | `13` | `14` | n/a: no universal participant or fidelity threshold | n/a: operational failure owned by family 06 | `15` | n/a: no version event | n/a: proportionality claim has named questions |
-| `UI-FAMILY-06` | `16` | n/a: alternative recovery paths are enumerated in the same contract | `17` | `17` | `18` | n/a: planned reversibility owned by family 09 | n/a: dependency failure is injected directly |
-| `UI-FAMILY-07` | `19` | n/a: one non-waivable safety floor | n/a: no numeric or finite limit | `21` | `20` | n/a: no version event | n/a: conflict evidence is inspected directly |
-| `UI-FAMILY-08` | `22` | `23` | n/a: platform limits are surface-owned inputs | n/a: failed access behavior appears as adversarial exclusion | `24` | n/a: no version event | n/a: modality equivalence is directly inspected |
-| `UI-FAMILY-09` | `25` | n/a: UI/UX conflict and child change are distinct cases | n/a: no finite limit | n/a: runtime recovery owned by family 06 | `26` | `25` | `27` |
-| `UI-FAMILY-10` | `28` | n/a: one bidirectional evidence model | n/a: no numeric or finite limit | n/a: missing evidence closes as `NEEDS_CONTEXT` in family 02 | `29`, `31`, `32` | n/a: artifact revision chronology is family 04 | `30` |
+| Family | Good | Alternative-valid | Negative / Bad | Boundary | Failure/recovery | Adversarial | Change | Counterfactual |
+|---|---|---|---|---|---|---|---|---|
+| `UI-FAMILY-01` | `01` | `02` | n/a: no invalid input, state, authorization, or precondition discrimination; intentional scope expansion is adversarial | n/a: no numeric or finite limit | n/a: failure owned by family 06 | `03` | n/a: no version event | n/a: outcome premise is directly locked |
+| `UI-FAMILY-02` | `04` | n/a: one actor-evidence class per claim | n/a: no supplied invalid input, state, authorization, or precondition; unavailable evidence conditions are a recoverable dependency failure | n/a: sample is risk-based, not a numeric threshold | `06` | `05` | n/a: no version event | n/a: representativeness is inspected, not assumed |
+| `UI-FAMILY-03` | `07` | n/a: alternative surface is exercised in `02` | n/a: no invalid input, state, authorization, or precondition discrimination; the invalid-looking local/whole mismatch is an intentional acceptance-gate attempt | `08` | n/a: injected failure owned by family 06 | `09` | n/a: no version event | n/a: state inventory is inspected directly |
+| `UI-FAMILY-04` | `10` | n/a: parent order has one valid chronology | n/a: no independently discriminating invalid input, state, authorization, or precondition case; premature-prototype pressure is an intentional gate bypass | n/a: stage transition is audited chronologically | `12` | `11` | n/a: no version event | n/a: chronology is evidenced, not premised |
+| `UI-FAMILY-05` | `13` | `14` | n/a: no invalid input, state, authorization, or precondition discrimination; incompatible surface bundling is intentional scope-label gaming | n/a: no universal participant or fidelity threshold | n/a: operational failure owned by family 06 | `15` | n/a: no version event | n/a: proportionality claim has named questions |
+| `UI-FAMILY-06` | `16` | n/a: alternative recovery paths are enumerated in the same contract | n/a: no invalid input, state, authorization, or precondition is supplied; the exercised defect is an injected dependency or timeout failure | `17` | `17` | `18` | n/a: planned reversibility owned by family 09 | n/a: dependency failure is injected directly |
+| `UI-FAMILY-07` | `19` | n/a: one non-waivable safety floor | n/a: no independently discriminating invalid input, state, authorization, or precondition case; unsafe evidence and identity pressure are governance failure or authority gaming | n/a: no numeric or finite limit | `21` | `20` | n/a: no version event | n/a: conflict evidence is inspected directly |
+| `UI-FAMILY-08` | `22` | `23` | n/a: no invalid input, state, authorization, or precondition discrimination; valid-looking inaccessible behavior games the access gate | n/a: platform limits are surface-owned inputs | n/a: failed access behavior appears as adversarial exclusion | `24` | n/a: no version event | n/a: modality equivalence is directly inspected |
+| `UI-FAMILY-09` | `25` | n/a: UI/UX conflict and child change are distinct cases | n/a: no invalid input, state, authorization, or precondition discrimination; the child waiver is an intentional authority override | n/a: no finite limit | n/a: runtime recovery owned by family 06 | `26` | `25` | `27` |
+| `UI-FAMILY-10` | `28` | n/a: one bidirectional evidence model | n/a: no independently discriminating invalid input, state, authorization, or precondition case; stale evidence, cosmetic concepts, and invalid smart-skips are acceptance-gate gaming | n/a: no numeric or finite limit | n/a: missing evidence closes as `NEEDS_CONTEXT` in family 02 | `29`, `31`, `32` | n/a: artifact revision chronology is family 04 | `30` |
 
-`UI-SCENARIO-17` genuinely exercises both an exact timeout transition and failure/recovery. Its primary and
-coverage role are failure/recovery only; boundary coverage is supporting context and is not claimed as a
-second minimum discharge.
+`UI-SCENARIO-17` is the set's one bounded n-ary record and discharges both Boundary and Failure/recovery. Its
+primary remains Failure/recovery; the case-level coverage-role explanations, per-type proof, and gaming probe
+justify the two matrix cells. No other case claims more than one minimum discharge.
 
 ## Source register and stable IDs
 
@@ -390,7 +390,24 @@ Renaming a title does not change an ID. A changed discrimination gets a new case
 
 - **Primary type + justification:** Failure/recovery — the defining concern is recovery from a timeout at the
   exact pending-to-timeout transition.
-- **Coverage-role:** Failure/recovery; boundary is supporting context, not a second discharge.
+- **Coverage-role:** Failure/recovery — injects an external-handoff timeout and requires containment,
+  late-result handling, and recovery; Boundary — exercises below, at, and above the exact pending-to-timeout
+  transition.
+- **Inseparability record:**
+  - `discharges: [boundary, failure/recovery]`.
+  - `per-type-proof:` Boundary cannot preserve this exact below/at/above timeout discrimination without the
+    timeout failure that activates containment and late-result recovery; Failure/recovery cannot preserve this
+    case's timeout-recovery discrimination without crossing the exact time-window boundary. Replacing the
+    timeout with another failure creates a different case and does not prove this obligation.
+  - `no-cosmetic-duplicate:` one below/at/above observation proves both discriminations; relabeling it as two
+    cases would duplicate the same Given/When/Then.
+  - `bounded + auditable:` the joint discharge applies only to this external-authorization timeout transition,
+    not to other boundaries or failures in the family.
+  - `gaming-probe gate (SR-12, P8):` a Boundary-only attempt collapses into the generic state transition already
+    covered by `UI-SCENARIO-08` and loses the timeout failure; a Failure/recovery-only attempt collapses into the
+    generic recovery floor covered by `UI-SCENARIO-16` and loses the exact threshold and late-result
+    discrimination. No dedicated single-type case can preserve this obligation, so both roles remain
+    inseparable here.
 - **Actor:** authenticating user.
 - **Given:** an external authorization handoff has a defined timeout and may return just before, exactly at, or
   just after it.
@@ -560,7 +577,8 @@ Renaming a title does not change an ID. A changed discrimination gets a new case
 
 - **Primary type + justification:** Change/regression — a downstream version introduces exact platform
   mechanics while preserving the existing contract.
-- **Coverage-role:** Change/regression; proves safe specialization across a lifecycle change.
+- **Coverage-role:** Good — proves the positive parent-preserving specialization floor; Change/regression —
+  proves safe specialization across a lifecycle change.
 - **Actor:** child-skill author and UI reviewer.
 - **Given:** a future web, CLI, desktop, mobile, or voice child adds exact standards, patterns, and examples.
 - **When:** its output is compared with the approved parent handoff.

--- a/.gobbi/projects/gobbi/skills/ui/scenarios.md
+++ b/.gobbi/projects/gobbi/skills/ui/scenarios.md
@@ -1,0 +1,737 @@
+# UI Design — Scenario Set
+
+Scenario source for one `ui` operation run. Its target is the parent contract in [`SKILL.md`](SKILL.md). Its
+consumer is the operational checklist and active Gobbi evaluation. The set exercises parent obligations; it
+does not add UI policy. Lifecycle mode: design obligations plus evaluation coverage.
+
+Scope is one complete observable interface outcome across one or more valid surfaces. It excludes adjacent
+outcomes, production implementation, and exact child-owned platform mechanics. Sensitive participant evidence
+is referenced through the active project's governed evidence records, never copied here.
+
+Scale limit: this source uses ten families and 32 cases, below the default split thresholds of about 12
+families and 40 distinct category/type cells. Split a future larger set under a parent index rather than
+growing this source without bound.
+
+## Coverage register
+
+All ten categories are selected because each can affect a cross-surface UI run. The named families are the
+category carriers; no concern is delegated through `covered-elsewhere`.
+
+| # | Category | Disposition | Family carriers |
+|---|---|---|---|
+| 1 | Purpose / outcomes / scope | selected | `UI-FAMILY-01` |
+| 2 | Actors / stakeholders / use-context | selected | `UI-FAMILY-02` |
+| 3 | Behavior / state / data | selected | `UI-FAMILY-03` |
+| 4 | Interfaces / dependencies / structure | selected | `UI-FAMILY-04` |
+| 5 | Quality attributes / resource economics | selected | `UI-FAMILY-05` |
+| 6 | Failure / recovery / operations | selected | `UI-FAMILY-06` |
+| 7 | Trust / harm / governance | selected | `UI-FAMILY-07` |
+| 8 | Inclusion / locale | selected | `UI-FAMILY-08` |
+| 9 | Change / compatibility / reversibility | selected | `UI-FAMILY-09` |
+| 10 | Evidence / traceability / clarity | selected | `UI-FAMILY-10` |
+
+## Category × case-type matrix
+
+Each selected category has a positive case and each family has an adversarial face. Other minima appear when
+the family's properties trigger them. An `n/a` cell names the property that makes that minimum inapplicable.
+
+| Family | Good | Alternative-valid | Boundary | Failure/recovery | Adversarial | Change | Counterfactual |
+|---|---|---|---|---|---|---|---|
+| `UI-FAMILY-01` | `01` | `02` | n/a: no numeric or finite limit | n/a: failure owned by family 06 | `03` | n/a: no version event | n/a: outcome premise is directly locked |
+| `UI-FAMILY-02` | `04` | n/a: one actor-evidence class per claim | n/a: sample is risk-based, not a numeric threshold | `06` | `05` | n/a: no version event | n/a: representativeness is inspected, not assumed |
+| `UI-FAMILY-03` | `07` | n/a: alternative surface is exercised in `02` | `08` | n/a: injected failure owned by family 06 | `09` | n/a: no version event | n/a: state inventory is inspected directly |
+| `UI-FAMILY-04` | `10` | n/a: parent order has one valid chronology | n/a: stage transition is audited chronologically | `12` | `11` | n/a: no version event | n/a: chronology is evidenced, not premised |
+| `UI-FAMILY-05` | `13` | `14` | n/a: no universal participant or fidelity threshold | n/a: operational failure owned by family 06 | `15` | n/a: no version event | n/a: proportionality claim has named questions |
+| `UI-FAMILY-06` | `16` | n/a: alternative recovery paths are enumerated in the same contract | `17` | `17` | `18` | n/a: planned reversibility owned by family 09 | n/a: dependency failure is injected directly |
+| `UI-FAMILY-07` | `19` | n/a: one non-waivable safety floor | n/a: no numeric or finite limit | `21` | `20` | n/a: no version event | n/a: conflict evidence is inspected directly |
+| `UI-FAMILY-08` | `22` | `23` | n/a: platform limits are surface-owned inputs | n/a: failed access behavior appears as adversarial exclusion | `24` | n/a: no version event | n/a: modality equivalence is directly inspected |
+| `UI-FAMILY-09` | `25` | n/a: UI/UX conflict and child change are distinct cases | n/a: no finite limit | n/a: runtime recovery owned by family 06 | `26` | `25` | `27` |
+| `UI-FAMILY-10` | `28` | n/a: one bidirectional evidence model | n/a: no numeric or finite limit | n/a: missing evidence closes as `NEEDS_CONTEXT` in family 02 | `29`, `31`, `32` | n/a: artifact revision chronology is family 04 | `30` |
+
+`UI-SCENARIO-17` genuinely exercises both an exact timeout transition and failure/recovery. Its primary and
+coverage role are failure/recovery only; boundary coverage is supporting context and is not claimed as a
+second minimum discharge.
+
+## Source register and stable IDs
+
+- `SRC-UI-PARENT` — [`SKILL.md`](SKILL.md), UI-R1–UI-R16 and P1–P9; sole policy owner.
+- `SRC-UI-DECISIONS` — [`ideation.md`](ideation.md); gate and decision-procedure trace.
+- `SRC-UI-ISO` — ISO 9241-210 and ISO 9241-11 references named by the parent.
+- `SRC-UI-ACCESS` — WCAG, WAI evaluation, and platform accessibility references named by the parent; applicable
+  only to their stated surfaces.
+- `SRC-UI-PLATFORM` — Apple, Windows, Android, GNU, and POSIX references named by the parent; these do not
+  override parent invariants.
+
+Case IDs are permanent `UI-SCENARIO-NN` values. Checklist reservations use permanent `UI-CHECK-NN` values.
+Renaming a title does not change an ID. A changed discrimination gets a new case ID.
+
+## UI-FAMILY-01 — One bounded outcome across valid surfaces
+
+- **Declared primary category:** 1 — Purpose / outcomes / scope. The defining discrimination is whether the
+  design completes the right bounded outcome rather than polishing an artifact or absorbing adjacent work.
+- **Secondary categories:** 2, 3, 4.
+- **Source / rationale:** `SRC-UI-PARENT` UI-R1, UI-R2, P1; `SRC-UI-DECISIONS` D1–D4.
+- **Actor + outcome:** a returning user completes one bounded login/authentication outcome.
+- **Situation / invariant:** GUI and CLI realizations may differ mechanically but must serve the same outcome
+  and keep registration, reset, administration, and onboarding out.
+- **Applicability / priority:** every run; gate-bearing.
+
+### UI-SCENARIO-01 — A graphical login completes the bounded outcome
+
+- **Primary type + justification:** Good — ordinary valid graphical realization reaches observable completion.
+- **Coverage-role:** Good; proves the positive outcome floor.
+- **Actor:** eligible returning user.
+- **Given:** an approved outcome contract includes entry, form interaction, progress, success, applicable
+  errors, and recovery, while adjacent outcomes are explicit non-goals.
+- **When:** the user authenticates through the graphical surface.
+- **Then:** the intended signed-in destination and system state agree on completion; failures remain
+  understandable and recoverable within the bounded attempt.
+- **Failure oracle:** a polished login screen that stops at credential submission, omits recovery, or redirects
+  without authenticated state fails.
+- **Evidence tuple:** observe end-to-end state; walk the approved path and inspect completion evidence; confirm
+  user-visible destination plus authenticated system state.
+- **Design obligation:** the specification must define the whole bounded outcome and false-completion signal.
+- **Trace:** UI-R1, P1; `UI-CHECK-01`, `UI-CHECK-17`.
+
+### UI-SCENARIO-02 — A CLI login realizes the same obligations differently
+
+- **Primary type + justification:** Alternative-valid — a materially different surface realizes the same
+  outcome through command, prompt/output, exit status, and an optional external handoff.
+- **Coverage-role:** Alternative-valid; proves that GUI mechanics are not universal.
+- **Actor:** eligible returning terminal user.
+- **Given:** `tool auth login` has a separately specified command flow, status, cancellation, timeout, recovery,
+  and verified authenticated terminal state mapped to the shared skeleton.
+- **When:** the user completes the command-line authentication path.
+- **Then:** the command's output and exit behavior expose the same abstract action, status, recovery, and
+  completion obligations without copying GUI mechanics.
+- **Failure oracle:** a CLI example that merely renames a graphical button, omits exit/error behavior, or lacks
+  separate evidence fails.
+- **Evidence tuple:** observe command/output/state; run a prototype task and inspect the surface matrix; confirm
+  separately testable mechanics and shared completion.
+- **Design obligation:** each surface must map shared obligations to distinct, testable mechanics.
+- **Trace:** UI-R2, P3–P4; `UI-CHECK-02`, `UI-CHECK-06`.
+
+### UI-SCENARIO-03 — Polished big-bang design hides scope failure
+
+- **Primary type + justification:** Adversarial — a cosmetically strong artifact attempts to pass without the
+  ordered outcome contract.
+- **Coverage-role:** Adversarial; proves cosmetic compliance cannot satisfy scope.
+- **Actor:** design reviewer.
+- **Given:** a finished-looking set of screens combines login, registration, password reset, administration,
+  and onboarding but has no locked outcome, skeleton chronology, complete states, or evidence.
+- **When:** it is presented as a completed UI run.
+- **Then:** the run is rejected and returned to P1; polish and breadth do not close missing obligations.
+- **Failure oracle:** acceptance because it “looks complete” fails the parent contract.
+- **Evidence tuple:** observe artifact history and scope; diff against the outcome contract; confirm missing
+  gates and adjacent outcomes.
+- **Design obligation:** big-bang polish must fail before construction continues.
+- **Trace:** UI-R1, UI-R6; `UI-CHECK-01`, `UI-CHECK-07`.
+
+## UI-FAMILY-02 — Representative people and ethical evidence conditions
+
+- **Declared primary category:** 2 — Actors / stakeholders / use-context. The defining discrimination is whether
+  participant context supports the UI claims.
+- **Secondary categories:** 7, 8, 10.
+- **Source / rationale:** `SRC-UI-PARENT` UI-R3, UI-R4, P1/P8; `SRC-UI-DECISIONS` D0, D2, D5.
+- **Actor + outcome:** representative participants supply bounded direct-use evidence under ethical conditions.
+- **Situation / invariant:** stakeholder authority and participant evidence are different roles.
+- **Applicability / priority:** every run; acceptance gate.
+
+### UI-SCENARIO-04 — Representative direct testing supports bounded claims
+
+- **Primary type + justification:** Good — the ordinary evidence path uses representative participants and
+  claim-sized methods.
+- **Coverage-role:** Good; proves the positive actor/evidence floor.
+- **Actor:** UI test participant and researcher.
+- **Given:** recruitment, consent, accommodations, method, data handling, and claim bounds match the target
+  contexts and risks.
+- **When:** participants use the post-approval prototype.
+- **Then:** observations support only the named interface claims and remain distinct from stakeholder decisions.
+- **Failure oracle:** “users liked it” without participant context, tasks, observations, or limits fails.
+- **Evidence tuple:** observe governed test record; inspect recruitment-to-claim trace; confirm direct behavior,
+  accommodations, consent, and bounded conclusions.
+- **Design obligation:** acceptance must rest on representative direct-use evidence.
+- **Trace:** UI-R3, UI-R4, P8; `UI-CHECK-03`, `UI-CHECK-13`.
+
+### UI-SCENARIO-05 — Project owner is claimed representative without evidence
+
+- **Primary type + justification:** Adversarial — authority is relabeled as representativeness to bypass direct
+  testing.
+- **Coverage-role:** Adversarial; proves stakeholder approval cannot game the evidence gate.
+- **Actor:** project owner and reviewer.
+- **Given:** only the owner has tried the prototype and no evidence connects their context to the target users.
+- **When:** owner approval is offered as representative-user evidence.
+- **Then:** the evidence is rejected; the run remains `NEEDS_CONTEXT` or schedules representative testing.
+- **Failure oracle:** accepting job title or product knowledge as proof of representativeness fails.
+- **Evidence tuple:** observe participant rationale; compare owner context with actor/context map; confirm whether
+  the relevant use conditions are genuinely shared.
+- **Design obligation:** owner evidence counts only when representativeness is demonstrated.
+- **Trace:** UI-R3, P1/P8; `UI-CHECK-03`, `UI-CHECK-13`.
+
+### UI-SCENARIO-06 — Missing users, consent, accommodations, or evidence fails closed
+
+- **Primary type + justification:** Failure/recovery — required research conditions are unavailable and the
+  correct recovery is a non-accepting status plus a plan.
+- **Coverage-role:** Failure/recovery; proves fail-closed handling.
+- **Actor:** UI designer and decision owner.
+- **Given:** representative access, consent, a needed accommodation, or required evidence cannot be obtained.
+- **When:** the final interface is proposed for acceptance.
+- **Then:** status is `NEEDS_CONTEXT`; assumptions and a recovery/test plan may be recorded, but acceptance is
+  blocked.
+- **Failure oracle:** a user decision, waiver, fixed participant count, or standards checklist changing the
+  status to accepted fails.
+- **Evidence tuple:** observe conditions register; inspect each prerequisite; confirm missing condition and
+  non-accepting status.
+- **Design obligation:** evidence-condition failure must stop acceptance without erasing planned recovery.
+- **Trace:** UI-R4, P1/P8; `UI-CHECK-03`, `UI-CHECK-13`.
+
+## UI-FAMILY-03 — Coherent units, interactions, states, and data
+
+- **Declared primary category:** 3 — Behavior / state / data. The defining discrimination is correct state and
+  interaction behavior across the skeleton.
+- **Secondary categories:** 1, 4, 6, 8.
+- **Source / rationale:** `SRC-UI-PARENT` UI-R1, UI-R6, UI-R11, P3–P5.
+- **Actor + outcome:** a user can understand and operate every state through completion.
+- **Situation / invariant:** each local interface unit must preserve whole-path state and feedback.
+- **Applicability / priority:** every run; required.
+
+### UI-SCENARIO-07 — Bottom-up units grow a complete coherent path
+
+- **Primary type + justification:** Good — the ordinary construction grows one unit while preserving the
+  approved skeleton.
+- **Coverage-role:** Good; proves the positive behavior/state floor.
+- **Actor:** UI designer and user.
+- **Given:** the skeleton is approved and the core unit names preconditions, inputs, outputs, content, feedback,
+  states, error, recovery, access, and surface mappings.
+- **When:** units are connected one at a time into the shortest complete path.
+- **Then:** each transition is observable and the whole path still matches the skeleton on every surface.
+- **Failure oracle:** a unit with a good isolated demo but an undefined incoming/outgoing state fails.
+- **Evidence tuple:** observe unit and transition records; walk both trace directions; confirm complete state
+  continuity.
+- **Design obligation:** every local unit must own its states and reconcile with the whole.
+- **Trace:** UI-R6, P4–P5; `UI-CHECK-06`, `UI-CHECK-07`.
+
+### UI-SCENARIO-08 — Exact transition states are specified
+
+- **Primary type + justification:** Boundary — the case sits on the transition from submitted to pending to
+  authenticated or failed.
+- **Coverage-role:** Boundary; proves both sides and the transition itself are defined.
+- **Actor:** returning user.
+- **Given:** login submission can be immediate, delayed, duplicated, interrupted, or resolved.
+- **When:** the interface crosses the exact submission/state transition.
+- **Then:** duplicate action is controlled, status is exposed, and success/failure cannot both appear or leave
+  stale controls active.
+- **Failure oracle:** specifying “loading” near the transition without entry, exit, duplicate, and stale-state
+  behavior fails.
+- **Evidence tuple:** observe state table; simulate before/at/after transition; confirm one valid state and
+  action set at each point.
+- **Design obligation:** every exact state transition needs entry, status, allowed action, exit, and recovery.
+- **Trace:** UI-R1, UI-R6, P5; `UI-CHECK-07`, `UI-CHECK-17`.
+
+### UI-SCENARIO-09 — A component works alone but breaks the skeleton
+
+- **Primary type + justification:** Adversarial — a successful local demo attempts to hide whole-interface
+  inconsistency.
+- **Coverage-role:** Adversarial; proves local quality is not whole-system quality.
+- **Actor:** component designer and reviewer.
+- **Given:** an authentication control is usable in isolation but changes action priority, hides system status,
+  creates an unreachable error, or conflicts with the CLI state model.
+- **When:** it is proposed for inclusion unchanged.
+- **Then:** it fails and returns to P3/P4 for unit or skeleton repair and whole-path regression review.
+- **Failure oracle:** accepting because the component library example passes fails.
+- **Evidence tuple:** observe local and whole traces; inject the unit into the skeleton; confirm broken hierarchy,
+  state, or surface mapping.
+- **Design obligation:** local units must be tested in the full skeleton and cross-surface contract.
+- **Trace:** UI-R6, P4–P5; `UI-CHECK-05`, `UI-CHECK-06`.
+
+## UI-FAMILY-04 — Construction order and artifact dependency
+
+- **Declared primary category:** 4 — Interfaces / dependencies / structure. The defining discrimination is the
+  dependency order among foundation, skeleton, specification, prototype, and revisions.
+- **Secondary categories:** 3, 10.
+- **Source / rationale:** `SRC-UI-PARENT` UI-R6, UI-R7, UI-R10, UI-R13, UI-R14.
+- **Actor + outcome:** the team builds and changes one authoritative interface contract in the required order.
+- **Situation / invariant:** the whole specification, including aesthetics, precedes every prototype.
+- **Applicability / priority:** every run; gate-bearing.
+
+### UI-SCENARIO-10 — Whole specification approval precedes prototype creation
+
+- **Primary type + justification:** Good — the valid chronology reaches the prototype only after all prior
+  gates pass.
+- **Coverage-role:** Good; proves the positive structural floor.
+- **Actor:** UI designer and decision owner.
+- **Given:** dated evidence shows foundation, skeleton, core, accumulated specification, concepts, aesthetics,
+  and complete whole-spec approval.
+- **When:** remaining uncertainty is translated into a prototype plan.
+- **Then:** the first prototype artifact is created after approval and traces to the approved specification.
+- **Failure oracle:** a clickable wireframe, coded demo, command stub, or mockup dated before approval fails.
+- **Evidence tuple:** observe artifact history; inspect timestamps/version lineage; confirm strict chronology.
+- **Design obligation:** prototype work must have an evidenced whole-spec predecessor.
+- **Trace:** UI-R6, UI-R7, UI-R10, UI-R13; `UI-CHECK-07`, `UI-CHECK-11`, `UI-CHECK-12`.
+
+### UI-SCENARIO-11 — Prototype is requested before the whole specification
+
+- **Primary type + justification:** Adversarial — schedule pressure attempts to reverse a load-bearing
+  dependency.
+- **Coverage-role:** Adversarial; proves a visible artifact cannot bypass the final gate.
+- **Actor:** stakeholder and UI designer.
+- **Given:** the skeleton or core path is approved, but alternative paths, accessibility, recovery, aesthetics,
+  or another whole-spec section remains incomplete.
+- **When:** a prototype is requested “to make progress” or “test the direction.”
+- **Then:** creation stops; the team completes and approves the whole specification first.
+- **Failure oracle:** treating a milestone gate as prototype permission fails.
+- **Evidence tuple:** observe gap register and artifact tree; compare with G5 criteria; confirm unresolved whole-
+  spec content and no prototype creation.
+- **Design obligation:** no milestone before G5 authorizes prototyping.
+- **Trace:** UI-R6, UI-R7, UI-R10, UI-R13; `UI-CHECK-11`, `UI-CHECK-12`.
+
+### UI-SCENARIO-12 — Prototype finding changes only the mockup
+
+- **Primary type + justification:** Failure/recovery — a test exposes a defect and the recovery sequence is
+  specification first, prototype second, retest third.
+- **Coverage-role:** Failure/recovery; proves durable contract recovery.
+- **Actor:** UI designer, test participant, and decision owner.
+- **Given:** direct testing shows that users miss an authentication error or cannot recover.
+- **When:** the mockup is updated without changing the owning specification clause.
+- **Then:** acceptance remains blocked; the specification is revised first, the prototype second, and affected
+  behavior is retested.
+- **Failure oracle:** a better-looking or better-working mockup with a stale handoff document fails.
+- **Evidence tuple:** observe ordered revision history; trace finding to spec, prototype, and retest; confirm the
+  exact sequence.
+- **Design obligation:** supported findings must update the durable contract before its test rendering.
+- **Trace:** UI-R14, P8; `UI-CHECK-14`, `UI-CHECK-18`.
+
+## UI-FAMILY-05 — Proportionate effort and separately evidenced surfaces
+
+- **Declared primary category:** 5 — Quality attributes / resource economics. The defining discrimination is
+  whether design and evidence effort is proportionate and separable enough to support the claims.
+- **Secondary categories:** 2, 4, 8, 10.
+- **Source / rationale:** `SRC-UI-PARENT` UI-R2, UI-R3, UI-R13, P1/P7/P8.
+- **Actor + outcome:** the team obtains the strongest needed evidence without fixed-count or production-fidelity
+  shortcuts.
+- **Situation / invariant:** uncertainty, diversity, impact, and risk set evidence and prototype effort.
+- **Applicability / priority:** every run; required.
+
+### UI-SCENARIO-13 — Prototype fidelity and sample match the questions
+
+- **Primary type + justification:** Good — ordinary planning uses risk and uncertainty rather than a universal
+  count or fidelity.
+- **Coverage-role:** Good; proves the positive proportionality floor.
+- **Actor:** UI researcher and designer.
+- **Given:** each test question names the behavior, participant context, uncertainty, risk, needed fidelity,
+  sample logic, and claim limit.
+- **When:** the prototype and direct-test plan are selected.
+- **Then:** effort is sufficient to answer the questions without production-like work or unsupported breadth.
+- **Failure oracle:** “five users” or “high fidelity” used without question-specific reasoning fails.
+- **Evidence tuple:** observe question-to-method matrix; inspect rationale; confirm each cost reduces named
+  uncertainty.
+- **Design obligation:** method, sample, fidelity, and claims must be risk- and question-bound.
+- **Trace:** UI-R3, UI-R13; `UI-CHECK-12`, `UI-CHECK-13`.
+
+### UI-SCENARIO-14 — One outcome legitimately spans GUI and CLI
+
+- **Primary type + justification:** Alternative-valid — two surfaces share a skeleton while carrying separate
+  mechanics and evidence.
+- **Coverage-role:** Alternative-valid; proves valid multi-surface scope.
+- **Actor:** returning user in graphical and terminal contexts.
+- **Given:** both login realizations share outcome, hierarchy/action/state relationships, and completion, while
+  each has its own mechanics, access model, prototype, test tasks, and evidence.
+- **When:** the run is reviewed as one multi-surface contract.
+- **Then:** shared and separate columns are traceable and independently testable.
+- **Failure oracle:** one prototype tested on one surface and generalized to the other fails.
+- **Evidence tuple:** observe surface matrix and prototypes; execute each test path; confirm shared skeleton plus
+  separate mechanics/access/evidence.
+- **Design obligation:** valid multi-surface runs must retain surface-specific testability.
+- **Trace:** UI-R2, UI-R13; `UI-CHECK-02`, `UI-CHECK-12`, `UI-CHECK-13`.
+
+### UI-SCENARIO-15 — Related surfaces are merged without shared skeleton or evidence
+
+- **Primary type + justification:** Adversarial — grouping by product label attempts to hide incompatible scope
+  and weak evidence.
+- **Coverage-role:** Adversarial; proves the multi-surface gate cannot be passed by naming.
+- **Actor:** design owner and reviewer.
+- **Given:** web login, desktop account administration, and CLI token management are placed in one run; they do
+  not share one outcome/skeleton and only the web artifact has mechanics, access, prototype, and evidence.
+- **When:** the bundle is called a cross-surface UI.
+- **Then:** the run is split; no evidence is generalized across surfaces.
+- **Failure oracle:** accepting because all surfaces concern “accounts” fails.
+- **Evidence tuple:** observe outcome/skeleton/surface matrix; compare completion and evidence; confirm mismatch
+  and missing separate proof.
+- **Design obligation:** surface grouping requires substantive shared structure and separate verification.
+- **Trace:** UI-R2, P1/P3/P7/P8; `UI-CHECK-02`, `UI-CHECK-12`.
+
+## UI-FAMILY-06 — Visible failure, recovery, and operational continuity
+
+- **Declared primary category:** 6 — Failure / recovery / operations. The defining discrimination is whether
+  failures are detected, explained, contained, and recoverable.
+- **Secondary categories:** 3, 4, 7, 8.
+- **Source / rationale:** `SRC-UI-PARENT` UI-R1, UI-R6, UI-R12, P3–P5/P8.
+- **Actor + outcome:** a user retains status, agency, and a safe route after interface or dependency failure.
+- **Situation / invariant:** failure behavior is part of the outcome, not an afterthought.
+- **Applicability / priority:** every run with applicable failure paths; gate-bearing.
+
+### UI-SCENARIO-16 — A failure is explained and recoverable on each surface
+
+- **Primary type + justification:** Good — the defining handled behavior succeeds.
+- **Coverage-role:** Good; proves the positive recovery floor.
+- **Actor:** returning user.
+- **Given:** an authentication attempt fails for a known recoverable reason.
+- **When:** the failure occurs in graphical and command-line prototypes.
+- **Then:** each surface exposes status and cause at an appropriate level, preserves safe input/state, offers a
+  valid retry/cancel/support route, and prevents false completion.
+- **Failure oracle:** generic “something went wrong,” hidden stderr, dead-end dialog, or silent nonzero exit
+  fails.
+- **Evidence tuple:** observe failure state; inject the cause on each surface; confirm detection, explanation,
+  containment, recovery, and no false success.
+- **Design obligation:** all applicable failure paths need surface-appropriate feedback and recovery.
+- **Trace:** UI-R1, UI-R12, P5; `UI-CHECK-10`, `UI-CHECK-17`.
+
+### UI-SCENARIO-17 — Timeout transition preserves agency and state
+
+- **Primary type + justification:** Failure/recovery — the defining concern is recovery from a timeout at the
+  exact pending-to-timeout transition.
+- **Coverage-role:** Failure/recovery; boundary is supporting context, not a second discharge.
+- **Actor:** authenticating user.
+- **Given:** an external authorization handoff has a defined timeout and may return just before, exactly at, or
+  just after it.
+- **When:** the timeout threshold is crossed.
+- **Then:** the interface chooses one coherent result, explains status, avoids duplicate completion, supports
+  safe retry/cancel, and reconciles a late response.
+- **Failure oracle:** indefinite spinner, hanging command, double success, or lost authenticated state fails.
+- **Evidence tuple:** observe transition state; simulate below/at/above timeout; confirm one terminal result and
+  recoverable late-response behavior.
+- **Design obligation:** exact timeout transitions need containment, late-result handling, and recovery.
+- **Trace:** UI-R1, UI-R6, P5; `UI-CHECK-07`, `UI-CHECK-17`.
+
+### UI-SCENARIO-18 — Visual error compliance hides unusable recovery
+
+- **Primary type + justification:** Adversarial — familiar error styling attempts to substitute for useful
+  behavior.
+- **Coverage-role:** Adversarial; proves cosmetic error presence cannot pass.
+- **Actor:** user with keyboard, screen reader, or terminal workflow.
+- **Given:** an error is red and matches a component library, but is not associated with the failed input,
+  announced, focusable, actionable, or exposed with correct CLI stream/exit behavior.
+- **When:** the user tries to identify and recover from the failure.
+- **Then:** the design fails despite visual compliance.
+- **Failure oracle:** a screenshot or component-name check passing while direct operation fails is the target
+  failure.
+- **Evidence tuple:** observe behavior by each applicable modality; perform error and recovery task; confirm
+  association, status, navigation, action, and completion.
+- **Design obligation:** error design must be behaviorally accessible and recoverable.
+- **Trace:** UI-R11, UI-R12; `UI-CHECK-10`, `UI-CHECK-17`.
+
+## UI-FAMILY-07 — Identity, trust, safety, and governance
+
+- **Declared primary category:** 7 — Trust / harm / governance. The defining discrimination is whether identity
+  and authority remain within the non-waivable accessibility and safety floor.
+- **Secondary categories:** 2, 6, 8, 10.
+- **Source / rationale:** `SRC-UI-PARENT` UI-R4, UI-R5, UI-R12, P2/P8.
+- **Actor + outcome:** users can trust interface meaning and action without exclusion or coercion.
+- **Situation / invariant:** identity conflict is surfaced for user decision but cannot waive safety/access.
+- **Applicability / priority:** every run; gate-bearing.
+
+### UI-SCENARIO-19 — Identity conflict is resolved with evidence and a protected floor
+
+- **Primary type + justification:** Good — the defining safe handling succeeds.
+- **Coverage-role:** Good; proves the positive trust/governance floor.
+- **Actor:** design owner, affected user, and UI designer.
+- **Given:** brand typography, color, motion, tone, or command brevity conflicts with access evidence, safety,
+  or a platform convention.
+- **When:** the foundation or aesthetics are decided.
+- **Then:** concrete clauses and evidence are presented; the user chooses among compliant directions; the
+  accessibility/safety floor remains intact and the decision propagates.
+- **Failure oracle:** silent override, load-order choice, or waiver of the floor fails.
+- **Evidence tuple:** observe conflict record and decision trace; compare all affected clauses; confirm floor
+  preservation and consistent propagation.
+- **Design obligation:** identity conflicts need explicit evidence-led resolution without waiving the floor.
+- **Trace:** UI-R5, UI-R12; `UI-CHECK-04`, `UI-CHECK-09`, `UI-CHECK-10`.
+
+### UI-SCENARIO-20 — Identity language is used to justify inaccessible behavior
+
+- **Primary type + justification:** Adversarial — brand authority attempts to bypass access and safety.
+- **Coverage-role:** Adversarial; proves identity cannot game acceptance.
+- **Actor:** design owner and affected user.
+- **Given:** “minimal,” “calm,” “premium,” or “developer-first” identity is cited to hide status, reduce
+  contrast, remove labels, suppress recovery detail, or require one modality.
+- **When:** the choice is proposed as intentional expression.
+- **Then:** it fails and returns to the owning structural/behavior/access decision; compliant alternatives are
+  discussed with the user.
+- **Failure oracle:** a documented brand rationale making the inaccessible behavior pass is the target failure.
+- **Evidence tuple:** observe identity and access clauses; operate the task in affected modalities; confirm lost
+  meaning, status, action, or recovery.
+- **Design obligation:** identity expression may not erase required interface meaning or operation.
+- **Trace:** UI-R11, UI-R12; `UI-CHECK-09`, `UI-CHECK-10`.
+
+### UI-SCENARIO-21 — Missing consent or unsafe evidence handling blocks acceptance
+
+- **Primary type + justification:** Failure/recovery — the governed test process fails and must recover through
+  `NEEDS_CONTEXT`, remediation, or a new ethical test.
+- **Coverage-role:** Failure/recovery; proves governance failure cannot be normalized.
+- **Actor:** participant and researcher.
+- **Given:** prototype testing lacks informed consent, needed accommodations, data minimization, or protected
+  evidence handling.
+- **When:** findings are offered as acceptance proof.
+- **Then:** the evidence is not used to accept the design; the run repairs conditions and retests or remains
+  `NEEDS_CONTEXT`.
+- **Failure oracle:** retroactive stakeholder approval or redaction alone converting invalid collection into
+  valid direct evidence fails.
+- **Evidence tuple:** observe governed records and retention controls; inspect provenance; confirm whether each
+  required condition existed during collection.
+- **Design obligation:** invalid evidence conditions must block acceptance and trigger safe recovery.
+- **Trace:** UI-R4, P8; `UI-CHECK-03`, `UI-CHECK-13`.
+
+## UI-FAMILY-08 — Accessibility, modality equivalence, and locale
+
+- **Declared primary category:** 8 — Inclusion / locale. The defining discrimination is equal access to action,
+  meaning, status, and recovery across applicable users and modalities.
+- **Secondary categories:** 2, 3, 6, 7.
+- **Source / rationale:** `SRC-UI-PARENT` UI-R11, UI-R12; `SRC-UI-ACCESS` and `SRC-UI-PLATFORM` within their
+  applicable surfaces.
+- **Actor + outcome:** users in varied ability, input, language, locale, device, and environment contexts can
+  complete and recover.
+- **Situation / invariant:** visual compliance is not behavioral equivalence.
+- **Applicability / priority:** every run; non-waivable gate.
+
+### UI-SCENARIO-22 — Required meaning and action survive applicable modalities
+
+- **Primary type + justification:** Good — ordinary access behavior supplies equivalent action, state, and
+  completion evidence.
+- **Coverage-role:** Good; proves the positive inclusion floor.
+- **Actor:** user employing keyboard, assistive technology, terminal, voice, reduced motion, zoom, or another
+  applicable mode.
+- **Given:** the specification maps every required action, status, error, recovery, and completion meaning to
+  applicable modalities.
+- **When:** the user performs the complete path without a prohibited modality dependency.
+- **Then:** sequence, meaning, control, feedback, and outcome remain coherent.
+- **Failure oracle:** same labels or content with unreachable controls, wrong order, hidden status, or changed
+  meaning fails.
+- **Evidence tuple:** observe modality matrix; perform the complete task in each claimed mode; confirm equal
+  obligation and completion.
+- **Design obligation:** every required interface obligation needs applicable modality realization.
+- **Trace:** UI-R12, P4–P8; `UI-CHECK-10`, `UI-CHECK-13`.
+
+### UI-SCENARIO-23 — Locale and terminal differences preserve meaning
+
+- **Primary type + justification:** Alternative-valid — a different language, format, direction, terminal
+  width, or color capability is a valid context.
+- **Coverage-role:** Alternative-valid; proves adaptation without changed outcome.
+- **Actor:** localized user or terminal user under constrained display capability.
+- **Given:** content can expand, direction or formats can differ, terminal width can shrink, and color may be
+  unavailable.
+- **When:** the same path is rendered and operated in the alternate valid context.
+- **Then:** hierarchy, labels, status, errors, commands, non-color meaning, recovery, and completion remain
+  understandable without clipping or ambiguity.
+- **Failure oracle:** truncated action labels, color-only status, reordered commands, or locale-incorrect data
+  causing a different action fails.
+- **Evidence tuple:** observe adapted rendering/output; test representative strings and terminal constraints;
+  confirm preserved meaning and operation.
+- **Design obligation:** adaptation must preserve action, state, and outcome meaning.
+- **Trace:** UI-R11, UI-R12; `UI-CHECK-09`, `UI-CHECK-10`.
+
+### UI-SCENARIO-24 — Visually compliant interface is behaviorally inaccessible or misleading
+
+- **Primary type + justification:** Adversarial — screenshots and component tokens attempt to pass while direct
+  operation or state interpretation fails.
+- **Coverage-role:** Adversarial; proves access and meaning cannot be cosmetic.
+- **Actor:** user with an applicable access need.
+- **Given:** contrast and visible labels appear compliant, but focus order, announcement, timing, status,
+  keyboard/command operation, or recovery is wrong; or output implies success while the state failed.
+- **When:** the complete outcome is attempted.
+- **Then:** the design fails even though a visual audit passes.
+- **Failure oracle:** acceptance from token/component/screenshot inspection without behavioral evidence is the
+  target failure.
+- **Evidence tuple:** observe end-to-end behavior; use applicable modalities and compare system state; confirm
+  inaccessible action or misleading result.
+- **Design obligation:** accessibility and truthfulness require behavioral, state-linked proof.
+- **Trace:** UI-R11, UI-R12; `UI-CHECK-10`, `UI-CHECK-17`.
+
+## UI-FAMILY-09 — Change, child specialization, and co-loaded compatibility
+
+- **Declared primary category:** 9 — Change / compatibility / reversibility. The defining discrimination is
+  whether downstream or co-loaded changes preserve the approved parent contract.
+- **Secondary categories:** 1, 4, 7, 10.
+- **Source / rationale:** `SRC-UI-PARENT` UI-R15, UI-R16, P9.
+- **Actor + outcome:** downstream surface owners change mechanics without silently changing the outcome or
+  parent invariants.
+- **Situation / invariant:** future children specialize; evidence-led user decisions resolve true conflicts.
+- **Applicability / priority:** handoff and any co-loaded/specialized run; gate-bearing when triggered.
+
+### UI-SCENARIO-25 — A future surface child specializes without weakening the parent
+
+- **Primary type + justification:** Change/regression — a downstream version introduces exact platform
+  mechanics while preserving the existing contract.
+- **Coverage-role:** Change/regression; proves safe specialization across a lifecycle change.
+- **Actor:** child-skill author and UI reviewer.
+- **Given:** a future web, CLI, desktop, mobile, or voice child adds exact standards, patterns, and examples.
+- **When:** its output is compared with the approved parent handoff.
+- **Then:** outcome, skeleton, state, recovery, access, evidence, aesthetics-last chronology, and test gates remain
+  present; only surface mechanics are specialized.
+- **Failure oracle:** a child document that narrows or omits a parent obligation fails regression.
+- **Evidence tuple:** observe parent/child clause map; diff obligations before/after; confirm preserved invariants
+  and explicit mechanic ownership.
+- **Design obligation:** child specialization needs a no-loss parent trace.
+- **Trace:** UI-R15, P9; `UI-CHECK-15`, `UI-CHECK-18`.
+
+### UI-SCENARIO-26 — A child convention is used to waive parent obligations
+
+- **Primary type + justification:** Adversarial — platform authority attempts to override the parent contract.
+- **Coverage-role:** Adversarial; proves child references cannot game inheritance.
+- **Actor:** surface designer and reviewer.
+- **Given:** a platform HIG, web pattern, design-system component, GNU/POSIX convention, or CLI practice is cited
+  to skip whole-spec approval, direct testing, recovery, modality equivalence, or specification-first revision.
+- **When:** the child design is offered for acceptance.
+- **Then:** the waiver fails; the parent invariant is restored or a concrete evidence conflict is presented to
+  the user without waiving access/safety.
+- **Failure oracle:** “the platform says so” ending the trace without user/evidence review fails.
+- **Evidence tuple:** observe cited child rule and parent map; compare effects; confirm omitted parent obligation.
+- **Design obligation:** child mechanics cannot waive parent outcome and evidence gates.
+- **Trace:** UI-R12, UI-R15; `UI-CHECK-10`, `UI-CHECK-15`.
+
+### UI-SCENARIO-27 — Co-loaded UI and UX clauses conflict
+
+- **Primary type + justification:** Counterfactual — it inverts the premise that the two independently valid
+  contracts agree in this context.
+- **Coverage-role:** Counterfactual; proves the disconfirmation response is an explicit user decision.
+- **Actor:** UI/UX designer and product decision owner.
+- **Given:** a UI hierarchy, interaction, aesthetic, or platform direction materially conflicts with a
+  co-loaded UX outcome, content, state, recovery, accessibility, evidence, or risk clause.
+- **When:** the conflict is discovered.
+- **Then:** exact clauses, evidence, trade-offs, and affected traces are shown to the user; no precedence or load
+  order is invented; the safety/access floor stays intact.
+- **Failure oracle:** silently choosing UI, UX, or the last-loaded guidance fails.
+- **Evidence tuple:** observe conflict record; compare clauses and user decision; confirm propagated resolution
+  without invented precedence.
+- **Design obligation:** co-loaded conflict must reopen user authority with evidence.
+- **Trace:** UI-R16, P9; `UI-CHECK-16`, `UI-CHECK-18`.
+
+## UI-FAMILY-10 — Evidence, traceability, concepts, and identity fallback
+
+- **Declared primary category:** 10 — Evidence / traceability / clarity. The defining discrimination is whether
+  a cold reader can resolve each claim to evidence, decision, specification, prototype, and retest.
+- **Secondary categories:** 1, 2, 4, 7.
+- **Source / rationale:** `SRC-UI-PARENT` UI-R3, UI-R5, UI-R8–UI-R10, UI-R14, P2/P6/P8/P9.
+- **Actor + outcome:** a cold reader can verify the design without hidden session context or evidence theater.
+- **Situation / invariant:** missing identity triggers a bounded brief; prior evidence informs but does not
+  replace the run's direct test; concepts differ materially.
+- **Applicability / priority:** every run; required.
+
+### UI-SCENARIO-28 — Missing DESIGN material yields a confirmed run-scoped brief
+
+- **Primary type + justification:** Good — the correct evidence fallback produces a bounded identity foundation
+  without inventing a project-wide document.
+- **Coverage-role:** Good; proves the positive traceability and identity-fallback floor.
+- **Actor:** project decision owner and UI designer.
+- **Given:** no adequate `DESIGN.md`, brand, product, or design-system document exists.
+- **When:** P2 establishes identity.
+- **Then:** live product/system/tokens are inspected; the user answers promise, users, values, voice, character,
+  patterns, constraints, anti-patterns, and expression questions; a temporary brief is confirmed in the feature
+  design document.
+- **Failure oracle:** silently inventing identity, skipping it, or creating a universal project-wide
+  `DESIGN.md` fails.
+- **Evidence tuple:** observe authority-chain register and decision trace; inspect feature document; confirm
+  live evidence, explicit questions, user lock, and bounded location.
+- **Design obligation:** identity fallback must be evidence-led, user-confirmed, and run-scoped.
+- **Trace:** UI-R5, P2; `UI-CHECK-04`, `UI-CHECK-18`.
+
+### UI-SCENARIO-29 — Prior evidence is offered in place of this run's direct test
+
+- **Primary type + justification:** Adversarial — relevant prior evidence attempts to bypass the current-run
+  direct prototype-test gate.
+- **Coverage-role:** Adversarial; proves relevance and recency cannot substitute for required direct use.
+- **Actor:** design owner and reviewer.
+- **Given:** prior UX research or earlier UI testing is offered instead of this run's direct prototype test.
+- **When:** the design is proposed for final lock.
+- **Then:** the replacement fails; representative users must directly use this run's post-G5 prototype under
+  UI-R3/UI-R4 before the design can lock.
+- **Failure oracle:** a strong prior-research section making an untested current prototype pass is the target
+  failure.
+- **Evidence tuple:** observe evidence dates/provenance; inspect current-run test record; confirm that no direct
+  use of this run's prototype supports the acceptance claim.
+- **Design obligation:** current-run direct prototype testing must remain independently evidenced.
+- **Trace:** UI-R3; `UI-CHECK-13`, `UI-CHECK-18`.
+
+### UI-SCENARIO-30 — A load-bearing premise is wrong and reopens the earliest branch
+
+- **Primary type + justification:** Counterfactual — the approved premise that two surfaces share a skeleton or
+  that the identity source governs is inverted by new evidence.
+- **Coverage-role:** Counterfactual; proves evidence reopens rather than being patched downstream.
+- **Actor:** UI designer and product decision owner.
+- **Given:** direct testing or authoritative project evidence disproves a surface, identity, hierarchy, or state
+  premise after later work exists.
+- **When:** the contradiction is confirmed.
+- **Then:** the earliest owning D-node and user gate reopen; the specification is reconciled before prototype
+  changes and affected paths are retested.
+- **Failure oracle:** preserving the old premise and editing only labels, aesthetics, or prototype behavior
+  fails.
+- **Evidence tuple:** observe premise and disconfirming source; walk decision/revision lineage; confirm earliest-
+  owner reopening and downstream propagation.
+- **Design obligation:** new evidence must reopen the earliest affected decision and update the durable contract.
+- **Trace:** UI-R7, UI-R8, UI-R14; `UI-CHECK-14`, `UI-CHECK-18`.
+
+### UI-SCENARIO-31 — Cosmetic variants are presented as two material concepts
+
+- **Primary type + justification:** Adversarial — superficial option count attempts to satisfy concept
+  divergence without a consequential design difference.
+- **Coverage-role:** Adversarial; proves material-concept comparison cannot be passed by relabeling.
+- **Actor:** design owner and reviewer.
+- **Given:** two interface “concepts” share the same hierarchy, action model, information flow, interaction,
+  and state communication and differ only by color, type, spacing, icon style, or wording.
+- **When:** they are offered as the UI-R9 comparison.
+- **Then:** they count as one concept; the run creates a materially different option or records the bounded
+  single-concept exception with real constraints plus direct evidence.
+- **Failure oracle:** two polished boards or variant names making the concept check pass is the target failure.
+- **Evidence tuple:** observe concept artifacts; compare consequential structure and behavior; confirm only
+  cosmetic variance and absence/presence of a valid exception.
+- **Design obligation:** concept comparison must change a consequential interface property or prove the
+  exception.
+- **Trace:** UI-R9; `UI-CHECK-08`, `UI-CHECK-18`.
+
+### UI-SCENARIO-32 — Smart-skip and silence are treated as user approval
+
+- **Primary type + justification:** Adversarial — process compression attempts to turn existing evidence or
+  continued work into authority the user did not give.
+- **Coverage-role:** Adversarial; proves adaptive interviewing cannot erase a decision axis or user gate.
+- **Actor:** UI designer and product decision owner.
+- **Given:** a design-bearing axis is skipped without both current evidence and a prior user lock, several axes
+  are bundled into one question, or G1–G6 is inferred from silence or continued work.
+- **When:** the decision record is used to justify construction, prototyping, acceptance, or handoff.
+- **Then:** the trace fails; the earliest undecided axis reopens, research/options/recommendation are supplied as
+  applicable, and the user gives one explicit decision per axis and gate.
+- **Failure oracle:** an apparently complete document with no resolvable user lock for an applicable axis or
+  gate is the target failure.
+- **Evidence tuple:** observe question and decision history; audit each D-node and G1–G6; confirm one-axis turns,
+  valid smart-skip pairs, researched recommendations, and explicit locks.
+- **Design obligation:** adaptive completion must preserve every applicable decision and explicit user gate.
+- **Trace:** UI-R7, UI-R8; `UI-CHECK-18`, `UI-CHECK-19`.
+
+## Obligation-to-check reservation
+
+| Obligation cluster | Scenario IDs | Reserved checks |
+|---|---|---|
+| One bounded outcome and adjacent-outcome control | `01`–`03` | `UI-CHECK-01` |
+| Shared skeleton plus separate multi-surface mechanics/evidence | `02`, `14`, `15` | `UI-CHECK-02`, `UI-CHECK-12` |
+| Representative people, consent, accommodations, bounded claims | `04`–`06`, `21`, `29` | `UI-CHECK-03`, `UI-CHECK-13` |
+| Identity authority chain, fallback, and conflict handling | `19`, `20`, `28` | `UI-CHECK-04`, `UI-CHECK-09` |
+| Top-down skeleton and bottom-up coherent units | `07`–`09` | `UI-CHECK-05`, `UI-CHECK-06` |
+| Complete behavior/state/recovery and exact order | `08`, `10`–`12`, `16`–`18` | `UI-CHECK-07`, `UI-CHECK-11`, `UI-CHECK-14`, `UI-CHECK-17` |
+| Material concepts | `31` | `UI-CHECK-08` |
+| Aesthetics-last and behavioral accessibility | `18`–`20`, `22`–`24` | `UI-CHECK-09`, `UI-CHECK-10` |
+| Parent-preserving handoff and co-load conflict | `25`–`27` | `UI-CHECK-15`, `UI-CHECK-16` |
+| Bidirectional evidence and cold-reader clarity | `10`, `12`, `25`, `28`–`32` | `UI-CHECK-18`, `UI-CHECK-19` |
+
+## Failability and omission audit
+
+- A polished big-bang artifact fails `UI-SCENARIO-03`.
+- Any prototype before whole-specification approval fails `UI-SCENARIO-11`.
+- A locally working unit that breaks the skeleton fails `UI-SCENARIO-09`.
+- Aesthetics or visual error polish before sound behavior/access fails `UI-SCENARIO-18`, `20`, or `24`.
+- Missing design material exercises `UI-SCENARIO-28`; identity/access conflict exercises `19`–`20`.
+- Missing users, consent, accommodations, or evidence fails closed through `05`, `06`, and `21`.
+- Prior evidence replacing direct testing fails `UI-SCENARIO-29`; cosmetic concepts fail `31`.
+- Invalid surface merging fails `UI-SCENARIO-15`; valid GUI/CLI scope is distinguished by `02` and `14`.
+- Child waiver and co-load precedence fail `UI-SCENARIO-26` and `27`.
+- Prototype-only correction fails `UI-SCENARIO-12`; evidence-driven earliest-branch reopening is `30`.
+- Invalid smart-skip, bundled axes, and silent approval fail `UI-SCENARIO-32`.
+
+Every load-bearing UI-R1–UI-R16 clause maps to at least one case and reserved check. Every case maps back to a
+live parent clause and forward to a reserved check. No exploratory or sensitive-evidence exemption is used.

--- a/.gobbi/projects/gobbi/skills/ui/scenarios.md
+++ b/.gobbi/projects/gobbi/skills/ui/scenarios.md
@@ -42,15 +42,16 @@ the family's properties trigger them. An `n/a` cell names the property that make
 | `UI-FAMILY-03` | `07` | n/a: alternative surface is exercised in `02` | n/a: no invalid input, state, authorization, or precondition discrimination; the invalid-looking local/whole mismatch is an intentional acceptance-gate attempt | `08` | n/a: injected failure owned by family 06 | `09` | n/a: no version event | n/a: state inventory is inspected directly |
 | `UI-FAMILY-04` | `10` | n/a: parent order has one valid chronology | n/a: no independently discriminating invalid input, state, authorization, or precondition case; premature-prototype pressure is an intentional gate bypass | n/a: stage transition is audited chronologically | `12` | `11` | n/a: no version event | n/a: chronology is evidenced, not premised |
 | `UI-FAMILY-05` | `13` | `14` | n/a: no invalid input, state, authorization, or precondition discrimination; incompatible surface bundling is intentional scope-label gaming | n/a: no universal participant or fidelity threshold | n/a: operational failure owned by family 06 | `15` | n/a: no version event | n/a: proportionality claim has named questions |
-| `UI-FAMILY-06` | `16` | n/a: alternative recovery paths are enumerated in the same contract | n/a: no invalid input, state, authorization, or precondition is supplied; the exercised defect is an injected dependency or timeout failure | `17` | `17` | `18` | n/a: planned reversibility owned by family 09 | n/a: dependency failure is injected directly |
+| `UI-FAMILY-06` | `16` | n/a: alternative recovery paths are enumerated in the same contract | n/a: no invalid input, state, authorization, or precondition is supplied; the exercised defect is an injected dependency or timeout failure | `17` | `16` | `18` | n/a: planned reversibility owned by family 09 | n/a: dependency failure is injected directly |
 | `UI-FAMILY-07` | `19` | n/a: one non-waivable safety floor | n/a: no independently discriminating invalid input, state, authorization, or precondition case; unsafe evidence and identity pressure are governance failure or authority gaming | n/a: no numeric or finite limit | `21` | `20` | n/a: no version event | n/a: conflict evidence is inspected directly |
 | `UI-FAMILY-08` | `22` | `23` | n/a: no invalid input, state, authorization, or precondition discrimination; valid-looking inaccessible behavior games the access gate | n/a: platform limits are surface-owned inputs | n/a: failed access behavior appears as adversarial exclusion | `24` | n/a: no version event | n/a: modality equivalence is directly inspected |
 | `UI-FAMILY-09` | `25` | n/a: UI/UX conflict and child change are distinct cases | n/a: no invalid input, state, authorization, or precondition discrimination; the child waiver is an intentional authority override | n/a: no finite limit | n/a: runtime recovery owned by family 06 | `26` | `25` | `27` |
 | `UI-FAMILY-10` | `28` | n/a: one bidirectional evidence model | n/a: no independently discriminating invalid input, state, authorization, or precondition case; stale evidence, cosmetic concepts, and invalid smart-skips are acceptance-gate gaming | n/a: no numeric or finite limit | n/a: missing evidence closes as `NEEDS_CONTEXT` in family 02 | `29`, `31`, `32` | n/a: artifact revision chronology is family 04 | `30` |
 
-`UI-SCENARIO-17` is the set's one bounded n-ary record and discharges both Boundary and Failure/recovery. Its
-primary remains Failure/recovery; the case-level coverage-role explanations, per-type proof, and gaming probe
-justify the two matrix cells. No other case claims more than one minimum discharge.
+`UI-FAMILY-06` uses the ordinary positive-floor-plus-one-minimum pattern: `UI-SCENARIO-16` carries the Good
+floor and the triggered Failure/recovery minimum, while `UI-SCENARIO-17` carries Boundary. Scenario 17 still
+matches Failure/recovery and keeps it as its author-declared primary type, but its coverage role is the Boundary
+subset. No case claims more than the positive floor plus at most one triggered minimum.
 
 ## Source register and stable IDs
 
@@ -373,7 +374,8 @@ Renaming a title does not change an ID. A changed discrimination gets a new case
 ### UI-SCENARIO-16 — A failure is explained and recoverable on each surface
 
 - **Primary type + justification:** Good — the defining handled behavior succeeds.
-- **Coverage-role:** Good; proves the positive recovery floor.
+- **Coverage-role:** Good — proves the positive recovery floor; Failure/recovery — proves that a known
+  recoverable failure is detected, explained, contained, and recoverable without false success.
 - **Actor:** returning user.
 - **Given:** an authentication attempt fails for a known recoverable reason.
 - **When:** the failure occurs in graphical and command-line prototypes.
@@ -390,24 +392,7 @@ Renaming a title does not change an ID. A changed discrimination gets a new case
 
 - **Primary type + justification:** Failure/recovery — the defining concern is recovery from a timeout at the
   exact pending-to-timeout transition.
-- **Coverage-role:** Failure/recovery — injects an external-handoff timeout and requires containment,
-  late-result handling, and recovery; Boundary — exercises below, at, and above the exact pending-to-timeout
-  transition.
-- **Inseparability record:**
-  - `discharges: [boundary, failure/recovery]`.
-  - `per-type-proof:` Boundary cannot preserve this exact below/at/above timeout discrimination without the
-    timeout failure that activates containment and late-result recovery; Failure/recovery cannot preserve this
-    case's timeout-recovery discrimination without crossing the exact time-window boundary. Replacing the
-    timeout with another failure creates a different case and does not prove this obligation.
-  - `no-cosmetic-duplicate:` one below/at/above observation proves both discriminations; relabeling it as two
-    cases would duplicate the same Given/When/Then.
-  - `bounded + auditable:` the joint discharge applies only to this external-authorization timeout transition,
-    not to other boundaries or failures in the family.
-  - `gaming-probe gate (SR-12, P8):` a Boundary-only attempt collapses into the generic state transition already
-    covered by `UI-SCENARIO-08` and loses the timeout failure; a Failure/recovery-only attempt collapses into the
-    generic recovery floor covered by `UI-SCENARIO-16` and loses the exact threshold and late-result
-    discrimination. No dedicated single-type case can preserve this obligation, so both roles remain
-    inseparable here.
+- **Coverage-role:** Boundary — exercises below, at, and above the exact pending-to-timeout transition.
 - **Actor:** authenticating user.
 - **Given:** an external authorization handoff has a defined timeout and may return just before, exactly at, or
   just after it.

--- a/.gobbi/projects/gobbi/skills/ux/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/ux/SKILL.md
@@ -1,0 +1,307 @@
+---
+name: ux
+description: Use when designing one complete observable user outcome across surfaces, from direct user research and an evidence-based experience specification through a tested disposable prototype and measurement handoff.
+allowed-tools: Read, Grep, Glob, Bash, Write, Edit, AskUserQuestion, WebSearch, WebFetch
+skill-type: operation
+---
+
+# User Experience Design
+
+Operation skill for designing one complete observable user outcome across web, command-line, desktop,
+mobile, voice, and future surfaces. A run starts with current evidence and direct generative research, grows
+one experience specification in controlled stages, then tests a disposable prototype with representative
+users. Load it when the outcome, flow, tasks, information, content intent, states, recovery, trust, or success
+evidence must be designed.
+
+This skill is independently loadable. It does not require or outrank a `ui` skill. When both are loaded, UX
+owns the outcome and experience contract; UI may own its surface realization. Neither wins by load order.
+
+---
+
+## Principles
+
+> **Design one complete user outcome, not an isolated artifact.**
+
+A screen, command, component, or happy path has value only as part of an outcome a person can finish. Design
+from entry through completion, including every actor, state, failure, recovery, handoff, and support step the
+outcome needs. Keep adjacent outcomes outside the run so depth is not traded for breadth.
+
+> **Direct evidence has priority over confident assumptions.**
+
+People's observed behavior, context, needs, barriers, and prototype use are stronger evidence than stakeholder
+preference or design convention. Research must be ethical, representative of the claim, and explicit about its
+limits. Missing evidence stays visible; it is never converted into certainty by polished prose.
+
+> **Set the whole frame from the top, then grow every detail from the bottom.**
+
+First establish the experience skeleton so each local choice has a place and purpose. Then start with the
+smallest meaningful task, information, content, and state unit, and grow complete paths one verified step at a
+time. A locally elegant unit that breaks the whole experience is wrong.
+
+> **Finish the specification before using a prototype to answer questions.**
+
+A partial design tested too early locks attention onto the first visible solution and hides missing paths. The
+whole experience specification must be complete and user-approved before a prototype is made. The prototype
+then tests the specification's riskiest assumptions; it does not substitute for them.
+
+> **Project identity guides the design from the foundation.**
+
+Identity is the product's promise, character, voice, values, existing language, and recognizable system. Use
+it to constrain the experience from the start, while resolving conflicts with user evidence, accessibility,
+safety, and platform conventions openly. Identity never excuses avoidable exclusion or harm.
+
+> **Acceptance requires evidence from the people affected.**
+
+Stakeholder approval can lock product intent, but it cannot prove that representative users understand, can
+complete, or can recover through the experience. A design is accepted only after direct prototype evaluation
+supports the claims being made and affected findings have been resolved and retested.
+
+---
+
+## Rules
+
+### Must-Follow
+
+- **UX-R1 — MUST bind one complete observable outcome per run.** Name the primary actor, necessary supporting
+  actors, trigger, entry, completion evidence, normal and alternative paths, applicable states, errors,
+  recovery, handoffs, support, scope, and non-goals. A screen, page, command, component, artifact, or happy path
+  is not an outcome. An adjacent outcome enters only after the user changes the scope contract.
+- **UX-R2 — MUST obtain new direct generative research from representative users before design convergence.**
+  Prior research, analytics, support records, domain expertise, and stakeholder input may frame the inquiry but
+  never replace new contact for the run. A project owner counts only when evidence shows that person is
+  genuinely representative of the relevant user context.
+- **UX-R3 — MUST obtain direct representative-user prototype evaluation before acceptance.** The evaluator
+  plans method, sample, accommodations, and claims from the research question, diversity, uncertainty, and
+  risk; this skill sets no fixed participant count. Prior usability results do not replace a new run's test.
+- **UX-R4 — MUST protect research participants and evidence.** Obtain informed consent, provide needed
+  accommodations, minimize and protect collected data, state limits, and avoid coercive or performative
+  research. If access to representative users, consent, accommodations, or required evidence is missing, return
+  `NEEDS_CONTEXT`; assumptions and a research plan may be recorded, but no final design may be called accepted.
+- **UX-R5 — MUST establish project identity through one evidence chain.** Use, in order: explicit `DESIGN.md`,
+  brand, product, or design-system documents; the live product, system, and tokens; then a user-confirmed
+  temporary identity brief. When material is missing, ask the kinds of questions those documents would answer
+  and capture a run-scoped brief in the feature design document. Do not create or prescribe a universal
+  project-wide `DESIGN.md`.
+- **UX-R6 — MUST follow the construction order without skipping or rearranging it.** Bind outcome and context;
+  establish reference, identity, and direct-research foundation; create the top-down experience skeleton; grow
+  the specification bottom-up; compare concepts; complete and obtain approval for the whole specification;
+  then prototype; test; revise the specification first and prototype second; retest; and hand off with
+  measurement. A prototype before whole-specification approval fails the run.
+- **UX-R7 — MUST stop at each user gate.** Obtain an explicit decision after the foundation and identity, the
+  skeleton, the core unit and path, the accumulated specification, the final whole specification, and the
+  post-test revision. Silence, continued work, or a stakeholder's earlier preference is not approval.
+- **UX-R8 — MUST compare at least two materially different concepts by default.** Cosmetic variations of one
+  pattern are one concept. A single-concept exception is valid only when real constraints plus direct evidence
+  show that divergence would be false; record the constraints, evidence, and exception.
+- **UX-R9 — MUST complete one evidence-bearing feature design document before prototyping.** The active project
+  or workflow controls its path. The document carries the full schema in Procedure and records evidence,
+  alternatives, decisions, rejections, limitations, success measures, and remaining uncertainty.
+- **UX-R10 — MUST design inclusion, trust, privacy, safety, harm prevention, agency, and recovery into the
+  experience.** When identity or stakeholder preference conflicts with accessibility, safety, direct user
+  evidence, or a platform convention, show the evidence and ask the user to decide. The accessibility and
+  safety floor cannot be waived.
+- **UX-R11 — MUST make the prototype disposable and proportionate to uncertainty.** It represents enough of the
+  approved specification to answer named questions and no more. It is a test artifact, never production
+  implementation or evidence that the feature is ready to ship.
+- **UX-R12 — MUST revise the specification before revising the prototype.** Every supported test finding first
+  changes the owning requirement, path, state, content intent, measure, or recorded decision; the prototype is
+  then brought back into agreement. Retest affected assumptions and regressions before the post-test gate.
+- **UX-R13 — MUST define success measures that resist gaming.** Each measure traces to the observable outcome,
+  names intended and harmful interpretations, includes failure and recovery signals, and states how evidence
+  will change the design. A proxy that can improve while the user outcome worsens cannot stand alone.
+- **UX-R14 — MUST preserve the experience contract across handoff.** Surface-specific designers and future
+  web, command-line, desktop, mobile, or voice child skills may specialize mechanics and standards, but must
+  preserve the parent outcome, evidence, state, recovery, accessibility, safety, and measurement obligations.
+  Any material deviation returns to the user; it is never made silently.
+
+### Must-Not-Follow
+
+- **NEVER design a polished whole solution in one pass.** Fix: establish the foundation and skeleton, then grow
+  the specification through the required gates.
+- **NEVER treat stakeholder preference, prior research, analytics, or an unrepresentative project owner as the
+  run's direct user evidence.** Fix: obtain new generative research and direct prototype evaluation from people
+  representative of the claims.
+- **NEVER run research after the solution is already locked merely to validate it.** Fix: reopen the earliest
+  affected decision, ask neutral generative questions, and let evidence change the direction.
+- **NEVER prototype before the whole specification is complete and explicitly approved.** Fix: finish and gate
+  the document first, then size a disposable prototype to the remaining uncertainty.
+- **NEVER apply a prototype finding only to the mockup.** Fix: revise the specification first, then the
+  prototype, then retest the affected evidence.
+- **NEVER let a locally strong task, state, or channel break the top-down skeleton or another required channel.**
+  Fix: repair the unit or skeleton and recheck the whole outcome, including cross-channel handoffs.
+- **NEVER use visual polish, familiar labels, or a present artifact as proof that an obligation is met.** Fix:
+  inspect behavior and direct-user evidence against the stated outcome and failure oracle.
+- **NEVER resolve co-loaded UX and UI guidance by precedence or load order.** Fix: identify the concrete
+  conflict, present evidence and trade-offs, and ask the user; keep the accessibility and safety floor.
+
+---
+
+## Procedure
+
+Run nine phases in order. Read [`ideation.md`](ideation.md) before the first user discussion. Work one decision
+axis per turn, keep stakeholder decisions separate from representative-user evidence, and use the active
+project's own feature-document and workflow locations.
+
+### P1 — Bind the outcome, authority, and research conditions
+
+Write one sentence naming the actor's observable outcome. Expand it into the primary actor, supporting actors,
+trigger, context, entry, completion evidence, required paths and channels, scope, and explicit non-goals.
+Identify who can lock product intent and who is representative enough to supply user evidence. Inventory user
+access, consent, accommodations, evidence, dependencies, and production constraints. Return `NEEDS_CONTEXT` on
+any UX-R4 gate failure.
+
+**Evidence:** a user-locked outcome contract, actor/context map, research conditions, and adjacent-outcome list.
+
+### P2 — Establish the reference, identity, and direct-research foundation
+
+Read the identity authority chain in UX-R5 and relevant internal experience, support, analytics, policy, and
+platform evidence. Research applicable external prior art. When identity is incomplete, elicit and confirm a
+temporary brief covering product promise, users, values, voice, recognizable patterns, constraints, and
+anti-patterns. Plan and conduct new direct generative research with representative users before any design
+converges. Record method, participants in non-identifying terms, consent, accommodations, evidence, competing
+interpretations, limits, and claims the sample can support.
+
+At the **foundation and identity gate**, present the sources, user evidence, brief, risks, conflicts, and
+recommended foundation. The user locks the foundation; research participants do not make product decisions.
+
+**Evidence:** identity/reference register, user-research record, limitations, and explicit user decision.
+
+### P3 — Create the top-down experience skeleton
+
+Map the outcome from trigger to completion before designing local detail. Show actor lanes, major phases,
+channels, dependencies, handoffs, decision points, state transitions, failure zones, recovery routes, support,
+and completion evidence. Keep the skeleton abstract enough that concepts can still differ. Check that every
+supporting actor and cross-channel transition serves the same bounded outcome.
+
+At the **skeleton gate**, show the whole map and its unresolved questions. The user approves or reopens the
+foundation.
+
+**Evidence:** approved experience skeleton with scope and uncertainty annotations.
+
+### P4 — Grow the core unit and path bottom-up
+
+Choose the smallest meaningful task, information, content, or state unit that advances the outcome. Specify its
+user intent, required information, preconditions, inputs, state, feedback, errors, recovery, accessibility,
+trust, and evidence. Connect it to the next unit, then grow the shortest complete core path while continuously
+checking it against the skeleton.
+
+At the **core unit and path gate**, demonstrate the core path, its failure oracle, and its fit in the skeleton.
+
+**Evidence:** approved unit records and one complete core path.
+
+### P5 — Grow the accumulated complete specification
+
+Extend the core path one unit at a time until every applicable normal, alternative, boundary, failure,
+recovery, support, handoff, and supporting-actor path is specified. Add content intent, information needs,
+states, timing, dependencies, cross-channel continuity, accessibility, trust, privacy, safety, agency, harm
+controls, and measurement points. Reconcile each new unit with the skeleton and prior units.
+
+At the **accumulated-specification gate**, review the complete path/state inventory and every known gap. A gap
+may remain recorded, but an applicable unresolved requirement prevents final approval.
+
+**Evidence:** accumulated specification, trace map, and resolved-or-open gap register.
+
+### P6 — Compare concepts and approve the whole specification
+
+Create at least two materially different concepts that both satisfy the accumulated obligations. Compare how
+each changes the experience skeleton, user control, cognitive and physical effort, failure/recovery, trust,
+accessibility, operational feasibility, and measurement. Recommend one and state the evidence that would change
+the recommendation. If UX-R8's exception applies, record it instead of drawing a cosmetic second concept.
+
+Integrate the user-locked concept into the whole specification. Resolve contradictions and recheck every actor,
+path, state, channel, recovery route, obligation, measure, and non-goal. At the **final whole-specification
+gate**, obtain explicit approval. Do not create a prototype until this gate passes.
+
+**Evidence:** concept comparison, rejected options, decision trace, complete specification, and approval.
+
+### P7 — Make a disposable prototype after approval
+
+Name the remaining uncertainties and test questions. Select the lowest prototype fidelity that can answer them
+without pretending to be production. Represent all approved paths and states needed by those questions,
+including applicable errors, recovery, accessibility, and cross-channel transitions. Mark simulated behavior
+and data clearly.
+
+**Evidence:** prototype plan, fidelity rationale, trace to the approved specification, and disposable artifact.
+
+### P8 — Test directly, revise the specification first, and retest
+
+Conduct direct prototype evaluation with representative users under UX-R3 and UX-R4. Observe comprehension,
+completion, alternatives, errors, recovery, trust, accessibility, workarounds, cross-channel continuity, and
+unintended harm. Separate observations from interpretations. Bound each claim to the evidence.
+
+For every supported finding, revise the owning part of the specification first. Then revise the prototype.
+Retest every affected assumption and regression. At the **post-test revision gate**, show the evidence, changes,
+remaining limits, and recommendation. Acceptance requires this gate and every applicable evidence obligation to
+pass.
+
+**Evidence:** test record, findings, specification-first revision trace, updated prototype, retest evidence, and
+explicit decision.
+
+### P9 — Hand off the contract and continue measurement
+
+Publish the approved feature design document, prototype status, evidence limits, no-silent-change contract,
+implementation questions, and measure plan. Map each obligation to its future owner without choosing exact
+surface mechanics. Define how outcome, failure, recovery, accessibility, trust, and guardrail measures will be
+read after release, who reviews them, and what evidence reopens the design.
+
+A run is complete only when the whole document is coherent, the prototype evidence supports its claims, all
+required user gates are explicit, and the handoff can be followed without hidden session context.
+
+**Evidence:** handed-off document, ownership/trace map, measurement plan, and reopen conditions.
+
+### Feature design document schema
+
+The skill defines the schema, not a universal path. The active project or workflow owns the actual document
+location.
+
+1. **Project Identity and References**
+2. **Outcome, Actors, Context, Scope, Non-Goals**
+3. **Direct User Research, Ethics, Evidence, Limitations**
+4. **Current Experience and Dependencies**
+5. **Top-Down Experience Skeleton**
+6. **Bottom-Up Tasks, Information, Content, States, Recovery**
+7. **Concepts, Alternatives, Decisions, Rejected Options**
+8. **Accessibility, Trust, Privacy, Harm, Agency**
+9. **Complete Specification, Success Measures, Instrumentation**
+10. **Prototype, Direct-User Test Evidence, Revisions, Handoff**
+
+### Cross-surface boundary example
+
+For a login/authentication run, the outcome is “an eligible returning user securely reaches the intended
+signed-in destination and can understand and recover from any failure encountered on that attempt.” The web
+experience may use a form and browser redirect. A command-line equivalent may use `tool auth login`, an
+external authorization handoff, status feedback, cancellation, timeout, and a verified authenticated terminal
+state. Both are the same outcome only when their evidence, security, recovery, and handoff obligations remain
+coherent. Registration, password reset, account administration, and post-login onboarding are adjacent outcomes
+and stay out of scope unless the user changes the contract.
+
+---
+
+## References
+
+- [ISO 9241-210: Human-centred design for interactive systems](https://www.iso.org/standard/77520.html)
+  validates iterative human-centred activity grounded in users, tasks, and environments.
+- [ISO 9241-11: Usability definitions and concepts](https://www.iso.org/standard/63500.html) validates the
+  outcome-and-context framing for effectiveness, efficiency, and satisfaction.
+- [Digital.gov Human-Centered Design Guide](https://digital.gov/guides/hcd/introduction) validates research,
+  synthesis, ideation, prototyping, and testing as connected design work.
+- [GOV.UK: Understand users and their needs](https://www.gov.uk/service-manual/service-standard/point-1-understand-user-needs)
+  validates evidence-led decisions based on real users and context.
+- [GOV.UK: Solve a whole problem for users](https://www.gov.uk/service-manual/service-standard/point-2-solve-a-whole-problem)
+  validates complete-outcome scope across necessary organizations and channels.
+- [Design Council Framework for Innovation](https://www.designcouncil.org.uk/resources/framework-for-innovation/)
+  validates divergence and convergence rather than premature commitment to one solution.
+- [GOV.UK: Making prototypes](https://www.gov.uk/service-manual/design/making-prototypes) validates prototypes
+  as proportionate learning artifacts rather than production output.
+- [GOV.UK: Plan user research for your service](https://www.gov.uk/service-manual/user-research/plan-user-research-for-your-service)
+  validates method and participation choices driven by learning goals rather than a universal count.
+- [GOV.UK: Getting users' consent for research](https://www.gov.uk/service-manual/user-research/getting-users-consent-for-research)
+  validates informed consent and participant agency.
+- [W3C WAI: Involving Users in Web Accessibility](https://www.w3.org/WAI/planning/involving-users/) validates
+  involving people with disabilities while keeping standards and expert review as separate evidence.
+- [GOV.UK: Define success and publish performance data](https://www.gov.uk/service-manual/service-standard/point-10-define-success-publish-performance-data)
+  validates outcome measures and continued performance review.
+- [`ideation.md`](ideation.md) owns the complete user-decision tree used by P1–P9.
+- [`scenarios.md`](scenarios.md) exercises this parent contract without adding policy.
+- [`checklists.md`](checklists.md) provides the unchecked operational evidence gates for this parent contract.
+- [`evaluation.md`](evaluation.md) extends active Gobbi evaluation with UX-specific selection and lenses.

--- a/.gobbi/projects/gobbi/skills/ux/checklists.md
+++ b/.gobbi/projects/gobbi/skills/ux/checklists.md
@@ -1,16 +1,27 @@
 # UX Design — Operational Checklist
 
-Unchecked source for running and evaluating one UX design outcome. Each run works a fresh filled copy and
-identifies this source plus the run; never mark this source. Mode: **operational**. Default use style is
+Unchecked reusable source for running and evaluating one UX design outcome. Never mark this source. Each run
+works a fresh filled copy that records three distinct provenance fields: this source's identity/path, its
+immutable source version or revision (for example a commit SHA, release tag, or content hash), and the run
+identity (for example session plus task/evaluation ID). Stable item IDs identify checks, not source bytes; the
+run identity identifies the execution, not the source revision. Mode: **operational**. Default use style is
 **read-do** at pause points A–D and **do-confirm** at pause point E; a filled copy declares the actual style at
 each pause point.
 
-Coverage closure means every applicable gate and required item has a terminal resolution. Acceptance is a
+Coverage closure means every applicable gate and required item has a valid terminal resolution. Acceptance is a
 separate result: every applicable gate and required item must be `PASS`, except that the checklist owner's
-bounded operational waiver may substitute on one item only when named authority covers that item's consequence
-and stop action and the authorization evidence and rationale are recorded. A waiver never counts as `PASS`, and
-accessibility or safety cannot be waived. A recorded-open or failed item can close coverage but cannot make this
-UX run accepted.
+bounded operational waiver may substitute on at most one **non-protected gate** when named authority covers that
+item's consequence and stop action and the authorization evidence and rationale are recorded. A waiver never
+counts as `PASS`.
+
+Five protected mandatory classes are explicitly non-waivable: (1) current-run direct generative research before
+convergence (`UX-CHECK-03`); (2) complete whole-specification approval before every prototype, including both
+document closure and chronology (`UX-CHECK-11`, `UX-CHECK-12`); (3) current direct representative-user prototype
+evaluation (`UX-CHECK-14`); (4) accessibility in any applicable item's claim or pass condition; and (5) safety
+in any applicable item's claim or pass condition. A waiver token on a protected item is invalid: it closes
+neither coverage nor acceptance. Resolve that item with a permitted terminal; `FAIL` or `recorded-open` can close
+coverage but cannot accept the run. A recorded-open or failed non-protected item likewise closes coverage
+without acceptance.
 
 ## Resolution legend
 
@@ -19,7 +30,24 @@ UX run accepted.
 - `n/a:<property>` — inspected evidence proves the applicability predicate false.
 - `recorded-open:<owner+resolution-method>` — operational coverage is closed but acceptance is not granted.
 - `waived/exception-authorized:<authority+rationale>` — permitted only for an operational gate when the named
-  authority covers its stated consequence; it does not count as `PASS` and cannot waive accessibility or safety.
+  authority covers its stated consequence; it does not count as `PASS`. It is invalid for direct generative
+  research, whole-specification-before-prototype document closure or chronology, direct representative-user
+  prototype evaluation, accessibility, or safety.
+
+## Protected-waiver acceptance truth table
+
+Each adversarial row holds every other applicable gate and required item at `PASS`. Coverage closure and
+acceptance are evaluated separately.
+
+| Protected class | Attempted protected-item resolution | All other applicable items | Coverage closed? | Accepted? |
+|---|---|---|---|---|
+| Direct generative research (`UX-CHECK-03`) | `waived/exception-authorized:<authority+rationale>` | `PASS` | No — invalid token | No |
+| Whole-specification-before-prototype (`UX-CHECK-11` or `UX-CHECK-12`) | `waived/exception-authorized:<authority+rationale>` | `PASS` | No — invalid token | No |
+| Direct representative-user prototype evaluation (`UX-CHECK-14`) | `waived/exception-authorized:<authority+rationale>` | `PASS` | No — invalid token | No |
+| Accessibility in any applicable item | `waived/exception-authorized:<authority+rationale>` | `PASS` | No — invalid token | No |
+| Safety in any applicable item | `waived/exception-authorized:<authority+rationale>` | `PASS` | No — invalid token | No |
+| Coverage/acceptance separation control | protected item is `FAIL:<finding-id>` or `recorded-open:<owner+resolution-method>` | `PASS` | Yes | No |
+| Bounded-waiver control | every protected item is `PASS`; one non-protected gate has a valid authorized waiver | `PASS` | Yes | Yes, only under the bounded exception |
 
 ## Pause point A — Before the skeleton: outcome, people, evidence, identity
 
@@ -224,3 +252,13 @@ UX run accepted.
 | `UX-CHECK-17` | `UX-SCENARIO-02`, `UX-SCENARIO-21`, `UX-SCENARIO-25`, `UX-SCENARIO-28` |
 | `UX-CHECK-18` | `UX-SCENARIO-27`, `UX-SCENARIO-28` |
 | `UX-CHECK-20` | `UX-SCENARIO-05`, `UX-SCENARIO-06`, `UX-SCENARIO-08` |
+
+## Filled-copy close
+
+Before resolving any item in a run-specific copy, record the reusable checklist source identity/path, the exact
+immutable source version/revision, and the distinct run identity. At close, repeat those three values with the
+result so another reader can reconstruct both the rules used and the execution that applied them. Inspect the
+named evidence before resolving each row, record coverage closure and acceptance separately, and replay every
+protected-waiver truth-table row. A protected waiver is an invalid resolution even when every other applicable
+item is `PASS`; a label, authority, rationale, owner, future plan, or present-but-empty artifact must never earn
+`PASS`.

--- a/.gobbi/projects/gobbi/skills/ux/checklists.md
+++ b/.gobbi/projects/gobbi/skills/ux/checklists.md
@@ -1,0 +1,226 @@
+# UX Design — Operational Checklist
+
+Unchecked source for running and evaluating one UX design outcome. Each run works a fresh filled copy and
+identifies this source plus the run; never mark this source. Mode: **operational**. Default use style is
+**read-do** at pause points A–D and **do-confirm** at pause point E; a filled copy declares the actual style at
+each pause point.
+
+Coverage closure means every applicable gate and required item has a terminal resolution. Acceptance is a
+separate result: every applicable gate and required item must be `PASS`, except that the checklist owner's
+bounded operational waiver may substitute on one item only when named authority covers that item's consequence
+and stop action and the authorization evidence and rationale are recorded. A waiver never counts as `PASS`, and
+accessibility or safety cannot be waived. A recorded-open or failed item can close coverage but cannot make this
+UX run accepted.
+
+## Resolution legend
+
+- `PASS` — the pass condition was verified from the named inspected evidence.
+- `FAIL:<finding-id>` — the pass condition was verified false and the finding/action is cited.
+- `n/a:<property>` — inspected evidence proves the applicability predicate false.
+- `recorded-open:<owner+resolution-method>` — operational coverage is closed but acceptance is not granted.
+- `waived/exception-authorized:<authority+rationale>` — permitted only for an operational gate when the named
+  authority covers its stated consequence; it does not count as `PASS` and cannot waive accessibility or safety.
+
+## Pause point A — Before the skeleton: outcome, people, evidence, identity
+
+- [ ] **UX-CHECK-01 [GATE, read-do] — One complete observable outcome is bound.**
+  - Applicability: unconditional.
+  - Pass: one outcome sentence names trigger/context, primary actor, observable completion, false completion,
+    scope, and non-goals; entry, alternatives, states, errors, recovery, handoffs, support, and supporting actors
+    required to complete it are in scope; independent adjacent outcomes are out.
+  - Evidence: user-locked outcome contract and outcome-to-path inventory.
+  - On fail: stop construction and return to P1; otherwise an incomplete or expanded outcome will govern every
+    later artifact.
+  - Source: `SKILL.md` UX-R1, P1; `UX-SCENARIO-01`–`04`.
+- [ ] **UX-CHECK-02 [REQUIRED, read-do] — Actors and contexts match the claims.**
+  - Applicability: unconditional.
+  - Pass: primary/supporting actors, decision authority, channels, environments, constraints, access needs, and
+    evidence gaps are named; the design does not collapse stakeholder, operator, approver, and affected person
+    into one generic user.
+  - Evidence: actor/context map plus evidence-limit annotations.
+  - On fail: return to P1–P2 and narrow unsupported claims.
+  - Source: `SKILL.md` UX-R1, UX-R2, P1–P2; `UX-SCENARIO-01`, `05`, `06`.
+- [ ] **UX-CHECK-03 [GATE, read-do] — New direct generative research precedes convergence.**
+  - Applicability: unconditional.
+  - Pass: current-run direct research with representative users addresses a named generative question before
+    concept convergence; prior evidence and stakeholder input are context only; neutral questions and
+    disconfirming observations can change the direction.
+  - Evidence: dated research plan/record, participant-context rationale, neutral prompts, synthesis, limitations,
+    and decision effects.
+  - On fail: halt design convergence and return to P1–P2; otherwise the run rests on untested assumptions or
+    performative evidence.
+  - Source: `SKILL.md` UX-R2, P1–P2; `UX-SCENARIO-05`–`08`.
+- [ ] **UX-CHECK-04 [GATE, read-do] — Research conditions and claims are ethical and supportable.**
+  - Applicability: every generative or evaluative research activity.
+  - Pass: representative access, informed consent, accommodations, privacy/data handling, method, and
+    claim-to-sample boundary are evidenced; no fixed count replaces risk/question reasoning; missing conditions
+    produce `NEEDS_CONTEXT` and no accepted-final claim.
+  - Evidence: recruitment rationale, consent/accommodation record, data plan, evidence limits, and current status.
+  - On fail: stop research/design acceptance and return `NEEDS_CONTEXT`; otherwise participants or unsupported
+    populations may be harmed or misrepresented.
+  - Source: `SKILL.md` UX-R3, UX-R4, P1–P2, P8; `UX-SCENARIO-05`, `07`, `22`, `23`.
+- [ ] **UX-CHECK-05 [GATE, read-do] — Project identity follows the evidence authority chain.**
+  - Applicability: unconditional.
+  - Pass: governing design/brand/product/system material, live product/system/tokens, and any user-confirmed
+    temporary brief are applied in that order; missing material triggers DESIGN-like questions and a run-scoped
+    brief; conflicts are explicit; no project-wide `DESIGN.md` is invented; accessibility/safety remain the floor.
+  - Evidence: identity/reference register, live evidence, temporary brief if needed, conflict record, and user
+    decision.
+  - On fail: stop at the foundation gate and return to P2; otherwise an invented, stale, or harmful identity will
+    constrain every later decision.
+  - Source: `SKILL.md` UX-R5, UX-R10, P2; `UX-SCENARIO-09`, `10`.
+- [ ] **UX-CHECK-20 [REQUIRED, read-do] — Stakeholder decisions and representative-user evidence remain distinct.**
+  - Applicability: unconditional.
+  - Pass: each product lock names its authority; each experience claim names representative-user evidence and
+    limits; a project owner counts as evidence only for contexts they genuinely represent.
+  - Evidence: decision/evidence ledger and representativeness rationale.
+  - On fail: return to the affected discussion or research step and correct the claim source.
+  - Source: `SKILL.md` UX-R2, UX-R7, P1–P2; `UX-SCENARIO-05`, `06`, `08`.
+
+## Pause point B — During specification growth: order and whole coherence
+
+- [ ] **UX-CHECK-06 [GATE, read-do] — Construction and user-gate order is intact.**
+  - Applicability: unconditional.
+  - Pass: evidence shows outcome/context → foundation/identity/research → skeleton → core unit/path → accumulated
+    specification → concepts → whole-spec approval → prototype → direct test → specification-first revision →
+    prototype revision → affected retest → handoff, with explicit foundation, skeleton, core, accumulated,
+    whole-spec, and post-test gates.
+  - Evidence: artifact chronology and explicit user-decision records; silence or continued work is not a record.
+  - On fail: stop at the earliest reordered or unapproved stage and reopen it; otherwise later evidence is built
+    on an unauthorized or incomplete design.
+  - Source: `SKILL.md` UX-R6, UX-R7, P1–P9; `UX-SCENARIO-09`, `11`, `12`, `18`.
+- [ ] **UX-CHECK-07 [GATE, read-do] — The top-down skeleton covers the whole outcome.**
+  - Applicability: unconditional after pause point A passes.
+  - Pass: actor lanes, major phases, channels, dependencies, handoffs, decisions, state transitions, failure
+    zones, recovery, support, completion evidence, scope, and uncertainty are mapped before local detail.
+  - Evidence: approved skeleton and source/outcome trace.
+  - On fail: stop bottom-up growth and return to P3; otherwise local units have no whole-experience contract.
+  - Source: `SKILL.md` UX-R6, UX-R7, P3; `UX-SCENARIO-01`, `04`, `11`, `14`, `19`.
+- [ ] **UX-CHECK-08 [REQUIRED, read-do] — The smallest meaningful unit grows into a coherent core path.**
+  - Applicability: unconditional after the skeleton gate.
+  - Pass: the unit states intent, information/content, preconditions, input/output, state, feedback, errors,
+    recovery, access, trust, and evidence; the shortest complete path connects units without breaking the
+    skeleton.
+  - Evidence: unit records, core-path walk, failure oracle, and core user decision.
+  - On fail: return to P4 and revise the unit or skeleton before growing more detail.
+  - Source: `SKILL.md` UX-R6, UX-R7, P4; `UX-SCENARIO-11`, `14`.
+- [ ] **UX-CHECK-09 [GATE, read-do] — Accumulated paths, states, recovery, and channels form one complete specification.**
+  - Applicability: unconditional before concept convergence.
+  - Pass: every applicable normal, alternative, boundary, error, interruption, failure, recovery, support,
+    handoff, cross-channel, and supporting-actor path is specified; content intent, access, trust, privacy, safety,
+    agency, harm, and measures trace to the skeleton; no local success breaks another required path.
+  - Evidence: path/state/obligation inventory, cross-channel walk, orphan sweep, gap register, and accumulated
+    user decision.
+  - On fail: stop finalization and return to P4–P5; otherwise a polished local fragment can mask a broken whole.
+  - Source: `SKILL.md` UX-R1, UX-R6, UX-R10, P4–P5; `UX-SCENARIO-01`, `02`, `11`, `14`, `19`–`21`.
+
+## Pause point C — Before any prototype: concepts and whole specification
+
+- [ ] **UX-CHECK-10 [GATE, read-do] — Concept divergence is material or the exception is proved.**
+  - Applicability: unconditional before selecting a concept.
+  - Pass: at least two concepts differ in experience structure/behavior and are compared across control, effort,
+    access, trust, failure, recovery, feasibility, and evidence; a recommendation and evidence-to-change precede
+    the user lock; or real constraints plus direct evidence and a user decision prove the single-concept exception.
+  - Evidence: concept models, trade-off matrix, sources, recommendation, exception proof if used, and decision.
+  - On fail: return to P6; otherwise cosmetic variation or the first idea can pass as genuine exploration.
+  - Source: `SKILL.md` UX-R8, P6; `UX-SCENARIO-10`, `15`–`17`.
+- [ ] **UX-CHECK-11 [GATE, do-confirm] — The complete feature design document passes as a whole.**
+  - Applicability: unconditional before prototype creation.
+  - Pass: all ten parent schema sections contain evidence-bearing content; every actor, path, state, recovery,
+    conflict, concept decision, accessibility/trust/safety obligation, measure, limitation, non-goal, and trace is
+    resolved or blocks approval; the active project owns the path; explicit whole-spec approval is recorded.
+  - Evidence: full document, schema/content inspection, two-way trace, gap register, and approval record.
+  - On fail: stop prototype creation and return to the earliest owning step; otherwise an incomplete contract will
+    be hidden by a tangible artifact.
+  - Source: `SKILL.md` UX-R7, UX-R9, P6 and Feature design document schema; `UX-SCENARIO-13`, `18`.
+- [ ] **UX-CHECK-12 [GATE, do-confirm] — No prototype predates whole-specification approval.**
+  - Applicability: unconditional.
+  - Pass: every prototype artifact was created after the explicit final whole-specification gate and traces to
+    that approved version; no milestone prototype was used to fill an incomplete specification.
+  - Evidence: immutable document approval and prototype creation/version chronology.
+  - On fail: block prototype/test acceptance, discard it as design evidence, and return to specification work;
+    otherwise premature visualization can lock a partial solution.
+  - Source: `SKILL.md` UX-R6, UX-R9, UX-R11, P6–P7; `UX-SCENARIO-13`, `18`, `22`.
+
+## Pause point D — After prototype evaluation: evidence and revision
+
+- [ ] **UX-CHECK-13 [REQUIRED, read-do] — The prototype is disposable, proportionate, and specification-traced.**
+  - Applicability: after `UX-CHECK-11` and `UX-CHECK-12` pass.
+  - Pass: named uncertainties determine the lowest sufficient fidelity; required paths, errors, recovery,
+    accessibility, and cross-channel transitions needed for those questions are usable; simulated behavior/data
+    are disclosed; the artifact is not production implementation.
+  - Evidence: prototype plan, fidelity rationale, spec trace, simulation disclosure, access-path inspection, and
+    disposal status.
+  - On fail: return to P7 before participant testing.
+  - Source: `SKILL.md` UX-R11, P7; `UX-SCENARIO-22`, `23`.
+- [ ] **UX-CHECK-14 [GATE, do-confirm] — Direct representative-user prototype evaluation supports acceptance claims.**
+  - Applicability: unconditional for final acceptance.
+  - Pass: new direct evaluation under `UX-CHECK-04` observes comprehension, completion, alternatives, errors,
+    recovery, trust, accessibility, workarounds, cross-channel continuity, and harm as applicable; claims are
+    bounded to evidence; prior tests, stakeholders, experts, and checklist presence do not substitute.
+  - Evidence: dated evaluation plan/record, participant-context rationale, consent/accommodations, observations,
+    interpretations, limits, and claim trace.
+  - On fail: block acceptance and return `NEEDS_CONTEXT` or rerun P8; otherwise the design claims human outcomes
+    without direct human evidence.
+  - Source: `SKILL.md` UX-R3, UX-R4, P8; `UX-SCENARIO-07`, `22`, `23`.
+- [ ] **UX-CHECK-15 [GATE, do-confirm] — Findings revise specification first, prototype second, then retest.**
+  - Applicability: every supported prototype finding.
+  - Pass: the finding first changes its owning requirement/path/state/content intent/measure/decision; the
+    prototype is brought back into agreement; affected assumptions and regressions are directly retested; the
+    post-test user decision is explicit.
+  - Evidence: ordered finding → specification revision → prototype revision → retest → user-decision trace.
+  - On fail: block acceptance and return to P8; otherwise the durable handoff remains wrong despite a better
+    mockup.
+  - Source: `SKILL.md` UX-R7, UX-R12, P8; `UX-SCENARIO-24`.
+
+## Pause point E — Before handoff: measurement and change control
+
+- [ ] **UX-CHECK-16 [GATE, do-confirm] — Success measures resist proxy gaming.**
+  - Applicability: unconditional at handoff.
+  - Pass: each outcome, failure, recovery, accessibility, trust, and harm measure traces to an obligation; names
+    intended and harmful interpretations, guardrails, owner/review cadence, and evidence that reopens design; a
+    constructed proxy-inversion case is detected.
+  - Evidence: measure-to-obligation map and metric-gaming probe.
+  - On fail: stop handoff and return to P6/P9; otherwise reported improvement can hide worse user outcomes.
+  - Source: `SKILL.md` UX-R13, P6, P9; `UX-SCENARIO-25`, `26`.
+- [ ] **UX-CHECK-17 [REQUIRED, do-confirm] — Handoff preserves the experience contract without choosing surface mechanics.**
+  - Applicability: unconditional at handoff.
+  - Pass: outcome, actors, evidence/limits, path/state/recovery/access/trust/safety/measure obligations, prototype
+    status, owners, implementation questions, and reopen conditions are explicit; future children may specialize
+    mechanics but cannot silently drop parent invariants.
+  - Evidence: cold-reader handoff trace, owner map, child-contract diff probe, and measurement plan.
+  - On fail: return to P9 and repair the no-silent-change contract.
+  - Source: `SKILL.md` UX-R14, P9; `UX-SCENARIO-02`, `21`, `25`, `28`.
+- [ ] **UX-CHECK-18 [GATE, do-confirm] — UX/UI or parent/child conflicts are evidence-led user decisions.**
+  - Applicability: another loaded skill or downstream specialization conflicts with this experience contract.
+  - Pass: exact conflicting clauses, evidence, trade-offs, and effects are presented to the user; no precedence or
+    load-order rule is invented; the accessibility/safety floor is preserved; the decision and affected traces
+    are updated.
+  - Evidence: conflict record, cited clauses/evidence, explicit user decision, and regression trace.
+  - On fail: stop the conflicting handoff/change and return to the owning user gate; otherwise guidance or child
+    mechanics can silently override the approved experience.
+  - Source: `SKILL.md` UX-R10, UX-R14 and co-load rule; `UX-SCENARIO-27`, `28`.
+
+## Guaranteed coverage map
+
+| Check | Scenario source |
+|---|---|
+| `UX-CHECK-01` | `UX-SCENARIO-01`, `UX-SCENARIO-02`, `UX-SCENARIO-03`, `UX-SCENARIO-04` |
+| `UX-CHECK-02` | `UX-SCENARIO-01`, `UX-SCENARIO-05`, `UX-SCENARIO-06` |
+| `UX-CHECK-03` | `UX-SCENARIO-05`, `UX-SCENARIO-06`, `UX-SCENARIO-08` |
+| `UX-CHECK-04` | `UX-SCENARIO-05`, `UX-SCENARIO-07`, `UX-SCENARIO-22`, `UX-SCENARIO-23` |
+| `UX-CHECK-05` | `UX-SCENARIO-09`, `UX-SCENARIO-10` |
+| `UX-CHECK-06` | `UX-SCENARIO-09`, `UX-SCENARIO-11`, `UX-SCENARIO-12`, `UX-SCENARIO-18` |
+| `UX-CHECK-07` | `UX-SCENARIO-01`, `UX-SCENARIO-04`, `UX-SCENARIO-11`, `UX-SCENARIO-14`, `UX-SCENARIO-19` |
+| `UX-CHECK-08` | `UX-SCENARIO-11`, `UX-SCENARIO-14` |
+| `UX-CHECK-09` | `UX-SCENARIO-01`, `UX-SCENARIO-02`, `UX-SCENARIO-11`, `UX-SCENARIO-14`, `UX-SCENARIO-19`, `UX-SCENARIO-20`, `UX-SCENARIO-21` |
+| `UX-CHECK-10` | `UX-SCENARIO-10`, `UX-SCENARIO-15`, `UX-SCENARIO-16`, `UX-SCENARIO-17` |
+| `UX-CHECK-11` | `UX-SCENARIO-13`, `UX-SCENARIO-18` |
+| `UX-CHECK-12` | `UX-SCENARIO-13`, `UX-SCENARIO-18`, `UX-SCENARIO-22` |
+| `UX-CHECK-13` | `UX-SCENARIO-22`, `UX-SCENARIO-23` |
+| `UX-CHECK-14` | `UX-SCENARIO-07`, `UX-SCENARIO-22`, `UX-SCENARIO-23` |
+| `UX-CHECK-15` | `UX-SCENARIO-24` |
+| `UX-CHECK-16` | `UX-SCENARIO-25`, `UX-SCENARIO-26` |
+| `UX-CHECK-17` | `UX-SCENARIO-02`, `UX-SCENARIO-21`, `UX-SCENARIO-25`, `UX-SCENARIO-28` |
+| `UX-CHECK-18` | `UX-SCENARIO-27`, `UX-SCENARIO-28` |
+| `UX-CHECK-20` | `UX-SCENARIO-05`, `UX-SCENARIO-06`, `UX-SCENARIO-08` |

--- a/.gobbi/projects/gobbi/skills/ux/evaluation.md
+++ b/.gobbi/projects/gobbi/skills/ux/evaluation.md
@@ -47,18 +47,38 @@ Frame.
    `UX-CHECK-*` item except conditional `UX-CHECK-18`. These cases distinguish a substantive completed run from
    big-bang polish, evidence theater, premature prototype work, cosmetic concepts, inaccessible evidence,
    mockup-only revision, and metric gaming.
-3. **Activate actor and surface variants.** Select `UX-SCENARIO-02` for a command-line or other alternative
+3. **Activate protected-waiver probes.** Copy the protected-waiver truth table below into the filled evaluation
+   checklist. Attempt an authorized waiver separately on direct generative research, whole-specification-before-
+   prototype closure/chronology, direct representative-user prototype evaluation, accessibility, and safety
+   while every other applicable item is `PASS`. Each protected waiver must remain an invalid resolution and the
+   run must remain not accepted.
+4. **Activate actor and surface variants.** Select `UX-SCENARIO-02` for a command-line or other alternative
    realization. Select `UX-SCENARIO-04` whenever a recovery/dependency boundary can be mistaken for an adjacent
    outcome. Select `UX-SCENARIO-19`–`21` when the outcome crosses a channel, actor, organization, or system.
-4. **Activate conflict and change cases.** Select `UX-SCENARIO-27` and `UX-CHECK-18` when UX and UI guidance or
+5. **Activate conflict and change cases.** Select `UX-SCENARIO-27` and `UX-CHECK-18` when UX and UI guidance or
    another loaded parent conflict. Select `UX-SCENARIO-28` for a downstream surface/child handoff or change.
-5. **Disposition non-selected cases with evidence.** Use `n/a:<property>` only when inspected target evidence
+6. **Disposition non-selected cases with evidence.** Use `n/a:<property>` only when inspected target evidence
    proves the trigger false. Do not omit an inconvenient path or relabel an applicable gate.
-6. **Copy exact checks.** Copy activated `UX-CHECK-*` records into the active phase's filled checklist without
+7. **Copy exact checks.** Copy activated `UX-CHECK-*` records into the active phase's filled checklist without
    changing their ID, claim, pass condition, evidence, or on-fail route. Resolve them through the active
    checklist/evaluation state machine.
-7. **Extend only the run copy.** A newly discovered UX scenario or check becomes a `scenario_gap` or
+8. **Extend only the run copy.** A newly discovered UX scenario or check becomes a `scenario_gap` or
    `checklist_gap` finding and an active-run Stage 1 addition. Evaluators never edit the shipped UX bundle.
+
+## Protected-waiver adversarial truth table
+
+This is an evaluation copy of the acceptance probe owned by [`checklists.md`](checklists.md). Hold every other
+applicable gate and required item at `PASS`; do not infer acceptance from coverage closure.
+
+| Protected class | Attempted resolution | Coverage result | Acceptance result | Required scenario evidence |
+|---|---|---|---|---|
+| Direct generative research (`UX-CHECK-03`) | authorized waiver | invalid / not closed | not accepted | `UX-SCENARIO-06`, `08` |
+| Whole-specification-before-prototype (`UX-CHECK-11` or `UX-CHECK-12`) | authorized waiver | invalid / not closed | not accepted | `UX-SCENARIO-13`, `18` |
+| Direct representative-user prototype evaluation (`UX-CHECK-14`) | authorized waiver | invalid / not closed | not accepted | `UX-SCENARIO-22` |
+| Accessibility in any applicable item | authorized waiver | invalid / not closed | not accepted | `UX-SCENARIO-10`, `23` |
+| Safety in any applicable item | authorized waiver | invalid / not closed | not accepted | `UX-SCENARIO-10`, `23` |
+| Coverage/acceptance control | protected item is `FAIL` or `recorded-open` | closed | not accepted | `UX-SCENARIO-07` |
+| Bounded-waiver control | protected items `PASS`; one valid non-protected gate waiver | closed | accepted only under the bounded exception | named non-protected scenario/check |
 
 ## Perspectives
 
@@ -76,7 +96,8 @@ artifact for the outcome or absorbing adjacent work?
 
 **Verify:** compare the user-locked outcome/scope with the skeleton, complete document, prototype questions,
 measures, and actual acceptance claim. Check that necessary supporting actors and recovery remain in while
-registration, reset, administration, or other independent outcomes remain out.
+registration, reset, administration, or other independent outcomes remain out. Replay the five protected-waiver
+rows with every other applicable check at `PASS`; none may yield acceptance.
 
 **Anti-patterns:** a screen or command called a feature outcome; stakeholder preference called user evidence;
 scope expansion hidden as “whole experience”; a proxy measure replacing user completion.
@@ -165,7 +186,9 @@ metric integrity, conflicts, and unsupported acceptance claims?
 
 **Verify:** attempt each required adversarial behavior probe; inspect consent/data limits; inject timeout and
 partial-state failure; test the accessibility/safety floor against identity pressure; invert the success metric;
-check final status when user evidence is missing.
+check final status when user evidence is missing. Separately attempt an authorized waiver on each of the five
+protected classes; verify the token is invalid, coverage remains unclosed until a permitted terminal replaces
+it, and acceptance remains unavailable even though every other applicable item is `PASS`.
 
 **Anti-patterns:** research theater; consent assumed; safety waiver; prior evidence replacing current direct
 contact; early prototype normalized after the fact; cosmetic compliance passing; acceptance declared with
@@ -183,21 +206,28 @@ cross-reference, and direct evidence inspection for design claims.
 3. Extract `UX-R*`, `UX-SCENARIO-*`, and `UX-CHECK-*` IDs. Prove every load-bearing parent rule has scenarios
    and checks, every scenario points to a live parent rule and check, every check points to live scenarios and
    parent clauses, and every applicable check is selected here.
-4. Verify the scenario coverage register dispositions all ten categories and each family has an adversarial
-   case or evidenced `n/a`; inspect each failure oracle against a cosmetically compliant but non-working target.
-5. Confirm the checklist source has only unchecked boxes. In the active filled copy, require named inspected
-   evidence and separate coverage closure from acceptance.
-6. Inspect dated/versioned history to prove foundation → skeleton → core → accumulated specification → whole
+4. Verify the scenario set declares purpose/target/consumer, lifecycle, scope/non-goals, scale, all ten category
+   dispositions, a complete family×case-type matrix with a property reason in every empty cell, source and
+   stable-ID registers, gaps/decisions, and a bidirectional orphan sweep. Confirm every family has all required
+   fields and every case has a justified primary type, declared coverage-role set, actor, Given/When/Then,
+   failure oracle, evidence tuple, obligation, source trace, and checklist trace.
+5. Confirm both checklist sources have only unchecked boxes. In each active filled copy, record source
+   identity/path, immutable source version/revision, and run identity as separate provenance values; require
+   named inspected evidence and separate coverage closure from acceptance.
+6. Replay the protected-waiver truth table with all other applicable items `PASS`. Assert mechanically in the
+   filled result that each of the five protected waiver attempts is invalid and not accepted; also prove a
+   protected `FAIL`/`recorded-open` may close coverage without acceptance.
+7. Inspect dated/versioned history to prove foundation → skeleton → core → accumulated specification → whole
    approval → prototype. Fail if any prototype predates the whole-spec gate.
-7. Inspect evidence provenance to prove new generative contact and new direct prototype evaluation with
+8. Inspect evidence provenance to prove new generative contact and new direct prototype evaluation with
    representative users, ethical conditions, accommodations, and bounded claims. Fail acceptance on absent
    conditions even if the stakeholder approved.
-8. Trace one prototype finding through specification revision first, prototype revision second, and affected
+9. Trace one prototype finding through specification revision first, prototype revision second, and affected
    direct retest third.
-9. Run the identity fallback and conflict probes, login/web + command-line boundary probe, adjacent-outcome
+10. Run the identity fallback and conflict probes, login/web + command-line boundary probe, adjacent-outcome
    probe, cross-channel failure probe, material-concept probe, inaccessible-prototype probe, metric-gaming probe,
    co-load conflict probe, and future-child deviation probe.
-10. Run the project markdown-link and retired-vocabulary guards against the canonical directory. Inspect live
+11. Run the project markdown-link and retired-vocabulary guards against the canonical directory. Inspect live
     runtime wiring through its owning sync mechanism; do not edit mirrors during evaluation.
 
 Tool evidence is required for chronology, file, path, ID, link, and wiring claims at confidence 75 or 100.
@@ -214,6 +244,9 @@ The Overall pass must answer:
   prototype evaluation support acceptance under ethical conditions?
 - Did identity come from the evidence chain, and were identity/accessibility/safety conflicts resolved visibly
   without waiving the floor?
+- Did every attempted waiver on direct generative research, whole-specification-before-prototype chronology,
+  direct representative-user prototype evaluation, accessibility, or safety remain invalid and unable to yield
+  acceptance, with coverage closure reported separately?
 - Was the top-down skeleton established before bottom-up growth, with every local unit reconciled to the whole?
 - Were two material concepts compared or was the single-concept exception genuinely proved?
 - Was the whole specification complete and explicitly approved before every prototype artifact?

--- a/.gobbi/projects/gobbi/skills/ux/evaluation.md
+++ b/.gobbi/projects/gobbi/skills/ux/evaluation.md
@@ -1,0 +1,227 @@
+# UX Design — Evaluation Entry
+
+Evaluator entrypoint for grading one UX design run. It extends the active Gobbi phase evaluation with the UX
+scenario and checklist sources. It does not replace the active phase's four stages, seven-perspective order,
+finding schema, scoring, verdict thresholds, output tree, or nine-output contract.
+
+At Stage 0, load and read the complete UX bundle:
+
+1. [`SKILL.md`](SKILL.md) — sole policy owner.
+2. [`ideation.md`](ideation.md) — user-decision procedure and gate trace.
+3. [`scenarios.md`](scenarios.md) — coverage frame and fail-able cases.
+4. [`checklists.md`](checklists.md) — unchecked operational evidence source.
+5. This `evaluation.md` entry — selection, perspective lenses, verification, and Overall anchors.
+
+Also load the active phase's own `scenario.md`, `checklist.md`, and `evaluation.md` bundle. UX additions are
+copied into the active evaluator's filled checklist under `## Stage 1 Additions`; the shipped UX source remains
+unchecked. Findings use only the active Gobbi metadata and destinations.
+
+## Parent-clause crosswalk
+
+| Parent clause | Scenario evidence | Checklist evidence |
+|---|---|---|
+| UX-R1 — one complete observable outcome | `UX-SCENARIO-01`–`04`, `19`–`21` | `UX-CHECK-01`, `02`, `07`, `09` |
+| UX-R2 — new direct generative research | `UX-SCENARIO-05`, `06`, `08` | `UX-CHECK-03`, `20` |
+| UX-R3 — direct representative-user prototype evaluation | `UX-SCENARIO-07`, `22`, `23` | `UX-CHECK-04`, `14` |
+| UX-R4 — ethical evidence conditions / `NEEDS_CONTEXT` | `UX-SCENARIO-05`, `07`, `23` | `UX-CHECK-04` |
+| UX-R5 — identity authority chain and bounded brief | `UX-SCENARIO-09`, `10` | `UX-CHECK-05` |
+| UX-R6 — exact construction order | `UX-SCENARIO-11`–`14`, `18` | `UX-CHECK-06`–`09`, `11`, `12` |
+| UX-R7 — explicit user gates | `UX-SCENARIO-11`, `12`, `18`, `24` | `UX-CHECK-06`, `08`, `11`, `15` |
+| UX-R8 — material concepts or evidenced exception | `UX-SCENARIO-15`–`17` | `UX-CHECK-10` |
+| UX-R9 — whole feature design document before prototype | `UX-SCENARIO-13`, `18` | `UX-CHECK-11`, `12` |
+| UX-R10 — inclusion, trust, safety, harm, agency | `UX-SCENARIO-10`, `19`, `20`, `23`, `27` | `UX-CHECK-05`, `09`, `13`, `18` |
+| UX-R11 — disposable proportionate prototype | `UX-SCENARIO-13`, `22`, `23` | `UX-CHECK-12`, `13` |
+| UX-R12 — specification-first revision and retest | `UX-SCENARIO-24` | `UX-CHECK-15` |
+| UX-R13 — measures resist gaming | `UX-SCENARIO-25`, `26` | `UX-CHECK-16` |
+| UX-R14 — no-silent-change handoff and specialization | `UX-SCENARIO-02`, `21`, `27`, `28` | `UX-CHECK-17`, `18` |
+
+## Selecting scenarios and checks
+
+Run this selection after Stage 0 target understanding and before the active evaluation freezes each Stage 1
+Frame.
+
+1. **Confirm target and status.** Extract the one outcome, current UX phase, feature design document, evidence
+   set, prototype status, and acceptance claim. If the target has no clear What, Why, or How, use the active
+   evaluation's Stage 0 gate.
+2. **Activate the invariant core.** Always select `UX-SCENARIO-01`, `03`, `05`–`18`, and `22`–`26`, plus every
+   `UX-CHECK-*` item except conditional `UX-CHECK-18`. These cases distinguish a substantive completed run from
+   big-bang polish, evidence theater, premature prototype work, cosmetic concepts, inaccessible evidence,
+   mockup-only revision, and metric gaming.
+3. **Activate actor and surface variants.** Select `UX-SCENARIO-02` for a command-line or other alternative
+   realization. Select `UX-SCENARIO-04` whenever a recovery/dependency boundary can be mistaken for an adjacent
+   outcome. Select `UX-SCENARIO-19`–`21` when the outcome crosses a channel, actor, organization, or system.
+4. **Activate conflict and change cases.** Select `UX-SCENARIO-27` and `UX-CHECK-18` when UX and UI guidance or
+   another loaded parent conflict. Select `UX-SCENARIO-28` for a downstream surface/child handoff or change.
+5. **Disposition non-selected cases with evidence.** Use `n/a:<property>` only when inspected target evidence
+   proves the trigger false. Do not omit an inconvenient path or relabel an applicable gate.
+6. **Copy exact checks.** Copy activated `UX-CHECK-*` records into the active phase's filled checklist without
+   changing their ID, claim, pass condition, evidence, or on-fail route. Resolve them through the active
+   checklist/evaluation state machine.
+7. **Extend only the run copy.** A newly discovered UX scenario or check becomes a `scenario_gap` or
+   `checklist_gap` finding and an active-run Stage 1 addition. Evaluators never edit the shipped UX bundle.
+
+## Perspectives
+
+Apply these UX lenses inside Gobbi's canonical order: Project → Structure → Performance → Aesthetics → Usage →
+Consistency → Risk, then Overall. Each perspective walks its activated cases and checks with independent
+evidence. A perspective may record no UX finding only after it has run its lens and stated applicable
+dispositions.
+
+### Project
+
+**Lens:** Does the run solve one right, observable outcome for the intended people without substituting an
+artifact for the outcome or absorbing adjacent work?
+
+**Activate:** `UX-SCENARIO-01`–`06`, `12`, `15`–`18`, `25`; `UX-CHECK-01`–`03`, `10`, `11`, `16`, `20`.
+
+**Verify:** compare the user-locked outcome/scope with the skeleton, complete document, prototype questions,
+measures, and actual acceptance claim. Check that necessary supporting actors and recovery remain in while
+registration, reset, administration, or other independent outcomes remain out.
+
+**Anti-patterns:** a screen or command called a feature outcome; stakeholder preference called user evidence;
+scope expansion hidden as “whole experience”; a proxy measure replacing user completion.
+
+### Structure
+
+**Lens:** Do the foundation, skeleton, bottom-up units, paths, states, concepts, specification, prototype, and
+handoff form one ordered and traceable contract?
+
+**Activate:** `UX-SCENARIO-09`, `11`, `13`, `14`, `18`–`21`, `24`, `28`; `UX-CHECK-05`–`09`, `11`–`13`, `15`,
+`17`.
+
+**Verify:** reconstruct the artifact chronology; walk both trace directions from parent rules and evidence to
+document clauses and from each clause back to evidence/decision; inject one local-unit and one cross-channel
+failure; inspect specification-first revision order.
+
+**Anti-patterns:** local unit works but breaks the skeleton; headings without content; prototype used to fill
+spec gaps; per-channel documents with no handoff contract; mockup repaired while the specification stays stale.
+
+### Performance
+
+**Lens:** Is research, concept exploration, prototype fidelity, evidence scope, and continued measurement
+proportionate to the question, uncertainty, diversity, impact, and risk without a fixed-count shortcut?
+
+**Activate:** `UX-SCENARIO-05`–`08`, `17`, `22`, `25`, `26`; `UX-CHECK-03`, `04`, `10`, `13`, `16`.
+
+**Verify:** compare each research/prototype choice with its question and claim; look for excess fidelity that
+does not reduce uncertainty, underpowered evidence that makes broad claims, and metrics whose cost or incentive
+distorts the outcome.
+
+**Anti-patterns:** universal participant count; production-like prototype by default; every available data
+point collected; measurement optimized for the headline number rather than learning and guardrails.
+
+### Aesthetics
+
+**Lens:** Is the experience specification clear, literal, identity-aware, and readable enough for users,
+stakeholders, researchers, surface designers, and implementers to understand without hidden context?
+
+**Activate:** `UX-SCENARIO-09`, `10`, `12`, `16`, `18`, `25`; `UX-CHECK-05`, `06`, `10`, `11`, `16`, `17`.
+
+**Verify:** inspect names, actor language, content intent, identity references, concept distinctions, state labels,
+decision/evidence separation, and feature-document schema content. Confirm polish is treated as expression, not
+proof.
+
+**Anti-patterns:** ornamental concepts; identity described only with adjectives; vague “user-friendly” claims;
+ambiguous state names; a beautiful artifact with missing evidence, recovery, or decision trace.
+
+### Usage
+
+**Lens:** Can representative people in their real contexts understand, complete, recover, switch channels, and
+exercise agency through the outcome, and can the next team use the handoff correctly?
+
+**Activate:** `UX-SCENARIO-01`, `02`, `04`–`08`, `10`, `14`, `19`–`24`; `UX-CHECK-01`–`04`, `07`–`09`, `13`–`15`,
+`17`, `20`.
+
+**Verify:** inspect direct observations rather than summary claims; test the happy, alternative, error,
+recovery, accessibility, support, and cross-channel paths; verify participant access/accommodations; give the
+handoff to a cold reader and observe whether hidden context is required.
+
+**Anti-patterns:** project owner assumed representative; inaccessible prototype; participant coached toward the
+solution; recovery deferred to support with no handoff; evaluator tests only the normal path.
+
+### Consistency
+
+**Lens:** Do identity, research findings, user decisions, skeleton, units, paths, states, concepts,
+specification, prototype, measures, co-loaded guidance, and handoff agree without silent override?
+
+**Activate:** `UX-SCENARIO-02`, `09`–`11`, `14`, `18`–`21`, `24`, `27`, `28`; `UX-CHECK-05`–`09`, `11`, `13`,
+`15`, `17`, `18`.
+
+**Verify:** compare all approved versions and traces; inspect cross-channel state and completion; compare
+prototype with the exact approved/revised specification; inspect UX/UI conflicts and child deviations; ensure
+identity conflicts carry one user decision everywhere affected.
+
+**Anti-patterns:** prototype and document disagree; one channel claims a different completion state; load order
+resolves parent conflict; child mechanics silently delete a parent obligation; a revision updates only one
+artifact.
+
+### Risk
+
+**Lens:** Does the run fail closed on missing evidence, consent, access, safety, privacy, trust, harm, recovery,
+metric integrity, conflicts, and unsupported acceptance claims?
+
+**Activate:** `UX-SCENARIO-03`, `06`–`10`, `12`–`14`, `16`, `17`, `20`, `21`, `23`, `24`, `26`–`28`;
+`UX-CHECK-01`, `03`–`06`, `09`–`18`, `20`.
+
+**Verify:** attempt each required adversarial behavior probe; inspect consent/data limits; inject timeout and
+partial-state failure; test the accessibility/safety floor against identity pressure; invert the success metric;
+check final status when user evidence is missing.
+
+**Anti-patterns:** research theater; consent assumed; safety waiver; prior evidence replacing current direct
+contact; early prototype normalized after the fact; cosmetic compliance passing; acceptance declared with
+`NEEDS_CONTEXT` conditions unresolved.
+
+## Recommended verification
+
+Use the strongest evidence the artifact admits. Run safe tools for file/path/history claims; use close reading,
+cross-reference, and direct evidence inspection for design claims.
+
+1. Parse `SKILL.md` frontmatter and confirm exact key order, `name: ux`, the allowed-tool list, and
+   `skill-type: operation`.
+2. Confirm exactly `SKILL.md`, `ideation.md`, `scenarios.md`, `checklists.md`, and `evaluation.md` form this
+   canonical bundle, with no singular `scenario.md` substitute.
+3. Extract `UX-R*`, `UX-SCENARIO-*`, and `UX-CHECK-*` IDs. Prove every load-bearing parent rule has scenarios
+   and checks, every scenario points to a live parent rule and check, every check points to live scenarios and
+   parent clauses, and every applicable check is selected here.
+4. Verify the scenario coverage register dispositions all ten categories and each family has an adversarial
+   case or evidenced `n/a`; inspect each failure oracle against a cosmetically compliant but non-working target.
+5. Confirm the checklist source has only unchecked boxes. In the active filled copy, require named inspected
+   evidence and separate coverage closure from acceptance.
+6. Inspect dated/versioned history to prove foundation → skeleton → core → accumulated specification → whole
+   approval → prototype. Fail if any prototype predates the whole-spec gate.
+7. Inspect evidence provenance to prove new generative contact and new direct prototype evaluation with
+   representative users, ethical conditions, accommodations, and bounded claims. Fail acceptance on absent
+   conditions even if the stakeholder approved.
+8. Trace one prototype finding through specification revision first, prototype revision second, and affected
+   direct retest third.
+9. Run the identity fallback and conflict probes, login/web + command-line boundary probe, adjacent-outcome
+   probe, cross-channel failure probe, material-concept probe, inaccessible-prototype probe, metric-gaming probe,
+   co-load conflict probe, and future-child deviation probe.
+10. Run the project markdown-link and retired-vocabulary guards against the canonical directory. Inspect live
+    runtime wiring through its owning sync mechanism; do not edit mirrors during evaluation.
+
+Tool evidence is required for chronology, file, path, ID, link, and wiring claims at confidence 75 or 100.
+Direct-research claims require the actual bounded evidence record; a document saying “users were consulted” is
+not proof. Apply side-effect preflight before any prototype interaction or external call.
+
+## Overall anchors
+
+The Overall pass must answer:
+
+- Is this exactly one complete observable outcome, including supporting actors, failure, recovery, and required
+  channels, while adjacent outcomes stay out?
+- Did new direct generative research influence design before convergence, and did direct representative-user
+  prototype evaluation support acceptance under ethical conditions?
+- Did identity come from the evidence chain, and were identity/accessibility/safety conflicts resolved visibly
+  without waiving the floor?
+- Was the top-down skeleton established before bottom-up growth, with every local unit reconciled to the whole?
+- Were two material concepts compared or was the single-concept exception genuinely proved?
+- Was the whole specification complete and explicitly approved before every prototype artifact?
+- Did findings revise the specification first, the prototype second, and affected assumptions/regressions third?
+- Can measures expose failure, exclusion, harm, and proxy gaming rather than reward them?
+- Does the handoff preserve the outcome contract across UX/UI co-loading and future surface specialization with
+  no silent change?
+- Would a polished big-bang document that lacks these behaviors fail the selected scenarios and checks?
+
+The preserve list should name the evidence chain, explicit gates, complete outcome boundary, coherent skeleton,
+strong recovery/access obligations, and specification-first revision traces that a later change must not weaken.

--- a/.gobbi/projects/gobbi/skills/ux/ideation.md
+++ b/.gobbi/projects/gobbi/skills/ux/ideation.md
@@ -1,0 +1,378 @@
+# UX Ideation — User Decision Tree
+
+Decision procedure for discussing and deciding one UX run with the user. Load it from `SKILL.md` P1 before
+asking the first design question. It deepens the parent procedure; it does not change the parent outcome,
+evidence gates, construction order, or acceptance rules.
+
+Here, **the user** means the project owner or stakeholder who has authority to lock product intent and scope.
+**Representative users** are research participants whose behavior and context supply experience evidence. A
+stakeholder decision cannot substitute for research evidence, and a participant observation does not itself
+lock a product decision. Trace both without merging them.
+
+## Interview conduct
+
+Default to the full tree. Adapt only when the run remains complete:
+
+1. Ask one decision axis per turn.
+2. Smart-skip an elicitation question only when current evidence answers it and the user has already locked that
+   answer for this run. Record the evidence and earlier decision that justified the skip.
+3. Never smart-skip a parent user gate. Restate the accumulated decision and obtain explicit approval.
+4. Before a design-bearing recommendation, research internal evidence and applicable external prior art.
+5. When meaningful alternatives exist, present two evidence-backed options, recommend one, and state what
+   evidence would change the recommendation. The user locks the choice.
+6. Ask follow-up questions specific to the project, evidence, conflict, and answers. The generic tree is a
+   coverage floor, not a script ceiling.
+7. Treat silence, continuation, a polished artifact, or an earlier adjacent decision as no decision.
+8. If an answer is vague, contradictory, or unsupported, show the conflict and ask a narrower follow-up. Do not
+   convert it into an assumption without marking the evidence gap.
+
+These conduct steps apply UX-R2, UX-R4, UX-R7, and UX-R8.
+
+## Decision record
+
+For each axis, keep a compact record:
+
+- **Axis:** the single question being decided.
+- **Evidence:** direct user research, internal evidence, external reference, or named constraint.
+- **Options:** materially different choices when alternatives exist.
+- **Recommendation:** chosen recommendation and evidence that would change it.
+- **User decision:** explicit lock, rejection, or request to investigate further.
+- **Representative-user evidence:** separate observations and limits; never relabel a stakeholder choice as
+  participant evidence.
+- **Effects:** parent rule, document section, skeleton/path/state/measure affected, and any branch reopened.
+
+## Dependency-ordered tree
+
+Walk D0–D14 in order. A later answer that invalidates an earlier one reopens the earliest affected node. Do not
+repair an unresolved foundation by making a downstream artifact more detailed.
+
+### D0 — Confirm the run can proceed
+
+**Discuss with the user**
+
+- What started this UX run now?
+- Who owns product intent and scope decisions?
+- Which representative users can be reached for new generative research and later prototype evaluation?
+- What consent, privacy, data-handling, accessibility, language, scheduling, or compensation conditions apply?
+- Which evidence is current, and which material is only prior context?
+
+**Decision**
+
+Lock the decision authority, research access, ethical conditions, and evidence inventory. If representative-user
+access, consent, accommodations, or required evidence is unavailable, return `NEEDS_CONTEXT` under UX-R4. The
+user may approve a research plan, but cannot approve the missing evidence into existence.
+
+**Trace:** UX-R2, UX-R3, UX-R4; `SKILL.md` P1.
+
+### D1 — Define the observable outcome
+
+**Discuss with the user**
+
+- Who experiences the outcome, in what triggering situation?
+- What observable change tells that person and the system the outcome is complete?
+- What would count as a false completion?
+- Is the proposed object a whole outcome, or only a page, screen, command, component, artifact, or happy path?
+
+**Decision**
+
+Lock one sentence in the form: “When `<trigger/context>` occurs, `<primary actor>` can `<complete observable
+outcome>`, evidenced by `<completion signal>`.” Split any independent outcome into another run.
+
+**Trace:** UX-R1; `SKILL.md` P1.
+
+### D2 — Identify actors and contexts
+
+**Discuss with the user**
+
+- Which primary actor is trying to finish the outcome?
+- Which supporting actors operate, approve, receive, assist, or are affected?
+- What device, channel, environment, time pressure, connectivity, language, ability, knowledge, and emotional
+  context materially changes the experience?
+- Which people are not represented by the evidence yet?
+
+**Decision**
+
+Lock the actor/context map and distinguish required supporting actors from stakeholders who merely need to be
+informed. Mark evidence limits for each claimed context.
+
+**Trace:** UX-R1, UX-R2, UX-R4; `SKILL.md` P1.
+
+### D3 — Lock scope and adjacent outcomes
+
+**Discuss with the user**
+
+- Which entry conditions, paths, states, recovery, handoffs, support steps, and completion states are necessary
+  for this outcome?
+- Which tempting neighboring outcomes are separate?
+- Which systems or teams are dependencies but not design scope?
+- What must remain unchanged?
+
+**Decision**
+
+Lock scope and explicit non-goals. For a login/authentication outcome, registration, password reset, account
+administration, and onboarding remain adjacent unless the user changes the contract. A necessary recovery path
+inside login remains in scope even when another team owns part of it.
+
+**Trace:** UX-R1; `SKILL.md` P1.
+
+### D4 — Set the generative research question
+
+**Discuss with the user**
+
+- What must be learned before experience design can converge?
+- Which assumptions would make the outcome, actor model, or context wrong if disproved?
+- Who is representative of each claim, including people likely to face access or recovery barriers?
+- Which method and sample can answer the question without claiming more than the evidence supports?
+- What neutral prompts will uncover current behavior, workarounds, language, failures, and trust concerns without
+  pitching the proposed solution?
+
+**Decision**
+
+Lock the research questions, recruitment logic, method, claim boundary, consent, accommodations, and stop
+conditions. Do not lock the solution. New direct research must occur before G1 closes and D7 design begins.
+
+**Trace:** UX-R2, UX-R4; `SKILL.md` P2.
+
+### D5 — Understand the current experience
+
+**Ask representative users during research**
+
+- Tell me about the last time you tried to achieve this outcome.
+- What started it, what did you do, what happened next, and how did you know you were done?
+- Where did you pause, switch channel, seek help, make an error, recover, abandon, or create a workaround?
+- What information, language, people, tools, and prior knowledge did you depend on?
+- What made the experience feel safe, unsafe, trustworthy, coercive, accessible, or excluding?
+
+**Discuss with the user after synthesis**
+
+- Which observed patterns are load-bearing, which are minority but high-risk, and which remain uncertain?
+- Where do analytics, support records, policy, or stakeholder accounts agree or conflict with direct evidence?
+
+**Decision**
+
+Lock the evidence interpretation and limitations, not a preferred solution. Record competing interpretations
+when evidence does not distinguish them.
+
+**Trace:** UX-R2, UX-R4; `SKILL.md` P2.
+
+### D6 — Establish project identity and references
+
+**Discuss with the user**
+
+- Which `DESIGN.md`, brand, product, design-system, service, content, or policy documents govern this outcome?
+- What does the live product or system already teach users through its language, sequence, feedback, trust
+  signals, and recognizable patterns?
+- What promise does the product make, to whom, in what voice, and with which values?
+- Which identity traits must be felt in this experience? Which traits or patterns must never appear?
+- Which existing conventions are deliberate, and which are inherited defects?
+- Where does identity conflict with direct evidence, accessibility, safety, or platform convention?
+
+**Decision**
+
+Use UX-R5's authority chain. If no governing material is sufficient, lock a temporary run-scoped identity brief
+covering promise, users, values, voice, recognizable patterns, constraints, and anti-patterns. Record conflicts
+for explicit decision; do not waive the accessibility or safety floor.
+
+**Trace:** UX-R5, UX-R10; `SKILL.md` P2.
+
+### Gate G1 — Foundation and identity
+
+Present D0–D6 as one foundation: outcome, actors, context, scope, direct research evidence and limits, references,
+identity brief, risks, and open conflicts. Recommend the foundation and name the evidence that would reopen it.
+The user explicitly approves or reopens an owning node.
+
+**Trace:** UX-R7; `SKILL.md` P2.
+
+### D7 — Design the top-down experience skeleton
+
+**Discuss with the user**
+
+- What are the major phases from trigger through observable completion?
+- Where do actors, channels, systems, and teams exchange control or information?
+- Which decisions, waits, failures, recovery routes, support paths, and completion signals must the skeleton show?
+- Which ordering constraints are real, and which can concepts challenge?
+- Where can a locally good unit cause the whole outcome to fail?
+
+**Options and decision**
+
+When the macro experience permits alternatives, show at least two skeletons or materially different sequencing
+options. Recommend one from the foundation evidence. Lock the skeleton without selecting detailed surface
+mechanics.
+
+**Trace:** UX-R6, UX-R10; `SKILL.md` P3.
+
+### Gate G2 — Skeleton
+
+Show the whole actor/phase/channel/state map, scope boundary, failure zones, recovery, and unresolved questions.
+The user explicitly approves it or reopens the foundation.
+
+**Trace:** UX-R7; `SKILL.md` P3.
+
+### D8 — Choose the smallest meaningful core unit
+
+**Discuss with the user**
+
+- What is the smallest task, information, content, or state unit that makes real progress toward completion?
+- What must the person know, decide, provide, perceive, or control at this unit?
+- What are its preconditions, input, output, feedback, error, recovery, accessibility, trust, and evidence needs?
+- How does it connect to the next unit without breaking the skeleton?
+
+**Decision**
+
+Lock the core unit and grow the shortest complete path from it. Reject a unit that is elegant in isolation but
+creates inconsistency, dead ends, hidden work, or cross-channel failure.
+
+**Trace:** UX-R6, UX-R10; `SKILL.md` P4.
+
+### Gate G3 — Core unit and path
+
+Demonstrate the core path in the skeleton, including one applicable failure and recovery route. State its failure
+oracle. The user explicitly approves it or reopens D7/D8.
+
+**Trace:** UX-R7; `SKILL.md` P4.
+
+### D9 — Grow every path, state, and obligation
+
+**Discuss with the user as the specification grows**
+
+- Which alternative-valid paths differ materially by actor, context, channel, input, or mode?
+- What happens at empty, first, many, limit, timeout, interruption, dependency-failure, partial-completion, and
+  resumption states where applicable?
+- What content intent and information are needed at each unit? What must never be implied or hidden?
+- How does each failure get detected, explained, contained, recovered, supported, and measured?
+- Are trust, privacy, safety, agency, accessibility, language, or harm obligations missing from any path?
+- Do cross-channel handoffs preserve state, intent, security, recovery, and completion evidence?
+
+**Decision**
+
+Lock each accumulated increment only after reconciling it with the skeleton and existing units. Keep unresolved
+evidence and product decisions visible.
+
+**Trace:** UX-R1, UX-R6, UX-R10, UX-R13; `SKILL.md` P5.
+
+### Gate G4 — Accumulated specification
+
+Present the complete actor/path/state/content/recovery/measure inventory and gap register. The user explicitly
+approves the accumulated specification or reopens the earliest owning decision. An applicable open requirement
+prevents the final gate.
+
+**Trace:** UX-R7, UX-R9; `SKILL.md` P5.
+
+### D10 — Compare materially different concepts
+
+**Discuss with the user**
+
+- Which experience models could satisfy the same approved obligations in genuinely different ways?
+- How does each affect user control, effort, learning, confidence, accessibility, failure, recovery, trust,
+  operations, and measurement?
+- What evidence supports or rejects each concept?
+- What would change the recommendation?
+
+**Decision**
+
+Present at least two materially different concepts and recommend one. If only one is viable, show the real
+constraints and direct evidence proving that a second would be false, then ask the user to lock the UX-R8
+exception. Do not count style or wording variations as different concepts.
+
+**Trace:** UX-R8; `SKILL.md` P6.
+
+### D11 — Complete the specification and success model
+
+**Discuss with the user**
+
+- Does the chosen concept satisfy every actor, path, state, content intent, recovery, support, inclusion, trust,
+  safety, agency, harm, and non-goal obligation?
+- What evidence proves each completion claim, and what remains uncertain?
+- Which outcome, failure, recovery, accessibility, trust, and guardrail measures show whether the experience is
+  working?
+- How could each proxy be gamed or improve while the real outcome worsens?
+- Which measure or evidence would reopen which decision?
+
+**Decision**
+
+Lock the concept, complete specification, measure set, instrumentation intent, limitations, rejected options,
+and reopen conditions.
+
+**Trace:** UX-R9, UX-R13; `SKILL.md` P6.
+
+### Gate G5 — Final whole specification
+
+Present the whole feature design document and its two-way trace from foundation to every obligation. The user
+explicitly approves it. No prototype work starts before this gate passes.
+
+**Trace:** UX-R6, UX-R7, UX-R9; `SKILL.md` P6.
+
+### D12 — Decide the prototype question and fidelity
+
+**Discuss with the user**
+
+- Which remaining assumptions are most uncertain or costly if wrong?
+- What must participants be able to perceive and do to answer those questions?
+- Which approved paths, errors, recovery, accessibility, and cross-channel transitions must the prototype
+  include?
+- What is the lowest fidelity that can produce valid evidence without being mistaken for production?
+- What behavior and data are simulated, and how will participants be told?
+
+**Decision**
+
+Lock the test questions, scope, fidelity, simulation boundaries, and disposal plan. Production implementation is
+not an option in this decision.
+
+**Trace:** UX-R11; `SKILL.md` P7.
+
+### D13 — Plan direct prototype evaluation
+
+**Discuss with the user**
+
+- Which representative users and contexts are needed for each claim?
+- What task framing avoids coaching toward the intended solution?
+- What will be observed for comprehension, completion, alternatives, error, recovery, trust, accessibility,
+  workaround, abandonment, and harm?
+- What consent, accommodations, privacy, and data-retention conditions apply?
+- What evidence is sufficient to revise, reject, or retain an assumption without a fixed participant-count rule?
+
+**Decision**
+
+Lock the evaluation plan and claim boundary. If the required conditions are missing, return `NEEDS_CONTEXT`.
+
+**Trace:** UX-R3, UX-R4; `SKILL.md` P8.
+
+### D14 — Interpret findings, revise, and hand off
+
+**Discuss with the user after testing**
+
+- Which observations are supported, disputed, limited, or contradicted?
+- Which specification clauses, paths, states, content intents, or measures do the findings reopen?
+- Has the specification been revised before the prototype?
+- Which prototype changes and regression retests restore agreement?
+- What limitations remain, who owns them, and do they block acceptance?
+- Who owns surface realization, implementation questions, measurement, review cadence, and future deviations?
+
+**Decision**
+
+Lock the specification-first revision, prototype update, affected retest, evidence limitations, handoff owners,
+and reopen conditions. If evidence conflicts with identity or stakeholder preference, show the conflict and let
+the user decide above the non-waivable accessibility and safety floor.
+
+**Trace:** UX-R10, UX-R12, UX-R14; `SKILL.md` P8–P9.
+
+### Gate G6 — Post-test revision
+
+Present direct-user evidence, limitations, specification changes, prototype changes, retest results, remaining
+risks, success measures, and handoff. The user explicitly accepts, reopens, or stops the run. Acceptance is not
+available when UX-R3 or UX-R4 is unmet.
+
+**Trace:** UX-R3, UX-R4, UX-R7, UX-R12; `SKILL.md` P8.
+
+## Completion sweep
+
+Before leaving ideation, confirm that:
+
+- every D-node has current evidence and a user decision, a recorded evidence gap, or a proved inapplicability;
+- every required G-gate carries explicit approval or a reopen decision;
+- stakeholder locks and representative-user evidence remain separate;
+- every design recommendation names its references and evidence-to-change;
+- at least two material concepts were compared or the UX-R8 exception is evidenced and locked;
+- the whole specification gate predates every prototype artifact;
+- post-test changes trace specification first, prototype second, and affected retest third; and
+- project-specific follow-ups raised by the evidence are resolved or named as blockers.

--- a/.gobbi/projects/gobbi/skills/ux/scenarios.md
+++ b/.gobbi/projects/gobbi/skills/ux/scenarios.md
@@ -1,0 +1,496 @@
+# UX Design — Scenario Source
+
+Scenario source for testing whether one UX run produces a complete, evidence-led, cross-surface experience
+specification and a directly tested disposable prototype. Load it for a pre-handoff self-check or through
+`evaluation.md`. Every case exercises a parent clause and reserves checklist IDs from `checklists.md`; this file
+adds no UX policy.
+
+## Coverage register
+
+| Category | Disposition | Coverage |
+|---|---|---|
+| 1 Purpose / outcomes / scope | selected | One complete outcome, observable completion, and adjacent-outcome exclusion. |
+| 2 Actors / stakeholders / use-context | selected | Primary/supporting actors, representative users, contexts, and stakeholder authority. |
+| 3 Behavior / state / data | selected | Skeleton, bottom-up units, paths, states, content intent, and specification-first revision. |
+| 4 Interfaces / dependencies / structure | selected | Channels, handoffs, supporting systems, UX/UI co-loading, and future child specialization. |
+| 5 Quality attributes / resource economics | selected | Research/prototype effort sized to uncertainty and risk; measures bounded against gaming. |
+| 6 Failure / recovery / operations | selected | Missing context, dependency failure, cross-channel loss, error recovery, retest, and handoff. |
+| 7 Trust / harm / governance | selected | Consent, privacy, identity conflict, safety, agency, harm, and evidence authority. |
+| 8 Inclusion / locale | selected | Representative inclusion, accommodations, accessibility, language/context, and non-waivable floor. |
+| 9 Change / compatibility / reversibility | selected | Disposable prototypes, revision order, regression retest, and child-skill deviations. |
+| 10 Evidence / traceability / clarity | selected | Direct evidence gates, decision traces, whole-spec approval, measures, and no-silent-change handoff. |
+
+## Family UX-F1 — One complete outcome across surfaces
+
+**Primary category:** 1 Purpose / outcomes / scope — the defining discrimination is whether the run owns a
+whole observable outcome. **Secondary:** 2 Actors / stakeholders / use-context, 4 Interfaces / dependencies /
+structure, 10 Evidence / traceability / clarity.
+
+### UX-SCENARIO-01 — Returning user completes authentication
+
+- **Primary type:** Positive.
+- **Coverage role:** positive — exercises a complete valid outcome.
+- **Given:** an eligible returning user needs to authenticate and reach the intended signed-in destination.
+- **When:** the run binds entry, actors, normal/alternative paths, states, errors, recovery, support, and
+  observable completion.
+- **Then:** the outcome is specified end to end without absorbing registration, password reset, account
+  administration, or onboarding.
+- **Failure oracle:** the design stops at a login screen, omits a recovery state, or claims success before the
+  intended destination is verified.
+- **Evidence tuple:** observe the feature document with a scope/path/state trace; confirm every required path
+  reaches the completion signal.
+- **Obligation:** the design must own one complete authentication outcome and explicit adjacent non-goals.
+- **Exercises:** UX-R1; P1, P3–P6; cross-surface boundary example.
+- **Checklist IDs:** `UX-CHECK-01`, `UX-CHECK-02`, `UX-CHECK-07`, `UX-CHECK-09`.
+
+### UX-SCENARIO-02 — Command-line authentication is an alternative-valid realization
+
+- **Primary type:** Alternative-valid.
+- **Coverage role:** alternative-valid — exercises another valid channel for the same outcome.
+- **Given:** `tool auth login` opens an external authorization handoff and returns control to the terminal.
+- **When:** the experience specifies feedback, cancellation, timeout, recovery, and verified authenticated state.
+- **Then:** the command-line path satisfies the same outcome obligations without copying web mechanics.
+- **Failure oracle:** a URL is printed with no state continuity, timeout/recovery, or terminal completion proof.
+- **Evidence tuple:** inspect the channel/path trace and test the specified handoff outcomes against the skeleton.
+- **Obligation:** cross-surface variants must preserve the outcome while allowing platform-specific mechanics.
+- **Exercises:** UX-R1, UX-R14; P3, P5, P9.
+- **Checklist IDs:** `UX-CHECK-01`, `UX-CHECK-09`, `UX-CHECK-17`.
+
+### UX-SCENARIO-03 — Adjacent outcomes are pressured into the run
+
+- **Primary type:** Adversarial / abuse / gaming.
+- **Coverage role:** adversarial — tests scope expansion disguised as completeness.
+- **Given:** a stakeholder asks to add registration, password reset, and account settings “while designing
+  login.”
+- **When:** the outcome contract is reviewed.
+- **Then:** necessary login recovery remains, independent outcomes stay out, and any scope change returns to the
+  user.
+- **Failure oracle:** adjacent features enter because they share screens, identity, or implementation code.
+- **Evidence tuple:** compare the request with the outcome sentence, completion signal, and locked non-goals.
+- **Obligation:** shared surface or code must not silently broaden the outcome contract.
+- **Exercises:** UX-R1; P1; `ideation.md` D3.
+- **Checklist IDs:** `UX-CHECK-01`.
+
+### UX-SCENARIO-04 — The scope edge is stated exactly
+
+- **Primary type:** Boundary / edge.
+- **Coverage role:** boundary — exercises the exact transition between required recovery and another outcome.
+- **Given:** failed credentials need explanation and retry, while forgotten credentials require a separate reset
+  outcome.
+- **When:** scope is classified at the handoff boundary.
+- **Then:** explanation, retry, and safe handoff are specified; the reset experience itself remains a named
+  dependency/non-goal.
+- **Failure oracle:** either required recovery is cut as “another feature,” or the entire reset outcome is
+  absorbed.
+- **Evidence tuple:** inspect the boundary clause and both sides of the handoff in the skeleton.
+- **Obligation:** scope must include necessary continuity while excluding independent completion contracts.
+- **Exercises:** UX-R1; P1, P3.
+- **Checklist IDs:** `UX-CHECK-01`, `UX-CHECK-07`.
+
+## Family UX-F2 — Direct research, representativeness, and ethics
+
+**Primary category:** 2 Actors / stakeholders / use-context — evidence validity turns on whose behavior and
+context support the claim. **Secondary:** 7 Trust / harm / governance, 8 Inclusion / locale, 10 Evidence /
+traceability / clarity.
+
+### UX-SCENARIO-05 — New generative research shapes the run
+
+- **Primary type:** Positive.
+- **Coverage role:** positive — exercises new direct evidence before convergence.
+- **Given:** prior research and analytics exist for related authentication behavior.
+- **When:** the team conducts a new, neutral generative inquiry with representative users for this bounded run.
+- **Then:** current behavior, barriers, workarounds, language, trust, and context inform the foundation with
+  explicit limits.
+- **Failure oracle:** the design converges from existing reports alone or research questions pitch the intended
+  solution.
+- **Evidence tuple:** inspect research dates, questions, participant-context rationale, observations, synthesis,
+  and decision effects.
+- **Obligation:** every run must add new representative-user generative evidence before convergence.
+- **Exercises:** UX-R2, UX-R4; P1–P2.
+- **Checklist IDs:** `UX-CHECK-03`, `UX-CHECK-04`, `UX-CHECK-20`.
+
+### UX-SCENARIO-06 — Prior evidence or the project owner is offered as a substitute
+
+- **Primary type:** Counterfactual / assumption.
+- **Coverage role:** counterfactual — inverts the premise that prior or owner evidence is sufficient.
+- **Given:** a project owner says they know users and a prior study already covered login.
+- **When:** representativeness and recency are examined.
+- **Then:** prior evidence frames the inquiry; the owner counts only for claims their real context represents;
+  new direct research remains required.
+- **Failure oracle:** seniority, domain knowledge, or document presence is treated as representative evidence.
+- **Evidence tuple:** compare claimed population/context with the owner's actual context and the new research
+  question.
+- **Obligation:** evidence authority must come from representativeness, not ownership or familiarity.
+- **Exercises:** UX-R2; P1–P2.
+- **Checklist IDs:** `UX-CHECK-03`, `UX-CHECK-20`.
+
+### UX-SCENARIO-07 — Representative access or consent is unavailable
+
+- **Primary type:** Failure / recovery.
+- **Coverage role:** failure/recovery — exercises the required stop and recovery plan.
+- **Given:** representative users cannot be reached, informed consent is absent, or needed accommodations are
+  unavailable.
+- **When:** the precondition gate runs.
+- **Then:** the run returns `NEEDS_CONTEXT`, records assumptions and a research plan, and withholds accepted-final
+  status.
+- **Failure oracle:** stakeholder approval, a proxy participant, or a disclaimer is used to bypass the gate.
+- **Evidence tuple:** inspect access/consent/accommodation records and final status language.
+- **Obligation:** missing ethical or evidence preconditions must fail closed without pretending the design is
+  accepted.
+- **Exercises:** UX-R3, UX-R4; P1, P8.
+- **Checklist IDs:** `UX-CHECK-03`, `UX-CHECK-04`, `UX-CHECK-14`.
+
+### UX-SCENARIO-08 — Research is performed after the solution is locked
+
+- **Primary type:** Adversarial / abuse / gaming.
+- **Coverage role:** adversarial — tests research used as validation theater.
+- **Given:** one polished concept is already treated as final before participants are contacted.
+- **When:** interviews are framed to confirm it and contrary observations cannot change the design.
+- **Then:** the earliest affected decision reopens and neutral generative research precedes convergence.
+- **Failure oracle:** the existence of interview sessions is accepted as evidence despite a non-falsifiable plan.
+- **Evidence tuple:** inspect question neutrality, timing, decision status, disconfirming probes, and recorded
+  changes from findings.
+- **Obligation:** research must be able to change the direction rather than decorate a locked answer.
+- **Exercises:** UX-R2, UX-R4; P2; Must-Not-Follow performative-research rule.
+- **Checklist IDs:** `UX-CHECK-03`, `UX-CHECK-20`.
+
+## Family UX-F3 — Identity and reference foundation
+
+**Primary category:** 7 Trust / harm / governance — identity has authority limits where it conflicts with
+evidence, access, or safety. **Secondary:** 1 Purpose / outcomes / scope, 8 Inclusion / locale, 10 Evidence /
+traceability / clarity.
+
+### UX-SCENARIO-09 — No governing DESIGN material exists
+
+- **Primary type:** Positive.
+- **Coverage role:** positive — exercises the documented identity fallback.
+- **Given:** no adequate `DESIGN.md`, brand, product, or design-system document exists.
+- **When:** the agent reads the live product and asks what those materials would define.
+- **Then:** the user confirms a run-scoped identity brief in the feature design document; no project-wide file
+  is invented.
+- **Failure oracle:** identity is guessed, ignored until polish, or converted into an unauthorized global
+  `DESIGN.md`.
+- **Evidence tuple:** inspect the authority-chain search, live-product evidence, identity questions, and explicit
+  confirmation.
+- **Obligation:** missing identity material must trigger evidence gathering and a bounded confirmed brief.
+- **Exercises:** UX-R5; P2; `ideation.md` D6.
+- **Checklist IDs:** `UX-CHECK-05`, `UX-CHECK-06`.
+
+### UX-SCENARIO-10 — Identity conflicts with accessibility or direct evidence
+
+- **Primary type:** Adversarial / abuse / gaming.
+- **Coverage role:** adversarial — tests brand authority used to excuse exclusion.
+- **Given:** an identity preference reduces comprehension, access, safety, or trust for representative users.
+- **When:** the conflict reaches a decision gate.
+- **Then:** evidence and trade-offs are shown to the user; the result stays above the accessibility and safety
+  floor.
+- **Failure oracle:** “on brand” overrides direct evidence or the conflict is silently decided by the agent.
+- **Evidence tuple:** inspect the conflict record, accessibility/safety evidence, options, and explicit decision.
+- **Obligation:** identity conflicts must be visible and cannot waive access or safety.
+- **Exercises:** UX-R5, UX-R10; P2, P5–P6.
+- **Checklist IDs:** `UX-CHECK-05`, `UX-CHECK-10`.
+
+## Family UX-F4 — Top-down skeleton and bottom-up growth
+
+**Primary category:** 3 Behavior / state / data — the defining discrimination is construction order and
+whole-to-unit coherence. **Secondary:** 4 Interfaces / dependencies / structure, 6 Failure / recovery /
+operations, 10 Evidence / traceability / clarity.
+
+### UX-SCENARIO-11 — Skeleton first, specification grows one unit at a time
+
+- **Primary type:** Positive.
+- **Coverage role:** positive — exercises the required construction sequence.
+- **Given:** the foundation is approved.
+- **When:** the agent maps the top-down skeleton, then grows the smallest meaningful unit into the core path and
+  every remaining path/state.
+- **Then:** each increment traces to the skeleton and passes its user gate before the whole specification closes.
+- **Failure oracle:** local detail precedes the skeleton, or the complete specification appears in one ungated
+  pass.
+- **Evidence tuple:** inspect artifact timestamps/order, unit-to-skeleton traces, and gate decisions.
+- **Obligation:** the design must grow top-down then bottom-up in observable increments.
+- **Exercises:** UX-R6, UX-R7; P3–P6.
+- **Checklist IDs:** `UX-CHECK-06`, `UX-CHECK-07`, `UX-CHECK-08`, `UX-CHECK-09`.
+
+### UX-SCENARIO-12 — A polished big-bang design is requested
+
+- **Primary type:** Adversarial / abuse / gaming.
+- **Coverage role:** adversarial — tests polish used to skip evidence and construction gates.
+- **Given:** a stakeholder requests a finished, polished design in one pass.
+- **When:** the required sequence is compared with the request.
+- **Then:** the run stays staged; polish cannot replace foundation, skeleton, unit growth, whole-spec, or test
+  evidence.
+- **Failure oracle:** a complete-looking artifact is accepted because review is easier after it exists.
+- **Evidence tuple:** inspect decision/order records and attempt to locate every required gate before the final
+  artifact.
+- **Obligation:** cosmetic completeness must fail when the staged operating contract is absent.
+- **Exercises:** UX-R6, UX-R7; Must-Not-Follow big-bang rule.
+- **Checklist IDs:** `UX-CHECK-06`.
+
+### UX-SCENARIO-13 — Prototype is requested before the whole specification
+
+- **Primary type:** Negative / Bad.
+- **Coverage role:** negative — exercises safe rejection of an invalid precondition.
+- **Given:** the skeleton or core path is approved but the accumulated/whole specification is incomplete.
+- **When:** someone asks for a prototype “to figure out the rest.”
+- **Then:** prototype work does not start; the run returns to specification growth and final approval.
+- **Failure oracle:** a milestone prototype exists before the timestamped whole-spec gate.
+- **Evidence tuple:** compare prototype creation time and scope with the final approval record.
+- **Obligation:** no prototype may precede whole-specification completion and approval.
+- **Exercises:** UX-R6, UX-R9, UX-R11; P5–P7.
+- **Checklist IDs:** `UX-CHECK-11`, `UX-CHECK-12`.
+
+### UX-SCENARIO-14 — A strong local unit breaks the experience skeleton
+
+- **Primary type:** Failure / recovery.
+- **Coverage role:** failure/recovery — exercises detection and return to the owning layer.
+- **Given:** one task or channel works well alone but creates a dead end, state loss, or conflicting handoff in
+  the skeleton.
+- **When:** the unit-to-skeleton trace is checked.
+- **Then:** the unit or skeleton is revised, all affected paths are rechecked, and the user gate reruns.
+- **Failure oracle:** local usability evidence is used to ignore whole-outcome failure.
+- **Evidence tuple:** inspect the failed integration path, revision, regression sweep, and renewed decision.
+- **Obligation:** local success cannot pass while the complete experience fails.
+- **Exercises:** UX-R6, UX-R7; P3–P5.
+- **Checklist IDs:** `UX-CHECK-07`, `UX-CHECK-08`, `UX-CHECK-09`.
+
+## Family UX-F5 — Concepts and whole-specification approval
+
+**Primary category:** 10 Evidence / traceability / clarity — concept selection and prototype eligibility depend
+on an explicit evidence trail. **Secondary:** 1 Purpose / outcomes / scope, 3 Behavior / state / data, 5 Quality
+attributes / resource economics.
+
+### UX-SCENARIO-15 — Two materially different concepts are compared
+
+- **Primary type:** Positive.
+- **Coverage role:** positive — exercises valid divergence and user selection.
+- **Given:** the accumulated specification admits different experience models.
+- **When:** two concepts are compared across effort, control, access, trust, failure, recovery, and evidence.
+- **Then:** a reference-backed recommendation and evidence-to-change precede the user's locked choice.
+- **Failure oracle:** the first plausible pattern becomes the design without material comparison.
+- **Evidence tuple:** inspect concept structures, trade-off matrix, references, recommendation, and decision.
+- **Obligation:** design convergence must follow a material concept comparison by default.
+- **Exercises:** UX-R8; P6.
+- **Checklist IDs:** `UX-CHECK-10`.
+
+### UX-SCENARIO-16 — One concept is duplicated cosmetically
+
+- **Primary type:** Adversarial / abuse / gaming.
+- **Coverage role:** adversarial — tests false divergence.
+- **Given:** two concepts differ only in naming, tone, layout polish, or minor sequence wording.
+- **When:** their skeleton, control model, path/state behavior, and recovery are compared.
+- **Then:** they count as one; a material alternative or the evidenced single-concept exception is required.
+- **Failure oracle:** two labeled mockups satisfy the concept gate despite identical experience mechanics.
+- **Evidence tuple:** remove cosmetic differences and compare the remaining experience models.
+- **Obligation:** the concept gate must discriminate structure and behavior, not presentation labels.
+- **Exercises:** UX-R8; P6.
+- **Checklist IDs:** `UX-CHECK-10`.
+
+### UX-SCENARIO-17 — A real constraint permits one concept
+
+- **Primary type:** Boundary / edge.
+- **Coverage role:** boundary — exercises the exact exception threshold.
+- **Given:** legal, safety, platform, or interoperability constraints plus direct evidence leave no truthful
+  material alternative.
+- **When:** the single-concept exception is proposed.
+- **Then:** the constraint, evidence, rejected false divergence, and user decision are recorded.
+- **Failure oracle:** convenience, deadline, or familiarity is accepted as proof that divergence is false.
+- **Evidence tuple:** attempt to construct a materially different compliant concept and inspect why evidence
+  rules it out.
+- **Obligation:** the exception must be evidence-bearing and narrower than a preference for one option.
+- **Exercises:** UX-R8; P6.
+- **Checklist IDs:** `UX-CHECK-10`.
+
+### UX-SCENARIO-18 — Whole document is complete before approval
+
+- **Primary type:** Positive.
+- **Coverage role:** positive — exercises whole-spec and document-schema closure.
+- **Given:** one concept is selected.
+- **When:** every schema section, actor, path, state, recovery, conflict, measure, limitation, and trace is
+  reviewed.
+- **Then:** explicit whole-spec approval is recorded before prototype creation.
+- **Failure oracle:** section headings, “mostly complete,” or earlier milestone approvals are treated as the
+  final gate.
+- **Evidence tuple:** inspect schema content, orphan sweep, explicit approval, and artifact chronology.
+- **Obligation:** the complete evidence-bearing specification must pass as a whole before prototyping.
+- **Exercises:** UX-R7, UX-R9; P6.
+- **Checklist IDs:** `UX-CHECK-06`, `UX-CHECK-11`, `UX-CHECK-12`.
+
+## Family UX-F6 — Cross-channel state, failure, and recovery
+
+**Primary category:** 4 Interfaces / dependencies / structure — the defining discrimination is continuity
+across actor, channel, and system boundaries. **Secondary:** 3 Behavior / state / data, 6 Failure / recovery /
+operations, 8 Inclusion / locale.
+
+### UX-SCENARIO-19 — Cross-channel handoff preserves the outcome
+
+- **Primary type:** Positive.
+- **Coverage role:** positive — exercises a valid multi-channel path.
+- **Given:** authentication moves from a terminal to a browser or from self-service to supported recovery.
+- **When:** intent, state, security, feedback, accessibility, return path, and completion evidence are specified.
+- **Then:** the person can continue and verify completion without reconstructing hidden state.
+- **Failure oracle:** each channel works alone but the transition loses context or leaves ambiguous completion.
+- **Evidence tuple:** walk the handoff in both directions against the skeleton and state inventory.
+- **Obligation:** required channels must form one coherent outcome, not separate local successes.
+- **Exercises:** UX-R1, UX-R10; P3–P5.
+- **Checklist IDs:** `UX-CHECK-07`, `UX-CHECK-09`.
+
+### UX-SCENARIO-20 — Handoff times out after partial progress
+
+- **Primary type:** Failure / recovery.
+- **Coverage role:** failure/recovery — exercises interruption, containment, and safe resumption.
+- **Given:** the external authorization handoff times out after one channel shows progress.
+- **When:** the person returns to the initiating channel.
+- **Then:** the experience states what happened, preserves no unsafe partial success, and offers a clear retry,
+  cancel, support, or safe exit path.
+- **Failure oracle:** one channel claims success, the other waits indefinitely, or retry duplicates a harmful
+  action.
+- **Evidence tuple:** inject the specified timeout at each transition and inspect state, messaging intent,
+  recovery, and completion evidence.
+- **Obligation:** cross-channel failure must be detectable, contained, recoverable, and consistent.
+- **Exercises:** UX-R1, UX-R10; P5.
+- **Checklist IDs:** `UX-CHECK-09`.
+
+### UX-SCENARIO-21 — Separate channel specs hide a broken whole
+
+- **Primary type:** Adversarial / abuse / gaming.
+- **Coverage role:** adversarial — tests cosmetic per-channel compliance.
+- **Given:** web and command-line sections each list polished screens/commands and success states.
+- **When:** the shared state and handoff contract are removed.
+- **Then:** the design fails because no evidence proves end-to-end continuity.
+- **Failure oracle:** present channel sections are accepted without a cross-channel path test.
+- **Evidence tuple:** attempt the complete outcome using only stated interface contracts and observe the orphan.
+- **Obligation:** local surface completeness cannot substitute for cross-channel integration evidence.
+- **Exercises:** UX-R1, UX-R14; P3–P5.
+- **Checklist IDs:** `UX-CHECK-09`, `UX-CHECK-17`.
+
+## Family UX-F7 — Disposable prototype and direct evaluation
+
+**Primary category:** 9 Change / compatibility / reversibility — the prototype is disposable, and findings
+change the specification before its representation. **Secondary:** 2 Actors / stakeholders / use-context,
+6 Failure / recovery / operations, 8 Inclusion / locale, 10 Evidence / traceability / clarity.
+
+### UX-SCENARIO-22 — Approved specification is tested with representative users
+
+- **Primary type:** Positive.
+- **Coverage role:** positive — exercises proportionate prototype and direct evaluation gates.
+- **Given:** the whole specification is approved and named uncertainties remain.
+- **When:** the lowest sufficient prototype is evaluated directly with representative users under consent and
+  accommodation conditions.
+- **Then:** observations and bounded claims address completion, errors, recovery, trust, access, and harm.
+- **Failure oracle:** stakeholder walkthrough, expert review, prior testing, or prototype presence is called
+  direct-user acceptance evidence.
+- **Evidence tuple:** inspect chronology, participant rationale, consent, task method, observations, limits, and
+  trace to test questions.
+- **Obligation:** prototype acceptance must rest on new direct representative-user evaluation.
+- **Exercises:** UX-R3, UX-R4, UX-R11; P7–P8.
+- **Checklist IDs:** `UX-CHECK-12`, `UX-CHECK-13`, `UX-CHECK-14`.
+
+### UX-SCENARIO-23 — Prototype excludes the access path being claimed
+
+- **Primary type:** Adversarial / abuse / gaming.
+- **Coverage role:** adversarial — tests inaccessible evidence used to claim inclusion.
+- **Given:** the specification claims an accessible path, but the prototype or study method prevents relevant
+  participants from using it.
+- **When:** the evidence claim is reviewed.
+- **Then:** the claim fails, the prototype/method is corrected from the specification, and affected users test it.
+- **Failure oracle:** a checklist note, expert opinion, or planned future implementation substitutes for usable
+  prototype evidence.
+- **Evidence tuple:** compare claimed access needs with participant accommodations, modality, and observed use.
+- **Obligation:** the prototype and method must permit direct evidence for each acceptance claim.
+- **Exercises:** UX-R3, UX-R4, UX-R10; P7–P8.
+- **Checklist IDs:** `UX-CHECK-04`, `UX-CHECK-13`, `UX-CHECK-14`.
+
+### UX-SCENARIO-24 — Finding changes only the mockup
+
+- **Primary type:** Failure / recovery.
+- **Coverage role:** failure/recovery — exercises specification-first repair and retest.
+- **Given:** prototype evaluation exposes a confusing recovery state.
+- **When:** the mockup is edited without changing its owning requirement or path.
+- **Then:** acceptance blocks; the specification changes first, the prototype follows, and affected assumptions
+  and regressions are retested.
+- **Failure oracle:** visual improvement is accepted while the handed-off contract remains wrong.
+- **Evidence tuple:** inspect finding timestamps and trace specification revision → prototype revision → retest.
+- **Obligation:** every supported finding must repair the durable experience contract before its test artifact.
+- **Exercises:** UX-R12; P8.
+- **Checklist IDs:** `UX-CHECK-15`.
+
+## Family UX-F8 — Measurement, co-loading, and handoff change control
+
+**Primary category:** 10 Evidence / traceability / clarity — the defining discrimination is whether claims and
+future changes stay tied to outcome evidence. **Secondary:** 4 Interfaces / dependencies / structure, 5 Quality
+attributes / resource economics, 7 Trust / harm / governance, 9 Change / compatibility / reversibility.
+
+### UX-SCENARIO-25 — Outcome measures include guardrails and reopen conditions
+
+- **Primary type:** Positive.
+- **Coverage role:** positive — exercises continued evidence after handoff.
+- **Given:** the design reaches post-test approval.
+- **When:** outcome, failure, recovery, access, trust, and harm measures are defined with owners and review
+  cadence.
+- **Then:** each measure states its interpretation limits, guardrails, and evidence that reopens the design.
+- **Failure oracle:** success is a dashboard proxy with no relation to completed outcomes or user harm.
+- **Evidence tuple:** trace each measure to an obligation and simulate an improving proxy with worsening user
+  outcome.
+- **Obligation:** measurement must support the outcome and expose harmful interpretations.
+- **Exercises:** UX-R13, UX-R14; P6, P9.
+- **Checklist IDs:** `UX-CHECK-16`, `UX-CHECK-17`.
+
+### UX-SCENARIO-26 — Metric improves while the user outcome worsens
+
+- **Primary type:** Adversarial / abuse / gaming.
+- **Coverage role:** adversarial — tests metric gaming and proxy inversion.
+- **Given:** authentication completion rate rises because recovery exits and difficult users are excluded.
+- **When:** the metric is read without failure, abandonment, accessibility, or harm guardrails.
+- **Then:** the metric set fails and the design/measurement decision reopens.
+- **Failure oracle:** a higher headline number alone is accepted as success.
+- **Evidence tuple:** construct the counterexample and inspect whether guardrails detect it.
+- **Obligation:** no gameable proxy may stand alone as outcome evidence.
+- **Exercises:** UX-R13; P9.
+- **Checklist IDs:** `UX-CHECK-16`.
+
+### UX-SCENARIO-27 — Co-loaded UI and UX guidance conflict
+
+- **Primary type:** Failure / recovery.
+- **Coverage role:** failure/recovery — exercises conflict detection and user resolution.
+- **Given:** UX evidence requires one recovery model while UI guidance recommends a conflicting surface pattern.
+- **When:** both skills are loaded.
+- **Then:** the concrete conflict, evidence, and trade-offs are shown to the user; no precedence or load-order
+  rule is invented, and the accessibility/safety floor remains.
+- **Failure oracle:** one parent silently overrides the other or the implementation chooses by convenience.
+- **Evidence tuple:** inspect both clauses, their evidence, the user decision, and preserved non-waivable floor.
+- **Obligation:** co-loaded parent conflicts must be explicit, evidence-led user decisions.
+- **Exercises:** UX-R10, UX-R14; Intro; Must-Not-Follow co-load rule.
+- **Checklist IDs:** `UX-CHECK-18`.
+
+### UX-SCENARIO-28 — Future child silently changes the experience contract
+
+- **Primary type:** Change / regression / compat.
+- **Coverage role:** change/regression — exercises specialization without parent regression.
+- **Given:** a future web, command-line, or desktop child skill specializes exact mechanics.
+- **When:** it drops a parent actor, state, recovery, access, safety, evidence, or measure obligation.
+- **Then:** the deviation fails and returns to the user before handoff; mechanics may differ, parent invariants may
+  not disappear silently.
+- **Failure oracle:** platform specificity is treated as authority to narrow the outcome contract.
+- **Evidence tuple:** diff child obligations against parent traces and run the complete outcome scenarios.
+- **Obligation:** child specialization must preserve parent evidence and experience invariants.
+- **Exercises:** UX-R14; P9.
+- **Checklist IDs:** `UX-CHECK-17`, `UX-CHECK-18`.
+
+## Triggered-minimum audit
+
+| Family | Boundary | Failure / recovery | Adversarial | Change / regression | Counterfactual |
+|---|---|---|---|---|---|
+| UX-F1 | `UX-SCENARIO-04` | `n/a: no dependency failure is the defining concern of this scope family` | `UX-SCENARIO-03` | `n/a: no existing-contract change occurs` | `n/a: no additional load-bearing premise beyond the outcome boundary` |
+| UX-F2 | `n/a: sample size is risk-based rather than a fixed numeric edge` | `UX-SCENARIO-07` | `UX-SCENARIO-08` | `n/a: the family tests current-run evidence, not a version transition` | `UX-SCENARIO-06` |
+| UX-F3 | `n/a: the authority chain is ordinal, not a quantity transition` | `n/a: no operational dependency failure is introduced` | `UX-SCENARIO-10` | `n/a: identity is established for this run` | `n/a: missing identity follows an explicit positive fallback` |
+| UX-F4 | `n/a: milestone order is categorical rather than numeric` | `UX-SCENARIO-14` | `UX-SCENARIO-12` | `n/a: construction is within one run` | `n/a: the order is a parent invariant, not an assumption` |
+| UX-F5 | `UX-SCENARIO-17` | `n/a: no dependency or partial mutation is introduced` | `UX-SCENARIO-16` | `n/a: concept comparison precedes change-controlled handoff` | `n/a: concept viability is tested directly by the exception boundary` |
+| UX-F6 | `n/a: timeout is exercised as failure/recovery, not a numeric product limit` | `UX-SCENARIO-20` | `UX-SCENARIO-21` | `n/a: no version transition occurs` | `n/a: cross-channel continuity is a required contract` |
+| UX-F7 | `n/a: prototype fidelity has no universal numeric limit` | `UX-SCENARIO-24` | `UX-SCENARIO-23` | `n/a: revision order is exercised as recovery within the run` | `n/a: direct evaluation is a required evidence gate` |
+| UX-F8 | `n/a: measure thresholds are outcome-specific` | `UX-SCENARIO-27` | `UX-SCENARIO-26` | `UX-SCENARIO-28` | `n/a: proxy inversion is covered adversarially` |
+
+## Guaranteed coverage map
+
+Every scenario names at least one `UX-CHECK-*` obligation. The authoritative check-to-scenario reverse map is
+in `checklists.md`. Parent-clause coverage closes in both directions through each case's **Exercises** field and
+the checklist's **Source** field.

--- a/.gobbi/projects/gobbi/skills/ux/scenarios.md
+++ b/.gobbi/projects/gobbi/skills/ux/scenarios.md
@@ -53,7 +53,7 @@ type inapplicable.
 ## Source register and stable IDs
 
 - `SRC-UX-PARENT` — [`SKILL.md`](SKILL.md), UX-R1–UX-R14 and P1–P9; sole policy owner.
-- `SRC-UX-DECISIONS` — [`ideation.md`](ideation.md); D0–D15 questions and G1–G6 decision-gate trace.
+- `SRC-UX-DECISIONS` — [`ideation.md`](ideation.md); D0–D14 questions and G1–G6 decision-gate trace.
 - `SRC-UX-ISO` — ISO 9241-210 and ISO 9241-11 references named by the parent.
 - `SRC-UX-RESEARCH` — Digital.gov user-research guidance and GOV.UK service/user-research guidance named by
   the parent; applicable only to their stated research claims.
@@ -440,7 +440,7 @@ discrimination gets a new case ID.
 - **Declared primary category:** 4 — Interfaces / dependencies / structure. The defining discrimination is
   whether state and completion remain coherent across actor, channel, and system boundaries.
 - **Secondary categories:** 3, 6, 8.
-- **Source / rationale:** `SRC-UX-PARENT` UX-R1, UX-R10, UX-R14, P3–P5/P9; `SRC-UX-DECISIONS` D3–D5/D15.
+- **Source / rationale:** `SRC-UX-PARENT` UX-R1, UX-R10, UX-R14, P3–P5/P9; `SRC-UX-DECISIONS` D3–D5/D14.
 - **Actor + outcome:** a person crosses terminal, browser, system, or support boundaries and still completes or
   safely recovers from one outcome.
 - **Situation / invariant:** locally polished channels do not prove the handoff, shared state, access path, or
@@ -567,7 +567,7 @@ discrimination gets a new case ID.
 - **Declared primary category:** 10 — Evidence / traceability / clarity. The defining discrimination is whether
   measures, parent conflicts, and future changes remain tied to observable outcome evidence.
 - **Secondary categories:** 4, 5, 7, 9.
-- **Source / rationale:** `SRC-UX-PARENT` UX-R10, UX-R13, UX-R14, P6/P9; `SRC-UX-DECISIONS` D15/G6;
+- **Source / rationale:** `SRC-UX-PARENT` UX-R10, UX-R13, UX-R14, P6/P9; `SRC-UX-DECISIONS` D14/G6;
   `SRC-UX-MEASUREMENT`.
 - **Actor + outcome:** product, measurement, UI/UX, and child-skill owners preserve a cold-readable experience
   contract after handoff.

--- a/.gobbi/projects/gobbi/skills/ux/scenarios.md
+++ b/.gobbi/projects/gobbi/skills/ux/scenarios.md
@@ -1,35 +1,89 @@
-# UX Design — Scenario Source
+# UX Design — Scenario Set
 
-Scenario source for testing whether one UX run produces a complete, evidence-led, cross-surface experience
-specification and a directly tested disposable prototype. Load it for a pre-handoff self-check or through
-`evaluation.md`. Every case exercises a parent clause and reserves checklist IDs from `checklists.md`; this file
-adds no UX policy.
+Scenario source for one `ux` operation run. Its target is the parent contract in [`SKILL.md`](SKILL.md). Its
+consumers are the operational checklist in [`checklists.md`](checklists.md) and the active Gobbi evaluation via
+[`evaluation.md`](evaluation.md). The set tests whether one run produces a complete, evidence-led,
+cross-surface experience specification and a directly tested disposable prototype. It exercises parent
+obligations; it does not add UX policy. Lifecycle mode: design obligations plus evaluation coverage.
+
+Scope is one complete observable experience outcome across one or more valid channels, actors, organizations,
+or systems. Non-goals are adjacent outcomes, production implementation, exact child-owned platform mechanics,
+and universal participant-count or prototype-fidelity rules. Sensitive participant evidence is referenced
+through the active project's governed evidence records and retention policy, never copied here.
+
+Scale limit: this source uses eight families and 28 cases, below the default split thresholds of about 12
+families and 40 distinct category/type cells. Split a future larger set under a parent index rather than growing
+this source without bound.
 
 ## Coverage register
 
-| Category | Disposition | Coverage |
-|---|---|---|
-| 1 Purpose / outcomes / scope | selected | One complete outcome, observable completion, and adjacent-outcome exclusion. |
-| 2 Actors / stakeholders / use-context | selected | Primary/supporting actors, representative users, contexts, and stakeholder authority. |
-| 3 Behavior / state / data | selected | Skeleton, bottom-up units, paths, states, content intent, and specification-first revision. |
-| 4 Interfaces / dependencies / structure | selected | Channels, handoffs, supporting systems, UX/UI co-loading, and future child specialization. |
-| 5 Quality attributes / resource economics | selected | Research/prototype effort sized to uncertainty and risk; measures bounded against gaming. |
-| 6 Failure / recovery / operations | selected | Missing context, dependency failure, cross-channel loss, error recovery, retest, and handoff. |
-| 7 Trust / harm / governance | selected | Consent, privacy, identity conflict, safety, agency, harm, and evidence authority. |
-| 8 Inclusion / locale | selected | Representative inclusion, accommodations, accessibility, language/context, and non-waivable floor. |
-| 9 Change / compatibility / reversibility | selected | Disposable prototypes, revision order, regression retest, and child-skill deviations. |
-| 10 Evidence / traceability / clarity | selected | Direct evidence gates, decision traces, whole-spec approval, measures, and no-silent-change handoff. |
+All ten categories are selected because each can affect a cross-surface UX run. The named families are the
+category carriers; no concern is delegated through `covered-elsewhere`.
+
+| # | Category | Disposition | Family carriers |
+|---|---|---|---|
+| 1 | Purpose / outcomes / scope | selected | `UX-F1`, `UX-F3`, `UX-F5` |
+| 2 | Actors / stakeholders / use-context | selected | `UX-F1`, `UX-F2`, `UX-F7` |
+| 3 | Behavior / state / data | selected | `UX-F4`, `UX-F5`, `UX-F6` |
+| 4 | Interfaces / dependencies / structure | selected | `UX-F1`, `UX-F4`, `UX-F6`, `UX-F8` |
+| 5 | Quality attributes / resource economics | selected | `UX-F5`, `UX-F8` |
+| 6 | Failure / recovery / operations | selected | `UX-F4`, `UX-F6`, `UX-F7` |
+| 7 | Trust / harm / governance | selected | `UX-F2`, `UX-F3`, `UX-F8` |
+| 8 | Inclusion / locale | selected | `UX-F2`, `UX-F3`, `UX-F6`, `UX-F7` |
+| 9 | Change / compatibility / reversibility | selected | `UX-F7`, `UX-F8` |
+| 10 | Evidence / traceability / clarity | selected | `UX-F1`–`UX-F5`, `UX-F7`, `UX-F8` |
+
+## Category × case-type matrix
+
+Each selected category has a positive carrier and every family has an adversarial face. Other minima appear
+when the family's properties trigger them. An empty cell is `n/a` only with the property that makes the case
+type inapplicable.
+
+| Family | Good | Alternative-valid | Negative / Bad | Boundary | Failure / recovery | Adversarial | Change / regression | Counterfactual |
+|---|---|---|---|---|---|---|---|---|
+| `UX-F1` | `01` | `02` | n/a: scope pressure is adversarial, not a prohibited side effect | `04` | n/a: recovery is part of the exact scope boundary | `03` | n/a: no version event occurs | n/a: the outcome boundary is directly locked |
+| `UX-F2` | `05` | n/a: method variation remains inside one direct-evidence path | n/a: missing preconditions require recovery rather than a prohibited action | n/a: sample size is risk-based, not a fixed edge | `07` | `08` | n/a: current-run evidence is not a version transition | `06` |
+| `UX-F3` | `09` | n/a: the authority chain has one valid order | n/a: missing identity uses the positive fallback | n/a: the authority chain is ordinal, not a quantity limit | n/a: missing identity is resolved by the bounded fallback | `10` | n/a: identity is established for this run | n/a: authority sources are inspected directly |
+| `UX-F4` | `11` | n/a: the parent chronology has one valid order | `13` | n/a: milestone order is categorical, not numeric | `14` | `12` | n/a: construction occurs within one run | n/a: chronology is evidenced, not assumed |
+| `UX-F5` | `15`, `18` | n/a: material alternatives are compared inside the valid case | n/a: invalid divergence is adversarial rather than a prohibited side effect | `17` | n/a: no dependency or partial mutation is introduced | `16` | n/a: comparison precedes change-controlled handoff | n/a: the single-concept exception is tested at its boundary |
+| `UX-F6` | `19` | n/a: channel variants belong to one continuity contract | n/a: unsafe partial state is exercised as recoverable failure | n/a: timeout is the failure transition, not a product limit | `20` | `21` | n/a: no version transition occurs | n/a: continuity is directly walked, not premised |
+| `UX-F7` | `22` | n/a: prototype-method variation remains inside one evidence path | n/a: inaccessible evidence is an adversarial acceptance attempt | n/a: fidelity has no universal numeric limit | `24` | `23` | n/a: specification-first revision is recovery within the run | n/a: direct evaluation is inspected, not assumed |
+| `UX-F8` | `25` | n/a: measures vary within one guarded measurement model | n/a: harmful proxy inversion is adversarial | n/a: measure thresholds are outcome-specific | `27` | `26` | `28` | n/a: proxy inversion is constructed directly |
+
+## Source register and stable IDs
+
+- `SRC-UX-PARENT` — [`SKILL.md`](SKILL.md), UX-R1–UX-R14 and P1–P9; sole policy owner.
+- `SRC-UX-DECISIONS` — [`ideation.md`](ideation.md); D0–D15 questions and G1–G6 decision-gate trace.
+- `SRC-UX-ISO` — ISO 9241-210 and ISO 9241-11 references named by the parent.
+- `SRC-UX-RESEARCH` — Digital.gov user-research guidance and GOV.UK service/user-research guidance named by
+  the parent; applicable only to their stated research claims.
+- `SRC-UX-ACCESS` — W3C WAI accessibility and inclusive-design references named by the parent; applicable only
+  to their stated surfaces, modalities, and evidence claims.
+- `SRC-UX-MEASUREMENT` — GOV.UK service performance and outcome-measure references named by the parent.
+
+Case IDs are permanent `UX-SCENARIO-NN` values. Family IDs remain permanent `UX-FN` values. Checklist
+reservations use permanent `UX-CHECK-NN` values. Renaming a title does not change an ID. A changed
+discrimination gets a new case ID.
 
 ## Family UX-F1 — One complete outcome across surfaces
 
-**Primary category:** 1 Purpose / outcomes / scope — the defining discrimination is whether the run owns a
-whole observable outcome. **Secondary:** 2 Actors / stakeholders / use-context, 4 Interfaces / dependencies /
-structure, 10 Evidence / traceability / clarity.
+- **Declared primary category:** 1 — Purpose / outcomes / scope. The defining discrimination is whether the run
+  owns a whole observable outcome rather than a surface fragment or adjacent work.
+- **Secondary categories:** 2, 4, 10.
+- **Source / rationale:** `SRC-UX-PARENT` UX-R1, UX-R14, P1/P3/P5/P9; `SRC-UX-DECISIONS` D1–D5.
+- **Actor + outcome:** a returning person completes one bounded authentication outcome with supporting actors.
+- **Situation / invariant:** web, command-line, and support handoffs may differ mechanically while preserving
+  one outcome, recovery, and explicit adjacent non-goals.
+- **Applicability / priority:** every run; gate-bearing.
+- **Cases:** `UX-SCENARIO-01`–`UX-SCENARIO-04`.
+- **Obligations / check links:** complete outcome, valid cross-surface realization, scope-pressure rejection,
+  and exact handoff boundary; `UX-CHECK-01`, `UX-CHECK-02`, `UX-CHECK-07`, `UX-CHECK-09`.
 
 ### UX-SCENARIO-01 — Returning user completes authentication
 
-- **Primary type:** Positive.
-- **Coverage role:** positive — exercises a complete valid outcome.
+- **Primary type + justification:** Good — ordinary valid authentication reaches the observable signed-in outcome end to end.
+- **Coverage-role set:** {Good} — exercises a complete valid outcome.
+- **Actor:** eligible returning user.
 - **Given:** an eligible returning user needs to authenticate and reach the intended signed-in destination.
 - **When:** the run binds entry, actors, normal/alternative paths, states, errors, recovery, support, and
   observable completion.
@@ -40,26 +94,28 @@ structure, 10 Evidence / traceability / clarity.
 - **Evidence tuple:** observe the feature document with a scope/path/state trace; confirm every required path
   reaches the completion signal.
 - **Obligation:** the design must own one complete authentication outcome and explicit adjacent non-goals.
-- **Exercises:** UX-R1; P1, P3–P6; cross-surface boundary example.
-- **Checklist IDs:** `UX-CHECK-01`, `UX-CHECK-02`, `UX-CHECK-07`, `UX-CHECK-09`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R1; P1, P3–P6; cross-surface boundary example.
+- **Checklist trace:** `UX-CHECK-01`, `UX-CHECK-02`, `UX-CHECK-07`, `UX-CHECK-09`.
 
 ### UX-SCENARIO-02 — Command-line authentication is an alternative-valid realization
 
-- **Primary type:** Alternative-valid.
-- **Coverage role:** alternative-valid — exercises another valid channel for the same outcome.
+- **Primary type + justification:** Alternative-valid — a materially different command-line channel satisfies the same outcome without copying web mechanics.
+- **Coverage-role set:** {Alternative-valid} — exercises another valid channel for the same outcome.
+- **Actor:** eligible returning terminal user.
 - **Given:** `tool auth login` opens an external authorization handoff and returns control to the terminal.
 - **When:** the experience specifies feedback, cancellation, timeout, recovery, and verified authenticated state.
 - **Then:** the command-line path satisfies the same outcome obligations without copying web mechanics.
 - **Failure oracle:** a URL is printed with no state continuity, timeout/recovery, or terminal completion proof.
 - **Evidence tuple:** inspect the channel/path trace and test the specified handoff outcomes against the skeleton.
 - **Obligation:** cross-surface variants must preserve the outcome while allowing platform-specific mechanics.
-- **Exercises:** UX-R1, UX-R14; P3, P5, P9.
-- **Checklist IDs:** `UX-CHECK-01`, `UX-CHECK-09`, `UX-CHECK-17`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R1, UX-R14; P3, P5, P9.
+- **Checklist trace:** `UX-CHECK-01`, `UX-CHECK-09`, `UX-CHECK-17`.
 
 ### UX-SCENARIO-03 — Adjacent outcomes are pressured into the run
 
-- **Primary type:** Adversarial / abuse / gaming.
-- **Coverage role:** adversarial — tests scope expansion disguised as completeness.
+- **Primary type + justification:** Adversarial — scope expansion is disguised as completeness to pressure the bounded outcome.
+- **Coverage-role set:** {Adversarial} — tests scope expansion disguised as completeness.
+- **Actor:** stakeholder and UX designer.
 - **Given:** a stakeholder asks to add registration, password reset, and account settings “while designing
   login.”
 - **When:** the outcome contract is reviewed.
@@ -68,13 +124,14 @@ structure, 10 Evidence / traceability / clarity.
 - **Failure oracle:** adjacent features enter because they share screens, identity, or implementation code.
 - **Evidence tuple:** compare the request with the outcome sentence, completion signal, and locked non-goals.
 - **Obligation:** shared surface or code must not silently broaden the outcome contract.
-- **Exercises:** UX-R1; P1; `ideation.md` D3.
-- **Checklist IDs:** `UX-CHECK-01`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R1; P1; `SRC-UX-DECISIONS` D3.
+- **Checklist trace:** `UX-CHECK-01`.
 
 ### UX-SCENARIO-04 — The scope edge is stated exactly
 
-- **Primary type:** Boundary / edge.
-- **Coverage role:** boundary — exercises the exact transition between required recovery and another outcome.
+- **Primary type + justification:** Boundary — the case exercises the exact transition between required login recovery and an independent reset outcome.
+- **Coverage-role set:** {Boundary} — exercises the exact transition between required recovery and another outcome.
+- **Actor:** returning user and recovery-service owner.
 - **Given:** failed credentials need explanation and retry, while forgotten credentials require a separate reset
   outcome.
 - **When:** scope is classified at the handoff boundary.
@@ -84,19 +141,31 @@ structure, 10 Evidence / traceability / clarity.
   absorbed.
 - **Evidence tuple:** inspect the boundary clause and both sides of the handoff in the skeleton.
 - **Obligation:** scope must include necessary continuity while excluding independent completion contracts.
-- **Exercises:** UX-R1; P1, P3.
-- **Checklist IDs:** `UX-CHECK-01`, `UX-CHECK-07`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R1; P1, P3.
+- **Checklist trace:** `UX-CHECK-01`, `UX-CHECK-07`.
 
 ## Family UX-F2 — Direct research, representativeness, and ethics
 
-**Primary category:** 2 Actors / stakeholders / use-context — evidence validity turns on whose behavior and
-context support the claim. **Secondary:** 7 Trust / harm / governance, 8 Inclusion / locale, 10 Evidence /
-traceability / clarity.
+- **Declared primary category:** 2 — Actors / stakeholders / use-context. The defining discrimination is
+  whether current behavior and context come directly from people representative of the claim.
+- **Secondary categories:** 7, 8, 10.
+- **Source / rationale:** `SRC-UX-PARENT` UX-R2–UX-R4, P1/P2/P8; `SRC-UX-DECISIONS` D0, D2, D5, G1/G6;
+  `SRC-UX-RESEARCH`.
+- **Actor + outcome:** representative participants supply new bounded generative evidence under ethical
+  conditions, distinct from stakeholder authority.
+- **Situation / invariant:** prior evidence and owners can frame questions but cannot replace current direct
+  generative contact or the conditions that make its claims supportable.
+- **Applicability / priority:** every run; acceptance-bearing and non-waivable for direct generative research,
+  accessibility, and safety.
+- **Cases:** `UX-SCENARIO-05`–`UX-SCENARIO-08`.
+- **Obligations / check links:** new generative research, evidence authority, fail-closed preconditions, and
+  anti-theater chronology; `UX-CHECK-03`, `UX-CHECK-04`, `UX-CHECK-14`, `UX-CHECK-20`.
 
 ### UX-SCENARIO-05 — New generative research shapes the run
 
-- **Primary type:** Positive.
-- **Coverage role:** positive — exercises new direct evidence before convergence.
+- **Primary type + justification:** Good — new neutral generative contact changes the current run before concept convergence.
+- **Coverage-role set:** {Good} — exercises new direct evidence before convergence.
+- **Actor:** representative research participant and UX researcher.
 - **Given:** prior research and analytics exist for related authentication behavior.
 - **When:** the team conducts a new, neutral generative inquiry with representative users for this bounded run.
 - **Then:** current behavior, barriers, workarounds, language, trust, and context inform the foundation with
@@ -106,13 +175,14 @@ traceability / clarity.
 - **Evidence tuple:** inspect research dates, questions, participant-context rationale, observations, synthesis,
   and decision effects.
 - **Obligation:** every run must add new representative-user generative evidence before convergence.
-- **Exercises:** UX-R2, UX-R4; P1–P2.
-- **Checklist IDs:** `UX-CHECK-03`, `UX-CHECK-04`, `UX-CHECK-20`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R2, UX-R4; P1–P2.
+- **Checklist trace:** `UX-CHECK-03`, `UX-CHECK-04`, `UX-CHECK-20`.
 
 ### UX-SCENARIO-06 — Prior evidence or the project owner is offered as a substitute
 
-- **Primary type:** Counterfactual / assumption.
-- **Coverage role:** counterfactual — inverts the premise that prior or owner evidence is sufficient.
+- **Primary type + justification:** Counterfactual — the premise that prior or owner knowledge is sufficient is inverted and tested against representativeness.
+- **Coverage-role set:** {Counterfactual} — inverts the premise that prior or owner evidence is sufficient.
+- **Actor:** project owner and UX researcher.
 - **Given:** a project owner says they know users and a prior study already covered login.
 - **When:** representativeness and recency are examined.
 - **Then:** prior evidence frames the inquiry; the owner counts only for claims their real context represents;
@@ -121,49 +191,66 @@ traceability / clarity.
 - **Evidence tuple:** compare claimed population/context with the owner's actual context and the new research
   question.
 - **Obligation:** evidence authority must come from representativeness, not ownership or familiarity.
-- **Exercises:** UX-R2; P1–P2.
-- **Checklist IDs:** `UX-CHECK-03`, `UX-CHECK-20`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R2; P1–P2.
+- **Checklist trace:** `UX-CHECK-03`, `UX-CHECK-20`.
 
 ### UX-SCENARIO-07 — Representative access or consent is unavailable
 
-- **Primary type:** Failure / recovery.
-- **Coverage role:** failure/recovery — exercises the required stop and recovery plan.
+- **Primary type + justification:** Failure/recovery — required evidence conditions are unavailable and the correct recovery is a non-accepting status plus plan.
+- **Coverage-role set:** {Failure/recovery} — exercises the required stop and recovery plan.
+- **Actor:** UX researcher and product decision owner.
 - **Given:** representative users cannot be reached, informed consent is absent, or needed accommodations are
   unavailable.
 - **When:** the precondition gate runs.
 - **Then:** the run returns `NEEDS_CONTEXT`, records assumptions and a research plan, and withholds accepted-final
   status.
-- **Failure oracle:** stakeholder approval, a proxy participant, or a disclaimer is used to bypass the gate.
+- **Failure oracle:** stakeholder approval, a proxy participant, a disclaimer, or an operational waiver is used
+  to bypass the direct-evidence, accessibility, safety, consent, or accommodation gate.
 - **Evidence tuple:** inspect access/consent/accommodation records and final status language.
 - **Obligation:** missing ethical or evidence preconditions must fail closed without pretending the design is
   accepted.
-- **Exercises:** UX-R3, UX-R4; P1, P8.
-- **Checklist IDs:** `UX-CHECK-03`, `UX-CHECK-04`, `UX-CHECK-14`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R3, UX-R4; P1, P8.
+- **Checklist trace:** `UX-CHECK-03`, `UX-CHECK-04`, `UX-CHECK-14`.
 
 ### UX-SCENARIO-08 — Research is performed after the solution is locked
 
-- **Primary type:** Adversarial / abuse / gaming.
-- **Coverage role:** adversarial — tests research used as validation theater.
+- **Primary type + justification:** Adversarial — interview activity is used as confirmation theater after the solution is already locked.
+- **Coverage-role set:** {Adversarial} — tests research used as validation theater.
+- **Actor:** representative participant, UX researcher, and product decision owner.
 - **Given:** one polished concept is already treated as final before participants are contacted.
-- **When:** interviews are framed to confirm it and contrary observations cannot change the design.
-- **Then:** the earliest affected decision reopens and neutral generative research precedes convergence.
-- **Failure oracle:** the existence of interview sessions is accepted as evidence despite a non-falsifiable plan.
+- **When:** interviews are framed to confirm it, contrary observations cannot change the design, or an
+  authorized operational waiver is offered in place of current direct generative research.
+- **Then:** the earliest affected decision reopens and neutral generative research precedes convergence; the
+  attempted waiver is invalid and cannot close or accept the protected item.
+- **Failure oracle:** interview-session presence or a recorded authority/rationale is accepted despite a
+  non-falsifiable plan or absent direct generative contact.
 - **Evidence tuple:** inspect question neutrality, timing, decision status, disconfirming probes, and recorded
   changes from findings.
 - **Obligation:** research must be able to change the direction rather than decorate a locked answer.
-- **Exercises:** UX-R2, UX-R4; P2; Must-Not-Follow performative-research rule.
-- **Checklist IDs:** `UX-CHECK-03`, `UX-CHECK-20`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R2, UX-R4; P2; Must-Not-Follow performative-research rule.
+- **Checklist trace:** `UX-CHECK-03`, `UX-CHECK-20`.
 
 ## Family UX-F3 — Identity and reference foundation
 
-**Primary category:** 7 Trust / harm / governance — identity has authority limits where it conflicts with
-evidence, access, or safety. **Secondary:** 1 Purpose / outcomes / scope, 8 Inclusion / locale, 10 Evidence /
-traceability / clarity.
+- **Declared primary category:** 7 — Trust / harm / governance. The defining discrimination is whether identity
+  authority remains bounded by evidence, accessibility, and safety.
+- **Secondary categories:** 1, 8, 10.
+- **Source / rationale:** `SRC-UX-PARENT` UX-R5, UX-R10, P2/P5/P6; `SRC-UX-DECISIONS` D6/D10;
+  `SRC-UX-ACCESS`.
+- **Actor + outcome:** the UX designer and product decision owner establish a bounded, evidence-backed identity
+  foundation without excluding representative people.
+- **Situation / invariant:** absent governing material triggers a run-scoped fallback; existing identity never
+  outranks direct evidence, accessibility, or safety.
+- **Applicability / priority:** every run; foundation gate and non-waivable access/safety floor.
+- **Cases:** `UX-SCENARIO-09`, `UX-SCENARIO-10`.
+- **Obligations / check links:** authority-chain fallback and visible identity conflict resolution;
+  `UX-CHECK-05`, `UX-CHECK-06`, `UX-CHECK-10`.
 
 ### UX-SCENARIO-09 — No governing DESIGN material exists
 
-- **Primary type:** Positive.
-- **Coverage role:** positive — exercises the documented identity fallback.
+- **Primary type + justification:** Good — the documented bounded fallback establishes identity when no governing material exists.
+- **Coverage-role set:** {Good} — exercises the documented identity fallback.
+- **Actor:** UX designer and product decision owner.
 - **Given:** no adequate `DESIGN.md`, brand, product, or design-system document exists.
 - **When:** the agent reads the live product and asks what those materials would define.
 - **Then:** the user confirms a run-scoped identity brief in the feature design document; no project-wide file
@@ -173,33 +260,46 @@ traceability / clarity.
 - **Evidence tuple:** inspect the authority-chain search, live-product evidence, identity questions, and explicit
   confirmation.
 - **Obligation:** missing identity material must trigger evidence gathering and a bounded confirmed brief.
-- **Exercises:** UX-R5; P2; `ideation.md` D6.
-- **Checklist IDs:** `UX-CHECK-05`, `UX-CHECK-06`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R5; P2; `SRC-UX-DECISIONS` D6.
+- **Checklist trace:** `UX-CHECK-05`, `UX-CHECK-06`.
 
 ### UX-SCENARIO-10 — Identity conflicts with accessibility or direct evidence
 
-- **Primary type:** Adversarial / abuse / gaming.
-- **Coverage role:** adversarial — tests brand authority used to excuse exclusion.
+- **Primary type + justification:** Adversarial — brand authority is used to pressure the non-waivable accessibility and safety floor.
+- **Coverage-role set:** {Adversarial} — tests brand authority used to excuse exclusion.
+- **Actor:** representative user, UX designer, and product decision owner.
 - **Given:** an identity preference reduces comprehension, access, safety, or trust for representative users.
 - **When:** the conflict reaches a decision gate.
 - **Then:** evidence and trade-offs are shown to the user; the result stays above the accessibility and safety
-  floor.
-- **Failure oracle:** “on brand” overrides direct evidence or the conflict is silently decided by the agent.
+  floor, and an attempted waiver on either protected class is invalid.
+- **Failure oracle:** “on brand,” named authority, or a waiver rationale overrides direct evidence,
+  accessibility, or safety, or the conflict is silently decided by the agent.
 - **Evidence tuple:** inspect the conflict record, accessibility/safety evidence, options, and explicit decision.
 - **Obligation:** identity conflicts must be visible and cannot waive access or safety.
-- **Exercises:** UX-R5, UX-R10; P2, P5–P6.
-- **Checklist IDs:** `UX-CHECK-05`, `UX-CHECK-10`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R5, UX-R10; P2, P5–P6.
+- **Checklist trace:** `UX-CHECK-05`, `UX-CHECK-10`.
 
 ## Family UX-F4 — Top-down skeleton and bottom-up growth
 
-**Primary category:** 3 Behavior / state / data — the defining discrimination is construction order and
-whole-to-unit coherence. **Secondary:** 4 Interfaces / dependencies / structure, 6 Failure / recovery /
-operations, 10 Evidence / traceability / clarity.
+- **Declared primary category:** 3 — Behavior / state / data. The defining discrimination is whether the
+  specification follows the required chronology and keeps every local unit coherent with the whole.
+- **Secondary categories:** 4, 6, 10.
+- **Source / rationale:** `SRC-UX-PARENT` UX-R6, UX-R7, UX-R9, UX-R11, P3–P7; `SRC-UX-DECISIONS` G2–G5.
+- **Actor + outcome:** the UX designer grows an approved skeleton into a complete specification before any
+  prototype exists.
+- **Situation / invariant:** a tangible or polished artifact cannot replace top-down skeleton, bottom-up growth,
+  accumulated review, or whole-specification approval.
+- **Applicability / priority:** every run; chronology is gate-bearing and whole-spec-before-prototype is
+  non-waivable.
+- **Cases:** `UX-SCENARIO-11`–`UX-SCENARIO-14`.
+- **Obligations / check links:** ordered growth, big-bang rejection, premature-prototype rejection, and
+  whole-to-unit repair; `UX-CHECK-06`–`UX-CHECK-12`.
 
 ### UX-SCENARIO-11 — Skeleton first, specification grows one unit at a time
 
-- **Primary type:** Positive.
-- **Coverage role:** positive — exercises the required construction sequence.
+- **Primary type + justification:** Good — the valid construction path establishes the whole before growing gated units.
+- **Coverage-role set:** {Good} — exercises the required construction sequence.
+- **Actor:** UX designer and product decision owner.
 - **Given:** the foundation is approved.
 - **When:** the agent maps the top-down skeleton, then grows the smallest meaningful unit into the core path and
   every remaining path/state.
@@ -208,13 +308,14 @@ operations, 10 Evidence / traceability / clarity.
   pass.
 - **Evidence tuple:** inspect artifact timestamps/order, unit-to-skeleton traces, and gate decisions.
 - **Obligation:** the design must grow top-down then bottom-up in observable increments.
-- **Exercises:** UX-R6, UX-R7; P3–P6.
-- **Checklist IDs:** `UX-CHECK-06`, `UX-CHECK-07`, `UX-CHECK-08`, `UX-CHECK-09`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R6, UX-R7; P3–P6.
+- **Checklist trace:** `UX-CHECK-06`, `UX-CHECK-07`, `UX-CHECK-08`, `UX-CHECK-09`.
 
 ### UX-SCENARIO-12 — A polished big-bang design is requested
 
-- **Primary type:** Adversarial / abuse / gaming.
-- **Coverage role:** adversarial — tests polish used to skip evidence and construction gates.
+- **Primary type + justification:** Adversarial — polish is used to bypass evidence, order, and approval gates.
+- **Coverage-role set:** {Adversarial} — tests polish used to skip evidence and construction gates.
+- **Actor:** stakeholder and UX designer.
 - **Given:** a stakeholder requests a finished, polished design in one pass.
 - **When:** the required sequence is compared with the request.
 - **Then:** the run stays staged; polish cannot replace foundation, skeleton, unit growth, whole-spec, or test
@@ -223,26 +324,31 @@ operations, 10 Evidence / traceability / clarity.
 - **Evidence tuple:** inspect decision/order records and attempt to locate every required gate before the final
   artifact.
 - **Obligation:** cosmetic completeness must fail when the staged operating contract is absent.
-- **Exercises:** UX-R6, UX-R7; Must-Not-Follow big-bang rule.
-- **Checklist IDs:** `UX-CHECK-06`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R6, UX-R7; Must-Not-Follow big-bang rule.
+- **Checklist trace:** `UX-CHECK-06`.
 
 ### UX-SCENARIO-13 — Prototype is requested before the whole specification
 
-- **Primary type:** Negative / Bad.
-- **Coverage role:** negative — exercises safe rejection of an invalid precondition.
+- **Primary type + justification:** Negative/Bad — premature prototype creation is a prohibited side effect while the whole specification is incomplete.
+- **Coverage-role set:** {Negative/Bad} — exercises safe rejection of an invalid precondition.
+- **Actor:** UX designer and product decision owner.
 - **Given:** the skeleton or core path is approved but the accumulated/whole specification is incomplete.
-- **When:** someone asks for a prototype “to figure out the rest.”
-- **Then:** prototype work does not start; the run returns to specification growth and final approval.
-- **Failure oracle:** a milestone prototype exists before the timestamped whole-spec gate.
+- **When:** someone asks for a prototype “to figure out the rest” or offers an authorized operational waiver for
+  the incomplete whole-specification gate.
+- **Then:** prototype work does not start; the waiver is invalid, and the run returns to specification growth
+  and final approval.
+- **Failure oracle:** a milestone prototype exists before the timestamped whole-spec gate, or a waiver token is
+  treated as permission to create or retain it.
 - **Evidence tuple:** compare prototype creation time and scope with the final approval record.
 - **Obligation:** no prototype may precede whole-specification completion and approval.
-- **Exercises:** UX-R6, UX-R9, UX-R11; P5–P7.
-- **Checklist IDs:** `UX-CHECK-11`, `UX-CHECK-12`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R6, UX-R9, UX-R11; P5–P7.
+- **Checklist trace:** `UX-CHECK-11`, `UX-CHECK-12`.
 
 ### UX-SCENARIO-14 — A strong local unit breaks the experience skeleton
 
-- **Primary type:** Failure / recovery.
-- **Coverage role:** failure/recovery — exercises detection and return to the owning layer.
+- **Primary type + justification:** Failure/recovery — a local success breaks the whole and must return to its owning layer.
+- **Coverage-role set:** {Failure/recovery} — exercises detection and return to the owning layer.
+- **Actor:** person attempting the outcome and UX designer.
 - **Given:** one task or channel works well alone but creates a dead end, state loss, or conflicting handoff in
   the skeleton.
 - **When:** the unit-to-skeleton trace is checked.
@@ -250,45 +356,58 @@ operations, 10 Evidence / traceability / clarity.
 - **Failure oracle:** local usability evidence is used to ignore whole-outcome failure.
 - **Evidence tuple:** inspect the failed integration path, revision, regression sweep, and renewed decision.
 - **Obligation:** local success cannot pass while the complete experience fails.
-- **Exercises:** UX-R6, UX-R7; P3–P5.
-- **Checklist IDs:** `UX-CHECK-07`, `UX-CHECK-08`, `UX-CHECK-09`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R6, UX-R7; P3–P5.
+- **Checklist trace:** `UX-CHECK-07`, `UX-CHECK-08`, `UX-CHECK-09`.
 
 ## Family UX-F5 — Concepts and whole-specification approval
 
-**Primary category:** 10 Evidence / traceability / clarity — concept selection and prototype eligibility depend
-on an explicit evidence trail. **Secondary:** 1 Purpose / outcomes / scope, 3 Behavior / state / data, 5 Quality
-attributes / resource economics.
+- **Declared primary category:** 10 — Evidence / traceability / clarity. The defining discrimination is whether
+  concept selection and prototype eligibility rest on an explicit, complete evidence trail.
+- **Secondary categories:** 1, 3, 5.
+- **Source / rationale:** `SRC-UX-PARENT` UX-R7–UX-R9, P6; `SRC-UX-DECISIONS` D11/D12, G4/G5;
+  `SRC-UX-ISO`.
+- **Actor + outcome:** the UX designer and product decision owner compare material concepts and approve one
+  complete feature design document.
+- **Situation / invariant:** cosmetic variants do not create divergence, and a bounded single-concept exception
+  does not weaken the whole-specification gate.
+- **Applicability / priority:** every run; concept gate plus non-waivable whole-specification approval.
+- **Cases:** `UX-SCENARIO-15`–`UX-SCENARIO-18`.
+- **Obligations / check links:** material comparison, anti-cosmetic probe, exception boundary, and document
+  closure; `UX-CHECK-06`, `UX-CHECK-10`–`UX-CHECK-12`.
 
 ### UX-SCENARIO-15 — Two materially different concepts are compared
 
-- **Primary type:** Positive.
-- **Coverage role:** positive — exercises valid divergence and user selection.
+- **Primary type + justification:** Good — materially distinct concepts are compared before a user selects one.
+- **Coverage-role set:** {Good} — exercises valid divergence and user selection.
+- **Actor:** UX designer and product decision owner.
 - **Given:** the accumulated specification admits different experience models.
 - **When:** two concepts are compared across effort, control, access, trust, failure, recovery, and evidence.
 - **Then:** a reference-backed recommendation and evidence-to-change precede the user's locked choice.
 - **Failure oracle:** the first plausible pattern becomes the design without material comparison.
 - **Evidence tuple:** inspect concept structures, trade-off matrix, references, recommendation, and decision.
 - **Obligation:** design convergence must follow a material concept comparison by default.
-- **Exercises:** UX-R8; P6.
-- **Checklist IDs:** `UX-CHECK-10`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R8; P6.
+- **Checklist trace:** `UX-CHECK-10`.
 
 ### UX-SCENARIO-16 — One concept is duplicated cosmetically
 
-- **Primary type:** Adversarial / abuse / gaming.
-- **Coverage role:** adversarial — tests false divergence.
+- **Primary type + justification:** Adversarial — cosmetic labels attempt to game the material-divergence gate.
+- **Coverage-role set:** {Adversarial} — tests false divergence.
+- **Actor:** design reviewer and UX designer.
 - **Given:** two concepts differ only in naming, tone, layout polish, or minor sequence wording.
 - **When:** their skeleton, control model, path/state behavior, and recovery are compared.
 - **Then:** they count as one; a material alternative or the evidenced single-concept exception is required.
 - **Failure oracle:** two labeled mockups satisfy the concept gate despite identical experience mechanics.
 - **Evidence tuple:** remove cosmetic differences and compare the remaining experience models.
 - **Obligation:** the concept gate must discriminate structure and behavior, not presentation labels.
-- **Exercises:** UX-R8; P6.
-- **Checklist IDs:** `UX-CHECK-10`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R8; P6.
+- **Checklist trace:** `UX-CHECK-10`.
 
 ### UX-SCENARIO-17 — A real constraint permits one concept
 
-- **Primary type:** Boundary / edge.
-- **Coverage role:** boundary — exercises the exact exception threshold.
+- **Primary type + justification:** Boundary — real constraints plus direct evidence are tested at the exact one-concept exception threshold.
+- **Coverage-role set:** {Boundary} — exercises the exact exception threshold.
+- **Actor:** UX designer and product decision owner.
 - **Given:** legal, safety, platform, or interoperability constraints plus direct evidence leave no truthful
   material alternative.
 - **When:** the single-concept exception is proposed.
@@ -297,47 +416,60 @@ attributes / resource economics.
 - **Evidence tuple:** attempt to construct a materially different compliant concept and inspect why evidence
   rules it out.
 - **Obligation:** the exception must be evidence-bearing and narrower than a preference for one option.
-- **Exercises:** UX-R8; P6.
-- **Checklist IDs:** `UX-CHECK-10`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R8; P6.
+- **Checklist trace:** `UX-CHECK-10`.
 
 ### UX-SCENARIO-18 — Whole document is complete before approval
 
-- **Primary type:** Positive.
-- **Coverage role:** positive — exercises whole-spec and document-schema closure.
+- **Primary type + justification:** Good — the complete feature design document closes and is approved before any prototype.
+- **Coverage-role set:** {Good} — exercises whole-spec and document-schema closure.
+- **Actor:** UX designer and product decision owner.
 - **Given:** one concept is selected.
 - **When:** every schema section, actor, path, state, recovery, conflict, measure, limitation, and trace is
   reviewed.
 - **Then:** explicit whole-spec approval is recorded before prototype creation.
-- **Failure oracle:** section headings, “mostly complete,” or earlier milestone approvals are treated as the
-  final gate.
+- **Failure oracle:** section headings, “mostly complete,” earlier milestone approvals, or a waiver are treated
+  as the final whole-specification gate.
 - **Evidence tuple:** inspect schema content, orphan sweep, explicit approval, and artifact chronology.
 - **Obligation:** the complete evidence-bearing specification must pass as a whole before prototyping.
-- **Exercises:** UX-R7, UX-R9; P6.
-- **Checklist IDs:** `UX-CHECK-06`, `UX-CHECK-11`, `UX-CHECK-12`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R7, UX-R9; P6.
+- **Checklist trace:** `UX-CHECK-06`, `UX-CHECK-11`, `UX-CHECK-12`.
 
 ## Family UX-F6 — Cross-channel state, failure, and recovery
 
-**Primary category:** 4 Interfaces / dependencies / structure — the defining discrimination is continuity
-across actor, channel, and system boundaries. **Secondary:** 3 Behavior / state / data, 6 Failure / recovery /
-operations, 8 Inclusion / locale.
+- **Declared primary category:** 4 — Interfaces / dependencies / structure. The defining discrimination is
+  whether state and completion remain coherent across actor, channel, and system boundaries.
+- **Secondary categories:** 3, 6, 8.
+- **Source / rationale:** `SRC-UX-PARENT` UX-R1, UX-R10, UX-R14, P3–P5/P9; `SRC-UX-DECISIONS` D3–D5/D15.
+- **Actor + outcome:** a person crosses terminal, browser, system, or support boundaries and still completes or
+  safely recovers from one outcome.
+- **Situation / invariant:** locally polished channels do not prove the handoff, shared state, access path, or
+  truthful completion.
+- **Applicability / priority:** any multi-channel, multi-actor, organizational, or system handoff; high-risk
+  when partial success can mislead or duplicate effects.
+- **Cases:** `UX-SCENARIO-19`–`UX-SCENARIO-21`.
+- **Obligations / check links:** coherent handoff, contained timeout recovery, and anti-local-compliance probe;
+  `UX-CHECK-07`, `UX-CHECK-09`, `UX-CHECK-17`.
 
 ### UX-SCENARIO-19 — Cross-channel handoff preserves the outcome
 
-- **Primary type:** Positive.
-- **Coverage role:** positive — exercises a valid multi-channel path.
+- **Primary type + justification:** Good — a valid multi-channel handoff preserves intent, state, accessibility, and completion.
+- **Coverage-role set:** {Good} — exercises a valid multi-channel path.
+- **Actor:** person crossing channels and supporting actor.
 - **Given:** authentication moves from a terminal to a browser or from self-service to supported recovery.
 - **When:** intent, state, security, feedback, accessibility, return path, and completion evidence are specified.
 - **Then:** the person can continue and verify completion without reconstructing hidden state.
 - **Failure oracle:** each channel works alone but the transition loses context or leaves ambiguous completion.
 - **Evidence tuple:** walk the handoff in both directions against the skeleton and state inventory.
 - **Obligation:** required channels must form one coherent outcome, not separate local successes.
-- **Exercises:** UX-R1, UX-R10; P3–P5.
-- **Checklist IDs:** `UX-CHECK-07`, `UX-CHECK-09`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R1, UX-R10; P3–P5.
+- **Checklist trace:** `UX-CHECK-07`, `UX-CHECK-09`.
 
 ### UX-SCENARIO-20 — Handoff times out after partial progress
 
-- **Primary type:** Failure / recovery.
-- **Coverage role:** failure/recovery — exercises interruption, containment, and safe resumption.
+- **Primary type + justification:** Failure/recovery — a timeout after partial progress exercises containment and safe resumption.
+- **Coverage-role set:** {Failure/recovery} — exercises interruption, containment, and safe resumption.
+- **Actor:** authenticating person and channel owner.
 - **Given:** the external authorization handoff times out after one channel shows progress.
 - **When:** the person returns to the initiating channel.
 - **Then:** the experience states what happened, preserves no unsafe partial success, and offers a clear retry,
@@ -347,63 +479,79 @@ operations, 8 Inclusion / locale.
 - **Evidence tuple:** inject the specified timeout at each transition and inspect state, messaging intent,
   recovery, and completion evidence.
 - **Obligation:** cross-channel failure must be detectable, contained, recoverable, and consistent.
-- **Exercises:** UX-R1, UX-R10; P5.
-- **Checklist IDs:** `UX-CHECK-09`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R1, UX-R10; P5.
+- **Checklist trace:** `UX-CHECK-09`.
 
 ### UX-SCENARIO-21 — Separate channel specs hide a broken whole
 
-- **Primary type:** Adversarial / abuse / gaming.
-- **Coverage role:** adversarial — tests cosmetic per-channel compliance.
+- **Primary type + justification:** Adversarial — polished local channel sections attempt to pass without a shared handoff contract.
+- **Coverage-role set:** {Adversarial} — tests cosmetic per-channel compliance.
+- **Actor:** authenticating person and design reviewer.
 - **Given:** web and command-line sections each list polished screens/commands and success states.
 - **When:** the shared state and handoff contract are removed.
 - **Then:** the design fails because no evidence proves end-to-end continuity.
 - **Failure oracle:** present channel sections are accepted without a cross-channel path test.
 - **Evidence tuple:** attempt the complete outcome using only stated interface contracts and observe the orphan.
 - **Obligation:** local surface completeness cannot substitute for cross-channel integration evidence.
-- **Exercises:** UX-R1, UX-R14; P3–P5.
-- **Checklist IDs:** `UX-CHECK-09`, `UX-CHECK-17`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R1, UX-R14; P3–P5.
+- **Checklist trace:** `UX-CHECK-09`, `UX-CHECK-17`.
 
 ## Family UX-F7 — Disposable prototype and direct evaluation
 
-**Primary category:** 9 Change / compatibility / reversibility — the prototype is disposable, and findings
-change the specification before its representation. **Secondary:** 2 Actors / stakeholders / use-context,
-6 Failure / recovery / operations, 8 Inclusion / locale, 10 Evidence / traceability / clarity.
+- **Declared primary category:** 9 — Change / compatibility / reversibility. The defining discrimination is
+  whether a disposable test artifact remains subordinate to the approved and revised specification.
+- **Secondary categories:** 2, 6, 8, 10.
+- **Source / rationale:** `SRC-UX-PARENT` UX-R3, UX-R4, UX-R11, UX-R12, P7/P8; `SRC-UX-DECISIONS` D13/D14,
+  G5/G6; `SRC-UX-ACCESS`.
+- **Actor + outcome:** representative participants directly use an accessible, uncertainty-sized prototype and
+  supported findings repair the durable contract first.
+- **Situation / invariant:** stakeholders, experts, prior evidence, future plans, and operational waivers cannot
+  replace current representative use or the access/safety conditions of that use.
+- **Applicability / priority:** every run seeking final acceptance; direct representative evaluation,
+  accessibility, and safety are non-waivable.
+- **Cases:** `UX-SCENARIO-22`–`UX-SCENARIO-24`.
+- **Obligations / check links:** direct prototype evaluation, accessible evidence, and specification-first
+  revision/retest; `UX-CHECK-04`, `UX-CHECK-12`–`UX-CHECK-15`.
 
 ### UX-SCENARIO-22 — Approved specification is tested with representative users
 
-- **Primary type:** Positive.
-- **Coverage role:** positive — exercises proportionate prototype and direct evaluation gates.
+- **Primary type + justification:** Good — representative users directly evaluate a post-approval, question-sized prototype.
+- **Coverage-role set:** {Good} — exercises proportionate prototype and direct evaluation gates.
+- **Actor:** representative prototype participant and UX researcher.
 - **Given:** the whole specification is approved and named uncertainties remain.
 - **When:** the lowest sufficient prototype is evaluated directly with representative users under consent and
   accommodation conditions.
 - **Then:** observations and bounded claims address completion, errors, recovery, trust, access, and harm.
-- **Failure oracle:** stakeholder walkthrough, expert review, prior testing, or prototype presence is called
-  direct-user acceptance evidence.
+- **Failure oracle:** stakeholder walkthrough, expert review, prior testing, prototype presence, or an
+  operational waiver is called direct representative-user acceptance evidence.
 - **Evidence tuple:** inspect chronology, participant rationale, consent, task method, observations, limits, and
   trace to test questions.
 - **Obligation:** prototype acceptance must rest on new direct representative-user evaluation.
-- **Exercises:** UX-R3, UX-R4, UX-R11; P7–P8.
-- **Checklist IDs:** `UX-CHECK-12`, `UX-CHECK-13`, `UX-CHECK-14`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R3, UX-R4, UX-R11; P7–P8.
+- **Checklist trace:** `UX-CHECK-12`, `UX-CHECK-13`, `UX-CHECK-14`.
 
 ### UX-SCENARIO-23 — Prototype excludes the access path being claimed
 
-- **Primary type:** Adversarial / abuse / gaming.
-- **Coverage role:** adversarial — tests inaccessible evidence used to claim inclusion.
+- **Primary type + justification:** Adversarial — an inaccessible prototype or method attempts to support an accessibility claim it cannot expose.
+- **Coverage-role set:** {Adversarial} — tests inaccessible evidence used to claim inclusion.
+- **Actor:** participant requiring an access accommodation and UX researcher.
 - **Given:** the specification claims an accessible path, but the prototype or study method prevents relevant
   participants from using it.
 - **When:** the evidence claim is reviewed.
-- **Then:** the claim fails, the prototype/method is corrected from the specification, and affected users test it.
-- **Failure oracle:** a checklist note, expert opinion, or planned future implementation substitutes for usable
-  prototype evidence.
+- **Then:** the claim fails, any accessibility or safety waiver is invalid, the prototype/method is corrected
+  from the specification, and affected users test it.
+- **Failure oracle:** a checklist note, expert opinion, planned future implementation, or waiver substitutes for
+  usable and safe prototype evidence.
 - **Evidence tuple:** compare claimed access needs with participant accommodations, modality, and observed use.
 - **Obligation:** the prototype and method must permit direct evidence for each acceptance claim.
-- **Exercises:** UX-R3, UX-R4, UX-R10; P7–P8.
-- **Checklist IDs:** `UX-CHECK-04`, `UX-CHECK-13`, `UX-CHECK-14`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R3, UX-R4, UX-R10; P7–P8.
+- **Checklist trace:** `UX-CHECK-04`, `UX-CHECK-13`, `UX-CHECK-14`.
 
 ### UX-SCENARIO-24 — Finding changes only the mockup
 
-- **Primary type:** Failure / recovery.
-- **Coverage role:** failure/recovery — exercises specification-first repair and retest.
+- **Primary type + justification:** Failure/recovery — a mockup-only fix leaves the durable contract wrong and must be repaired in order.
+- **Coverage-role set:** {Failure/recovery} — exercises specification-first repair and retest.
+- **Actor:** UX designer and representative prototype participant.
 - **Given:** prototype evaluation exposes a confusing recovery state.
 - **When:** the mockup is edited without changing its owning requirement or path.
 - **Then:** acceptance blocks; the specification changes first, the prototype follows, and affected assumptions
@@ -411,19 +559,30 @@ change the specification before its representation. **Secondary:** 2 Actors / st
 - **Failure oracle:** visual improvement is accepted while the handed-off contract remains wrong.
 - **Evidence tuple:** inspect finding timestamps and trace specification revision → prototype revision → retest.
 - **Obligation:** every supported finding must repair the durable experience contract before its test artifact.
-- **Exercises:** UX-R12; P8.
-- **Checklist IDs:** `UX-CHECK-15`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R12; P8.
+- **Checklist trace:** `UX-CHECK-15`.
 
 ## Family UX-F8 — Measurement, co-loading, and handoff change control
 
-**Primary category:** 10 Evidence / traceability / clarity — the defining discrimination is whether claims and
-future changes stay tied to outcome evidence. **Secondary:** 4 Interfaces / dependencies / structure, 5 Quality
-attributes / resource economics, 7 Trust / harm / governance, 9 Change / compatibility / reversibility.
+- **Declared primary category:** 10 — Evidence / traceability / clarity. The defining discrimination is whether
+  measures, parent conflicts, and future changes remain tied to observable outcome evidence.
+- **Secondary categories:** 4, 5, 7, 9.
+- **Source / rationale:** `SRC-UX-PARENT` UX-R10, UX-R13, UX-R14, P6/P9; `SRC-UX-DECISIONS` D15/G6;
+  `SRC-UX-MEASUREMENT`.
+- **Actor + outcome:** product, measurement, UI/UX, and child-skill owners preserve a cold-readable experience
+  contract after handoff.
+- **Situation / invariant:** a favorable proxy, load order, or platform specialization cannot silently override
+  outcome, evidence, accessibility, safety, or recovery obligations.
+- **Applicability / priority:** every handoff; conflict/change cases activate on co-loading or specialization.
+- **Cases:** `UX-SCENARIO-25`–`UX-SCENARIO-28`.
+- **Obligations / check links:** guarded measures, anti-gaming, evidence-led conflict resolution, and
+  parent-preserving specialization; `UX-CHECK-16`–`UX-CHECK-18`.
 
 ### UX-SCENARIO-25 — Outcome measures include guardrails and reopen conditions
 
-- **Primary type:** Positive.
-- **Coverage role:** positive — exercises continued evidence after handoff.
+- **Primary type + justification:** Good — outcome measures include guardrails, owners, limits, and evidence-based reopen conditions.
+- **Coverage-role set:** {Good} — exercises continued evidence after handoff.
+- **Actor:** product decision owner and measurement owner.
 - **Given:** the design reaches post-test approval.
 - **When:** outcome, failure, recovery, access, trust, and harm measures are defined with owners and review
   cadence.
@@ -432,26 +591,28 @@ attributes / resource economics, 7 Trust / harm / governance, 9 Change / compati
 - **Evidence tuple:** trace each measure to an obligation and simulate an improving proxy with worsening user
   outcome.
 - **Obligation:** measurement must support the outcome and expose harmful interpretations.
-- **Exercises:** UX-R13, UX-R14; P6, P9.
-- **Checklist IDs:** `UX-CHECK-16`, `UX-CHECK-17`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R13, UX-R14; P6, P9.
+- **Checklist trace:** `UX-CHECK-16`, `UX-CHECK-17`.
 
 ### UX-SCENARIO-26 — Metric improves while the user outcome worsens
 
-- **Primary type:** Adversarial / abuse / gaming.
-- **Coverage role:** adversarial — tests metric gaming and proxy inversion.
+- **Primary type + justification:** Adversarial — a favorable proxy is gamed while completion, access, or harm worsens.
+- **Coverage-role set:** {Adversarial} — tests metric gaming and proxy inversion.
+- **Actor:** affected user and measurement owner.
 - **Given:** authentication completion rate rises because recovery exits and difficult users are excluded.
 - **When:** the metric is read without failure, abandonment, accessibility, or harm guardrails.
 - **Then:** the metric set fails and the design/measurement decision reopens.
 - **Failure oracle:** a higher headline number alone is accepted as success.
 - **Evidence tuple:** construct the counterexample and inspect whether guardrails detect it.
 - **Obligation:** no gameable proxy may stand alone as outcome evidence.
-- **Exercises:** UX-R13; P9.
-- **Checklist IDs:** `UX-CHECK-16`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R13; P9.
+- **Checklist trace:** `UX-CHECK-16`.
 
 ### UX-SCENARIO-27 — Co-loaded UI and UX guidance conflict
 
-- **Primary type:** Failure / recovery.
-- **Coverage role:** failure/recovery — exercises conflict detection and user resolution.
+- **Primary type + justification:** Failure/recovery — conflicting parent guidance is surfaced and recovered through an evidence-led user decision.
+- **Coverage-role set:** {Failure/recovery} — exercises conflict detection and user resolution.
+- **Actor:** UX owner, UI owner, and product decision owner.
 - **Given:** UX evidence requires one recovery model while UI guidance recommends a conflicting surface pattern.
 - **When:** both skills are loaded.
 - **Then:** the concrete conflict, evidence, and trade-offs are shown to the user; no precedence or load-order
@@ -459,13 +620,14 @@ attributes / resource economics, 7 Trust / harm / governance, 9 Change / compati
 - **Failure oracle:** one parent silently overrides the other or the implementation chooses by convenience.
 - **Evidence tuple:** inspect both clauses, their evidence, the user decision, and preserved non-waivable floor.
 - **Obligation:** co-loaded parent conflicts must be explicit, evidence-led user decisions.
-- **Exercises:** UX-R10, UX-R14; Intro; Must-Not-Follow co-load rule.
-- **Checklist IDs:** `UX-CHECK-18`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R10, UX-R14; Intro; Must-Not-Follow co-load rule.
+- **Checklist trace:** `UX-CHECK-18`.
 
 ### UX-SCENARIO-28 — Future child silently changes the experience contract
 
-- **Primary type:** Change / regression / compat.
-- **Coverage role:** change/regression — exercises specialization without parent regression.
+- **Primary type + justification:** Change/regression — future specialization changes mechanics and is checked for parent-contract regression.
+- **Coverage-role set:** {Change/regression} — exercises specialization without parent regression.
+- **Actor:** child-skill author and product decision owner.
 - **Given:** a future web, command-line, or desktop child skill specializes exact mechanics.
 - **When:** it drops a parent actor, state, recovery, access, safety, evidence, or measure obligation.
 - **Then:** the deviation fails and returns to the user before handoff; mechanics may differ, parent invariants may
@@ -473,24 +635,59 @@ attributes / resource economics, 7 Trust / harm / governance, 9 Change / compati
 - **Failure oracle:** platform specificity is treated as authority to narrow the outcome contract.
 - **Evidence tuple:** diff child obligations against parent traces and run the complete outcome scenarios.
 - **Obligation:** child specialization must preserve parent evidence and experience invariants.
-- **Exercises:** UX-R14; P9.
-- **Checklist IDs:** `UX-CHECK-17`, `UX-CHECK-18`.
+- **Source trace:** `SRC-UX-PARENT`; UX-R14; P9.
+- **Checklist trace:** `UX-CHECK-17`, `UX-CHECK-18`.
 
-## Triggered-minimum audit
+## Source-to-scenario and obligation ledger
 
-| Family | Boundary | Failure / recovery | Adversarial | Change / regression | Counterfactual |
-|---|---|---|---|---|---|
-| UX-F1 | `UX-SCENARIO-04` | `n/a: no dependency failure is the defining concern of this scope family` | `UX-SCENARIO-03` | `n/a: no existing-contract change occurs` | `n/a: no additional load-bearing premise beyond the outcome boundary` |
-| UX-F2 | `n/a: sample size is risk-based rather than a fixed numeric edge` | `UX-SCENARIO-07` | `UX-SCENARIO-08` | `n/a: the family tests current-run evidence, not a version transition` | `UX-SCENARIO-06` |
-| UX-F3 | `n/a: the authority chain is ordinal, not a quantity transition` | `n/a: no operational dependency failure is introduced` | `UX-SCENARIO-10` | `n/a: identity is established for this run` | `n/a: missing identity follows an explicit positive fallback` |
-| UX-F4 | `n/a: milestone order is categorical rather than numeric` | `UX-SCENARIO-14` | `UX-SCENARIO-12` | `n/a: construction is within one run` | `n/a: the order is a parent invariant, not an assumption` |
-| UX-F5 | `UX-SCENARIO-17` | `n/a: no dependency or partial mutation is introduced` | `UX-SCENARIO-16` | `n/a: concept comparison precedes change-controlled handoff` | `n/a: concept viability is tested directly by the exception boundary` |
-| UX-F6 | `n/a: timeout is exercised as failure/recovery, not a numeric product limit` | `UX-SCENARIO-20` | `UX-SCENARIO-21` | `n/a: no version transition occurs` | `n/a: cross-channel continuity is a required contract` |
-| UX-F7 | `n/a: prototype fidelity has no universal numeric limit` | `UX-SCENARIO-24` | `UX-SCENARIO-23` | `n/a: revision order is exercised as recovery within the run` | `n/a: direct evaluation is a required evidence gate` |
-| UX-F8 | `n/a: measure thresholds are outcome-specific` | `UX-SCENARIO-27` | `UX-SCENARIO-26` | `UX-SCENARIO-28` | `n/a: proxy inversion is covered adversarially` |
+This ledger supplies the source→scenario direction. Every listed case supplies the reverse
+scenario→obligation direction in its **Obligation**, **Source trace**, and **Checklist trace** fields. The
+checklist's Guaranteed coverage map supplies check→scenario reversal.
 
-## Guaranteed coverage map
+| Source obligation | Scenario IDs | Obligation / reserved checks |
+|---|---|---|
+| UX-R1 — one complete observable outcome | `01`–`04`, `19`–`21` | Bound outcome, exact boundary, cross-channel continuity; `UX-CHECK-01`, `02`, `07`, `09` |
+| UX-R2 — new direct generative research | `05`, `06`, `08` | Current representative generative evidence before convergence; `UX-CHECK-03`, `20` |
+| UX-R3 — direct representative-user prototype evaluation | `07`, `22`, `23` | Current direct prototype-use evidence; `UX-CHECK-04`, `14` |
+| UX-R4 — ethical evidence conditions / `NEEDS_CONTEXT` | `05`, `07`, `23` | Consent, accommodation, data protection, claim bounds, and fail-closed status; `UX-CHECK-04` |
+| UX-R5 — identity authority chain and bounded fallback | `09`, `10` | Governed identity or user-confirmed run brief; `UX-CHECK-05` |
+| UX-R6 — exact construction order | `11`–`14`, `18` | Skeleton, bottom-up growth, whole approval, then prototype; `UX-CHECK-06`–`09`, `11`, `12` |
+| UX-R7 — explicit user gates | `11`, `12`, `18`, `24` | Observable approvals and revision decisions; `UX-CHECK-06`, `08`, `11`, `15` |
+| UX-R8 — material concepts or evidenced exception | `15`–`17` | Consequential divergence or bounded exception proof; `UX-CHECK-10` |
+| UX-R9 — whole feature document before prototype | `13`, `18` | Complete, approved document and valid chronology; `UX-CHECK-11`, `12` |
+| UX-R10 — inclusion, trust, safety, harm, agency | `10`, `19`, `20`, `23`, `27` | Protected floor and visible conflict resolution; `UX-CHECK-05`, `09`, `13`, `18` |
+| UX-R11 — disposable, proportionate prototype | `13`, `22`, `23` | Question-sized, specification-traced artifact; `UX-CHECK-12`, `13` |
+| UX-R12 — specification-first revision and retest | `24` | Durable-contract repair before artifact and retest; `UX-CHECK-15` |
+| UX-R13 — measures resist gaming | `25`, `26` | Outcome guardrails and proxy-inversion detection; `UX-CHECK-16` |
+| UX-R14 — no-silent-change handoff/specialization | `02`, `21`, `27`, `28` | Evidence-led conflict and parent-preserving change; `UX-CHECK-17`, `18` |
 
-Every scenario names at least one `UX-CHECK-*` obligation. The authoritative check-to-scenario reverse map is
-in `checklists.md`. Parent-clause coverage closes in both directions through each case's **Exercises** field and
-the checklist's **Source** field.
+## Failability and protected-waiver audit
+
+- A polished big-bang artifact fails `UX-SCENARIO-12`; local surface polish without continuity fails `21`.
+- Prior evidence or owner authority replacing new generative research fails `06`; an operational waiver or
+  confirmatory research after convergence fails `08`.
+- Any prototype before complete whole-specification approval, including one justified by a waiver, fails `13`;
+  headings, milestone approval, or a waiver masquerading as whole closure fails `18`.
+- Stakeholder, expert, prior-test, prototype-presence, or waiver substitution for direct representative-user
+  evaluation fails `22`.
+- Identity or authority pressure against accessibility/safety fails `10`; inaccessible evidence or an
+  accessibility/safety waiver fails `23`.
+- Missing representative access, consent, accommodations, or required evidence fails closed through `07`.
+- Cosmetic concept divergence fails `16`; the legitimate one-concept boundary is exercised by `17`.
+- Prototype-only repair fails `24`; proxy gaming fails `26`; load-order conflict and child regression fail `27`
+  and `28`.
+
+## Orphan sweep, coverage gaps, and decisions
+
+- **Source→scenario sweep:** every load-bearing UX-R1–UX-R14 parent clause appears in the ledger above with at
+  least one live case and reserved check.
+- **Scenario→obligation sweep:** every `UX-SCENARIO-01`–`UX-SCENARIO-28` case has one observable obligation,
+  source trace, and checklist trace. No scenario is exploratory and none is orphaned.
+- **Category/case sweep:** all ten categories are selected, every family has a Good case and adversarial face,
+  and every empty matrix cell records the property making that type inapplicable.
+- **Sensitive evidence decision:** cases name governed evidence pointers and methods only; participant records
+  remain in the active project's retention-controlled evidence store.
+- **Scale decision:** keep eight families and 28 stable cases. The protected-waiver counterexamples are concrete
+  variations of existing cases `08`, `10`, `13`, `18`, `22`, and `23`, so no new case ID is needed.
+- **Coverage gaps:** none. A future new parent obligation, family, or distinct discrimination reopens this sweep
+  and receives a new stable ID rather than repurposing an existing case.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added independent, cross-surface `ui` and `ux` parent operation skills with staged specification workflows, adaptive decision trees, scenario/checklist/evaluation companions, and required representative-user prototype testing.
 - PR-FIN-1a — `gobbi config init [--level workspace|project|session] [--session-id <id>] [--project <name>] [--force]` verb: scaffolds the minimum-valid `{schemaVersion: 1}` seed at the target level; refuses without `--force` if file exists; `--force` overwrites with a stderr WARN line. (#214)
 - PR-FIN-1a — CFG-19..CFG-23 integration tests: workspace init, project init, session init, `--force` WARN assertion, and fresh-setup ordering invariant (#185 lock). (#214)
 

--- a/plugins/gobbi/.claude-plugin/plugin.json
+++ b/plugins/gobbi/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gobbi",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Full gobbi workflow system — structured orchestration with multi-stance evaluation, adaptive planning, and git workflow isolation for Claude Code",
   "author": {
     "name": "HahyeonJeon"

--- a/plugins/gobbi/.codex-plugin/plugin.json
+++ b/plugins/gobbi/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gobbi",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Gobbi workflow skills and hooks for Codex.",
   "author": {
     "name": "HahyeonJeon",


### PR DESCRIPTION
## Summary

- Add general UI and UX design operation skills for cross-surface product work.
- Make each design run focus on one observable outcome and grow from reference and project-identity evidence through incremental, testable design stages.
- Ship the skills through the shared Claude Code and Codex plugin package at version 0.5.4.

## Changes

- Add five-file UI and UX skill bundles with ideation, scenario, checklist, and evaluation contracts.
- Define parent obligations for future web, CLI, desktop, and other surface-specific child skills.
- Add evidence-gated bottom-up construction, representative-user research and testing, accessibility and safety protections, and bounded operational-waiver semantics.
- Wire canonical sources into `.agents`, `.claude`, plugin manifests, marketplace metadata, inventory documentation, and the changelog.

## Test plan

- [x] Run `scripts/sync-plugin-package.sh --check`.
- [x] Run all 10 `scripts/test-sync-plugin-package.sh` reconciliation tests.
- [x] Run `scripts/check-codex-compatibility.sh`.
- [x] Validate the local Claude plugin manifest with `claude plugin validate --strict ./plugins/gobbi`.
- [x] Run `scripts/validate-plugin-publish-readiness.sh --base 8298e04b` and confirm `PUBLISH-READY`.
- [x] Complete a fresh Codex-only seven-perspective evaluation with 161/161 checklist rows resolved and zero failures.

## Linked issues

None.
