### PR TITLE
feat(startup): add IP-3 evidence-led follow-up depth (reconcile of #363 onto develop)

### DIFF
--- a/.gobbi/projects/gobbi/skills/startup/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/startup/SKILL.md
@@ -24,8 +24,12 @@ explicitly requests a baseline reset. A normal resume or runtime context boundar
    stronger evidence than compliments, surveys, or promises.
 3. **Ask neutrally, then take a position.** Do not pitch inside a question. State the evidence read and
    what evidence would change it. Push a vague or contradicted answer at most twice, then leave it open.
-4. **Attack the riskiest assumption first.** Spend depth according to uncertainty × reversibility ×
-   magnitude, while still accounting for every required topic.
+4. **Attack the riskiest assumption first, then follow the evidence down.** Spend depth according to
+   uncertainty × reversibility × magnitude, while still accounting for every required topic. A concrete,
+   evidenced answer is a launch point for depth, not a stop signal: when it exposes a new in-scope claim,
+   dependency, contradiction, or untested assumption, ask the next disconfirming probe and keep descending
+   while each probe still moves the evidence within the branch's scope. This depth is distinct from the
+   at-most-twice vague-repair cap in principle 3, which only bounds re-asking a still-vague answer.
 5. **Name one first user and their switch.** Separate actors, operators, approvers, and affected people;
    identify their job, current alternative, push, pull, anxiety, and habit.
 

--- a/.gobbi/projects/gobbi/skills/startup/topics.md
+++ b/.gobbi/projects/gobbi/skills/startup/topics.md
@@ -48,7 +48,10 @@ per turn. The tree feeds ordinary Ideation DISCUSSION; it is not a storage schem
    If the re-answer is still vague, probe a second time (the [`discussion`](../discussion/SKILL.md)
    § Push-once-then-push-again rule); if it is still vague after the second probe, close the branch
    `open` with an owner and resolution method rather than accepting a vague answer or pushing
-   indefinitely. Do not probe when the first answer is already concrete and evidenced.
+   indefinitely. This at-most-twice cap governs a still-vague or contradicted answer only; do not re-ask
+   merely to restate an answer that already landed concrete. A concrete, evidenced answer is not a stop
+   signal — when it exposes a new in-scope claim, dependency, contradiction, or untested assumption, open
+   an evidence-advancing follow-up under rule 9.
 6. Classify each answer in transient working context as `confirmed`, `assumption`, `open`, or
    `contradicted`, and account for every Level-2 branch as `confirmed`, `proven-irrelevant` with a reason,
    or `open` with an owner. The returned packet preserves these distinctions.
@@ -56,6 +59,15 @@ per turn. The tree feeds ordinary Ideation DISCUSSION; it is not a storage schem
    evidence and the confirmation.
 8. Re-open an earlier branch when a later answer contradicts it. Architecture must not silently redefine
    scope; roadmap must not silently redefine the quality bar.
+9. **Follow the evidence down as far as it keeps moving.** A concrete, evidenced answer may open a deeper
+   follow-up under the same branch when it exposes a new in-scope claim, dependency, contradiction, or
+   untested assumption AND the follow-up can produce new evidence. Keep descending that chain while each
+   probe still advances the evidence within the branch's topic scope. Each probe is still one question per
+   turn (rule 1); the chain simply continues across turns and stops only when the next probe would not move
+   the evidence, when it would leave topic scope, or when the branch is settled. This is DEPTH, distinct
+   from the rule-5 vague-repair cap: the cap bounds re-asking a still-vague answer, this rule pursues
+   evidence off a concrete one. A follow-up deepens its parent branch, inherits that branch's closure
+   state, and never adds a required branch.
 
 **Design-bearing markers.** Branches that settle a direction carry an inline marker under their heading.
 The core design cluster is **Topics 6–9**, plus the always-design-bearing capability and journey branches
@@ -538,12 +550,14 @@ affected summary again. The ordinary Ideation cursor and artifacts—not Startup
   blocks a readiness claim, but may be returned explicitly for ordinary Ideation to resolve.
 - **Smart-skip shortens, it does not drop.** Existing docs/repo evidence may close a branch when the user
   confirms — but coverage stays mandatory; smart-skip removes redundant questions, never required branches.
-- **Probe up to twice, then record open.** Probe a vague answer with a concrete example, past-behavior
-  question, or counterexample. If the re-answer is still vague, probe a second time (the
-  [`discussion`](../discussion/SKILL.md) § Push-once-then-push-again rule); if it is still vague after the
-  second probe, close the branch `open` with an owner and resolution method rather than accepting
-  a vague answer or pushing indefinitely. Do not probe when the first answer is already concrete and
-  evidenced.
+- **Probe up to twice, then record open — a still-vague answer only.** Probe a vague answer with a
+  concrete example, past-behavior question, or counterexample. If the re-answer is still vague, probe a
+  second time (the [`discussion`](../discussion/SKILL.md) § Push-once-then-push-again rule); if it is still
+  vague after the second probe, close the branch `open` with an owner and resolution method rather than
+  accepting a vague answer or pushing indefinitely. This at-most-twice cap governs a still-vague or
+  contradicted answer only; a concrete, evidenced answer is not a stop signal — when it exposes a new
+  in-scope claim, dependency, contradiction, or untested assumption, open an evidence-advancing follow-up
+  ([How to traverse the tree](#how-to-traverse-the-tree) rule 9), still one question per turn.
 - **Re-open on contradiction.** When a later answer contradicts an earlier branch, re-open the earlier
   branch and resolve it in the coverage frame — do not paper over it. Architecture must not silently redefine
   scope; roadmap must not silently redefine the quality bar.
@@ -553,7 +567,8 @@ affected summary again. The ordinary Ideation cursor and artifacts—not Startup
 - **Safe decline or stop.** A decline or interruption causes no Startup-owned cleanup because this
   operation writes no session or durable files.
 - **Depth override.** After the first real problem event, score assumptions by uncertainty × reversibility
-  × magnitude and give the riskiest claim the first disconfirming probe.
+  × magnitude and give the riskiest claim the first disconfirming probe, then follow that probe down as an
+  evidence-led chain (rule 9) until the evidence stops moving.
 - **JTBD switching forces are user / problem understanding.** In 3.2 and 3.3, probe the four forces —
   push, pull, anxiety of the new, and habit / allegiance to the old — and the event that overcame them in
   the last real switch, to close the gap where a real problem still fails to produce a change in behavior.


### PR DESCRIPTION
## Reconcile of parked PR #363 onto the latest `develop`

PR #363 branched from old develop (`9f7898a3`) and collided with `origin/develop`'s
later lean redesign of the startup skill (`recording.md` deleted, `scenario.md`/
`checklist.md` renamed to plural, `SKILL.md` thinned). Per the decision to **follow
the latest**, this re-applies only the one surviving, non-conflicting improvement
onto the current `origin/develop` base — it does not cherry-pick #363's commits.

### Applied — IP-3 "follow the evidence down"
Re-expressed into the current ST-rules / craft-principles structure (the old A4/A6
axiom + P-phase structure it targeted no longer exists):
- `SKILL.md` principle 4 gains the follow-the-evidence-down depth clause — a concrete
  answer is a launch point for depth, not a stop signal; explicitly distinct from the
  at-most-twice vague-repair cap.
- `topics.md` gains traversal **rule 9**, reframes rule 5 + the "Probe up to twice"
  bullet (a concrete answer no longer hard-stops probing), and ties the depth override
  into rule 9.

### Followed the latest (preserved)
- All three "one question per turn" pacing rules are **untouched**. IP-3's "no turn
  cap" is harmonized to mean the depth chain continues *across* turns — each probe is
  still one question per turn — so depth and pacing coexist.

### Dropped as superseded by the latest
- **IP-2** pacing removal — origin re-affirmed the pacing (ST-5).
- **IP-1** phase-result-document contract — `recording.md` is deleted and the design
  says Startup writes nothing.
- The **~3,000-line SOP migration** of scenario/checklist/evaluation — reverses
  origin's deliberate lean eval-bundle.

Net: the ~3,700-line parked PR reduces to a **~40-line focused enhancement** (2 files,
+29 / −10) that fits the current design.

### Caveat
Claude-only (Codex was unavailable, user-waived). No dual-system evaluation pass; a
behavioral-rule change like this would normally receive one.

Supersedes #363.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JCAs6h6ixcob1ACs4yGdt
