### PR TITLE
feat(desktop): add desktop application delivery skill

### DIFF
--- a/.agents/skills/desktop
+++ b/.agents/skills/desktop
@@ -1,0 +1,1 @@
+../../.gobbi/projects/gobbi/skills/desktop

--- a/.claude/skills/desktop/SKILL.md
+++ b/.claude/skills/desktop/SKILL.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/desktop/SKILL.md

--- a/.claude/skills/desktop/checklists.md
+++ b/.claude/skills/desktop/checklists.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/desktop/checklists.md

--- a/.claude/skills/desktop/evaluation.md
+++ b/.claude/skills/desktop/evaluation.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/desktop/evaluation.md

--- a/.claude/skills/desktop/fidelity-ladder.md
+++ b/.claude/skills/desktop/fidelity-ladder.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/desktop/fidelity-ladder.md

--- a/.claude/skills/desktop/filesystem-data.md
+++ b/.claude/skills/desktop/filesystem-data.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/desktop/filesystem-data.md

--- a/.claude/skills/desktop/ideation.md
+++ b/.claude/skills/desktop/ideation.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/desktop/ideation.md

--- a/.claude/skills/desktop/native-integration.md
+++ b/.claude/skills/desktop/native-integration.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/desktop/native-integration.md

--- a/.claude/skills/desktop/packaging-distribution.md
+++ b/.claude/skills/desktop/packaging-distribution.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/desktop/packaging-distribution.md

--- a/.claude/skills/desktop/process-model.md
+++ b/.claude/skills/desktop/process-model.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/desktop/process-model.md

--- a/.claude/skills/desktop/runtime-deltas.md
+++ b/.claude/skills/desktop/runtime-deltas.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/desktop/runtime-deltas.md

--- a/.claude/skills/desktop/scenarios.md
+++ b/.claude/skills/desktop/scenarios.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/desktop/scenarios.md

--- a/.claude/skills/desktop/scripts/check_relation.py
+++ b/.claude/skills/desktop/scripts/check_relation.py
@@ -1,0 +1,1 @@
+../../../../.gobbi/projects/gobbi/skills/desktop/scripts/check_relation.py

--- a/.claude/skills/desktop/security.md
+++ b/.claude/skills/desktop/security.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/desktop/security.md

--- a/.claude/skills/desktop/signing-updates.md
+++ b/.claude/skills/desktop/signing-updates.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/desktop/signing-updates.md

--- a/.claude/skills/desktop/windows-lifecycle.md
+++ b/.claude/skills/desktop/windows-lifecycle.md
@@ -1,0 +1,1 @@
+../../../.gobbi/projects/gobbi/skills/desktop/windows-lifecycle.md

--- a/.claude/skills/evaluation/checklist/mistakes.md
+++ b/.claude/skills/evaluation/checklist/mistakes.md
@@ -1,0 +1,1 @@
+../../../../.gobbi/projects/gobbi/skills/evaluation/checklist/mistakes.md

--- a/.gobbi/projects/gobbi/archive/mistakes/docs-sync/2026-07-26-union-diff-must-reach-named-primitive-granularity.md
+++ b/.gobbi/projects/gobbi/archive/mistakes/docs-sync/2026-07-26-union-diff-must-reach-named-primitive-granularity.md
@@ -4,7 +4,7 @@ description: A compaction union-diff that stops at condition/footgun granularity
 type: mistakes
 scope: project
 feature: null
-status: active
+status: superseded
 created: 2026-07-14
 session: 6a9e0963-2ca1-4d07-83d3-1889aa16bcf4
 tags: [docs-sync, verification]
@@ -13,7 +13,9 @@ author: claude
 priority: high
 domain: docs-sync
 supersedes: null
-superseded_by: null
+superseded_by: named-primitives-must-survive-generalization
+archived_at: 2026-07-26
+archive_reason: superseded
 related: [union-diff-occurrence-vs-distinct-primitive, gate-c-structural-mapping-is-not-semantic-union-preservation, consolidating-per-perspective-verification-tables-narrows-the-union]
 ---
 

--- a/.gobbi/projects/gobbi/archive/mistakes/tooling/2026-07-26-agent-teams-idle-notification-is-not-completion.md
+++ b/.gobbi/projects/gobbi/archive/mistakes/tooling/2026-07-26-agent-teams-idle-notification-is-not-completion.md
@@ -4,7 +4,7 @@ description: "An Agent-Teams teammate's idle_notification was treated as a failu
 type: mistakes
 scope: project
 feature: null
-status: active
+status: superseded
 priority: medium
 domain: process
 created: 2026-07-16
@@ -12,6 +12,10 @@ session: e5c0af1d-005d-4455-a58f-efe601ed342f
 tags: [tooling, process]
 keywords: [agent-teams, teammate, idle-notification, completion-signal, double-dispatch, fresh-background-executor, taskstop]
 author: claude
+supersedes: null
+superseded_by: idle-notification-carries-no-delivery-information
+archived_at: 2026-07-26
+archive_reason: superseded
 ---
 
 # An Agent-Teams idle_notification is not a completion signal

--- a/.gobbi/projects/gobbi/archive/mistakes/verification/2026-07-26-adversarially-test-a-newly-authored-acceptance-predicate.md
+++ b/.gobbi/projects/gobbi/archive/mistakes/verification/2026-07-26-adversarially-test-a-newly-authored-acceptance-predicate.md
@@ -4,7 +4,7 @@ description: A newly-authored checklist acceptance predicate named specific cons
 type: mistakes
 scope: project
 feature: null
-status: active
+status: superseded
 created: 2026-07-16
 session: 054f402b-a9ab-4af6-875d-078233778a0b
 tags: [process, verification, execution]
@@ -12,6 +12,10 @@ keywords: [acceptance-predicate, new-check, soundness, compile-proof, readonly-d
 author: claude
 priority: high
 domain: verification
+supersedes: null
+superseded_by: new-gate-needs-known-good-and-known-bad-witness
+archived_at: 2026-07-26
+archive_reason: superseded
 ---
 
 # A new acceptance check claimed constructs "sufficient" that a compiled probe falsified

--- a/.gobbi/projects/gobbi/archive/mistakes/verification/2026-07-26-grep-absence-claim-needs-exact-pattern.md
+++ b/.gobbi/projects/gobbi/archive/mistakes/verification/2026-07-26-grep-absence-claim-needs-exact-pattern.md
@@ -4,7 +4,7 @@ description: A "feature X is absent" claim backed by a grep must quote the EXACT
 type: mistakes
 scope: project
 feature: null
-status: active
+status: superseded
 created: 2026-06-14
 session: 2026-06-14-f2732c8e-c37d-4ebf-8f25-575e8a17d87d
 tags: [process, verification]
@@ -13,7 +13,9 @@ author: claude
 priority: high
 domain: process
 supersedes: null
-superseded_by: null
+superseded_by: grep-scope-must-match-the-claim-being-tested
+archived_at: 2026-07-26
+archive_reason: superseded
 ---
 
 # A grep-backed absence claim must use the exact discriminating pattern

--- a/.gobbi/projects/gobbi/archive/mistakes/verification/2026-07-26-teammate-finalize-read-crosses-in-progress-write.md
+++ b/.gobbi/projects/gobbi/archive/mistakes/verification/2026-07-26-teammate-finalize-read-crosses-in-progress-write.md
@@ -4,7 +4,7 @@ description: A manager "not on disk / unchanged" read can cross with a teammate'
 type: mistakes
 scope: project
 feature: null
-status: active
+status: superseded
 created: 2026-07-07
 session: 39f3dfb0-49df-44d4-a6bd-d2e4743b36e3
 tags: [verification, process]
@@ -13,7 +13,9 @@ author: claude
 priority: medium
 domain: process
 supersedes: null
-superseded_by: null
+superseded_by: line-count-cannot-confirm-write-completion
+archived_at: 2026-07-26
+archive_reason: superseded
 related: [teammate-finalize-brief-crosses-with-in-progress-turn]
 ---
 

--- a/.gobbi/projects/gobbi/features/workflow/decisions/workflow/2026-07-23-proj-6-001-union-diff-obligation-not-gate.md
+++ b/.gobbi/projects/gobbi/features/workflow/decisions/workflow/2026-07-23-proj-6-001-union-diff-obligation-not-gate.md
@@ -73,5 +73,5 @@ inventory to Execution's own Verify evidence for task 03, rather than blocking P
 - [[cons-6-001-gate-copy-identity-unasserted]] — the sibling Medium finding from the same iter-6
   evaluation; both are "the verification machinery is strong at the mechanical level, weaker one level
   up" findings
-- `mistakes/docs-sync/union-diff-must-reach-named-primitive-granularity.md` — the recorded trap this
+- `archive/mistakes/docs-sync/2026-07-26-union-diff-must-reach-named-primitive-granularity.md` — the recorded trap this
   finding is a live instance of

--- a/.gobbi/projects/gobbi/mistakes/assumption/mandated-interface-needs-evidence-owner.md
+++ b/.gobbi/projects/gobbi/mistakes/assumption/mandated-interface-needs-evidence-owner.md
@@ -1,0 +1,39 @@
+---
+name: mandated-interface-needs-evidence-owner
+description: A required interface is an unsupported assumption when no evidence row owns why it is required.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-26
+session: bb2794ce-bc3d-422a-b011-f8b4750c6eed
+tags: [assumption, process]
+keywords: [mandated-interface, evidence-owner, closing-condition]
+author: codex
+priority: high
+domain: assumption
+supersedes: null
+superseded_by: null
+---
+
+# Give every mandated interface an evidence owner
+
+## What happened
+
+Two required desktop section shapes named platform interfaces that had no supporting claim in the
+design's evidence register.
+
+## Why it happens
+
+A mandated document shape can make its mechanism appear researched and settled even when only the
+outcome was established.
+
+## Correct approach
+
+Keep the obligation explicit, mark the mechanism with a closing condition, and route the gap to
+the evidence owner. Do not invent a mechanism or silently weaken the obligation.
+
+## How to detect
+
+A requirement names a concrete interface, but the evidence register contains no row that owns why
+that interface is necessary.

--- a/.gobbi/projects/gobbi/mistakes/docs-sync/named-primitives-must-survive-generalization.md
+++ b/.gobbi/projects/gobbi/mistakes/docs-sync/named-primitives-must-survive-generalization.md
@@ -1,0 +1,43 @@
+---
+name: named-primitives-must-survive-generalization
+description: Generalizing a source condition can silently drop the named interfaces that make the condition executable.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-26
+session: bb2794ce-bc3d-422a-b011-f8b4750c6eed
+tags: [docs-sync, verification]
+keywords: [named-primitives, generalization, union-diff, source-fidelity]
+author: codex
+priority: high
+domain: docs-sync
+supersedes: union-diff-must-reach-named-primitive-granularity
+superseded_by: null
+---
+
+# Preserve named primitives through generalization
+
+## What happened
+
+A desktop child generalized roughly forty required platform interfaces into broad phrases.
+Link, count, anchor, and condition-level gates passed while named mechanisms disappeared.
+
+## Why it happens
+
+Generalization reads as clean prose. When the comparison unit is only the parent condition, it
+does not test whether the executable API, parameter, switch, or property survived.
+
+## Correct approach
+
+Enumerate every named primitive in the source and diff that set against the result. Preserve each
+name unless a user-approved scope decision explicitly removes it.
+
+## How to detect
+
+The source names concrete mechanisms, the result retains only their heading or general category,
+and the verification cites structural coverage rather than a primitive-level diff.
+
+## Related
+
+- [[union-diff-must-reach-named-primitive-granularity]] — the compaction-specific predecessor preserved in archive.

--- a/.gobbi/projects/gobbi/mistakes/docs-sync/pointer-does-not-protect-stale-characterization.md
+++ b/.gobbi/projects/gobbi/mistakes/docs-sync/pointer-does-not-protect-stale-characterization.md
@@ -1,0 +1,38 @@
+---
+name: pointer-does-not-protect-stale-characterization
+description: Pointing to an owner does not make a neighboring restatement update when the owned value changes.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-26
+session: bb2794ce-bc3d-422a-b011-f8b4750c6eed
+tags: [docs-sync, verification]
+keywords: [single-owner, pointer, restatement, stale-characterization]
+author: codex
+priority: high
+domain: docs-sync
+supersedes: null
+superseded_by: null
+---
+
+# A pointer does not protect a stale characterization
+
+## What happened
+
+A sibling pointed at a version owner and also copied what the owner's row meant. When the owner
+changed, the pointer remained correct and the neighboring characterization became false.
+
+## Why it happens
+
+Pointer text resolves to current owner bytes. A restatement beside it is a second copy whose
+meaning does not update.
+
+## Correct approach
+
+Let the owner carry the value and its versioned meaning. At the pointer site, state only a
+property that remains true when the owned value changes.
+
+## How to detect
+
+A sentence beside an owner pointer would become false if the referenced row changed.

--- a/.gobbi/projects/gobbi/mistakes/docs-sync/restoration-must-not-join-a-frozen-set.md
+++ b/.gobbi/projects/gobbi/mistakes/docs-sync/restoration-must-not-join-a-frozen-set.md
@@ -1,0 +1,39 @@
+---
+name: restoration-must-not-join-a-frozen-set
+description: Restoring an item as another member can contradict a protected set whose cardinality is frozen elsewhere.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-25
+session: bb2794ce-bc3d-422a-b011-f8b4750c6eed
+tags: [docs-sync, process]
+keywords: [restoration, frozen-set, cardinality, re-description]
+author: codex
+priority: high
+domain: docs-sync
+supersedes: null
+superseded_by: null
+---
+
+# Keep restorations outside frozen sets
+
+## What happened
+
+A restored mechanism was first described as a fourth member of a nearby set. A protected passage
+elsewhere fixed that set at exactly three mechanisms.
+
+## Why it happens
+
+Restoration is naturally written as an addition to the nearest list, while the cardinality
+constraint may live in another section and be under a must-preserve instruction.
+
+## Correct approach
+
+Before describing a restored item as a member, search every protected set it could join. When the
+set is frozen, describe the restored item by its distinct role rather than renumbering the set.
+
+## How to detect
+
+An exception restores deleted behavior and the edit uses ordinal language such as "fourth" or
+adds it to an enumerated set whose size is owned elsewhere.

--- a/.gobbi/projects/gobbi/mistakes/refactor/row-label-rename-needs-inbound-reference-sweep.md
+++ b/.gobbi/projects/gobbi/mistakes/refactor/row-label-rename-needs-inbound-reference-sweep.md
@@ -1,0 +1,37 @@
+---
+name: row-label-rename-needs-inbound-reference-sweep
+description: Renaming an owned table row can leave inbound prose pointers stale because link checks do not see row labels.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-26
+session: bb2794ce-bc3d-422a-b011-f8b4750c6eed
+tags: [refactor, rename-sweep, docs-sync]
+keywords: [row-label, inbound-reference, table-owner]
+author: codex
+priority: high
+domain: refactor
+supersedes: null
+superseded_by: null
+---
+
+# Sweep inbound references when a row label changes
+
+## What happened
+
+A version-owner row was renamed while a sibling still pointed to its old title. The Markdown
+link checker passed because a row label is not a link.
+
+## Why it happens
+
+Rename planning often inventories paths and anchors but omits human-resolved table labels.
+
+## Correct approach
+
+Treat row labels as an inbound reference class. Sweep prose, fences, inventories, and
+cross-document mentions, then repoint them in the same change.
+
+## How to detect
+
+A table row title changes and verification contains no exact search for the old label.

--- a/.gobbi/projects/gobbi/mistakes/refactor/sweep-for-x-when-authoring-a-no-x-rule.md
+++ b/.gobbi/projects/gobbi/mistakes/refactor/sweep-for-x-when-authoring-a-no-x-rule.md
@@ -1,0 +1,44 @@
+---
+name: sweep-for-x-when-authoring-a-no-x-rule
+description: A pass can author a no-X rule and leave X in the same file unless the rule immediately runs its own sweep.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-25
+session: bb2794ce-bc3d-422a-b011-f8b4750c6eed
+tags: [refactor, verification]
+keywords: [no-x-rule, self-sweep, residual, acceptance-predicate]
+author: codex
+priority: high
+domain: refactor
+supersedes: null
+superseded_by: null
+related: [sweep-every-occurrence-when-fixing-a-multi-surface-claim]
+---
+
+# Sweep for X when authoring a no-X rule
+
+## What happened
+
+A refactor added a rule that a hoistable file must contain no policy identifiers, rewrote most
+sites, and left three identifiers in the same pass.
+
+## Why it happens
+
+The author treats the new prohibition as prose about future edits instead of an acceptance
+predicate over the bytes just written.
+
+## Correct approach
+
+Run the complete X sweep immediately after writing a no-X rule. Record the exact subject and
+result beside the rule, and prove the predicate with a planted residual when it is load-bearing.
+
+## How to detect
+
+One edit introduces both a prohibition and the cleanup intended to satisfy it, but no final
+whole-subject scan proves the new state.
+
+## Related
+
+- [[sweep-every-occurrence-when-fixing-a-multi-surface-claim]] — the broader multi-surface sweep discipline.

--- a/.gobbi/projects/gobbi/mistakes/tooling/gate-failure-needs-a-named-diagnosis.md
+++ b/.gobbi/projects/gobbi/mistakes/tooling/gate-failure-needs-a-named-diagnosis.md
@@ -1,0 +1,38 @@
+---
+name: gate-failure-needs-a-named-diagnosis
+description: A non-zero gate with only a traceback is fail-closed but cannot identify the violated property.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-26
+session: bb2794ce-bc3d-422a-b011-f8b4750c6eed
+tags: [tooling, verification]
+keywords: [gate-diagnostic, traceback, failure-contract]
+author: codex
+priority: high
+domain: tooling
+supersedes: null
+superseded_by: null
+---
+
+# Give every gate failure a named diagnosis
+
+## What happened
+
+A negative verification could exit non-zero through an unhandled exception and appear to prove
+the planted rejection.
+
+## Why it happens
+
+Exit status is treated as the whole failure contract, so fixture setup errors and unrelated
+runtime failures are folded into expected rejection.
+
+## Correct approach
+
+Emit a stable diagnosis naming the subject and failed property. Negative tests assert both
+status and that exact diagnosis; tracebacks remain unexpected failures.
+
+## How to detect
+
+A negative fixture accepts any non-zero status, or the only explanation of failure is a traceback.

--- a/.gobbi/projects/gobbi/mistakes/tooling/idle-notification-carries-no-delivery-information.md
+++ b/.gobbi/projects/gobbi/mistakes/tooling/idle-notification-carries-no-delivery-information.md
@@ -1,0 +1,44 @@
+---
+name: idle-notification-carries-no-delivery-information
+description: An idle notification says an agent is available; it does not prove what work or report was delivered.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-25
+session: bb2794ce-bc3d-422a-b011-f8b4750c6eed
+tags: [tooling, process]
+keywords: [idle-notification, delivery, stale-summary, artifact]
+author: codex
+priority: high
+domain: tooling
+supersedes: agent-teams-idle-notification-is-not-completion
+superseded_by: null
+---
+
+# Idle says nothing about delivery
+
+## What happened
+
+Six agents became idle without delivering their current report. Several idle summaries described
+an earlier turn. Acting on those summaries caused repeated requests and one stale-state dispute.
+
+## Why it happens
+
+Idle is an availability event. Its timing and summary are not coupled to a message delivery or to
+the final bytes of a file-producing assignment.
+
+## Correct approach
+
+For file-producing work, reread the exact artifact or commit from disk. For a report-only
+assignment, require the explicit report message. Never accept, reject, or redispatch work from an
+idle summary.
+
+## How to detect
+
+The next action depends on an idle notification, but no exact disk artifact, commit, or report
+message has been received and verified.
+
+## Related
+
+- [[agent-teams-idle-notification-is-not-completion]] — the narrower completion-signal predecessor preserved in archive.

--- a/.gobbi/projects/gobbi/mistakes/verification/fixture-pass-is-not-real-tree-pass.md
+++ b/.gobbi/projects/gobbi/mistakes/verification/fixture-pass-is-not-real-tree-pass.md
@@ -1,0 +1,37 @@
+---
+name: fixture-pass-is-not-real-tree-pass
+description: A mechanism's fixture suite can pass while the same mechanism rejects the live repository.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-26
+session: bb2794ce-bc3d-422a-b011-f8b4750c6eed
+tags: [verification, tooling]
+keywords: [fixture-suite, real-tree, sync, topology]
+author: codex
+priority: high
+domain: verification
+supersedes: null
+superseded_by: null
+---
+
+# A fixture pass is not a real-tree pass
+
+## What happened
+
+The sync fixture suite passed while correctly rejecting version drift. The live repository
+contained that drift, so the real sync failed.
+
+## Why it happens
+
+Controlled mechanism behavior and live-state readiness are folded into one green claim.
+
+## Correct approach
+
+Run the fixture suite and the mechanism against the real target as separate gates. Report each
+result and its limit.
+
+## How to detect
+
+A report cites passing fixtures but does not show the same operation against the current real target.

--- a/.gobbi/projects/gobbi/mistakes/verification/grep-scope-must-match-the-claim-being-tested.md
+++ b/.gobbi/projects/gobbi/mistakes/verification/grep-scope-must-match-the-claim-being-tested.md
@@ -1,0 +1,47 @@
+---
+name: grep-scope-must-match-the-claim-being-tested
+description: A search produces a wrong conclusion when its subject set or pattern differs from the claim it is used to prove.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-25
+session: bb2794ce-bc3d-422a-b011-f8b4750c6eed
+tags: [verification, process]
+keywords: [grep-scope, exact-pattern, count, absence]
+author: codex
+priority: high
+domain: verification
+supersedes: grep-absence-claim-needs-exact-pattern
+superseded_by: null
+---
+
+# Match the search scope to the claim
+
+## What happened
+
+Four manager searches produced wrong conclusions: a vocabulary count omitted nested bundles,
+discrepancy counts included ledger sections, and a routing check used wording narrower than the
+claim. The producer's counts were right each time.
+
+## Why it happens
+
+A search result looks objective even when its pattern or traversed set differs from the set the
+claim ranges over. Exact wording can also false-miss a valid presence.
+
+## Correct approach
+
+State the subject set and counting unit before running the search. Confirm the command traverses
+that set. For presence, prefer a structural or broader search followed by inspection. For
+absence, run and cite the exact discriminating pattern. Treat a disagreement as a scope mismatch
+until reproduced.
+
+## How to detect
+
+A count disagrees with an owner's result, a nested or ledger surface is omitted or included
+without explanation, or the quoted claim and executed search use different patterns.
+
+## Related
+
+- [[grep-absence-claim-needs-exact-pattern]] — the narrower absence-only predecessor preserved in archive.
+- [[scan-form-needs-independent-or-planted-witness]] — adds independent proof for actionable scans.

--- a/.gobbi/projects/gobbi/mistakes/verification/line-count-cannot-confirm-write-completion.md
+++ b/.gobbi/projects/gobbi/mistakes/verification/line-count-cannot-confirm-write-completion.md
@@ -1,0 +1,46 @@
+---
+name: line-count-cannot-confirm-write-completion
+description: A line count can match an intermediate write state and cannot prove that a producer's change is absent or complete.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-25
+session: bb2794ce-bc3d-422a-b011-f8b4750c6eed
+tags: [verification, process]
+keywords: [read-write-race, line-count, fingerprint, producer]
+author: codex
+priority: high
+domain: verification
+supersedes: teammate-finalize-read-crosses-in-progress-write
+superseded_by: null
+---
+
+# A line count cannot confirm write completion
+
+## What happened
+
+Three manager reads crossed an in-progress write. A plausible line count and absent tokens were
+reported as proof that the edit had not landed, and twice the producer was nearly told to reapply
+already-complete work.
+
+## Why it happens
+
+A line count is a weak fingerprint. A multi-stage write can pass through an intermediate state
+whose count resembles the preimage, so one observation cannot distinguish no write from a write
+in progress.
+
+## Correct approach
+
+Use content hashes and modification time, then reread after the producer's handoff. Require a
+stable fingerprint across two observations before declaring bytes absent or final. When disk
+evidence contradicts a manager observation, reproduce the manager claim before issuing a rewrite.
+
+## How to detect
+
+A producer disputes a manager's count or token observation, the writer may still be active, or a
+reapply instruction is based on one point-in-time read.
+
+## Related
+
+- [[teammate-finalize-read-crosses-in-progress-write]] — the narrower read-race predecessor preserved in archive.

--- a/.gobbi/projects/gobbi/mistakes/verification/new-gate-needs-known-good-and-known-bad-witness.md
+++ b/.gobbi/projects/gobbi/mistakes/verification/new-gate-needs-known-good-and-known-bad-witness.md
@@ -1,0 +1,43 @@
+---
+name: new-gate-needs-known-good-and-known-bad-witness
+description: A new gate can reject every input and still look correct when tested only on a planted violation.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-26
+session: bb2794ce-bc3d-422a-b011-f8b4750c6eed
+tags: [verification, execution]
+keywords: [acceptance-gate, witness, reject-all, shell-range]
+author: codex
+priority: high
+domain: verification
+supersedes: adversarially-test-a-newly-authored-acceptance-predicate
+superseded_by: null
+---
+
+# Prove every new gate with good and bad witnesses
+
+## What happened
+
+A proposed gate used an embedded hyphen in a `tr` deletion set. The command returned empty and
+would have rejected every subject while still rejecting the planted defect.
+
+## Why it happens
+
+Testing only a violation proves that rejection occurs. It cannot distinguish a sound predicate
+from a broken predicate that rejects everything.
+
+## Correct approach
+
+Prove one known-good subject is accepted and one known-bad subject is rejected for the exact
+named reason. Assert both status and diagnosis.
+
+## How to detect
+
+A new check has a negative fixture but no positive witness, or its negative test accepts any
+non-zero exit without checking the cause.
+
+## Related
+
+- [[adversarially-test-a-newly-authored-acceptance-predicate]] — the predecessor preserved in archive.

--- a/.gobbi/projects/gobbi/mistakes/verification/scan-form-needs-independent-or-planted-witness.md
+++ b/.gobbi/projects/gobbi/mistakes/verification/scan-form-needs-independent-or-planted-witness.md
@@ -1,0 +1,43 @@
+---
+name: scan-form-needs-independent-or-planted-witness
+description: A single scan can return a plausible wrong result unless another derivation or planted defect tests the instrument.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-26
+session: bb2794ce-bc3d-422a-b011-f8b4750c6eed
+tags: [verification, tooling]
+keywords: [scan-form, independent-derivation, planted-witness, count]
+author: codex
+priority: high
+domain: verification
+supersedes: null
+superseded_by: null
+related: [claimed-count-not-reproduced-by-scan]
+---
+
+# Prove a scan independently or with a planted witness
+
+## What happened
+
+Seven manager scans produced zero or wrong counts against correct artifacts. Four recurred after
+the scan-unit rule had been documented.
+
+## Why it happens
+
+A single pattern can be internally consistent while measuring the wrong structure. Re-running
+the same form adds no independent evidence.
+
+## Correct approach
+
+For a count or absence claim that will drive action, compare two independently derived results or
+prove the instrument rejects a known-bad subject first.
+
+## How to detect
+
+An actionable result comes from one search form with no independent derivation and no planted witness.
+
+## Related
+
+- [[claimed-count-not-reproduced-by-scan]] — the final-count reproduction discipline this strengthens.

--- a/.gobbi/projects/gobbi/mistakes/verification/support-window-claim-must-name-version.md
+++ b/.gobbi/projects/gobbi/mistakes/verification/support-window-claim-must-name-version.md
@@ -1,0 +1,38 @@
+---
+name: support-window-claim-must-name-version
+description: A claim over every supported release can expire without triggering a version-literal maintenance sweep.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-26
+session: bb2794ce-bc3d-422a-b011-f8b4750c6eed
+tags: [verification, docs-sync]
+keywords: [support-window, version, temporal-claim]
+author: codex
+priority: high
+domain: verification
+supersedes: null
+superseded_by: null
+---
+
+# Name the version in support-window claims
+
+## What happened
+
+A compatibility correction said an API remained available on every currently supported major.
+The statement would become false when the support window reached the removal release.
+
+## Why it happens
+
+"Currently supported" appears safer than a version literal while hiding the boundary that should
+trigger re-verification.
+
+## Correct approach
+
+Name the decisive version, or state a stable property that no support-window change can falsify.
+
+## How to detect
+
+A compatibility claim covers all supported releases but names neither a release boundary nor a
+window-independent invariant.

--- a/.gobbi/projects/gobbi/mistakes/verification/verify-subagent-characterization-against-owner.md
+++ b/.gobbi/projects/gobbi/mistakes/verification/verify-subagent-characterization-against-owner.md
@@ -1,0 +1,40 @@
+---
+name: verify-subagent-characterization-against-owner
+description: A reproduced count does not prove a subagent's interpretation of what the counted owner means.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-25
+session: bb2794ce-bc3d-422a-b011-f8b4750c6eed
+tags: [verification, process]
+keywords: [subagent-claim, owner, characterization, count]
+author: codex
+priority: high
+domain: verification
+supersedes: null
+superseded_by: null
+---
+
+# Verify a subagent characterization against the owner
+
+## What happened
+
+A nonexistent "nine-output contract" and a false interpretation of the repository's `skeleton`
+vocabulary were propagated into later artifacts. The second claim carried accurate occurrence
+counts, which made its wrong interpretation look verified.
+
+## Why it happens
+
+Counts prove quantity, not sense. Reproducing a report's number can suppress the separate check
+of what the named owner actually says.
+
+## Correct approach
+
+Open the named owner before building on a subagent's characterization. Verify the meaning
+separately from the count, and sample where corpus occurrences live when the claim is semantic.
+
+## How to detect
+
+A claim says an owner or corpus "means" something, cites a subagent report, and offers a count
+without a direct owner quotation or representative sample.

--- a/.gobbi/projects/gobbi/mistakes/verification/versioned-restatement-needs-owner-discriminator.md
+++ b/.gobbi/projects/gobbi/mistakes/verification/versioned-restatement-needs-owner-discriminator.md
@@ -1,0 +1,38 @@
+---
+name: versioned-restatement-needs-owner-discriminator
+description: A restatement sweep over-flags platform divergence unless it tests whether a sentence characterizes a versioned row.
+type: mistakes
+scope: project
+feature: null
+status: active
+created: 2026-07-26
+session: bb2794ce-bc3d-422a-b011-f8b4750c6eed
+tags: [verification, docs-sync]
+keywords: [restatement, version-owner, platform-divergence]
+author: codex
+priority: high
+domain: verification
+supersedes: null
+superseded_by: null
+---
+
+# Use the owner discriminator for versioned restatements
+
+## What happened
+
+A description-based sweep produced twelve apparent restatement defects. The owner's boundary
+showed that all twelve were valid unversioned operating-system divergences.
+
+## Why it happens
+
+Similar wording is treated as the predicate instead of asking which fact the owner actually
+owns.
+
+## Correct approach
+
+Call a sentence a restatement defect only when it characterizes the state of a versioned owner
+row. Preserve a sibling sentence that names an unversioned platform divergence.
+
+## How to detect
+
+A restatement finding does not identify the versioned row whose state is allegedly copied.

--- a/.gobbi/projects/gobbi/notes/docs/2026-07-26-desktop-session-mistake-candidates.md
+++ b/.gobbi/projects/gobbi/notes/docs/2026-07-26-desktop-session-mistake-candidates.md
@@ -1,0 +1,147 @@
+---
+name: desktop-session-mistake-candidates
+description: Twelve Execution-phase mistake candidates from the desktop-skill session, preserved from the gitignored session tree
+type: notes
+scope: project
+feature: null
+status: active
+created: 2026-07-26
+session: bb2794ce-bc3d-422a-b011-f8b4750c6eed
+tags: [process, docs]
+keywords: [mistake-candidates, verification, single-owner, gates]
+author: claude
+steps_completed: [execution]
+shipped: false
+---
+
+# Execution-phase mistake candidates
+
+Twelve candidates produced during Execution that were **never written to typed staging**. They existed only
+in the manager's runtime task list, which no agent can read, and would have been lost at session end. Written
+here so promotion has a source. Each names its reporter.
+
+Routing — skill-owned versus cross-cutting project tier — is an Always-Ask user decision at promotion, and is
+not decided here.
+
+---
+
+## E1 — Generalising a source's named primitives is a union drop no structural gate sees
+*Reported by the mechanics author, self-caught mid-task.*
+
+**What happened.** A child document was written by generalising roughly forty named platform interfaces the
+design required by name — writing "the archive integrity switches" where the design named them individually.
+
+**Why it happens.** Generalising reads as good prose. The design's own reason for naming primitives is that a
+rule naming no mechanism cannot be executed, and two rules had already been found unexecutable for exactly
+this in an earlier iteration.
+
+**How to recognise it.** Link, count, and anchor gates were all green across the defect. Only a
+primitive-level self-diff against the source found it.
+
+**Correct approach.** When a source names an interface, carry the name. Diff at primitive granularity, not at
+condition granularity, before declaring a child complete.
+
+## E2 — `tr -d 'ABC-D'` reads an embedded hyphen as a character range
+*Reported by the mechanics author, caught before use.*
+
+**What happened.** A gate used `tr -d 'DESK-G'` to strip an identifier prefix. `tr` read `K-G` as a reversed
+range, returned empty, and would have false-**failed** every input.
+
+**Correct approach.** Prove a new gate on a **known-good** input as well as a planted violation. A gate tested
+only against a defect looks correct when it rejects everything.
+
+## E3 — A design can mandate a section shape naming interfaces its own evidence register never researched
+*Reported by the mechanics author.*
+
+**What happened.** Two children's mandated shapes named platform interfaces with no corresponding evidence
+row anywhere.
+
+**Correct approach.** Write the obligations at full strength and mark the mechanisms with closing conditions.
+Report the gap-register items upward rather than editing the parent, and never invent the mechanism to fill
+the shape.
+
+## E4 — Pointing at a single-owner value protects against a stale value, not a stale characterisation
+*Reported by the mechanics author; the manager then violated it in the commit that stated it.*
+
+**What happened.** A sibling restated what an owner's row *meant* alongside pointing at it. When the owner's
+value was corrected, the neighbouring pure-pointer sentence self-healed and the restatement was left wrong.
+
+**Correct approach.** State the property in terms that stay true whatever the value is, and let the pointer
+carry the value. If a sentence would become false when the owner's value changes, it is restating rather than
+pointing.
+
+## E5 — Renaming a row in a single-owner table requires sweeping inbound row-label pointers
+*Reported by the trace verifier.*
+
+**What happened.** The manager renamed a row in the version owner and swept nothing. A sibling was left with a
+correct sentence pointing at a row title that no longer existed.
+
+**How to recognise it.** The link checker passes it — a row label is not a link.
+
+**Correct approach.** Treat a row label as a reference class. Renaming one requires the same inbound sweep a
+path rename does.
+
+## E6 — A claim quantified over a support window is worse than a stale value
+*Reported by the trace verifier.*
+
+**What happened.** A correction replaced an asserted removal with "on every currently supported major the
+access still exists" — true at the time, false once the support window reaches the removal version.
+
+**Why it is worse than a stale value.** It names no version, so the owner's own re-verify trigger — *every
+sibling statement naming a version* — is structurally unable to find it.
+
+**Correct approach.** Name the version, or state the property in a form no window crossing can falsify.
+
+## E7 — The discriminator for restatement defects in a single-owner family
+*Reported by the trace verifier. The highest-value item here.*
+
+A restatement is a defect **only when the sentence characterises the state of a versioned row**. A sentence
+naming an **unversioned per-operating-system divergence** is the sanctioned form, not a restatement — the
+delta matrix exists precisely so a sibling can state an obligation once and name the platform that changes it.
+
+Twelve absence-claim candidates resolved as twelve false positives under this test, where a description-based
+sweep would have produced twelve arguments. It is grounded in the owner's own published purpose rather than in
+reviewer taste, which is what makes it a predicate instead of a heuristic.
+
+## E8 — A verification script must fail with a named diagnosis, not a traceback
+*Reported by the triad author.*
+
+An unhandled exception that exits non-zero is technically fail-closed and useless as a gate. An exit code
+without a named cause is half a gate.
+
+## E9 — Author counts from a scan of the finished text, never from the drafting plan
+*Reported by the triad author.*
+
+A header stated case and cell counts taken from the drafting plan; the finished file held different numbers.
+Caught by scanning before commit — but the header had already been written, which is the trap.
+
+## E10 — An Evidence line that would detect a violation is not a Pass condition that forbids it
+*Reported by the trace verifier, from a planted fixture.*
+
+A planted fixture's evidence method would have caught the missing condition, so a reviewer reading the
+evidence line alone would have passed it. The obligation test requires the **pass condition** to own the
+primitive.
+
+## E11 — A guard's own fixture suite passing is not evidence the guard passes on the real repository
+*Reported by the wiring author.*
+
+The sync mechanism's test suite exits zero **while proving that source topology rejects marketplace drift** —
+and that exact drift is live in this repository, where the mechanism fails. A green test suite for a mechanism
+and a green run of that mechanism are different claims.
+
+## E12 — Manager: seven scan-form mismatches in one session
+*The manager's own, reported by three separate agents.*
+
+**What happened.** Seven times a scan returned zero or a wrong count against an artifact that was correct:
+a fidelity sweep that omitted two nested bundles; three "discrepancies" that were the manager failing to
+exclude ledger sections; a routing-instruction check that confirmed existence rather than location; scenario
+headings read at three hashes when they carry four; a heading pattern that missed a live pointer.
+
+**Why the recorded rule was not enough.** The subject-versus-scan-unit rule was written down mid-session and
+the error recurred four more times after it. What the subagents did differently is the actionable part: their
+extractors **parse structure and compare two independently-derived sets**, and they proved each against a
+planted fixture before citing it. The manager's were single-pass pattern matches trusted on sight.
+
+**Correct approach.** For any count or absence claim that will be acted on: derive it twice by different
+means and compare, or prove the instrument against a known-bad input first. A passing check that would pass
+equally on a known-broken input is not a check.

--- a/.gobbi/projects/gobbi/notes/docs/2026-07-26-desktop-session-mistake-candidates.md
+++ b/.gobbi/projects/gobbi/notes/docs/2026-07-26-desktop-session-mistake-candidates.md
@@ -7,7 +7,7 @@ feature: null
 status: active
 created: 2026-07-26
 session: bb2794ce-bc3d-422a-b011-f8b4750c6eed
-tags: [process, docs]
+tags: [process]
 keywords: [mistake-candidates, verification, single-owner, gates]
 author: claude
 steps_completed: [execution]

--- a/.gobbi/projects/gobbi/notes/docs/2026-07-26-desktop-skill-session.md
+++ b/.gobbi/projects/gobbi/notes/docs/2026-07-26-desktop-skill-session.md
@@ -1,0 +1,156 @@
+---
+name: desktop-skill-session
+description: Built the 14-file desktop skill (Electron + TypeScript) across a full Gobbi run; complete and correct but unwired in both runtimes
+type: notes
+scope: project
+feature: null
+status: active
+created: 2026-07-26
+session: bb2794ce-bc3d-422a-b011-f8b4750c6eed
+tags: [docs, process]
+keywords: [desktop, electron, typescript, skill-writing, cold-use-test, single-owner, verification]
+author: claude
+steps_completed: [configuration, ideation, planning, execution]
+shipped: true
+---
+
+# Building the `desktop` skill — session handoff
+
+Written to tracked memory rather than the session tree, because `.gitignore:21` excludes
+`.gobbi/projects/*/sessions/` and everything under it dies with the worktree.
+
+## Where to pick up
+
+**Branch:** `claude-2026-07-25-bb2794ce-bc3d-422a-b011-f8b4750c6eed`, off `develop` at `6f3066c1`.
+**Worktree:** `.gobbi/projects/gobbi/worktrees/claude-2026-07-25-bb2794ce-bc3d-422a-b011-f8b4750c6eed`
+**HEAD:** `1beaac73` · **24 commits** · tree clean · **nothing pushed, no pull request opened.**
+**Session record:** `<worktree>/.gobbi/projects/gobbi/sessions/2026-07-25-bb2794ce-.../` — gitignored, so
+read it before the worktree is removed.
+
+## What shipped
+
+Fourteen files at `.gobbi/projects/gobbi/skills/desktop/`, **5,969 lines**.
+
+| File | Role |
+|---|---|
+| `SKILL.md` (1,088) | Sole policy owner: 30 rules, 11 prohibitions, 4 protected floors, 10 phases, 8 gates |
+| `fidelity-ladder.md` (259) | Nine generic design rungs; hoistable — no policy identifiers, no paths |
+| `runtime-deltas.md` (~180) | Sole owner of every version literal and per-OS divergence |
+| `ideation.md` (452) | The per-run decision tree; the family's real router |
+| 7 mechanics children | Privilege boundary, security, lifecycle, native integration, local data, packaging, signing |
+| `scenarios.md` (1,161) · `checklists.md` (757) · `evaluation.md` (323) | 63 cases, 46 checks, the crosswalk |
+
+**Independently proved**, not asserted: the four protected floors diffed member-by-member against their
+generic parent with **no narrowing**; the rung-closing predicate rejecting four counterexamples and
+**accepting** the sanctioned re-entry case non-vacuously; the trace closing at **79 edges across five
+surfaces** with zero orphans in both directions, proved at both ends with planted fixtures.
+
+## What did NOT ship — three separate facts, do not fold them together
+
+**1. The skill has no discovery path in either runtime.** `.claude/skills/desktop` and
+`.agents/skills/desktop` do not exist. `scripts/sync-plugin-package.sh` fail-closes on a **pre-existing**
+package-version mismatch: Codex manifest `0.5.3`, Claude manifest `0.5.3`, Claude marketplace `0.5.4`.
+History shows `2aa5f5a7` bumped manifest and marketplace to `0.5.4` together, then `dc5fd3c4`
+("docs(memory): close workflow redesign session") reverted **only the manifest** — an accidental partial
+revert. **The user ruled versions out of scope for this session.** Fix is one line in either direction and it
+is a release decision. Wiring steps W1 and W3 are unrun.
+
+**2. Neither cold-load record exists.** The authoring standard requires one per target runtime and defines
+**no waiver path**. The `codex` leg is an **override** — two peer invocations returned zero-byte responses
+from service-side capacity errors, so it is unobtainable rather than skipped. The `claude-code` leg was never
+attempted, because a cold load through a runtime entrypoint is impossible while the mirrors are absent. The
+override record at `3-execution/task-15-wiring/outputs/codex-cold-load-override.md` originally claimed the
+`claude-code` record was produced; **that was false and is corrected in place with the error recorded.**
+
+**3. The authoring standard's P6 bundle: coverage CLOSED, acceptance NOT GRANTED.** Five items are
+`recorded-open`. Nothing should be read as "P6 passed."
+
+## Workflow deviations — all user decisions
+
+- **Codex waived session-wide** after two empty peer responses. Recorded as a deliberate override of the
+  narrow-waiver rule, which the schema cannot express (a waiver is keyed to one system, step and iteration).
+- **Ideation cap raised 3 → 4** for a bounded fix round.
+- **Planning EVALUATION skipped entirely.**
+- **Per-task Execution EVALUATION dropped**, with two adversarial passes retained.
+
+Consequence: only **three** independent reads happened all session — an adversarial proof of the floors and
+predicates, a two-ended proof of the trace and family consistency, and a cold-use test.
+
+## The finding that matters most
+
+The skill passed every mechanical gate and three verification passes. Then a fresh agent tried to **use** it
+cold on a real scenario — a three-platform menu-bar notes app — and could not plan the central requirement.
+`native-integration.md`'s own header claimed ownership of *tray* and *dock* and the family contained neither.
+The Procedure routed to 2 of 13 children. `P1` never pointed at the decision tree that `ideation.md` says is
+loaded at `P1`, so following the entry document literally skipped it.
+
+**None of those are checkable.** There is no gate for "a document honours its own ownership line." All four
+were fixed; the lesson is that **verification and use test different things**, and passing every gate says
+nothing about whether an artifact works.
+
+The same reader listed **fourteen things it would have gotten wrong** working from general knowledge —
+notably the migration *downgrade* path, which it called the one it would have shipped broken.
+
+## Open items for the next session, ranked
+
+1. **The relation test has no runnable implementation in the repository.** `evaluation.md` specifies it
+   precisely; both agents who ran one built it in `/tmp`, now gone. The triad's central claim is specified
+   but not executable. Small, well-specified work.
+2. **Version reconciliation**, then W1/W3, then both cold-load records. Unblocks discovery in both runtimes.
+3. **Hoist `fidelity-ladder.md` into `ui`/`ux`.** A known residual ships with it: a non-token altitude leak
+   passes every remaining gate, because the reviewed semantic check was deleted for being unsound in both
+   readings. The hoist session's first obligation.
+4. **Outbound drag-and-drop has no check** — deliberately scoped out to avoid re-conjoining claims.
+5. **`gobbi/SKILL.md`'s "every non-floor skill is indexed once" is false** — `desktop`'s row was added, ten
+   peers remain absent, and the base needs reconciling (27 top-level dirs vs 31 `SKILL.md` files).
+6. **`agents/evaluator.md:37,39`** point at a `§ Finding Metadata` section of `evaluation/SKILL.md` that does
+   not exist, calling it the single source of truth. Every evaluator dispatched through that path is pointed
+   at nothing.
+7. **`state.json.lastVerdict` is a trailing field** — it showed `FAIL` beside `iteration=3` while that FAIL
+   belonged to iteration 2, and a fresh evaluator read them as a pair and blocked partly on it.
+8. **The record placement contract has no home for step-level working evidence** spanning iterations.
+9. **Reduced-motion API-absence stated at three sites** — latent, because there is no owner row to point at
+   and no announced expiry. The fix is a design decision about where API-surface facts are owned.
+10. **`DESK-CHECK-17`'s field enumerates two conditions while its Pass carries four legs** — a coverage
+    question on a protected item, not a count fix.
+
+## Mistake candidates — 19, none promoted
+
+Seven staged at `1-ideation/staging/decisions/`; twelve written up at
+`4-wrap-up/working/iteration-1/research/execution-mistake-candidates.md`. **Both locations are gitignored.**
+Routing is Always-Ask and was never run. Two candidates have no valid area in the vocabulary (their only tag
+is not an area for their type), and one `related:` target does not exist in the tree.
+
+The three most transferable:
+
+- **A restatement is a defect only when the sentence characterises the state of a *versioned row*.** Naming an
+  *unversioned per-OS divergence* is the sanctioned form. Twelve absence-claim candidates resolved as twelve
+  false positives under this test where a description-based sweep would have produced twelve arguments.
+- **A guard's own fixture suite passing is not evidence the guard passes on the real repository.** The sync
+  test suite exits zero *while proving* that source topology rejects marketplace drift — and that drift is
+  live here.
+- **Pointing at a single-owner value protects against a stale value, not a stale characterisation of it.**
+  Pure-pointer sentences self-heal when the owner is corrected; restatements rot silently.
+
+## Manager errors, recorded because they recurred
+
+**Seven scan-form mismatches.** Seven times a scan returned zero or a wrong count against an artifact that was
+correct. Three separate agents' counts were right where mine were wrong. Writing the subject-versus-scan-unit
+rule down mid-session did **not** stop it recurring four more times. What the subagents did differently:
+their extractors parse structure and compare two independently-derived sets, and each was proved against a
+planted fixture before being cited.
+
+**Three unverified propagations.** A non-existent "nine-output contract" carried from a study report into two
+artifacts; a `skeleton`-vocabulary premise the tree refutes, amplified to the user as the session's best
+finding; and three version rows written from recollection, two of which were factually wrong by a whole major
+— in the file that is the family's sole owner of version literals.
+
+**Eight crossed reads.** Reading a working tree while an agent holds the write lock returns whichever half of
+the operation has landed. Two agents refused to act on a manager read that contradicted disk and were right
+both times; I nearly made the reciprocal error and edited a file mid-write.
+
+## Related
+
+- [[project_desktop_skill]]
+- [[feedback_askuserquestion_for_decisions]]
+- [[feedback_skill_structure]]

--- a/.gobbi/projects/gobbi/notes/docs/2026-07-26-desktop-skill-session.md
+++ b/.gobbi/projects/gobbi/notes/docs/2026-07-26-desktop-skill-session.md
@@ -1,156 +1,210 @@
 ---
 name: desktop-skill-session
-description: Built the 14-file desktop skill (Electron + TypeScript) across a full Gobbi run; complete and correct but unwired in both runtimes
+description: Completed repository delivery and durable findings for the fifteen-file desktop operation skill.
 type: notes
 scope: project
 feature: null
 status: active
 created: 2026-07-26
 session: bb2794ce-bc3d-422a-b011-f8b4750c6eed
-tags: [docs, process]
-keywords: [desktop, electron, typescript, skill-writing, cold-use-test, single-owner, verification]
-author: claude
-steps_completed: [configuration, ideation, planning, execution]
-shipped: true
+tags: [wrap-up, memory, verification, git, codex]
+keywords: [desktop, relation-checker, repository-discovery, cold-use, promotion]
+author: codex
+features_touched: []
+steps_completed: [ideation, planning, execution]
+shipped: [desktop, desktop-skill-session, grep-scope-must-match-the-claim-being-tested, idle-notification-carries-no-delivery-information, line-count-cannot-confirm-write-completion, restoration-must-not-join-a-frozen-set, sweep-for-x-when-authoring-a-no-x-rule, verify-subagent-characterization-against-owner, named-primitives-must-survive-generalization, new-gate-needs-known-good-and-known-bad-witness, mandated-interface-needs-evidence-owner, pointer-does-not-protect-stale-characterization, row-label-rename-needs-inbound-reference-sweep, support-window-claim-must-name-version, versioned-restatement-needs-owner-discriminator, gate-failure-needs-a-named-diagnosis, fixture-pass-is-not-real-tree-pass, scan-form-needs-independent-or-planted-witness]
 ---
 
-# Building the `desktop` skill — session handoff
+# Desktop skill session handoff
 
-Written to tracked memory rather than the session tree, because `.gitignore:21` excludes
-`.gobbi/projects/*/sessions/` and everything under it dies with the worktree.
+## 1. Outcome and agreed scope
 
-## Where to pick up
+The session completed the repository delivery path for the `desktop` operation skill. The final
+canonical family has fifteen files under `.gobbi/projects/gobbi/skills/desktop/`: fourteen
+Markdown owners plus `scripts/check_relation.py`. The accepted completion pass added the runnable
+relation proof, reconciled both plugin manifests to `0.5.4`, generated both repository discovery
+views through the canonical sync owner, and applied the nineteen user-approved mistake outcomes.
 
-**Branch:** `claude-2026-07-25-bb2794ce-bc3d-422a-b011-f8b4750c6eed`, off `develop` at `6f3066c1`.
-**Worktree:** `.gobbi/projects/gobbi/worktrees/claude-2026-07-25-bb2794ce-bc3d-422a-b011-f8b4750c6eed`
-**HEAD:** `1beaac73` · **24 commits** · tree clean · **nothing pushed, no pull request opened.**
-**Session record:** `<worktree>/.gobbi/projects/gobbi/sessions/2026-07-25-bb2794ce-.../` — gitignored, so
-read it before the worktree is removed.
+The locked scope is the three-outcome contract in
+`.gobbi/projects/gobbi/sessions/2026-07-25-bb2794ce-bc3d-422a-b011-f8b4750c6eed/1-ideation/outputs/ideation.md`
+as narrowed by
+`.gobbi/projects/gobbi/sessions/2026-07-25-bb2794ce-bc3d-422a-b011-f8b4750c6eed/2-planning/working/iteration-4/synthesis.md`.
+The user explicitly removed installed-cache and runtime cold-use tests. The eight residual design
+items remain deferred and are listed in section 7.
 
-## What shipped
+## 2. Completed or shipped work, with artifact and verification evidence
 
-Fourteen files at `.gobbi/projects/gobbi/skills/desktop/`, **5,969 lines**.
+- Tasks 01–15 produced the accepted fourteen-document desktop family. The branch history and
+  ownership limits are indexed in
+  `.gobbi/projects/gobbi/sessions/2026-07-25-bb2794ce-bc3d-422a-b011-f8b4750c6eed/3-execution/outputs/execution.md`.
+- Task 17 added the standard-library relation command in commit
+  `1af689b8b4fa0e9a5918e2be5e39072908de7c92`. Its accepted result is
+  `.gobbi/projects/gobbi/sessions/2026-07-25-bb2794ce-bc3d-422a-b011-f8b4750c6eed/3-execution/task-17-relation-checker/outputs/result.md`.
+  The command proves exact equality across four non-empty projections: 63 scenario subjects,
+  46 checklist subjects, and 79 edges. Its self-test rejects F-A and F-B at the required ends.
+  The separate F-C review rejects preserved-edge semantic loss and accepts the real bundle.
+- Task 16 reconciled repository discovery in commit
+  `3cf18f21466a365cf81effef41617d428434e995`. Its accepted result is
+  `.gobbi/projects/gobbi/sessions/2026-07-25-bb2794ce-bc3d-422a-b011-f8b4750c6eed/3-execution/task-16-cold-load-record/outputs/result.md`.
+  Both manifests now report `0.5.4`; the canonical source, Codex discovery, Claude Code
+  discovery, and source package expose the same fifteen-file inventory. Normal sync,
+  `--check`, second-run idempotence, and all 13 sync fixtures passed.
+- Before the promotion commit, the session branch contained 27 focused commits after base
+  `6f3066c152bcdb4ed21645a547fd1f7d75cfe6df`. The complete C00–C27 inventory is recorded in
+  `3-execution/outputs/execution.md`.
+- Wrap-up accounts for 22 final typed sources: nine immutable Ideation decisions, twelve
+  Wrap-up decisions derived from tracked reporter evidence, and this handoff note. Nineteen
+  mistake inputs receive their approved terminal outcomes, two later inputs are explicit skips,
+  and this note replaces the earlier tracked handoff.
 
-| File | Role |
-|---|---|
-| `SKILL.md` (1,088) | Sole policy owner: 30 rules, 11 prohibitions, 4 protected floors, 10 phases, 8 gates |
-| `fidelity-ladder.md` (259) | Nine generic design rungs; hoistable — no policy identifiers, no paths |
-| `runtime-deltas.md` (~180) | Sole owner of every version literal and per-OS divergence |
-| `ideation.md` (452) | The per-run decision tree; the family's real router |
-| 7 mechanics children | Privilege boundary, security, lifecycle, native integration, local data, packaging, signing |
-| `scenarios.md` (1,161) · `checklists.md` (757) · `evaluation.md` (323) | 63 cases, 46 checks, the crosswalk |
+Installed-cache behavior was not tested or accepted.
 
-**Independently proved**, not asserted: the four protected floors diffed member-by-member against their
-generic parent with **no narrowing**; the rung-closing predicate rejecting four counterexamples and
-**accepting** the sanctioned re-entry case non-vacuously; the trace closing at **79 edges across five
-surfaces** with zero orphans in both directions, proved at both ends with planted fixtures.
+Codex runtime cold use and P7 were not tested or accepted.
 
-## What did NOT ship — three separate facts, do not fold them together
+Claude Code runtime cold use and P7 were not tested or accepted.
 
-**1. The skill has no discovery path in either runtime.** `.claude/skills/desktop` and
-`.agents/skills/desktop` do not exist. `scripts/sync-plugin-package.sh` fail-closes on a **pre-existing**
-package-version mismatch: Codex manifest `0.5.3`, Claude manifest `0.5.3`, Claude marketplace `0.5.4`.
-History shows `2aa5f5a7` bumped manifest and marketplace to `0.5.4` together, then `dc5fd3c4`
-("docs(memory): close workflow redesign session") reverted **only the manifest** — an accidental partial
-revert. **The user ruled versions out of scope for this session.** Fix is one line in either direction and it
-is a release decision. Wiring steps W1 and W3 are unrun.
+## 3. Dual-system evaluation result, approved finding dispositions, and any waiver
 
-**2. Neither cold-load record exists.** The authoring standard requires one per target runtime and defines
-**no waiver path**. The `codex` leg is an **override** — two peer invocations returned zero-byte responses
-from service-side capacity errors, so it is unobtainable rather than skipped. The `claude-code` leg was never
-attempted, because a cold load through a runtime entrypoint is impossible while the mirrors are absent. The
-override record at `3-execution/task-15-wiring/outputs/codex-cold-load-override.md` originally claimed the
-`claude-code` record was produced; **that was false and is corrected in place with the error recorded.**
+Task 17 and Task 16 each received one fresh Codex `PASS` report with no findings. Their exact
+reports, hashes, and empty disposition batches are cited by their accepted results above. The
+user waived Claude separately for Execution Task 17 iteration 1 and Task 16 iteration 1; neither
+result claims a dual-system evaluation pair.
 
-**3. The authoring standard's P6 bundle: coverage CLOSED, acceptance NOT GRANTED.** Five items are
-`recorded-open`. Nothing should be read as "P6 passed."
+Planning iteration 4 retained `REVISE`. The user explicitly directed Execution and approved
+`PL4-CODEX-001` as deferred to the two task contracts; the durable decision is
+`2-planning/working/iteration-4/research/finding-disposition-batch.md`.
 
-## Workflow deviations — all user decisions
+Wrap-up iteration 2 uses the user's exact Codex-only waiver because Claude remains unavailable at
+its usage limit. The waiver permits one Codex creator and requires a distinct fresh Codex
+evaluator. It creates no Claude-labelled draft, cross-review, or report. At this WORK handoff
+boundary, Wrap-up evaluation and its disposition batch are still the next workflow gate; no
+Wrap-up verdict is claimed in advance.
 
-- **Codex waived session-wide** after two empty peer responses. Recorded as a deliberate override of the
-  narrow-waiver rule, which the schema cannot express (a waiver is keyed to one system, step and iteration).
-- **Ideation cap raised 3 → 4** for a bounded fix round.
-- **Planning EVALUATION skipped entirely.**
-- **Per-task Execution EVALUATION dropped**, with two adversarial passes retained.
+## 4. Decisions to respect
 
-Consequence: only **three** independent reads happened all session — an adversarial proof of the floors and
-predicates, a two-ended proof of the trace and family consistency, and a cold-use test.
+- Preserve the three-outcome completion scope and the eight deferred residuals. A count does not
+  move an item across that itemized boundary.
+- Keep both plugin manifests and the Claude marketplace on `0.5.4`. Repository sync remains the
+  sole writer of `.agents/skills/desktop` and `.claude/skills/desktop`.
+- Keep source-package behavior, repository discovery, installed-cache behavior, and target-runtime
+  use as separate claims.
+- Keep relation equality and obligation meaning as separate proof legs. The checked-in command
+  owns F-A/F-B; a named semantic reviewer owns F-C.
+- Preserve exactly the approved mistake arithmetic: five supersessions, eleven other active
+  project records, two skill-owned traps, one drop, and zero deletions.
+- Skip `return-routing-must-preserve-output-ownership` and
+  `scope-count-must-follow-itemization`. Their session sources remain immutable evidence and no
+  durable record is created from either.
+- Publication is a ready pull request to `develop`, with no issue and no draft. Merge remains a
+  separate live user decision after the exact pull request, head, base, checks, and cleanup target
+  are reverified.
 
-## The finding that matters most
+## 5. Durable memory promoted or superseded
 
-The skill passed every mechanical gate and three verification passes. Then a fresh agent tried to **use** it
-cold on a real scenario — a three-platform menu-bar notes app — and could not plan the central requirement.
-`native-integration.md`'s own header claimed ownership of *tray* and *dock* and the family contained neither.
-The Procedure routed to 2 of 13 children. `P1` never pointed at the decision tree that `ideation.md` says is
-loaded at `P1`, so following the entry document literally skipped it.
+Wrap-up creates sixteen active project mistake records:
 
-**None of those are checkable.** There is no gate for "a document honours its own ownership line." All four
-were fixed; the lesson is that **verification and use test different things**, and passing every gate says
-nothing about whether an artifact works.
+- `mistakes/verification/grep-scope-must-match-the-claim-being-tested.md`
+- `mistakes/tooling/idle-notification-carries-no-delivery-information.md`
+- `mistakes/verification/line-count-cannot-confirm-write-completion.md`
+- `mistakes/docs-sync/restoration-must-not-join-a-frozen-set.md`
+- `mistakes/refactor/sweep-for-x-when-authoring-a-no-x-rule.md`
+- `mistakes/verification/verify-subagent-characterization-against-owner.md`
+- `mistakes/docs-sync/named-primitives-must-survive-generalization.md`
+- `mistakes/verification/new-gate-needs-known-good-and-known-bad-witness.md`
+- `mistakes/assumption/mandated-interface-needs-evidence-owner.md`
+- `mistakes/docs-sync/pointer-does-not-protect-stale-characterization.md`
+- `mistakes/refactor/row-label-rename-needs-inbound-reference-sweep.md`
+- `mistakes/verification/support-window-claim-must-name-version.md`
+- `mistakes/verification/versioned-restatement-needs-owner-discriminator.md`
+- `mistakes/tooling/gate-failure-needs-a-named-diagnosis.md`
+- `mistakes/verification/fixture-pass-is-not-real-tree-pass.md`
+- `mistakes/verification/scan-form-needs-independent-or-planted-witness.md`
 
-The same reader listed **fourteen things it would have gotten wrong** working from general knowledge —
-notably the migration *downgrade* path, which it called the one it would have shipped broken.
+It also adds one active section to `skills/workflow/mistakes.md` and creates
+`skills/evaluation/checklist/mistakes.md` with one active checklist-owned trap.
 
-## Open items for the next session, ranked
+Five reciprocal supersessions preserve their prior bodies at:
 
-1. **The relation test has no runnable implementation in the repository.** `evaluation.md` specifies it
-   precisely; both agents who ran one built it in `/tmp`, now gone. The triad's central claim is specified
-   but not executable. Small, well-specified work.
-2. **Version reconciliation**, then W1/W3, then both cold-load records. Unblocks discovery in both runtimes.
-3. **Hoist `fidelity-ladder.md` into `ui`/`ux`.** A known residual ships with it: a non-token altitude leak
-   passes every remaining gate, because the reviewed semantic check was deleted for being unsound in both
-   readings. The hoist session's first obligation.
-4. **Outbound drag-and-drop has no check** — deliberately scoped out to avoid re-conjoining claims.
-5. **`gobbi/SKILL.md`'s "every non-floor skill is indexed once" is false** — `desktop`'s row was added, ten
-   peers remain absent, and the base needs reconciling (27 top-level dirs vs 31 `SKILL.md` files).
-6. **`agents/evaluator.md:37,39`** point at a `§ Finding Metadata` section of `evaluation/SKILL.md` that does
-   not exist, calling it the single source of truth. Every evaluator dispatched through that path is pointed
-   at nothing.
-7. **`state.json.lastVerdict` is a trailing field** — it showed `FAIL` beside `iteration=3` while that FAIL
-   belonged to iteration 2, and a fresh evaluator read them as a pair and blocked partly on it.
-8. **The record placement contract has no home for step-level working evidence** spanning iterations.
-9. **Reduced-motion API-absence stated at three sites** — latent, because there is no owner row to point at
-   and no announced expiry. The fix is a design decision about where API-surface facts are owned.
-10. **`DESK-CHECK-17`'s field enumerates two conditions while its Pass carries four legs** — a coverage
-    question on a protected item, not a count fix.
+- `archive/mistakes/verification/2026-07-26-grep-absence-claim-needs-exact-pattern.md`
+- `archive/mistakes/tooling/2026-07-26-agent-teams-idle-notification-is-not-completion.md`
+- `archive/mistakes/verification/2026-07-26-teammate-finalize-read-crosses-in-progress-write.md`
+- `archive/mistakes/docs-sync/2026-07-26-union-diff-must-reach-named-primitive-granularity.md`
+- `archive/mistakes/verification/2026-07-26-adversarially-test-a-newly-authored-acceptance-predicate.md`
 
-## Mistake candidates — 19, none promoted
+The E9 source is dropped because `claimed-count-not-reproduced-by-scan` already owns its full
+lesson. No record is deleted. The promotion manifest, apply receipts, body-identity checks,
+frontmatter validation, skill-mistake validation, link validation, retired-path sweep, and
+source/package topology check are stored under
+`4-wrap-up/working/iteration-2/research/`.
 
-Seven staged at `1-ideation/staging/decisions/`; twelve written up at
-`4-wrap-up/working/iteration-1/research/execution-mistake-candidates.md`. **Both locations are gitignored.**
-Routing is Always-Ask and was never run. Two candidates have no valid area in the vocabulary (their only tag
-is not an area for their type), and one `related:` target does not exist in the tree.
+## 6. Pre-finalization Git state and authorized finalization plan
 
-The three most transferable:
+The pre-promotion branch is
+`claude-2026-07-25-bb2794ce-bc3d-422a-b011-f8b4750c6eed`, based on `develop` at
+`6f3066c152bcdb4ed21645a547fd1f7d75cfe6df`, with clean starting HEAD
+`3cf18f21466a365cf81effef41617d428434e995`. The absolute worktree is
+`/playinganalytics/git/gobbi/.gobbi/projects/gobbi/worktrees/claude-2026-07-25-bb2794ce-bc3d-422a-b011-f8b4750c6eed`.
+The Wrap-up promotion is one manifest-owned tracked delta with planned subject
+`docs(memory): promote desktop session findings` and the session provenance trailer.
 
-- **A restatement is a defect only when the sentence characterises the state of a *versioned row*.** Naming an
-  *unversioned per-OS divergence* is the sanctioned form. Twelve absence-claim candidates resolved as twelve
-  false positives under this test where a description-based sweep would have produced twelve arguments.
-- **A guard's own fixture suite passing is not evidence the guard passes on the real repository.** The sync
-  test suite exits zero *while proving* that source topology rejects marketplace drift — and that drift is
-  live here.
-- **Pointing at a single-owner value protects against a stale value, not a stale characterisation of it.**
-  Pure-pointer sentences self-heal when the owner is corrected; restatements rot silently.
+After Wrap-up PASS RECORD, the manager is authorized to re-probe Git posture, push the exact
+session branch, and open or reuse one ready pull request whose head is that branch and whose base
+is exactly `develop`. No issue is configured. The manager must then requery protection, required
+checks, review state, mergeability, and exact head/base before asking for live squash-merge
+authority. Cleanup may remove only the exact clean worktree and exact session refs after the pull
+request is confirmed merged and the main checkout fast-forwards.
 
-## Manager errors, recorded because they recurred
+No push, pull request, merge, branch deletion, worktree removal, or cleanup is claimed here.
 
-**Seven scan-form mismatches.** Seven times a scan returned zero or a wrong count against an artifact that was
-correct. Three separate agents' counts were right where mine were wrong. Writing the subject-versus-scan-unit
-rule down mid-session did **not** stop it recurring four more times. What the subagents did differently:
-their extractors parse structure and compare two independently-derived sets, and each was proved against a
-planted fixture before being cited.
+## 7. Unresolved, blocked, or deferred items with explicit reasons
 
-**Three unverified propagations.** A non-existent "nine-output contract" carried from a study report into two
-artifacts; a `skeleton`-vocabulary premise the tree refutes, amplified to the user as the session's best
-finding; and three version rows written from recollection, two of which were factually wrong by a whole major
-— in the file that is the family's sole owner of version literals.
+| Item | Why it remains open | Exact continuation |
+|---|---|---|
+| Fidelity-ladder hoist and altitude residual | Generic interface ownership was outside the locked completion pass. | Start a UI/UX or generic-interface design session and prove the semantic altitude check before moving the file. |
+| Outbound drag-and-drop coverage | It was intentionally excluded to avoid re-conjoining accepted claims. | Add a protected desktop coverage task with a new scenario/check decision. |
+| Generic Gobbi skill-map reconciliation | Desktop discovery is fixed, but ten other top-level rows remain outside scope. | Recount canonical top-level skills and update the index owner in a separate reconciliation. |
+| Dangling evaluator metadata pointer | The missing `§ Finding Metadata` owner section is unrelated to desktop delivery. | Repair the evaluation owner and both evaluator-role pointers together. |
+| Trailing `state.json.lastVerdict` semantics | The state/iteration ownership question requires workflow and Record design. | Define which iteration owns the trailing verdict, then update schema, writer, and readers. |
+| Step-level evidence home | Record has no accepted home for evidence spanning iterations. | Design the path and lifecycle in Record before adding another working-file convention. |
+| Reduced-motion API ownership and expiry | The same absence fact is repeated at three sites without an owner. | Choose one version/API owner and repoint the three carriers. |
+| `DESK-CHECK-17` coverage mismatch | Its field names two conditions while `Pass` has four legs. | Run a protected coverage decision before changing the check. |
 
-**Eight crossed reads.** Reading a working tree while an agent holds the write lock returns whichever half of
-the operation has landed. Two agents refused to act on a manager read that contradicted disk and were right
-both times; I nearly made the reciprocal error and edited a file mid-write.
+Runtime cold use remains excluded by the user's decision, not silently deferred inside these
+eight rows. A future acceptance pass must use each target runtime through its normal entrypoint.
+P6 remains unaccepted. Whole-skill acceptance and release readiness remain unaccepted.
 
-## Related
+## 8. Known risks and accepted exceptions
 
-- [[project_desktop_skill]]
-- [[feedback_askuserquestion_for_decisions]]
-- [[feedback_skill_structure]]
+- The repository can discover the desktop skill, but no accepted evidence proves that either
+  target runtime loads and uses it correctly. Repository topology must not be reported as P7.
+- The relation command proves exact route equality, not the meaning of each mapped obligation.
+  Future changes still require the separate F-C semantic review.
+- Claude was unavailable for the final two Execution tasks and Wrap-up iteration 2. The user
+  approved narrow Codex-only waivers, so cross-system independence is absent at those gates.
+- Planning iteration 4 remained `REVISE` under the user's explicit Execution-entry exception.
+  The task-level companion and complete-session gates carried the deferred finding.
+- Tasks 01–15 remain historical accepted work with the deviations recorded in
+  `3-execution/outputs/execution.md`; this completion pass does not retroactively create missing
+  historical task results or evaluation pairs.
+
+## 9. Exact next-session start point: objective, required reads, current branch/worktree state, and first action
+
+If Git finalization has not completed, the objective is to finish only the evaluated publication,
+merge, and exact cleanup plan. Read, in order:
+
+1. `.gobbi/projects/gobbi/notes/docs/2026-07-26-desktop-skill-session.md`
+2. `.gobbi/projects/gobbi/sessions/2026-07-25-bb2794ce-bc3d-422a-b011-f8b4750c6eed/3-execution/outputs/execution.md`
+3. `.gobbi/projects/gobbi/sessions/2026-07-25-bb2794ce-bc3d-422a-b011-f8b4750c6eed/3-execution/task-17-relation-checker/outputs/result.md`
+4. `.gobbi/projects/gobbi/sessions/2026-07-25-bb2794ce-bc3d-422a-b011-f8b4750c6eed/3-execution/task-16-cold-load-record/outputs/result.md`
+5. `.gobbi/projects/gobbi/sessions/2026-07-25-bb2794ce-bc3d-422a-b011-f8b4750c6eed/4-wrap-up/working/iteration-2/research/promotion-verification.md`
+6. `.gobbi/projects/gobbi/sessions/2026-07-25-bb2794ce-bc3d-422a-b011-f8b4750c6eed/session.json`
+7. `.gobbi/projects/gobbi/sessions/2026-07-25-bb2794ce-bc3d-422a-b011-f8b4750c6eed/state.json`
+
+The retained branch and worktree are the exact values in section 6. The first safe action is the
+read-only Git posture probe followed by a fresh status, branch-head, remote, and pull-request
+inventory. Do not remove the worktree or either branch until the exact pull request is confirmed
+merged and the cleanup gate passes.
+
+If finalization already completed, begin a new session from updated `develop`. Choose one of the
+eight deferred rows or a target-runtime cold-use/P7 pass as the new scoped objective; do not reopen
+the accepted three-outcome completion pass.

--- a/.gobbi/projects/gobbi/notes/docs/2026-07-26-desktop-skill-session.md
+++ b/.gobbi/projects/gobbi/notes/docs/2026-07-26-desktop-skill-session.md
@@ -139,13 +139,14 @@ source/package topology check are stored under
 
 ## 6. Pre-finalization Git state and authorized finalization plan
 
-The pre-promotion branch is
-`claude-2026-07-25-bb2794ce-bc3d-422a-b011-f8b4750c6eed`, based on `develop` at
-`6f3066c152bcdb4ed21645a547fd1f7d75cfe6df`, with clean starting HEAD
-`3cf18f21466a365cf81effef41617d428434e995`. The absolute worktree is
+The focused promotion commit containing this note exists on branch
+`claude-2026-07-25-bb2794ce-bc3d-422a-b011-f8b4750c6eed`. Its parent is
+`3cf18f21466a365cf81effef41617d428434e995` and its subject is
+`docs(memory): promote desktop session findings`. Its exact self hash is intentionally not
+embedded because changing this note would change that hash. The absolute worktree is
 `/playinganalytics/git/gobbi/.gobbi/projects/gobbi/worktrees/claude-2026-07-25-bb2794ce-bc3d-422a-b011-f8b4750c6eed`.
-The Wrap-up promotion is one manifest-owned tracked delta with planned subject
-`docs(memory): promote desktop session findings` and the session provenance trailer.
+The next manager must re-probe the live HEAD, parent, subject, tree, status, and provenance trailer
+before any finalization action.
 
 After Wrap-up PASS RECORD, the manager is authorized to re-probe Git posture, push the exact
 session branch, and open or reuse one ready pull request whose head is that branch and whose base
@@ -154,7 +155,8 @@ checks, review state, mergeability, and exact head/base before asking for live s
 authority. Cleanup may remove only the exact clean worktree and exact session refs after the pull
 request is confirmed merged and the main checkout fast-forwards.
 
-No push, pull request, merge, branch deletion, worktree removal, or cleanup is claimed here.
+Push, pull-request creation, merge, branch deletion, worktree removal, and cleanup remain future
+manager actions after Wrap-up PASS RECORD. None is claimed here.
 
 ## 7. Unresolved, blocked, or deferred items with explicit reasons
 

--- a/.gobbi/projects/gobbi/notes/process/2026-07-16-typescript-skill-review-handoff.md
+++ b/.gobbi/projects/gobbi/notes/process/2026-07-16-typescript-skill-review-handoff.md
@@ -55,7 +55,7 @@ web-verified against primary sources.
 - `mistakes/docs-sync/sweep-every-occurrence-when-fixing-a-multi-surface-claim.md` — a claim fix must grep-sweep
   every surface (rule/child/scenario/checklist/crosswalk); a spot-fix leaves residuals that re-fail next round
   (A2, A4 each half-applied).
-- `mistakes/verification/adversarially-test-a-newly-authored-acceptance-predicate.md` — a new check/scenario is
+- `archive/mistakes/verification/2026-07-26-adversarially-test-a-newly-authored-acceptance-predicate.md` — a new check/scenario is
   an executable claim; compile the counterexample it must reject before shipping; frame acceptance as a
   property, not a list of "sufficient" constructs (the readonly check was unsound twice).
 

--- a/.gobbi/projects/gobbi/skills/desktop/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/desktop/SKILL.md
@@ -599,9 +599,12 @@ to be followed, not to be pointed at.
 *Input:* the user trigger, the live application if one exists, project rules, applicable mistakes, and the
 decision authority.
 
-*Action:* write the one-sentence outcome and expand it per `DESK-R01`; enumerate the claimed operating
-systems; run the six-criterion wrong-choice test per `DESK-R03`; state the ownership boundary per `DESK-R04`;
-open the design record per `DESK-R29`.
+*Action:* **load [`ideation.md`](ideation.md) first and keep it open through `P6`** — it is the run's decision
+tree, it fires every `DESK-R27` gate in interview order, and its `D5` establishes the participant conditions
+before any rung begins, so a run that reaches `P3` without it has already passed a fail-closed axis. Then write
+the one-sentence outcome and expand it per `DESK-R01`; enumerate the claimed operating systems; run the
+six-criterion wrong-choice test per `DESK-R03`; state the ownership boundary per `DESK-R04`; open the design
+record per `DESK-R29`.
 
 *Evidence:* the locked outcome and scope contract, the operating-system claim set, the wrong-choice result
 table with an inspected result per criterion, and the authority map naming every `DESK-R27` gate and who
@@ -777,7 +780,9 @@ condition that produced it, never a summary of it.
 
 *Action:* resolve the research, task-analysis, information-architecture, navigation, and user-flow rungs,
 each by its own question and validation method, in the generative-then-evaluative order per `DESK-R09`;
-record each rung's resolution and its substantiating evidence.
+record each rung's resolution and its substantiating evidence. Each rung's question, default artifact,
+done-condition, and closing evidence are [`fidelity-ladder.md`](fidelity-ladder.md)'s; the applicability
+decision for each was taken at [`ideation.md`](ideation.md)'s `D6`.
 
 *Evidence:* rung register rows 0–4, each with its resolution kind, artifact or citation pointer, and the
 inspected findings that satisfy that kind's conditions; the participant consent and accommodation record for
@@ -825,7 +830,8 @@ explicit approval or reopening before any visual rung begins; then resolve the w
 interactive-prototype rungs, stating each visual artifact's position on all three fidelity axes; run the
 round cadence per `DESK-R09`; hold the four floors per `DESK-R10`–`DESK-R13`, including each floor's property
 check and residual clause; present the complete design record at `DESK-G4`, the design acceptance gate, per
-`DESK-R27`.
+`DESK-R27`. The rung questions and the three axis definitions are [`fidelity-ladder.md`](fidelity-ladder.md)'s;
+the two gates run through [`ideation.md`](ideation.md)'s `D8` and `D9`.
 
 *Evidence:* rung register row 5 carrying the `DESK-G3` decision; rung register rows 6–8 with the
 per-visual-artifact three-axis statement; the direct representative-user records per claimed operating system
@@ -873,10 +879,14 @@ otherwise `P5`.
 
 *Input:* the accepted design record and the platform foundation.
 
-*Action:* fix the process split and the privileged surface; enumerate every inter-process channel with its
-payload type, its validation, and its sender rule; fix the window and lifecycle contract, the local data
-contract including the migration and downgrade path, the native integration set, the security posture as the
-two distinct kinds of work, and the per-operating-system deltas.
+*Action:* fix the process split and the privileged surface, and enumerate every inter-process channel with its
+payload type, its validation, and its sender rule ([`process-model.md`](process-model.md)); fix the window and
+lifecycle contract, including the entry-mode inventory
+([`windows-lifecycle.md`](windows-lifecycle.md)); the local data contract including the migration and downgrade
+path ([`filesystem-data.md`](filesystem-data.md)); the native integration set, tray and dock included
+([`native-integration.md`](native-integration.md)); the security posture as the two distinct kinds of work
+([`security.md`](security.md)); and the per-operating-system deltas
+([`runtime-deltas.md`](runtime-deltas.md)).
 
 *Evidence:* the approved application contract with a channel inventory, a lifecycle and window-state map, a
 data and migration map, and a per-operating-system delta matrix.
@@ -895,10 +905,12 @@ implementation; otherwise `P6`.
 
 *Input:* the locked application contract.
 
-*Action:* select the applicable scenario cases and checks; set the quality targets from a project owner or
-current evidence; decide the hardening-versus-testability build matrix as an explicit user decision at
-`DESK-G5`; apply the build-tool selection criterion at `DESK-G6`; plan the signing, notarization, update,
-channel, staged-rollout, and stop-condition controls.
+*Action:* select the applicable scenario cases ([`scenarios.md`](scenarios.md)) and checks
+([`checklists.md`](checklists.md)); set the quality targets from a project owner or current evidence; decide
+the hardening-versus-testability build matrix as an explicit user decision at `DESK-G5`; apply the build-tool
+selection criterion at `DESK-G6` ([`packaging-distribution.md`](packaging-distribution.md)); plan the signing,
+notarization, update, channel, staged-rollout, and stop-condition controls
+([`signing-updates.md`](signing-updates.md)).
 
 *Evidence:* the case and check register, the quality-target table with a source per target, the recorded
 build-matrix decision with both horns stated, and the release-control plan.
@@ -921,8 +933,9 @@ marked as needing its own authority; otherwise `P7`.
 phase's own record, because the three-target split is derived from the verified preload-context sentence and
 is not documented by any primary source, so the phase states it as derived wherever it states it — plus the
 shared contract type, the bridge surface, the channel signatures with stub handlers, the window creation
-path, and the instrumentation points; connect the smallest real path from a window through the bridge to a
-privileged effect and a truthful completion.
+path, and the instrumentation points ([`process-model.md`](process-model.md) owns the context split and the
+crossable-type boundary); connect the smallest real path from a window through the bridge to a privileged
+effect and a truthful completion.
 
 *Evidence:* a green type-check per target, an import and build check, and one end-to-end trace with the
 effect observed at its authoritative source.
@@ -941,8 +954,9 @@ body; otherwise `P8`.
 
 *Action:* add the ordinary path, then the alternative-valid classes, the exact boundaries, the failures and
 recovery, the adversarial behavior, the per-operating-system deltas, and the compatibility and migration
-behavior; move code, contract, data, configuration, documentation, tests, and instrumentation together in
-each slice and verify that slice before the next.
+behavior — the case classes are [`scenarios.md`](scenarios.md)'s and the deltas are
+[`runtime-deltas.md`](runtime-deltas.md)'s; move code, contract, data, configuration, documentation, tests,
+and instrumentation together in each slice and verify that slice before the next.
 
 *Evidence:* an ordered slice log, each entry carrying its own fresh focused verification and its updated
 affected-surface trace.
@@ -959,9 +973,11 @@ otherwise `P9`.
 *Input:* the grown implementation and the quality targets.
 
 *Action:* run the language-level order to build, then the four added gates per `DESK-R23` — package per
-operating system, install and smoke-test in a clean environment, verify signature and notarization on the
-real artifact, rehearse an update from the previously released version — and take each remaining claim to the
-evidence class that owns it per `DESK-R25`.
+operating system ([`packaging-distribution.md`](packaging-distribution.md)), install and smoke-test in a clean
+environment, verify signature and notarization on the real artifact, rehearse an update from the previously
+released version ([`signing-updates.md`](signing-updates.md)) — resolve the applicable items of
+[`checklists.md`](checklists.md)'s implementation pause point, and take each remaining claim to the evidence
+class that owns it per `DESK-R25`.
 
 *Evidence:* the claim-owner verification matrix naming the exact command or action, environment, version and
 configuration, fresh result, artifact pointer, and limitation for each claim; a per-operating-system row for

--- a/.gobbi/projects/gobbi/skills/desktop/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/desktop/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: desktop
+description: Use when designing, building, and releasing one desktop application outcome as an Electron and TypeScript vertical slice, from the design fidelity ladder through a signed, update-rehearsed per-OS release.
+allowed-tools: Read, Grep, Glob, Bash, Write, Edit, AskUserQuestion, WebSearch, WebFetch
+skill-type: operation
+---
+
+# Desktop Application Delivery
+
+Carry the whole desktop delivery spine — the stack commitment, the ownership boundary, the four protected
+floors, the thirty live rules and eleven identified prohibitions, and the ten ordered phases.
+
+## Principles
+
+## Rules
+
+### Must-Follow
+
+### Must-Not-Follow
+
+## Procedure
+
+## References

--- a/.gobbi/projects/gobbi/skills/desktop/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/desktop/SKILL.md
@@ -217,8 +217,10 @@ across revisions.
   `commandLine` parsed by matching and never by position; the deep-link route per operating system
   (`open-url` on macOS; `second-instance` with the link as the **last** element on Windows and Linux); a
   three-state theme driven by `nativeTheme.themeSource` (`'system' | 'dark' | 'light'`) with its `updated`
-  event handled live; and one shortcut map per platform using `CommandOrControl`, excluding system-reserved
-  combinations.
+  event handled live; one shortcut map per platform using `CommandOrControl`, excluding system-reserved
+  combinations; and, where the outcome is entered from or resident in a status-area icon, the tray mechanism —
+  an icon with a context menu, re-set rather than mutated in place to change an item — with no activation
+  gesture promised on a system whose own specification leaves the gesture to the environment.
 
 **Release**
 
@@ -1013,8 +1015,9 @@ Every borrowed fact has one owner. This section names the owner; it never restat
   ASAR fuses, what ASAR is not, and the supply-chain scanner gap.
 - [`windows-lifecycle.md`](windows-lifecycle.md) owns creation and first paint, state restoration, per-OS
   quit and activation, single-instance and argument handling, deep links, and the entry-mode inventory.
-- [`native-integration.md`](native-integration.md) owns menus, shortcuts, notifications, dialogs, clipboard,
-  drag-and-drop, custom window chrome, theming, and file associations.
+- [`native-integration.md`](native-integration.md) owns menus, the tray and menu-bar residency, the macOS dock
+  property, shortcuts, notifications, dialogs, clipboard, drag-and-drop, custom window chrome, theming, and
+  file associations.
 - [`filesystem-data.md`](filesystem-data.md) owns user-data locations, durable writes, schema migration
   including the downgrade path, at-rest secret handling, and the never-write list.
 - [`packaging-distribution.md`](packaging-distribution.md) owns per-OS targets, the build-tool selection
@@ -1053,7 +1056,7 @@ Every borrowed fact has one owner. This section names the owner; it never restat
 
 ### Gap register
 
-Thirteen items this skill carries as gaps rather than as facts. Each keeps its marking word at its point of
+Fourteen items this skill carries as gaps rather than as facts. Each keeps its marking word at its point of
 use, and each row below names what would close it, so a later session can close one without re-deriving the
 search. This register is the skill's own; it is not the per-run unknown and gap register that `DESK-R29`
 requires inside the design record.
@@ -1077,6 +1080,7 @@ need no closing condition, and items 16 and 17 are reader-owned decisions rather
 | 13 | **UNVERIFIED** | information density and dense professional layouts, and offline-first desktop behavior — no authoritative source found, and the platform's own calm-design principle pulls against density | an authoritative source on either is found | research |
 | 14 | **UNVERIFIED** | a rationale for the removal of the former remote module — the process-model document gives none | a maintainer statement on the removal rationale is found | retrieval |
 | 15 | **UNVERIFIED** | end-to-end typed IPC guidance — no official guidance exists and no community library is canonical, so every such library is a new production dependency and therefore a `DESK-G7` decision, never a default | official guidance appears, or one library becomes canonical | retrieval |
+| 18 | **UNVERIFIED** | the dock interface's own hide, show, and activation-policy operations — the property's per-system presence is documented, but the operations live on a separate page that was not retrieved, so nothing about their behaviour is stated | that page is read, or another authoritative source covers those operations | retrieval |
 
 Two further items are **not** gaps and are not listed above, because they are decisions the reader owns
 rather than facts to close: which build tool is the default, which `DESK-R27` routes to `DESK-G6` as a stated

--- a/.gobbi/projects/gobbi/skills/desktop/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/desktop/SKILL.md
@@ -263,7 +263,9 @@ across revisions.
   four projections of the authoritative case-to-check relation agree exactly; and the verifier is proved at
   both ends and against every planted fixture before its result is cited. This rule is the parent owner of
   the trace obligation [`scenarios.md`](scenarios.md), [`checklists.md`](checklists.md), and
-  [`evaluation.md`](evaluation.md) implement.
+  [`evaluation.md`](evaluation.md) implement. Run the mechanical leg through
+  [`scripts/check_relation.py`](scripts/check_relation.py); its output distinguishes the script-proved
+  relation leg from the review-proved obligation leg.
 - **`DESK-R29` — MUST keep one design record for the run, whose location the active project owns.** The
   record carries the rung register, the three-axis statement for each artifact at rungs 6–8, the four floor
   resolutions with their union checks and property checks, the participant consent and accommodation records,

--- a/.gobbi/projects/gobbi/skills/desktop/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/desktop/SKILL.md
@@ -7,17 +7,1079 @@ skill-type: operation
 
 # Desktop Application Delivery
 
-Carry the whole desktop delivery spine — the stack commitment, the ownership boundary, the four protected
-floors, the thirty live rules and eleven identified prohibitions, and the ten ordered phases.
+Deliver one desktop application outcome — a windowed program a user installs on macOS, Windows, or Linux and
+launches outside a browser — as an Electron and TypeScript vertical slice. One outcome spans the design
+fidelity ladder, the privilege boundary between the three execution contexts, and a packaged, signed,
+update-rehearsed release on every operating system claimed. Load this skill when the work targets an
+installed windowed application; do not load it for a browser page, a command-line tool, a library, or a
+service.
+
+The skill also states when Electron is the wrong answer. `DESK-R03` carries the six-criterion test and the
+alternative each positive criterion points at, and `P1` runs that test as its first action, before the stack
+is committed.
 
 ## Principles
 
+> **P-1 — One desktop outcome spans design, three processes, and a release that cannot be recalled.**
+> The unit of work is not a window, an inter-process handler, a packaged build, or a happy path. It is the
+> bounded outcome from entry through verified completion on every operating system claimed, including the
+> installed and updated state on a user's machine that no later change can reach.
+
+> **P-2 — The design progression is a ladder of questions, not a stack of artifacts.**
+> Each rung asks something the next rung cannot answer for it. A named artifact is the default way to answer
+> a rung, and an existing answer may close it, but an unanswered rung stays open no matter how polished the
+> artifacts above it look. The progression is iterative scaffolding and is re-enterable, not a one-way gate
+> chain.
+
+> **P-3 — The privilege boundary is the product's real perimeter, and the type system cannot see it.**
+> The boundary between the privileged process and the presentation process presents as an ordinary typed
+> function call while carrying data an attacker can shape. A declared type states a shape; it never
+> validates one. Every crossing is validated at run time, on both the payload and the caller.
+
+> **P-4 — Platform conformance is a behavior contract, not a visual style.**
+> Each operating system's users expect specific behavior — where a window reopens, what a right-click on the
+> frame does, which key combination is reserved, how the application behaves with no window open. Matching an
+> appearance while breaking one of those behaviors reads as a broken application, and no amount of visual
+> polish repairs it.
+
+> **P-5 — A claim is only as strong as the evidence class that owns it.**
+> Source inspection, a passing test, a rendered image, a running development build, an installed packaged
+> build, a verified signature, a rehearsed update, and a representative user's own use each prove a different
+> thing. Merging them into one status is how an unproved property ships.
+
+> **P-6 — Where the platform's authority cannot be read, say so.**
+> An unverifiable convention must not be filled in from a plausible summary, and it must not be softened into
+> a hedge either. A hedge is a positive claim about the world and can be false in the same way the assertion
+> was. Mark the gap, name what would close it, and write the rule so it does not depend on the answer.
+
 ## Rules
+
+Every clause below carries a permanent identifier. `DESK-R01`–`DESK-R31` name Must-Follow policy and
+`DESK-N01`–`DESK-N12` name prohibitions; two identifiers were withdrawn during design and are never
+reallocated, which leaves **thirty** live rules and **eleven** live prohibitions. `DESK-FLOOR-01`–`04` name
+the protected floors and `DESK-FLOOR-01-PROPERTY`–`04-PROPERTY` their property checks. The remaining
+namespaces belong to the siblings that own them: `DESK-RUNG-0`–`8` to the ladder, `DESK-G1`–`DESK-G8` to the
+decision tree, `DESK-PAUSE-1`–`4` and `DESK-CHECK-NN` to the checklist, `DESK-FAMILY-01`–`10` and
+`DESK-SCENARIO-NN` to the scenario source. Renaming a title never changes an identifier; a clause whose
+discrimination changes gets a new identifier rather than reusing the old one, so a finding stays resolvable
+across revisions.
 
 ### Must-Follow
 
+**Frame and scope**
+
+- **`DESK-R01` — MUST bind one complete desktop application outcome and its boundary.** Name the actors, the
+  trigger, the entry modes, visible and system completion, false completion, the paths, states, failures, and
+  recovery routes, the local data effects, the support route, every claimed operating system, the scope, and
+  the non-goals.
+- **`DESK-R02` — MUST stop at the desktop application boundary.** Whole-product discovery, project startup, a
+  second application, a component-library or renderer-framework policy, and unrelated cleanup are out of
+  scope until the user changes the contract.
+
+  Nested per-surface bundles for desktop interface mechanics and desktop experience research are planned for
+  a later session and do not exist today. Nothing in this skill loads or requires them; the design authority
+  for desktop work is complete in this family as shipped.
+- **`DESK-R03` — MUST run the wrong-choice test before committing to the stack.** Check each of the six
+  criteria below, record the inspected result of each, and route a positive result to the user as a stack
+  decision rather than proceeding. A positive result on **any one** criterion is a decision for the user, not
+  a reason to proceed carefully.
+
+  | # | Electron is the wrong answer when … | The mechanism that makes it decisive |
+  |---|---|---|
+  | 1 | distribution size or memory footprint is a stated product requirement | the bundled browser-engine baseline is structural and is not tunable away |
+  | 2 | Linux must be first-class with update parity | there is no built-in Linux auto-updater and no Linux ASAR-integrity support; both are built and maintained by hand |
+  | 3 | the team cannot sustain a continuous engine-upgrade treadmill | only the supported-major window named in the version baseline is supported, on the cadence it names, while browser-engine vulnerabilities reach the platform continuously through the engine roll; staying on one major for years is not available |
+  | 4 | the renderer must load third-party or user-supplied remote content | the platform's own documentation advises against loading, reading, or processing untrusted content in an unsandboxed process, **including the privileged process** — doable, but the expensive path |
+  | 5 | deep native integration or a platform-exclusive interface is the point | native frameworks supply platform behaviors for free; here each one is re-implemented per operating system |
+  | 6 | 32-bit Windows or older-ARM Linux must be supported past the end-of-life date named in the version baseline | the last series shipping those prebuilts, and the date support ends, are both pinned in the version baseline |
+
+  Each criterion points at the alternative that answers it. This table names conditions and mechanisms only;
+  it ranks nothing, quotes no size figure as a fact, and says nothing comparative about frameworks this
+  design did not research.
+
+  | Criterion that fired | The alternative that answers it | Why, from the same mechanism |
+  |---|---|---|
+  | 1 | a **native app** per claimed system; **Tauri** where a web renderer must be kept | the bundled engine baseline is structural. Published size figures for the alternatives are secondary-lead only and are usable as order-of-magnitude context, never as a quoted fact or a ranking |
+  | 2 | a **PWA** or a **plain web app** | the missing piece is a per-OS installer and updater that must be hand-built for Linux. A browser-delivered application has neither to build |
+  | 3 | a **PWA** or a **plain web app** | the treadmill exists because the application ships and therefore owns the engine. When the user's own browser owns it, the upgrade is not the team's work |
+  | 4 | a **plain web app** or a **PWA** | a browser's origin model and its own sandbox are built for exactly this input class |
+  | 5 | a **native app** per claimed system | native frameworks supply the platform behaviors; here each is re-implemented per system |
+  | 6 | a **plain web app**, or a **native app** built for that architecture | the prebuilts end with the stated series. A browser-delivered application inherits whatever the platform's own browser supports |
+- **`DESK-R04` — MUST treat this skill as the sole design owner for desktop work.** This skill owns the design
+  progression and its acceptance gate. The generic interface and experience skills are not co-loaded for
+  desktop work and hold no acceptance authority on this path, so nothing upstream supplies the four floors
+  below and this skill reconstructs all four itself.
+
+**The design ladder**
+
+- **`DESK-R05` — MUST resolve every one of the nine ladder rungs.** Each rung is answered by producing its
+  default artifact, by citing an existing answer that addresses that rung's own question, or by proving the
+  rung inapplicable from inspected evidence. The rung definitions live in
+  [`fidelity-ladder.md`](fidelity-ladder.md); this rule is what makes them binding.
+- **`DESK-R06` — MUST make a rung's resolution recorded and substantiated, because an unresolved rung fails
+  the run.** A rung with no recorded resolution, or a resolution whose inspected evidence does not satisfy
+  that resolution kind's own conditions, is a silent skip and blocks acceptance. The acceptance predicate and
+  its per-kind conditions are [the rung-acceptance predicate](#the-rung-acceptance-predicate) below.
+- **`DESK-R07` — MUST treat fidelity as three independent axes.** Interactivity, visuals, and content and
+  navigation vary separately; an artifact may legitimately be high in one and low in another, so no single
+  low-to-high dial may govern the progression.
+- **`DESK-R08` — MUST apply the desktop instantiation of the ladder's shape-conditioned default at the
+  wireframe and mockup rungs: the primary artifact is a wireflow.** The ladder states the selection rule in
+  product-shape terms; this rule states that a desktop application satisfies the wireflow condition — few
+  windows with heavy in-place state change — so a formal page-oriented site map is not the default
+  deliverable for this shape, because a desktop application has windows and modes rather than pages. The
+  default is a default and not a mandate: a run may choose page wireframes and a site map, and records why
+  its product's shape differs from the stated condition. What it may not do is skip the rung. This rule is a
+  desktop override and lives here, never inside a generic rung definition.
+- **`DESK-R09` — MUST use each rung's own validation method in its own order.** Generative structure work
+  precedes evaluative structure validation, structural validation needs no visual design, and iteration
+  budget goes to several small rounds rather than one large one.
+
+  This rule binds the round cadence, never a participant count for acceptance. `DESK-R13` sets no fixed
+  count: the method, the sample, and the claim boundary are derived from the question, the diversity of the
+  affected people, the uncertainty, the impact, and the risk. The five-user figure the cadence uses is the
+  iteration heuristic and is never the acceptance threshold.
+
+**The four protected floors**
+
+- **`DESK-R10` — MUST hold the accessibility floor as a property across at least the complete named union.**
+  Every required action, state, and meaning of the outcome stays available through every applicable modality;
+  no identity, platform convention, aesthetic choice, or child convention reduces that availability. The
+  enumerated union is a stated minimum, not the extent of the obligation. The floor is non-waivable, and its
+  full statement is `DESK-FLOOR-01`.
+- **`DESK-R11` — MUST hold the safety floor as a property across at least the complete named union.** No
+  clause of the run permits an action whose consequence the actor cannot foresee, refuse, or recover from.
+  The enumerated union is a stated minimum, not the extent of the obligation. The floor is non-waivable, and
+  its full statement is `DESK-FLOOR-02`.
+- **`DESK-R12` — MUST hold participant consent and protection at every activity that involves a person, and
+  fail closed when any required condition is missing.** Informed consent, needed accommodations, and data
+  minimization and protection precede any participant activity at any rung. The fail-closed triggers are
+  missing access to representative users, missing consent, missing accommodations, and missing required
+  evidence; any one of them stops the run and reports missing context rather than proceeding. The enumerated
+  union is a stated minimum. The floor is non-waivable, and its full statement is `DESK-FLOOR-03`.
+- **`DESK-R13` — MUST make direct representative-user evidence the acceptance evidence, across the full
+  observation-dimension set.** Acceptance requires representative people using this run's own artifacts, per
+  claimed operating system, with observations covering every applicable dimension the generic parent names.
+  No fixed participant count applies; every other signal is context only. The enumerated union is a stated
+  minimum. The floor is non-waivable, and its full statement is `DESK-FLOOR-04`.
+
+**Architecture and implementation**
+
+- **`DESK-R14` — MUST keep the four execution contexts and their privileges explicit.** The privileged main
+  process owns native access and lifecycle, the renderer process is web-standards-only, the preload script is
+  the single sanctioned privilege channel, and a `utilityProcess` is used for isolated work; state which
+  context each unit of the outcome runs in.
+- **`DESK-R15` — MUST validate both the payload and the caller at every privileged inter-process crossing.**
+  Every `ipcMain.handle` and `ipcMain.on` handler runtime-validates its payload into a domain type and
+  verifies `event.senderFrame` before any privileged effect; `contextIsolation` does not prevent an
+  unexpected frame from sending.
+- **`DESK-R16` — MUST give the `contextBridge` surface one source-of-truth contract type and cross it with
+  cloneable shapes only.** One type module is imported type-only by both sides; only structured-cloneable
+  values and plain asynchronous functions cross; prototypes, classes, constructors, and `Symbol`-keyed
+  members do not survive the crossing.
+- **`DESK-R17` — MUST configure three separate compilation targets and keep `@types/node` out of the renderer
+  target — and MUST carry the derived marking with this rule.** Three tsconfig projects with their own `lib`,
+  `types`, and module settings, wired by project references over one type-only shared layer; including `node`
+  in the renderer's `types` is a defect because it type-checks green over code that throws at run time.
+  **INFERRED — the three-target split itself is derived, not documented.** No primary source states it; it
+  follows from the verified sentence that the preload context has DOM APIs and a limited subset of Node and
+  Electron APIs, and following-from is not documented-as. That marking travels with this rule wherever the
+  rule is restated, taught, or exercised, including `P7`.
+- **`DESK-R18` — MUST key cross-process resource disposal to lifecycle, not to scope exit.** Every privileged
+  resource held on behalf of a renderer names the window or `webContents` lifecycle event that releases it,
+  with `will-quit` as the last-resort terminal.
+
+**Security**
+
+- **`DESK-R19` — MUST leave the safe defaults intact and write every applicable positive control.** The two
+  kinds of work are distinct: for the default group the correct action is inaction, and for the positive
+  group the control does not exist until it is written — the session permission-request handler, the Content
+  Security Policy, `will-navigate` and `setWindowOpenHandler` limits, `shell.openExternal` handling, IPC
+  sender validation, and the rest of the positive group.
+- **`DESK-R20` — MUST harden with Electron fuses at build time and never treat the ASAR archive as a security
+  boundary.** Set the build-time fuses; **pair `enableEmbeddedAsarIntegrityValidation` with
+  `onlyLoadAppFromAsar`** so unvalidated code cannot load; and never place a secret in the bundle — ASAR
+  conceals source from cursory inspection and nothing more.
+
+**Platform conformance**
+
+- **`DESK-R21` — MUST build the platform-standard menu from Electron's documented `role` values and assert no
+  unverified platform convention.** Specify `role` for any item matching a standard role rather than
+  reimplementing the behavior in a `click` handler. **UNVERIFIED — the vendor's own prescriptive design
+  guidance could not be read**, because its pages are client-rendered and return no body content to a fetch,
+  so this skill states no macOS minimum menu set, no menu ordering, and no Window-menu document-ordering
+  convention as fact.
+- **`DESK-R22` — MUST satisfy the per-operating-system behavior obligations the outcome touches, each with
+  its named mechanism.** Window state restoration (not built in — a dependency decision); the first-paint
+  pair (`show: false` plus `ready-to-show`, **and** `backgroundColor` set anyway); `window-all-closed` and
+  macOS `activate` semantics with no window open; `requestSingleInstanceLock()` plus `second-instance` with
+  `commandLine` parsed by matching and never by position; the deep-link route per operating system
+  (`open-url` on macOS; `second-instance` with the link as the **last** element on Windows and Linux); a
+  three-state theme driven by `nativeTheme.themeSource` (`'system' | 'dark' | 'light'`) with its `updated`
+  event handled live; and one shortcut map per platform using `CommandOrControl`, excluding system-reserved
+  combinations.
+
+**Release**
+
+- **`DESK-R23` — MUST extend the verification order with the packaged, installed, signed, and updated
+  gates.** After the language-level order terminates at build, add: package a per-operating-system installer,
+  install and smoke-test that artifact in a clean environment, verify signature and notarization on the real
+  artifact, and rehearse an update from the previously released version.
+- **`DESK-R24` — MUST treat release as irreversible.** A shipped version cannot be recalled and old versions
+  persist on user machines indefinitely, so rollback means a forward fix plus a stated supported-old-version
+  window, and the release gate proves the installable artifact and the rehearsed update from the previous
+  release.
+
+**Evidence and honesty**
+
+- **`DESK-R25` — MUST keep every evidence class and its claim boundary separate.** Report design acceptance,
+  implementation correctness, packaged-artifact evidence, signature and notarization evidence,
+  update-rehearsal evidence, per-operating-system evidence, release readiness, release authority, and
+  post-release outcome as distinct claims; never merge them into one tested status.
+- **`DESK-R26` — MUST pin every version-sensitive statement, verify each claim at its owner, and mark what is
+  unknown.** Name the platform version any version-dependent statement depends on, so a stale statement is
+  self-identifying rather than silently wrong; keep every version literal in the single owner block in
+  [`runtime-deltas.md`](runtime-deltas.md) and point there rather than restating one; verify a mechanism
+  claim by reading the owner document for it; mark an unverified or unknown fact as such instead of asserting
+  or hedging it; and surface a genuine conflict between two authorities to the reader as a decision rather
+  than resolving it silently.
+
+**Authority, trace, and the record**
+
+- **`DESK-R27` — MUST stop at every named user gate and obtain an explicit decision.** The named gates, in
+  fire order, which is what fixes their identifiers: `DESK-G1` the stack-fit decision when any wrong-choice
+  criterion is positive; `DESK-G2` ladder-rung applicability; **`DESK-G3` the structural-skeleton approval
+  gate — the user explicitly approves the surface-neutral structure, or reopens it, before any visual rung
+  begins**; `DESK-G4` the design acceptance gate; `DESK-G5` the hardening-versus-testability build-matrix
+  decision; `DESK-G6` the build-tool selection; `DESK-G7` the adoption of any new production dependency,
+  including a window-state library or a typed-IPC library; and `DESK-G8` release authority. Silence,
+  continued work, an earlier decision on a different axis, or a stakeholder's enthusiasm is not approval.
+  This rule is the parent owner of the gate authority that [`ideation.md`](ideation.md) runs.
+- **`DESK-R28` — MUST prove the bidirectional trace and prove the verifier itself.** Every load-bearing rule
+  resolves to at least one scenario family and one check; every case and check resolves to a live rule; the
+  four projections of the authoritative case-to-check relation agree exactly; and the verifier is proved at
+  both ends and against every planted fixture before its result is cited. This rule is the parent owner of
+  the trace obligation [`scenarios.md`](scenarios.md), [`checklists.md`](checklists.md), and
+  [`evaluation.md`](evaluation.md) implement.
+- **`DESK-R29` — MUST keep one design record for the run, whose location the active project owns.** The
+  record carries the rung register, the three-axis statement for each artifact at rungs 6–8, the four floor
+  resolutions with their union checks and property checks, the participant consent and accommodation records,
+  the locked application contract, the claim-owner verification matrix, and the run's own unknown and gap
+  register. This skill defines the record's required content; the active project or workflow owns its path,
+  and no universal project-wide file name is prescribed. A heading with no resolved content does not satisfy
+  this rule.
+- **`DESK-R31` — MUST state a planned-but-absent capability as prose only, with no path, link, or load
+  target.** A forward mention says the capability is planned and not present today, names no path or file,
+  carries no markdown link or path-shaped code span, and states that nothing in this skill loads or requires
+  it. Pointing at content an owner does not hold is a dangling pointer that resolves, which is worse than a
+  broken one.
+
 ### Must-Not-Follow
+
+Each entry is the negative face of a named Must-Follow rule, so a finding can cite it and it is reachable
+from both trace directions.
+
+- **`DESK-N01` — NEVER call a window, an inter-process handler, a passing development build, or a packaged
+  artifact a finished outcome.** Fix: return to `DESK-R01` and close the missing layers, paths, and operating
+  systems. *Positive counterpart:* `DESK-R01`.
+- **`DESK-N02` — NEVER skip a ladder rung silently, or answer a rung with an artifact produced after a later
+  rung.** Fix: record the rung's resolution with its substantiating evidence, or prove it inapplicable from
+  inspected evidence. *Positive counterparts:* `DESK-R05`, `DESK-R06`.
+- **`DESK-N03` — NEVER present fidelity as one low-to-high dial.** Fix: state the three axes independently
+  for the artifact in question. *Positive counterpart:* `DESK-R07`.
+- **`DESK-N04` — NEVER treat a mockup, a rendered capture, or a running development build as behavioral,
+  accessibility, or acceptance evidence.** Fix: take each claim to the evidence class that owns it.
+  *Positive counterparts:* `DESK-R13`, `DESK-R25`.
+- **`DESK-N05` — NEVER weaken, narrow, soften, or waive any of the four protected floors, and never accept a
+  waiver token on one.** Fix: resolve the item with a permitted terminal; the token closes neither coverage
+  nor acceptance. *Positive counterparts:* `DESK-R10`–`DESK-R13`.
+- **`DESK-N06` — NEVER trust an inter-process payload or its sender because the declared type says it is
+  safe.** Fix: validate the payload into a domain type and verify the sending frame before the privileged
+  effect. *Positive counterpart:* `DESK-R15`.
+- **`DESK-N07` — NEVER include `@types/node` in the renderer target's configuration.** Fix: remove it; a
+  green type-check over code the sandbox rejects is a correctness and security inversion. *Positive
+  counterpart:* `DESK-R17`.
+- **`DESK-N08` — NEVER treat the ASAR archive, minification, or packaging as a security boundary, and never
+  bundle a secret.** Fix: move the secret out of the artifact and rely on the fuses and the ASAR-integrity
+  pair for load-time integrity. *Positive counterpart:* `DESK-R20`.
+- **`DESK-N09` — NEVER state an unverified platform convention as fact, and never hedge it into a claim about
+  what has not shipped.** Fix: mark the gap, name the retrieval or test that would close it, and write the
+  rule so it does not depend on the answer. *Positive counterparts:* `DESK-R21`, `DESK-R26`.
+- **`DESK-N10` — NEVER resolve the hardening-versus-testability conflict or the build-tool choice on the
+  reader's behalf.** Fix: present both horns with their consequences as an explicit user decision, and state
+  the selection criterion rather than a mandate. *Positive counterpart:* `DESK-R27`.
+- **`DESK-N12` — NEVER name a deferred nested bundle as an existing owner, load target, or link
+  destination.** Fix: state in prose that it is planned and absent, with no path and no link. *Positive
+  counterpart:* `DESK-R31`.
+
+### The rung-acceptance predicate
+
+`DESK-R06`'s predicate. It is stated **positively and substantively** — each condition is about what the
+inspection *found*, not about whether an inspection happened, because a procedural condition ("the pointer
+was inspected") is satisfied by an empty file at a valid path.
+
+> A rung is **accepted** when **both** of exactly two conditions hold: (1) its register row carries one of
+> the three resolution kinds, and (2) that resolution is **substantiated** — what the inspection of the named
+> evidence found satisfies every condition this rung's own question and this resolution kind impose. Nothing
+> else accepts a rung.
+
+**Arity, stated once and only here: exactly two conditions, conjoined, on the acceptance side.** Both are
+necessary, and the truth table below is the four combinations of the two. Conjoining on the *acceptance* side
+narrows what is accepted, which is the safe direction; the escape-hatch defect this guards against was an AND
+on a *failure* condition, where each extra conjunct shrinks the set that fails. Condition (2) is itself the
+conjunction of that kind's own conditions, each individually necessary.
+
+**The coverage-only exclusion, stated as an exclusion.** A named owner, a recorded plan to answer the rung
+later, a scheduled study, a stakeholder's approval, a sign-off, or an artifact at a higher rung closes
+*coverage* of the run's own bookkeeping and **never** acceptance. None of these may appear as a **disjunct**
+anywhere in this predicate, in any check that implements it, or in any evaluation replay of it.
+
+#### The three resolution kinds
+
+One row per rung in the rung register, nine rows.
+
+| Resolution kind | Recorded value |
+|---|---|
+| Answered by producing the artifact | `answered:<pointer to the artifact produced in this run>` |
+| Answered by citing an existing answer | `answered-by-citation:<pointer + scope statement>` |
+| Proved inapplicable | `n-a:<the property proved false + the inspected evidence that proves it>` |
+
+#### Substantive conditions per resolution kind
+
+**`answered:` — answered by producing the artifact in this run.**
+
+- **A1 — the named artifact resolves to substantive content.** The pointer opens, and what it opens is not
+  empty, not a heading-only outline, and not a placeholder. A valid file can still be the wrong content.
+- **A2 — the content answers this rung's own question text**, not the rung's topic.
+- **A3 — the rung's `Done-condition` holds, read off the inspected artifact** rather than off a claim that it
+  holds.
+- **A4 — the rung's own `Closing evidence` exists and was inspected**, and where that evidence involves a
+  person, `DESK-FLOOR-03`'s conditions held for that activity at the time it ran.
+- **A5 — chronology, with sanctioned re-entry distinguished from a back-fill.** The condition rejects an
+  artifact produced after a later rung's artifact **and left unreconciled**. It does not reject a revision
+  reached through the re-entry the ladder itself mandates. Precisely:
+  - **Rejected** — the row's artifact post-dates a later rung's artifact, the row records **no** re-entry,
+    and no downstream rung that depended on the earlier answer carries a re-check. That is the back-fill this
+    condition exists to catch: an answer produced late to make the register look complete.
+  - **Accepted** — the row's artifact post-dates a later rung's artifact **because** a later rung's answer
+    invalidated it and the run re-entered the earliest affected rung, the row records the re-entry and what
+    triggered it, and every downstream rung that depended on the earlier answer carries a re-check against
+    the revision. Re-entry is normal; leaving the downstream rungs unreconciled is not.
+
+  Both ends are load-bearing. The ladder is explicitly re-enterable and `P3` and `P4` mandate returning to
+  the earliest affected rung, so a bare "not produced after a later rung's artifact" would forbid the exact
+  state the procedure requires.
+
+**`answered-by-citation:` — a citation closes a rung only when all five conditions hold.** These five are not
+advice adjacent to the predicate; they **are** its `answered-by-citation` branch.
+
+1. **It addresses this rung's own question.** A citation is checked against the rung's question text, not
+   against the rung's topic. A content inventory does not close the navigation rung; a task analysis does not
+   close the information-architecture rung.
+2. **It resolves to an inspectable artifact whose inspected content is substantive**, per A1's standard. The
+   pointer names a path, a document and section, a prior session record, or another artifact a reader can
+   open. A remembered decision, a conversation, or an assertion that the answer exists somewhere is not a
+   citation.
+3. **It states why it is still valid for this outcome.** The row records what has not changed since the cited
+   answer was produced. A cited answer whose subject has since changed does not close the rung.
+4. **It states what it does not cover.** A citation that answers part of the rung's question closes only that
+   part; the remainder stays open and is answered or proved inapplicable in its own right. This is the clause
+   that stops a partially-covering citation from silently closing a whole rung.
+5. **It does not point forward or at itself.** A citation may not name an artifact produced later in this
+   run, and may not name the rung's own output. This is the chronology condition, and it is unchanged by A5:
+   a re-entered rung is re-*answered*, not closed by a forward-pointing citation.
+
+**`n-a:` — proved inapplicable.**
+
+- **N1 — it names a property, not a reason.** The row names the specific property of *this* outcome that
+  makes the rung's question unanswerable or moot. "Small project," "no budget," "not needed here," and "the
+  team already knows this" are reasons, not properties, and none of them closes a rung.
+- **N2 — the property is proved from inspected evidence about this run's own outcome.** The inspection found
+  the property; a plausible written account of why the rung does not apply is not a proof.
+- **N3 — it is falsifiable.** The row names the observation that would make the rung applicable again.
+- **N4 — it does not rest on a coverage property.** An owner, a plan, a schedule, or a sign-off cannot make a
+  rung inapplicable.
+
+#### Truth table
+
+| Resolution kind recorded | Resolution substantiated | Rung accepted? | Coverage closed? |
+|---|---|---|---|
+| yes | yes | yes | yes |
+| yes | no | **no** | yes — the row exists, so the bookkeeping is closed; acceptance is not |
+| no | yes | **no** — a resolution kind is required, and evidence with no recorded resolution is not a resolution | no |
+| no | no | **no** | no |
+
+#### The disjunct escape-hatch probe
+
+The recorded defect this probe exists to catch is an acceptance predicate that admitted a coverage property
+as a **disjunct**. Probe it directly, and note that the *conjunct* form of this question is vacuous: adding a
+conjunct only shrinks an accepted set, so it passes a defective predicate. Only the disjunct form fails one.
+
+| Step | What is done | Expected result |
+|---|---|---|
+| 1 | Construct the three-term form `accepted ⇔ (kind recorded ∧ substantiated) ∨ owned` and evaluate it on the case *(kind recorded, **not** substantiated, owner named)* | the three-term form returns **accepted** — the escape hatch is real and reachable |
+| 2 | Evaluate the shipped two-condition predicate on the same case | the shipped predicate returns **not accepted** |
+| 3 | Search the shipped predicate text, every check that implements it, and every evaluation replay of it for `owned`, `recorded-open`, `planned`, `scheduled`, or `signed-off` in a disjunctive position | zero occurrences |
+
+The probe **passes** when step 1 reproduces the hatch, step 2 rejects the same case, and step 3 returns zero.
+Any step failing means the predicate has the hatch, and the repair belongs to this predicate, never to the
+check that implements it.
+
+#### The five adversarial counterexamples — four rejected, one accepted
+
+| # | Counterexample | Disposition | Why |
+|---|---|---|---|
+| C1 | **Back-filled chronology** — a rung answered by an artifact produced after a later rung's artifact, with no recorded re-entry and no downstream re-check | **reject** | `answered` A5's reject end, or citation condition 5; the chronology condition is inside the predicate, not adjacent to it |
+| C2 | **Wrong-target citation** — a rung closed by citing a real, inspectable, current artifact that answers a *different* rung's question | **reject** | citation condition 1; the citation branch's conditions are the predicate's conditions, so the question-versus-topic test is a condition of acceptance |
+| C3 | **Uninspected inapplicability** — a rung marked inapplicable with a plausible written reason and no inspected evidence that the property is false | **reject** | `n-a` N1 **and** N2: a reason is not a property, and no inspection found the property |
+| C4 | **Hollow pointer** — all nine rows present, every resolution kind recorded, one row's pointer resolving to an empty or placeholder artifact | **reject** | `answered` A1, and A2 and A3 in turn; the condition is what the inspection *found*, so an inspected empty file fails A1 outright |
+| C5 | **Sanctioned re-entry** — a rung-8 round shows the taxonomy is wrong; the run re-enters rung 2, the row records the re-entry and its trigger, and rungs 3, 4, and 5 each carry a re-check against the revised taxonomy | **accept** | A5's accept end holds. A predicate that rejects this case forbids the state `P3` and `P4` mandate, and is unsound in the opposite direction from C1 |
+
+A predicate that admits any of C1–C4, that rejects C5, or that fails any step of the probe above is unsound,
+and the repair belongs here rather than to a check. Each counterexample is constructed as a disposable
+fixture, run, proved rejected or accepted, and discarded; the recorded proof is the disposition and the
+condition that produced it, never a summary of it.
+
+### The four protected floors
+
+Because this skill is the sole design owner for desktop work, nothing upstream supplies the floors the
+generic interface and experience skills protect. All four are reconstructed here at full strength.
+
+**Reconstruction form.** Each floor is a **property**, never an enumerated list of sufficient constructs,
+because a property is closed against the cases nobody thought of and a construct list is defeated by the
+first case absent from it. Each floor then carries three further parts, applied uniformly so no floor is left
+with its closure at a larger number:
+
+1. **Stated minimum.** Every union is a minimum enumeration, never the extent of the obligation. Lengthening
+   a member list is not a fix for a closed list; it reproduces the closure at a larger number.
+2. **Residual clause.** Any further instance that satisfies the floor's property is a member of that floor by
+   the property, whether or not it appears in the list. Discovering one **adds** a member; it never narrows
+   the floor.
+3. **Property check.** Each floor carries one check whose **claim is the property itself**, evidenced by a
+   sweep of the run's own clause, activity, or claim inventory. Its pass condition is explicitly **not
+   satisfiable** by "every listed member passed" — that is the member check, a different check with a
+   different claim. A run in which every listed member passes and one unlisted instance of the property is
+   unhandled **fails the floor**.
+
+**Deliberate widening 1, marked.** Parts 1–3 apply to **all four** floors, not only to the two whose parent
+states an open property. `DESK-FLOOR-01` and `DESK-FLOOR-04` face a parent that *enumerates*, so their union
+additionally works as a drop-detector: the stated count and members let an auditor prove no parent-named
+dimension was lost. They keep that job unchanged and gain the minimum, the residual, and the property check
+on top of it. Applying the triad uniformly is stricter than the parent, which is permitted.
+
+**Strictness may relax; coverage may not.** No clause may present a floor as weaker, narrower, or waivable
+than the generic parent states it. Widening is permitted, happens **four** times, and each instance is marked
+as such — this one, plus one in `DESK-FLOOR-03`'s reach, one in `DESK-FLOOR-03`'s placement, and one in
+`DESK-FLOOR-04`'s evidence axis. Where the parent states the same union twice at different granularities,
+this skill takes the **wider** reading and records the discrepancy at the point of use.
+
+**Non-waivability, uniformly.** For all four: a waiver token is invalid and closes neither coverage nor
+acceptance. A failed or recorded-open resolution closes coverage only, never acceptance. No child convention,
+platform authority, co-loaded contract, precedence rule, or load order can authorize or widen an exception.
+
+**Acceptance reuses the operational checklist's own terminal enum; this skill defines no floor acceptance
+predicate of its own.**
+
+> A floor is **accepted** when every one of its items resolves **`PASS`**. An item that does not apply
+> resolves **`n/a:<property>`** and is not an applicable item. Nothing else accepts a floor.
+
+Every term above is defined by [`evaluation/checklist/SKILL.md`](../evaluation/checklist/SKILL.md), not here:
+its **CR-3** makes acceptance the single positive condition that every applicable gate and required item
+resolves `PASS`, and states that a `FAIL:<id>`, a `recorded-open`, or a `deferred` is coverage-closed but not
+accepted — an owner or a pointer closes coverage, never acceptance. Its **CR-6** is the evidence floor: a
+`PASS` cites what proves the pass condition true, and an `n/a:<property>` cites the inspected evidence that
+the applicability predicate is false, so an applicable item can never be relabeled `n/a` to dodge the gate.
+Its **CR-4** scopes every soft token to its permitted modes.
+
+#### `DESK-FLOOR-01` — Accessibility
+
+**Property.** Every required action, state, and meaning of the outcome remains available through every
+applicable modality, and no identity choice, platform convention, aesthetic decision, component library, or
+child convention reduces that availability.
+
+**Union check — 16 members, a stated minimum.** Members 1–14 are the generic parent's own named dimensions;
+15–16 are desktop additions.
+
+1. perception · 2. operation · 3. focus or cursor flow · 4. reading or announcement order · 5. input
+alternatives · 6. status · 7. error identification · 8. recovery · 9. timing · 10. motion · 11. contrast or
+non-color cues · 12. language · 13. locale · 14. adaptation · 15. per-operating-system assistive-technology
+behavior, using the verified named screen readers for the claimed systems — **UNVERIFIED: no Linux
+screen-reader guidance exists**, and that gap is recorded rather than implied away · 16. reduced motion
+honored from the renderer's own media query, because no such property exists on the platform theme API.
+
+**Union-count note, recorded deliberately.** The generic parent states this union twice at different
+granularities: its rule text lists 14 items with `language` and `locale` separate, and its checklist item
+lists 13 with `language/locale` combined. This floor takes the **wider** reading — 14 — because a union may
+not narrow. Anyone auditing this floor against the parent will see 13 in one place and 14 in another; that is
+the reason.
+
+**Residual clause.** The sixteen are a minimum. Any further modality, dimension, or mechanism through which a
+required action, state, or meaning of *this* outcome becomes unavailable is a member of this floor by the
+property, whether or not it is listed. Discovering one adds a member and never narrows the floor.
+
+**Property check — `DESK-FLOOR-01-PROPERTY`.** *Claim:* every required action, state, and meaning of this
+outcome is available through every applicable modality. *Evidence:* a sweep of the run's own action, state,
+and meaning inventory against the modality set the outcome's surfaces actually require, with direct
+behavioral results — not a member-by-member roll-up.
+*Criticality:* **gate**. *Applicability:* **unconditional** — this check is never conditional and never
+resolves `n/a`, because the property it claims holds of every desktop outcome; an applicability declaration
+is a required field, and leaving it open would let an author close a non-waivable floor with
+`n/a:<property>`. *Explicitly not satisfied by:* "members 1–16 all passed." *On fail:* block acceptance and
+return to the owning rung or phase.
+
+**Why members 15 and 16 are additions and not restatement.** The renderer is a browser engine, so web
+accessibility applies unchanged. Member 15 exists because assistive-technology behavior is
+per-operating-system. Member 16 exists because the platform theme API exposes high-contrast,
+inverted-scheme, reduced-transparency, and differentiate-without-color signals but has **no** reduced-motion
+property — reduced motion comes from the renderer's media query, and inventing a theme property for it is a
+defect.
+
+#### `DESK-FLOOR-02` — Safety
+
+**Property.** No clause of the run permits an action whose consequence the actor cannot foresee, refuse, or
+recover from.
+
+The generic parent protects safety in **any** applicable item's claim or pass condition — an open property
+over the whole run, with no enumeration anywhere. The nine members below are therefore a minimum enumeration
+of the surfaces already known, never the extent of the obligation.
+
+**Union check — 9 members, a stated minimum.** Each is a desktop surface where an unforeseeable,
+unrefusable, or unrecoverable consequence is reachable:
+
+1. a destructive action on the user's own data, which pairs with an explicit confirmation and a recovery
+route · 2. an accelerator misfire, which pairs with undo, because an accelerator with no undo makes an
+accidental trigger unrecoverable · 3. a local data write that can be interrupted, which is durable or
+detectably incomplete · 4. a schema migration, **including its downgrade path**, because a user who installs
+an older version after a newer one must not lose or corrupt data · 5. an at-rest secret store failure, which
+fails closed rather than silently storing in the clear · 6. opening an external target derived from untrusted
+content · 7. an update install racing live application state, which uses the platform's own
+pre-quit-for-update hook rather than quitting under the application's feet · 8. a shipped release, which is
+irreversible and therefore gated per `DESK-R24` · 9. a second-instance launch whose arguments are neither
+ordered nor complete as expected, which is parsed by matching rather than by position.
+
+**Residual clause.** Any other clause of this run that permits an action whose consequence the actor cannot
+foresee, refuse, or recover from is a member of this floor **by the property**, whether or not it appears
+above. Discovering one adds a member; it never narrows the floor. A run that satisfies members 1–9 and leaves
+such a clause unhandled **fails this floor**. Lengthening this list is not a substitute for the property — a
+longer list is still a closed list.
+
+**Property check — `DESK-FLOOR-02-PROPERTY`.** *Claim:* no clause of this run permits an action whose
+consequence the actor cannot foresee, refuse, or recover from. *Evidence:* a sweep of the run's **own clause
+inventory** — every rule, phase step, channel, native integration, data operation, and release control the
+run actually contains — each dispositioned foreseeable / refusable / recoverable or handled.
+*Criticality:* **gate**. *Applicability:* **unconditional** — this check is never conditional and never resolves `n/a`,
+because the property it claims holds of every desktop outcome; an applicability declaration is a required
+field, and leaving it open would let an author close a non-waivable floor with `n/a:<property>`.
+*Explicitly not satisfied by:* "members 1–9 all passed."
+*On fail:* block acceptance and return to the clause's owning phase.
+
+**Why member 9 is a safety member and not merely a correctness one.** The platform documents that the
+argument list on a second instance is not exactly the same list, that its order might change, and that
+additional arguments might be appended. Positional indexing therefore silently acts on the wrong argument —
+for a deep link or a file-open request, an action on a target the user did not choose.
+
+#### `DESK-FLOOR-03` — Participant consent and protection
+
+**Property.** No activity involving a person begins, and no observation from one is used as evidence, unless
+informed consent, needed accommodations, access to genuinely representative people, and the required evidence
+conditions are in place, with collected data minimized and protected; a missing condition stops the run and
+reports missing context rather than proceeding.
+
+The parent states this as an obligation over **any** activity involving a person, with a fail-closed trigger
+set rather than a member list. The seven members below are a minimum enumeration, never the extent of the
+obligation.
+
+**Union check — 7 members, a stated minimum.**
+
+1. informed consent · 2. needed accommodations · 3. data minimization · 4. data protection and retention ·
+5. observation kept separate from interpretation · 6. stated evidence limits · 7. **fail closed on the
+parent's complete trigger set** — any one of **missing access to representative users, missing informed
+consent, missing needed accommodations, or missing required evidence** yields a missing-context stop; the run
+may record an assumptions register and a test plan but may not accept a design.
+
+**The trigger set is the parent's four, in full.** Dropping either access to representative users or required
+evidence is the difference between a floor that stops a run with no representative access and one that lets
+it proceed on whoever was available.
+
+**Residual clause.** Any other activity of this run that involves a person, or any other observation from a
+person used as evidence, is governed by this floor **by the property**, whether or not the activity type
+appears in the ladder or in the list above. A newly recognized participant activity adds a governed activity;
+it never narrows the floor.
+
+**Property check — `DESK-FLOOR-03-PROPERTY`.** *Claim:* every activity of this run that involves a person,
+and every observation from a person used as evidence, was governed by this floor at the time it ran.
+*Evidence:* a sweep of the run's **own activity inventory** — every rung round, interview, observation, card
+sort, tree test, informal walkthrough, recruitment screening, and post-release contact whose output is cited
+as evidence anywhere — each carrying its consent, accommodation, minimization, protection, and
+representativeness record. *Criticality:* **gate**. *Applicability:* **unconditional** — this check is never
+conditional and never resolves `n/a`, because the property it claims holds of every desktop outcome; an
+applicability declaration is a required field, and leaving it open would let an author close a non-waivable
+floor with `n/a:<property>`. *Explicitly not satisfied by:* "members 1–7 all passed," and explicitly not
+satisfied by governing only the activities the ladder happens to name. *On fail:* stop and report missing
+context; no design is accepted.
+
+**Deliberate widening 2, marked — reach.** The generic parent's participant activity is concentrated at one
+post-approval prototype test. This ladder puts people at **six** rungs — interviews at rung 0, observation at
+rung 1, a card sort and a tree test at rung 2, a tree test at rung 3, a round at rung 6, and a round at rung
+8 — so the floor applies at **every** participant activity, not only the last one. That is a widening of
+reach, not a relaxation.
+
+**Deliberate widening 3, marked — placement.** The parent declares four explicitly non-waivable protected
+classes: accessibility, safety, current direct representative-user prototype testing, and complete
+whole-specification approval before every prototype. Participant consent and protection lives in the parent's
+rules and in the applicability conditions of its direct-evidence check, rather than as a separately numbered
+protected class. This skill reconstructs it as a **first-class non-waivable floor** in its own right, which is
+stricter than the parent's own placement and is why it is not folded into `DESK-FLOOR-04`.
+
+#### `DESK-FLOOR-04` — Direct representative-user evidence is the acceptance evidence
+
+**Property.** Acceptance of the design requires direct evidence from representative people using this run's
+own artifacts, across the full observation-dimension set, per claimed operating system; every other signal is
+context only.
+
+**Union check — 7 members, a stated minimum.**
+
+1. no fixed participant count — the method, sample, and claim boundary are derived from the question, the
+diversity of affected people, the uncertainty, the impact, and the risk · 2. prior research, earlier tests,
+analytics, expert review, heuristic review, standards conformance, and stakeholder approval are context only
+· 3. a captured rendering and a static high-fidelity artifact are context only and never behavioral or
+accessibility evidence · 4. the project owner counts as representative only when evidence shows that person
+genuinely is · 5. claims stay bounded to the evidence, with observation separated from interpretation ·
+6. **per claimed operating system** — evidence obtained on one operating system does not support a claim
+about another · 7. **the complete observation-dimension set — fourteen dimensions**: perception,
+comprehension, operation, completion, alternatives, errors, recovery, feedback, status recognition, trust,
+accessibility, adaptation, workarounds, and unintended harm, each as applicable.
+
+**Member 7 takes the wider of the parent's two statements.** The parent names **13** dimensions in its
+checklist item and **14** in its own procedure step — the checklist item omits `feedback`, shortens `status
+recognition` to `status`, and shortens `unintended harm` to `harm`. Presenting a non-waivable parent floor at
+the narrower count would be a narrowing, so this floor carries **14**. Workflow, affordance, and realistic
+response speed remain what the acceptance rung's *question* asks; the fourteen are the observation coverage
+the acceptance evidence must carry. This is the set the ladder's acceptance rung points at by role, and it is
+enumerated here and nowhere else, because a set enumerated twice drifts.
+
+**Residual clause.** The seven are a minimum. Any further dimension the outcome makes material, and any
+further claimed target axis the run declares, is a member of this floor by the property. Discovering one adds
+a member; it never narrows the floor.
+
+**Property check — `DESK-FLOOR-04-PROPERTY`.** *Claim:* every human-outcome claim this run makes is supported
+by direct representative-user evidence from this run's own artifacts, on the operating system the claim is
+about. *Evidence:* a sweep of the run's **own claim inventory** — every claim about what a person can
+perceive, understand, operate, complete, or recover from — each mapped to the participant record and the
+operating system that supports it, with unsupported claims removed or restated as context.
+*Criticality:* **gate**. *Applicability:* **unconditional** — this check is never conditional and never resolves `n/a`,
+because the property it claims holds of every desktop outcome; an applicability declaration is a required
+field, and leaving it open would let an author close a non-waivable floor with `n/a:<property>`.
+*Explicitly not satisfied by:* "members 1–7 all passed."
+*On fail:* block acceptance and rerun the owning rung or report missing context.
+
+**Deliberate widening 4, marked — evidence axis.** Member 6 is a desktop addition. The generic parent
+requires separate evidence per claimed *surface*; here the operating system is itself an evidence axis, because window
+behavior, menu structure, notification behavior, shortcut mapping, and assistive-technology behavior all
+differ per system. Claiming three systems from evidence on one is the specific failure this member blocks.
+This is the second desktop instantiation held here rather than in a generic rung definition: the ladder's
+acceptance rung states its closing evidence generically, per claimed surface or delivery target the run
+declares, and the fact that a desktop run's claimed targets are operating systems is a desktop override.
+
+#### The parent's fourth protected class, and what carries its function here
+
+The generic parent's fourth non-waivable class is **complete whole-specification approval before every
+prototype**, including both document closure and chronology. It is deliberately **not** reconstructed, and
+that is a direct consequence of this skill being the sole design owner rather than an omission:
+
+- That class is the surface the ownership boundary routes around. Its pass condition requires that repository
+  or artifact history prove no mockup, wireframe, coded demo, command stub, or other prototype predates the
+  whole-specification approval. This skill's ladder *requires* wireflows at rung 6, a high-fidelity artifact
+  at rung 7, and an interactive prototype at rung 8 — all before build. Under the parent's class those
+  artifacts are prohibited before approval; under the behavioral-principle instruction to bring concrete
+  materials generated before the prose they are required. The contradiction is real, surface-neutral, and
+  pre-existing. Not co-loading the parent routes around it; it does not resolve it.
+- **What carries its protective function here.** Three mechanisms, named so the loss is not silent: the rung
+  order itself (`DESK-R05`); the citation chronology condition and its adversarial counterexample C1, which
+  reject an answer produced after a later rung; and the design acceptance gate at `P4`, which requires the
+  complete rung register plus all four floors before implementation begins.
+- **Residual gap, stated — narrowed by `DESK-G3`, and not closed.** Those three mechanisms enforce *ordering
+  within the ladder* and *completeness at the gate*. The structural-approval gate `DESK-G3` fires before any
+  visual rung, so this design does have a pre-prototype approval point. What that point approves is the
+  surface-neutral *structure*, not the whole specification — so the parent's stronger property, that no
+  artifact of any prototype kind may exist before a single whole-specification approval, is still not
+  reproduced. The gap is narrower and it survives. **Route any future proposal to close it back to the
+  ownership decision that created it, because reconstructing the class would reintroduce the contradiction
+  that decision routes around.**
 
 ## Procedure
 
+Ten phases, in order. Each states its input, its action, the evidence it produces, and the branch it takes on
+success, failure, or missing context. Ladder rungs 0–8 belong to `P3` and `P4`; the ladder's Build terminus
+is `P7` and `P8`.
+
+One worked example runs through all ten phases, marked **Clipmark** at each. It is this skill's only
+illustration of the ladder, so it walks the ladder rung by rung rather than summarizing it. Clipmark is a
+screen-capture annotator; the bounded outcome is *capture a region of the screen, annotate it, and save the
+result to a folder the user chooses*. No such application exists in this repository — the example is written
+to be followed, not to be pointed at.
+
+### `P1` — Frame the outcome, the authority, and the stack fit
+
+*Input:* the user trigger, the live application if one exists, project rules, applicable mistakes, and the
+decision authority.
+
+*Action:* write the one-sentence outcome and expand it per `DESK-R01`; enumerate the claimed operating
+systems; run the six-criterion wrong-choice test per `DESK-R03`; state the ownership boundary per `DESK-R04`;
+open the design record per `DESK-R29`.
+
+*Evidence:* the locked outcome and scope contract, the operating-system claim set, the wrong-choice result
+table with an inspected result per criterion, and the authority map naming every `DESK-R27` gate and who
+holds it.
+
+*Next:* a positive wrong-choice criterion routes to the user at `DESK-G1` as a stack decision and may end the
+run; an unresolved scope or authority conflict stays in `P1`; otherwise `P2`.
+
+> **Clipmark — `P1`.** Outcome: capture a screen region, annotate it, save it where the user chooses.
+> Claimed systems: macOS and Windows; Linux is explicitly out of the claim set, which is recorded as a scope
+> statement rather than left implicit. Wrong-choice test, inspected result per criterion: 1 no stated size
+> requirement; 2 negative, because Linux is not claimed; 3 the team accepts the engine cadence; 4 no remote
+> content is loaded; 5 **positive-looking** — screen capture and a global shortcut are native integrations —
+> inspected and resolved negative, because the platform exposes both and no platform-exclusive interface is
+> the point; 6 no legacy architecture is claimed. No criterion fires, so `DESK-G1` is recorded as not
+> triggered rather than skipped. Ownership boundary: this skill owns the design progression; a separate
+> cloud-sync product idea is named as out of scope under `DESK-R02`.
+
+### `P2` — Establish the platform, version, and evidence foundation
+
+*Input:* the locked outcome, the operating-system claim set, and the governing sources the outcome touches.
+
+*Action:* pin the version baseline in [`runtime-deltas.md`](runtime-deltas.md) as the single owner of every
+version literal; inspect the existing application's configuration, privilege boundary, data locations, and
+release setup; reach a named owner document for every load-bearing external claim before it is written as a
+fact; assess each source for authority, currency, and applicability; record every gap as a gap.
+
+*Evidence:* the version-baseline block, the claim-to-owner register with no row left unnamed, and the gap
+register with a named closing condition per gap.
+
+*Next:* a material claim with no named owner document returns to a bounded study of that exact question; a
+missing governing source is recorded as a gap, never filled in; otherwise `P3`.
+
+> **Clipmark — `P2`.** The version baseline is pinned once and every later statement whose truth depends on
+> it names that version in the same sentence. Two gaps are opened rather than closed by inference: the
+> vendor's prescriptive design guidance cannot be retrieved (`DESK-R21`), so no menu-ordering claim is made;
+> and the three-target compilation split is recorded with its `INFERRED` marking from `DESK-R17` rather than
+> as a documented fact.
+
+### `P3` — Walk ladder rungs 0 through 4
+
+*Input:* the locked outcome, the foundation, and the participant conditions from `DESK-R12`.
+
+*Action:* resolve the research, task-analysis, information-architecture, navigation, and user-flow rungs,
+each by its own question and validation method, in the generative-then-evaluative order per `DESK-R09`;
+record each rung's resolution and its substantiating evidence.
+
+*Evidence:* rung register rows 0–4, each with its resolution kind, artifact or citation pointer, and the
+inspected findings that satisfy that kind's conditions; the participant consent and accommodation record for
+every activity involving a person.
+
+*Next:* a missing participant condition — access, consent, accommodations, or required evidence — stops the
+run and reports missing context; a rung whose answer invalidates an earlier rung returns to the earliest
+affected rung; otherwise `P4`.
+
+> **Clipmark — `P3`, rung by rung.**
+>
+> - **Rung 0, research and problem definition.** Question: is this the right problem, for whom, in what
+>   situation? Six contextual interviews with support engineers who annotate screenshots daily. Consent,
+>   accommodations, and data minimization recorded per `DESK-FLOOR-03` *before* the first session, not after.
+>   Resolution: `answered:` the persona set and interview guide in the design record.
+> - **Rung 1, task analysis.** Question: what does the user actually do, in what order, at what cognitive
+>   cost? Observation in the real work context, because a self-report alone does not close this rung. The
+>   observed cost concentrates in re-finding the saved file, not in the capture. Resolution: `answered:` the
+>   hierarchical task-analysis diagram.
+> - **Rung 2, information architecture.** Question: what exists, how is it organized, and what is it called?
+>   A generative card sort produced the users' own grouping and vocabulary, then an evaluative tree test
+>   graded it — in that order, because running only a card sort leaves the structure ungraded and running
+>   only a tree test grades a structure the users never shaped. Resolution: `answered:` the inventory and
+>   taxonomy.
+> - **Rung 3, navigation design.** Question: can users reach it? Tree testing reported both success rate and
+>   directness; the first round passed success and failed directness on "recent captures," which was found
+>   by wandering. Resolution: `answered:` the revised command structure.
+> - **Rung 4, user flows.** Question: what is the path through a task, end to end? Each task from rung 1 has
+>   a complete path including decision points, waits, failures, and recovery routes. The walkthrough named
+>   one task with no flow — "capture cancelled mid-selection" — which was then designed rather than
+>   discovered later. Resolution: `answered:` the flow set.
+>
+> No rung is closed by a citation here, so citation conditions 1–5 do not apply to this run's rows 0–4. Had
+> an existing taxonomy been cited at rung 2, it would have had to address rung 2's own question, resolve to
+> an inspectable and substantive artifact, state why it is still valid, state what it does not cover, and
+> not point forward.
+
+### `P4` — Walk ladder rungs 5 through 8, through two user gates
+
+*Input:* rung register rows 0–4 and the three-axis fidelity decision per rung.
+
+*Action:* resolve the structural-skeleton rung first and **stop at `DESK-G3`** — present the surface-neutral
+structure, its state and path map, its surface mapping, and its open questions, and obtain the user's
+explicit approval or reopening before any visual rung begins; then resolve the wireflow, mockup, and
+interactive-prototype rungs, stating each visual artifact's position on all three fidelity axes; run the
+round cadence per `DESK-R09`; hold the four floors per `DESK-R10`–`DESK-R13`, including each floor's property
+check and residual clause; present the complete design record at `DESK-G4`, the design acceptance gate, per
+`DESK-R27`.
+
+*Evidence:* rung register row 5 carrying the `DESK-G3` decision; rung register rows 6–8 with the
+per-visual-artifact three-axis statement; the direct representative-user records per claimed operating system
+covering the full observation-dimension set; the four floor resolutions with their union checks and property
+checks; and the explicit user decisions at both gates.
+
+*Next:* a reopening at `DESK-G3` returns to the structural rung and no visual rung starts; starting a visual
+rung with `DESK-G3` unresolved is itself a `DESK-R27` failure; an unresolved rung or an unmet floor blocks
+`DESK-G4` and returns to the owning rung; acceptance is unavailable while `DESK-R12` or `DESK-R13` is unmet;
+otherwise `P5`.
+
+> **Clipmark — `P4`, rung by rung.**
+>
+> - **Rung 5, structural skeleton, surface-neutral.** Question: does one whole structure hold the outcome
+>   together before any surface, layout, or visual decision is made? The specification names the hierarchy,
+>   the stages, the command structure, action priority, information flow, system status, state
+>   relationships, decision points, failure zones, recovery routes, handoffs, adaptation, and completion
+>   evidence — without assuming a graphical layout — plus the mapping of each claimed surface onto that one
+>   structure. Being non-visual, this rung carries no position on the visuals axis and owes no fidelity
+>   statement. **The run stops at `DESK-G3`.** The user approved with one reopening condition, and the
+>   register row records the *approval decision*, not merely the artifact. Resolution: `answered:`.
+> - **Rung 6, low-fidelity structure.** Question: does the structure hold when a person tries to use it?
+>   Clipmark is few windows with heavy in-place state change, so per `DESK-R08` the default primary artifact
+>   is a **wireflow**, not page wireframes plus a site map. Three axes stated independently: interactivity
+>   low (a facilitator simulates the response), visuals low, content medium (real capture filenames, no
+>   final chrome). A round with representative users found a dead end after a cancelled capture. That round
+>   is **iteration evidence, not acceptance evidence**. Resolution: `answered:`.
+> - **Rung 7, high-fidelity presentation.** Question: do hierarchy and affordance read correctly with real
+>   content and every state present? The rung-6 artifact carried to high visual and content fidelity, with
+>   every state named in the design record present. Axes: interactivity low, visuals high, content high.
+>   This artifact is a static simulation, so per `DESK-N04` it is not offered as behavioral or accessibility
+>   evidence. Resolution: `answered:` plus heuristic review and component-level checks.
+> - **Rung 8, interactive prototype.** Question: can the task be completed unaided, at a realistic response
+>   speed? Axes: interactivity high, visuals high, content high. A round with representative users on this
+>   run's own post-approval artifact, **run separately on macOS and on Windows** because `DESK-FLOOR-04`
+>   member 6 makes the operating system an evidence axis, covering every applicable dimension of the
+>   fourteen, with observations separated from interpretation. Resolution: `answered:`.
+>
+> All four floors are then resolved on both their member check and their property check. The safety property
+> check caught what the member list did not: an unlisted tray-menu action cleared the capture cache with no
+> confirmation and no recovery route — the `X5` shape, found by sweeping the run's own clause inventory
+> rather than by re-reading members 1–9. `DESK-G4` is presented only after that is fixed.
+
+### `P5` — Lock the desktop application contract
+
+*Input:* the accepted design record and the platform foundation.
+
+*Action:* fix the process split and the privileged surface; enumerate every inter-process channel with its
+payload type, its validation, and its sender rule; fix the window and lifecycle contract, the local data
+contract including the migration and downgrade path, the native integration set, the security posture as the
+two distinct kinds of work, and the per-operating-system deltas.
+
+*Evidence:* the approved application contract with a channel inventory, a lifecycle and window-state map, a
+data and migration map, and a per-operating-system delta matrix.
+
+*Next:* a contradiction with the existing application or with the accepted design returns to its owner before
+implementation; otherwise `P6`.
+
+> **Clipmark — `P5`.** Three channels are enumerated: `capture:region`, `annotate:commit`, and `file:save`.
+> Each names its payload type, its runtime validation into a domain type, and its `event.senderFrame` check,
+> because a declared type states a shape and never validates one (`P-3`, `DESK-R15`). `file:save` writes
+> outside the application's own data directory, so it is main-only and the renderer never receives a path.
+> Window state restoration is not built in, so restoring the last capture-window bounds is a dependency
+> decision routed to `DESK-G7` rather than assumed.
+
+### `P6` — Plan proof, the build matrix, and release controls
+
+*Input:* the locked application contract.
+
+*Action:* select the applicable scenario cases and checks; set the quality targets from a project owner or
+current evidence; decide the hardening-versus-testability build matrix as an explicit user decision at
+`DESK-G5`; apply the build-tool selection criterion at `DESK-G6`; plan the signing, notarization, update,
+channel, staged-rollout, and stop-condition controls.
+
+*Evidence:* the case and check register, the quality-target table with a source per target, the recorded
+build-matrix decision with both horns stated, and the release-control plan.
+
+*Next:* an undecided build matrix or an unsourced target stays in `P6`; any irreversible external step is
+marked as needing its own authority; otherwise `P7`.
+
+> **Clipmark — `P6`.** The hardening-versus-testability conflict is presented at `DESK-G5` with both horns
+> named and neither resolved on the reader's behalf (`DESK-N10`): either the release build is not automatable
+> by the inspect-fuse path, or the automated build is not the hardened one. The user chose a hardened release
+> build plus a separate automatable build, and the decision is recorded with its consequence — the automated
+> suite does not exercise the artifact that ships, which is carried forward as a stated verification limit
+> rather than absorbed.
+
+### `P7` — Build the thin three-target vertical code skeleton
+
+*Input:* the locked contract and the accepted design record.
+
+*Action:* materialize the three compilation projects — and carry `DESK-R17`'s `INFERRED` marking into this
+phase's own record, because the three-target split is derived from the verified preload-context sentence and
+is not documented by any primary source, so the phase states it as derived wherever it states it — plus the
+shared contract type, the bridge surface, the channel signatures with stub handlers, the window creation
+path, and the instrumentation points; connect the smallest real path from a window through the bridge to a
+privileged effect and a truthful completion.
+
+*Evidence:* a green type-check per target, an import and build check, and one end-to-end trace with the
+effect observed at its authoritative source.
+
+*Next:* a structural defect returns to `P5`; a privilege or type-boundary defect returns to `P5` and not to a
+body; otherwise `P8`.
+
+> **Clipmark — `P7`.** The vertical path is: window → bridge → `file:save` → a real file on disk, observed by
+> reading the disk rather than by trusting the handler's return value. The renderer target excludes
+> `@types/node` (`DESK-N07`); adding it would have type-checked green over a `fs` call the sandbox rejects at
+> run time.
+
+### `P8` — Grow behavior one verified slice at a time
+
+*Input:* the verified code skeleton and the case register.
+
+*Action:* add the ordinary path, then the alternative-valid classes, the exact boundaries, the failures and
+recovery, the adversarial behavior, the per-operating-system deltas, and the compatibility and migration
+behavior; move code, contract, data, configuration, documentation, tests, and instrumentation together in
+each slice and verify that slice before the next.
+
+*Evidence:* an ordered slice log, each entry carrying its own fresh focused verification and its updated
+affected-surface trace.
+
+*Next:* a slice that breaks the contract returns to `P5`; an in-scope path left unimplemented blocks `P9`;
+otherwise `P9`.
+
+> **Clipmark — `P8`.** The cancelled-capture recovery path found at rung 6 is implemented as its own slice
+> rather than deferred, because rung 4's flow set named it and `DESK-N01` forbids calling the outcome
+> finished with a designed path unimplemented.
+
+### `P9` — Verify the whole change through the extended order
+
+*Input:* the grown implementation and the quality targets.
+
+*Action:* run the language-level order to build, then the four added gates per `DESK-R23` — package per
+operating system, install and smoke-test in a clean environment, verify signature and notarization on the
+real artifact, rehearse an update from the previously released version — and take each remaining claim to the
+evidence class that owns it per `DESK-R25`.
+
+*Evidence:* the claim-owner verification matrix naming the exact command or action, environment, version and
+configuration, fresh result, artifact pointer, and limitation for each claim; a per-operating-system row for
+each claimed system.
+
+*Next:* a failed gate returns to its owning phase; an unrunnable gate is recorded as a limitation and blocks
+the claim it would have proved, never widened into a weaker signal; otherwise `P10`.
+
+> **Clipmark — `P9`.** The update rehearsal is run from the previously released version, not from a fresh
+> install, because a fresh install proves a different claim. The macOS notarization check runs against the
+> real packaged artifact rather than against the development build, and the two results stay separate rows
+> in the matrix per `DESK-R25`.
+
+### `P10` — Evaluate independently and hand off release readiness
+
+*Input:* the complete evidence bundle.
+
+*Action:* route independent review through [`evaluation.md`](evaluation.md); prove the trace and the verifier
+per `DESK-R28`; keep the claims separate per `DESK-R25`; publish the contract, the design acceptance state,
+the verification limits, the per-operating-system support matrix, the signing and update configuration, the
+channel and rollout plan, the stop conditions, the supported-old-version window per `DESK-R24`, and the
+release-authority state at `DESK-G8`.
+
+*Evidence:* the evaluation outputs, the filled checklist copy, the claim ledger, and a cold-reader handoff
+that lets another operator release or forward-fix with no hidden session context.
+
+*Next:* any applicable gate not passing blocks release readiness; a finding returns to its earliest owning
+rule and reruns the affected gate and any dependent whole-outcome proof.
+
+> **Clipmark — `P10`.** Release authority is asked for at `DESK-G8` with the supported-old-version window
+> stated, because the release is irreversible: the shipped build cannot be recalled and old versions persist
+> on user machines indefinitely, so rollback means a forward fix (`DESK-R24`). The handoff records that the
+> automated suite exercised the non-hardened build — the `P6` limit — rather than letting it disappear into
+> a green summary.
+
 ## References
+
+Every borrowed fact has one owner. This section names the owner; it never restates what the owner holds.
+
+**Inside this family — the thirteen siblings.** Each owns its own mechanics; this file owns all policy.
+
+- [`fidelity-ladder.md`](fidelity-ladder.md) owns the nine generic rungs, the three fidelity axes, the
+  shape-conditioned selection rule, the card-sort-then-tree-test order, the round cadence, and the
+  deliverable vocabulary. Every desktop instantiation of one of its defaults lives here instead.
+- [`ideation.md`](ideation.md) owns the per-run decision tree and the content of the `DESK-G` gates that
+  `DESK-R27` makes binding.
+- [`process-model.md`](process-model.md) owns the four execution contexts, the IPC pattern table, sender and
+  payload validation, the `contextBridge` crossable-type boundary, `MessagePort` lifetime, and the
+  three-target split.
+- [`security.md`](security.md) owns the two kinds of security work, CSP delivery, the fuse set and the paired
+  ASAR fuses, what ASAR is not, and the supply-chain scanner gap.
+- [`windows-lifecycle.md`](windows-lifecycle.md) owns creation and first paint, state restoration, per-OS
+  quit and activation, single-instance and argument handling, deep links, and the entry-mode inventory.
+- [`native-integration.md`](native-integration.md) owns menus, shortcuts, notifications, dialogs, clipboard,
+  drag-and-drop, custom window chrome, theming, and file associations.
+- [`filesystem-data.md`](filesystem-data.md) owns user-data locations, durable writes, schema migration
+  including the downgrade path, at-rest secret handling, and the never-write list.
+- [`packaging-distribution.md`](packaging-distribution.md) owns per-OS targets, the build-tool selection
+  criterion, ASAR packaging, native-module rebuild, and resource-path resolution.
+- [`signing-updates.md`](signing-updates.md) owns signing, notarization, update feeds, channels, staged
+  rollout, and the supported-old-version window.
+- [`runtime-deltas.md`](runtime-deltas.md) is the **sole owner of every version literal in this family** —
+  the platform, engine, and runtime versions, the supported-major set, the cadence, the end-of-life date, the
+  per-feature availability versions, and the archive-integrity per-system minimums. Every other file states
+  the property and points here.
+- [`scenarios.md`](scenarios.md) owns the ten families, the case set, and the authoritative case-to-check
+  relation.
+- [`checklists.md`](checklists.md) owns the `DESK-CHECK-NN` items, the pause points, the two projection
+  tables, and the two truth tables — the gate-resolution table and the protected-waiver acceptance table that
+  exercises the non-waivability rule stated above. This file states the rule; that file tables it.
+- [`evaluation.md`](evaluation.md) owns the evaluator entrypoint, the rule-to-coverage crosswalk, and the
+  desktop lenses.
+
+**Outside this family.**
+
+- [`coding`](../coding/SKILL.md) owns language-agnostic construction quality, including the trust-boundary
+  property this skill instantiates at the privilege boundary.
+- [`typescript`](../typescript/SKILL.md) owns general language idiom, with
+  [`typing.md`](../typescript/typing.md) for declaration-versus-verification and declaration-file authoring,
+  [`modules-tooling.md`](../typescript/modules-tooling.md) for the flag set and the import-extension fork,
+  and [`async-resources.md`](../typescript/async-resources.md) for disposal.
+- [`evaluation`](../evaluation/SKILL.md) owns the evaluator perspectives, causal findings, and verdict
+  derivation. [`evaluation/scenario`](../evaluation/scenario/SKILL.md) owns scenario-set construction, and
+  [`evaluation/checklist`](../evaluation/checklist/SKILL.md) owns the operational checklist mechanics — its
+  terminal enum, its acceptance rule, and its evidence floor, which this skill's floors reuse rather than
+  restate.
+- [`vision`](../vision/SKILL.md) and [`vision/ui.md`](../vision/ui.md) own capture limits, and are loaded
+  only when captured renderings are evaluated.
+- [`discussion`](../discussion/SKILL.md) owns question and decision quality at every `DESK-R27` gate.
+- [`skill-writing`](../skill-writing/SKILL.md) owns the authoring standard this file is written against.
+
+### Gap register
+
+Thirteen items this skill carries as gaps rather than as facts. Each keeps its marking word at its point of
+use, and each row below names what would close it, so a later session can close one without re-deriving the
+search. This register is the skill's own; it is not the per-run unknown and gap register that `DESK-R29`
+requires inside the design record.
+
+The `#` column keeps the design's own item numbers so a later session can cross-reference them, which is why
+the sequence has gaps: items 6 and 8 are secondary-lead-only leads whose treatment is already fixed and which
+need no closing condition, and items 16 and 17 are reader-owned decisions rather than facts to close.
+
+| # | Marking | Gap | Closing condition | Kind |
+|---|---|---|---|---|
+| 1 | **INFERRED** | the three-configuration split — main gets `@types/node` and no DOM, the renderer gets the DOM and must exclude `node`, preload is a third and narrowest target | a primary source states the three-target split, or the derived label stands permanently | retrieval |
+| 2 | **UNKNOWN** | whether the main process can run a TypeScript entry directly through the runtime's own type stripping | one test: run a TypeScript main entry under the pinned runtime version and record the result | test |
+| 3 | **UNVERIFIED** | the Windows update signature-verification mechanism — the updater documentation provides no details | the vendor documents the mechanism | retrieval |
+| 4 | **UNVERIFIED** | whether a custom V8 startup-snapshot workflow for application code is documented | the vendor documents such a workflow for application code | retrieval |
+| 5 | **UNVERIFIED** | bundle-size and memory-leak lore, secondary-lead only | an authoritative source replaces the lore; otherwise it stays unstated permanently | retrieval, low value |
+| 7 | **NOT RESEARCHED** | Flutter desktop and .NET/MAUI — no comparative claim about either appears anywhere in this skill | a bounded study of the two, if a future run needs the comparison | research |
+| 9 | **UNVERIFIED** | the vendor's whole prescriptive design-guidance surface; its pages are client-rendered and return no body content to a fetch | a JavaScript-rendering retrieval path for that guidance | tooling |
+| 10 | **UNVERIFIED** | macOS hardened runtime and entitlements — the code-signing document does not cover them | that document, or another authoritative source, covers hardened runtime and entitlements | retrieval |
+| 11 | **UNVERIFIED** | Linux screen-reader guidance — none exists, which is why `DESK-FLOOR-01` member 15 states the gap instead of implying parity across three systems | platform guidance for the third operating system's screen reader appears | retrieval |
+| 12 | **NOT FOUND** | a maintained free replacement for the standard static scanner, which its own maintainers state is no longer maintained | a maintained free scanner appears, or the gap is accepted permanently | retrieval |
+| 13 | **UNVERIFIED** | information density and dense professional layouts, and offline-first desktop behavior — no authoritative source found, and the platform's own calm-design principle pulls against density | an authoritative source on either is found | research |
+| 14 | **UNVERIFIED** | a rationale for the removal of the former remote module — the process-model document gives none | a maintainer statement on the removal rationale is found | retrieval |
+| 15 | **UNVERIFIED** | end-to-end typed IPC guidance — no official guidance exists and no community library is canonical, so every such library is a new production dependency and therefore a `DESK-G7` decision, never a default | official guidance appears, or one library becomes canonical | retrieval |
+
+Two further items are **not** gaps and are not listed above, because they are decisions the reader owns
+rather than facts to close: which build tool is the default, which `DESK-R27` routes to `DESK-G6` as a stated
+criterion; and the build-time-hardening-versus-test-automation conflict, which `DESK-R27` routes to `DESK-G5`
+as an explicit build-matrix decision with both horns named.
+
+**This skill has not been exercised on a real project.** No desktop application exists in this repository, so
+the worked example in `P1`–`P10` and a bounded cold-load proof are its only exercise before first real use.
+Do not mistake its completeness for field validation.

--- a/.gobbi/projects/gobbi/skills/desktop/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/desktop/SKILL.md
@@ -119,7 +119,8 @@ across revisions.
 - **`DESK-R06` — MUST make a rung's resolution recorded and substantiated, because an unresolved rung fails
   the run.** A rung with no recorded resolution, or a resolution whose inspected evidence does not satisfy
   that resolution kind's own conditions, is a silent skip and blocks acceptance. The acceptance predicate and
-  its per-kind conditions are [the rung-acceptance predicate](#the-rung-acceptance-predicate) below.
+  its per-kind conditions are [the rung-closing decision rule](#the-rung-closing-decision-rule), stated in Procedure at
+  the point it governs.
 - **`DESK-R07` — MUST treat fidelity as three independent axes.** Interactivity, visuals, and content and
   navigation vary separately; an artifact may legitimately be high in one and low in another, so no single
   low-to-high dial may govern the progression.
@@ -311,134 +312,6 @@ from both trace directions.
 - **`DESK-N12` — NEVER name a deferred nested bundle as an existing owner, load target, or link
   destination.** Fix: state in prose that it is planned and absent, with no path and no link. *Positive
   counterpart:* `DESK-R31`.
-
-### The rung-acceptance predicate
-
-`DESK-R06`'s predicate. It is stated **positively and substantively** — each condition is about what the
-inspection *found*, not about whether an inspection happened, because a procedural condition ("the pointer
-was inspected") is satisfied by an empty file at a valid path.
-
-> A rung is **accepted** when **both** of exactly two conditions hold: (1) its register row carries one of
-> the three resolution kinds, and (2) that resolution is **substantiated** — what the inspection of the named
-> evidence found satisfies every condition this rung's own question and this resolution kind impose. Nothing
-> else accepts a rung.
-
-**Arity, stated once and only here: exactly two conditions, conjoined, on the acceptance side.** Both are
-necessary, and the truth table below is the four combinations of the two. Conjoining on the *acceptance* side
-narrows what is accepted, which is the safe direction; the escape-hatch defect this guards against was an AND
-on a *failure* condition, where each extra conjunct shrinks the set that fails. Condition (2) is itself the
-conjunction of that kind's own conditions, each individually necessary.
-
-**The coverage-only exclusion, stated as an exclusion.** A named owner, a recorded plan to answer the rung
-later, a scheduled study, a stakeholder's approval, a sign-off, or an artifact at a higher rung closes
-*coverage* of the run's own bookkeeping and **never** acceptance. None of these may appear as a **disjunct**
-anywhere in this predicate, in any check that implements it, or in any evaluation replay of it.
-
-#### The three resolution kinds
-
-One row per rung in the rung register, nine rows.
-
-| Resolution kind | Recorded value |
-|---|---|
-| Answered by producing the artifact | `answered:<pointer to the artifact produced in this run>` |
-| Answered by citing an existing answer | `answered-by-citation:<pointer + scope statement>` |
-| Proved inapplicable | `n-a:<the property proved false + the inspected evidence that proves it>` |
-
-#### Substantive conditions per resolution kind
-
-**`answered:` — answered by producing the artifact in this run.**
-
-- **A1 — the named artifact resolves to substantive content.** The pointer opens, and what it opens is not
-  empty, not a heading-only outline, and not a placeholder. A valid file can still be the wrong content.
-- **A2 — the content answers this rung's own question text**, not the rung's topic.
-- **A3 — the rung's `Done-condition` holds, read off the inspected artifact** rather than off a claim that it
-  holds.
-- **A4 — the rung's own `Closing evidence` exists and was inspected**, and where that evidence involves a
-  person, `DESK-FLOOR-03`'s conditions held for that activity at the time it ran.
-- **A5 — chronology, with sanctioned re-entry distinguished from a back-fill.** The condition rejects an
-  artifact produced after a later rung's artifact **and left unreconciled**. It does not reject a revision
-  reached through the re-entry the ladder itself mandates. Precisely:
-  - **Rejected** — the row's artifact post-dates a later rung's artifact, the row records **no** re-entry,
-    and no downstream rung that depended on the earlier answer carries a re-check. That is the back-fill this
-    condition exists to catch: an answer produced late to make the register look complete.
-  - **Accepted** — the row's artifact post-dates a later rung's artifact **because** a later rung's answer
-    invalidated it and the run re-entered the earliest affected rung, the row records the re-entry and what
-    triggered it, and every downstream rung that depended on the earlier answer carries a re-check against
-    the revision. Re-entry is normal; leaving the downstream rungs unreconciled is not.
-
-  Both ends are load-bearing. The ladder is explicitly re-enterable and `P3` and `P4` mandate returning to
-  the earliest affected rung, so a bare "not produced after a later rung's artifact" would forbid the exact
-  state the procedure requires.
-
-**`answered-by-citation:` — a citation closes a rung only when all five conditions hold.** These five are not
-advice adjacent to the predicate; they **are** its `answered-by-citation` branch.
-
-1. **It addresses this rung's own question.** A citation is checked against the rung's question text, not
-   against the rung's topic. A content inventory does not close the navigation rung; a task analysis does not
-   close the information-architecture rung.
-2. **It resolves to an inspectable artifact whose inspected content is substantive**, per A1's standard. The
-   pointer names a path, a document and section, a prior session record, or another artifact a reader can
-   open. A remembered decision, a conversation, or an assertion that the answer exists somewhere is not a
-   citation.
-3. **It states why it is still valid for this outcome.** The row records what has not changed since the cited
-   answer was produced. A cited answer whose subject has since changed does not close the rung.
-4. **It states what it does not cover.** A citation that answers part of the rung's question closes only that
-   part; the remainder stays open and is answered or proved inapplicable in its own right. This is the clause
-   that stops a partially-covering citation from silently closing a whole rung.
-5. **It does not point forward or at itself.** A citation may not name an artifact produced later in this
-   run, and may not name the rung's own output. This is the chronology condition, and it is unchanged by A5:
-   a re-entered rung is re-*answered*, not closed by a forward-pointing citation.
-
-**`n-a:` — proved inapplicable.**
-
-- **N1 — it names a property, not a reason.** The row names the specific property of *this* outcome that
-  makes the rung's question unanswerable or moot. "Small project," "no budget," "not needed here," and "the
-  team already knows this" are reasons, not properties, and none of them closes a rung.
-- **N2 — the property is proved from inspected evidence about this run's own outcome.** The inspection found
-  the property; a plausible written account of why the rung does not apply is not a proof.
-- **N3 — it is falsifiable.** The row names the observation that would make the rung applicable again.
-- **N4 — it does not rest on a coverage property.** An owner, a plan, a schedule, or a sign-off cannot make a
-  rung inapplicable.
-
-#### Truth table
-
-| Resolution kind recorded | Resolution substantiated | Rung accepted? | Coverage closed? |
-|---|---|---|---|
-| yes | yes | yes | yes |
-| yes | no | **no** | yes — the row exists, so the bookkeeping is closed; acceptance is not |
-| no | yes | **no** — a resolution kind is required, and evidence with no recorded resolution is not a resolution | no |
-| no | no | **no** | no |
-
-#### The disjunct escape-hatch probe
-
-The recorded defect this probe exists to catch is an acceptance predicate that admitted a coverage property
-as a **disjunct**. Probe it directly, and note that the *conjunct* form of this question is vacuous: adding a
-conjunct only shrinks an accepted set, so it passes a defective predicate. Only the disjunct form fails one.
-
-| Step | What is done | Expected result |
-|---|---|---|
-| 1 | Construct the three-term form `accepted ⇔ (kind recorded ∧ substantiated) ∨ owned` and evaluate it on the case *(kind recorded, **not** substantiated, owner named)* | the three-term form returns **accepted** — the escape hatch is real and reachable |
-| 2 | Evaluate the shipped two-condition predicate on the same case | the shipped predicate returns **not accepted** |
-| 3 | Search the shipped predicate text, every check that implements it, and every evaluation replay of it for `owned`, `recorded-open`, `planned`, `scheduled`, or `signed-off` in a disjunctive position | zero occurrences |
-
-The probe **passes** when step 1 reproduces the hatch, step 2 rejects the same case, and step 3 returns zero.
-Any step failing means the predicate has the hatch, and the repair belongs to this predicate, never to the
-check that implements it.
-
-#### The five adversarial counterexamples — four rejected, one accepted
-
-| # | Counterexample | Disposition | Why |
-|---|---|---|---|
-| C1 | **Back-filled chronology** — a rung answered by an artifact produced after a later rung's artifact, with no recorded re-entry and no downstream re-check | **reject** | `answered` A5's reject end, or citation condition 5; the chronology condition is inside the predicate, not adjacent to it |
-| C2 | **Wrong-target citation** — a rung closed by citing a real, inspectable, current artifact that answers a *different* rung's question | **reject** | citation condition 1; the citation branch's conditions are the predicate's conditions, so the question-versus-topic test is a condition of acceptance |
-| C3 | **Uninspected inapplicability** — a rung marked inapplicable with a plausible written reason and no inspected evidence that the property is false | **reject** | `n-a` N1 **and** N2: a reason is not a property, and no inspection found the property |
-| C4 | **Hollow pointer** — all nine rows present, every resolution kind recorded, one row's pointer resolving to an empty or placeholder artifact | **reject** | `answered` A1, and A2 and A3 in turn; the condition is what the inspection *found*, so an inspected empty file fails A1 outright |
-| C5 | **Sanctioned re-entry** — a rung-8 round shows the taxonomy is wrong; the run re-enters rung 2, the row records the re-entry and its trigger, and rungs 3, 4, and 5 each carry a re-check against the revised taxonomy | **accept** | A5's accept end holds. A predicate that rejects this case forbids the state `P3` and `P4` mandate, and is unsound in the opposite direction from C1 |
-
-A predicate that admits any of C1–C4, that rejects C5, or that fails any step of the probe above is unsound,
-and the repair belongs here rather than to a check. Each counterexample is constructed as a disposable
-fixture, run, proved rejected or accepted, and discarded; the recorded proof is the disposition and the
-condition that produced it, never a summary of it.
 
 ### The four protected floors
 
@@ -765,6 +638,136 @@ missing governing source is recorded as a gap, never filled in; otherwise `P3`.
 > vendor's prescriptive design guidance cannot be retrieved (`DESK-R21`), so no menu-ordering claim is made;
 > and the three-target compilation split is recorded with its `INFERRED` marking from `DESK-R17` rather than
 > as a documented fact.
+
+### The rung-closing decision rule
+
+`DESK-R05` and `DESK-R06` make the nine rungs binding; this is the decision rule that closes one, and it
+governs every rung resolution recorded in `P3` and `P4` below. It is stated **positively and
+substantively** — each condition is about what the inspection *found*, not about whether an inspection
+happened, because a procedural condition ("the pointer was inspected") is satisfied by an empty file at a
+valid path.
+
+> A rung is **accepted** when **both** of exactly two conditions hold: (1) its register row carries one of
+> the three resolution kinds, and (2) that resolution is **substantiated** — what the inspection of the named
+> evidence found satisfies every condition this rung's own question and this resolution kind impose. Nothing
+> else accepts a rung.
+
+**Arity, stated once and only here: exactly two conditions, conjoined, on the acceptance side.** Both are
+necessary, and the truth table below is the four combinations of the two. Conjoining on the *acceptance* side
+narrows what is accepted, which is the safe direction; the escape-hatch defect this guards against was an AND
+on a *failure* condition, where each extra conjunct shrinks the set that fails. Condition (2) is itself the
+conjunction of that kind's own conditions, each individually necessary.
+
+**The coverage-only exclusion, stated as an exclusion.** A named owner, a recorded plan to answer the rung
+later, a scheduled study, a stakeholder's approval, a sign-off, or an artifact at a higher rung closes
+*coverage* of the run's own bookkeeping and **never** acceptance. None of these may appear as a **disjunct**
+anywhere in this predicate, in any check that implements it, or in any evaluation replay of it.
+
+#### The three resolution kinds
+
+One row per rung in the rung register, nine rows.
+
+| Resolution kind | Recorded value |
+|---|---|
+| Answered by producing the artifact | `answered:<pointer to the artifact produced in this run>` |
+| Answered by citing an existing answer | `answered-by-citation:<pointer + scope statement>` |
+| Proved inapplicable | `n-a:<the property proved false + the inspected evidence that proves it>` |
+
+#### Substantive conditions per resolution kind
+
+**`answered:` — answered by producing the artifact in this run.**
+
+- **A1 — the named artifact resolves to substantive content.** The pointer opens, and what it opens is not
+  empty, not a heading-only outline, and not a placeholder. A valid file can still be the wrong content.
+- **A2 — the content answers this rung's own question text**, not the rung's topic.
+- **A3 — the rung's `Done-condition` holds, read off the inspected artifact** rather than off a claim that it
+  holds.
+- **A4 — the rung's own `Closing evidence` exists and was inspected**, and where that evidence involves a
+  person, `DESK-FLOOR-03`'s conditions held for that activity at the time it ran.
+- **A5 — chronology, with sanctioned re-entry distinguished from a back-fill.** The condition rejects an
+  artifact produced after a later rung's artifact **and left unreconciled**. It does not reject a revision
+  reached through the re-entry the ladder itself mandates. Precisely:
+  - **Rejected** — the row's artifact post-dates a later rung's artifact, the row records **no** re-entry,
+    and no downstream rung that depended on the earlier answer carries a re-check. That is the back-fill this
+    condition exists to catch: an answer produced late to make the register look complete.
+  - **Accepted** — the row's artifact post-dates a later rung's artifact **because** a later rung's answer
+    invalidated it and the run re-entered the earliest affected rung, the row records the re-entry and what
+    triggered it, and every downstream rung that depended on the earlier answer carries a re-check against
+    the revision. Re-entry is normal; leaving the downstream rungs unreconciled is not.
+
+  Both ends are load-bearing. The ladder is explicitly re-enterable and `P3` and `P4` mandate returning to
+  the earliest affected rung, so a bare "not produced after a later rung's artifact" would forbid the exact
+  state the procedure requires.
+
+**`answered-by-citation:` — a citation closes a rung only when all five conditions hold.** These five are not
+advice adjacent to the predicate; they **are** its `answered-by-citation` branch.
+
+1. **It addresses this rung's own question.** A citation is checked against the rung's question text, not
+   against the rung's topic. A content inventory does not close the navigation rung; a task analysis does not
+   close the information-architecture rung.
+2. **It resolves to an inspectable artifact whose inspected content is substantive**, per A1's standard. The
+   pointer names a path, a document and section, a prior session record, or another artifact a reader can
+   open. A remembered decision, a conversation, or an assertion that the answer exists somewhere is not a
+   citation.
+3. **It states why it is still valid for this outcome.** The row records what has not changed since the cited
+   answer was produced. A cited answer whose subject has since changed does not close the rung.
+4. **It states what it does not cover.** A citation that answers part of the rung's question closes only that
+   part; the remainder stays open and is answered or proved inapplicable in its own right. This is the clause
+   that stops a partially-covering citation from silently closing a whole rung.
+5. **It does not point forward or at itself.** A citation may not name an artifact produced later in this
+   run, and may not name the rung's own output. This is the chronology condition, and it is unchanged by A5:
+   a re-entered rung is re-*answered*, not closed by a forward-pointing citation.
+
+**`n-a:` — proved inapplicable.**
+
+- **N1 — it names a property, not a reason.** The row names the specific property of *this* outcome that
+  makes the rung's question unanswerable or moot. "Small project," "no budget," "not needed here," and "the
+  team already knows this" are reasons, not properties, and none of them closes a rung.
+- **N2 — the property is proved from inspected evidence about this run's own outcome.** The inspection found
+  the property; a plausible written account of why the rung does not apply is not a proof.
+- **N3 — it is falsifiable.** The row names the observation that would make the rung applicable again.
+- **N4 — it does not rest on a coverage property.** An owner, a plan, a schedule, or a sign-off cannot make a
+  rung inapplicable.
+
+#### Truth table
+
+| Resolution kind recorded | Resolution substantiated | Rung accepted? | Coverage closed? |
+|---|---|---|---|
+| yes | yes | yes | yes |
+| yes | no | **no** | yes — the row exists, so the bookkeeping is closed; acceptance is not |
+| no | yes | **no** — a resolution kind is required, and evidence with no recorded resolution is not a resolution | no |
+| no | no | **no** | no |
+
+#### The disjunct escape-hatch probe
+
+The recorded defect this probe exists to catch is an acceptance predicate that admitted a coverage property
+as a **disjunct**. Probe it directly, and note that the *conjunct* form of this question is vacuous: adding a
+conjunct only shrinks an accepted set, so it passes a defective predicate. Only the disjunct form fails one.
+
+| Step | What is done | Expected result |
+|---|---|---|
+| 1 | Construct the three-term form `accepted ⇔ (kind recorded ∧ substantiated) ∨ owned` and evaluate it on the case *(kind recorded, **not** substantiated, owner named)* | the three-term form returns **accepted** — the escape hatch is real and reachable |
+| 2 | Evaluate the shipped two-condition predicate on the same case | the shipped predicate returns **not accepted** |
+| 3 | Search the shipped predicate text, every check that implements it, and every evaluation replay of it for `owned`, `recorded-open`, `planned`, `scheduled`, or `signed-off` in a disjunctive position | zero occurrences |
+
+The probe **passes** when step 1 reproduces the hatch, step 2 rejects the same case, and step 3 returns zero.
+Any step failing means the predicate has the hatch, and the repair belongs to this predicate, never to the
+check that implements it.
+
+#### The five adversarial counterexamples — four rejected, one accepted
+
+| # | Counterexample | Disposition | Why |
+|---|---|---|---|
+| C1 | **Back-filled chronology** — a rung answered by an artifact produced after a later rung's artifact, with no recorded re-entry and no downstream re-check | **reject** | `answered` A5's reject end, or citation condition 5; the chronology condition is inside the predicate, not adjacent to it |
+| C2 | **Wrong-target citation** — a rung closed by citing a real, inspectable, current artifact that answers a *different* rung's question | **reject** | citation condition 1; the citation branch's conditions are the predicate's conditions, so the question-versus-topic test is a condition of acceptance |
+| C3 | **Uninspected inapplicability** — a rung marked inapplicable with a plausible written reason and no inspected evidence that the property is false | **reject** | `n-a` N1 **and** N2: a reason is not a property, and no inspection found the property |
+| C4 | **Hollow pointer** — all nine rows present, every resolution kind recorded, one row's pointer resolving to an empty or placeholder artifact | **reject** | `answered` A1, and A2 and A3 in turn; the condition is what the inspection *found*, so an inspected empty file fails A1 outright |
+| C5 | **Sanctioned re-entry** — a rung-8 round shows the taxonomy is wrong; the run re-enters rung 2, the row records the re-entry and its trigger, and rungs 3, 4, and 5 each carry a re-check against the revised taxonomy | **accept** | A5's accept end holds. A predicate that rejects this case forbids the state `P3` and `P4` mandate, and is unsound in the opposite direction from C1 |
+
+A predicate that admits any of C1–C4, that rejects C5, or that fails any step of the probe above is unsound,
+and the repair belongs here rather than to a check. Each counterexample is constructed as a disposable
+fixture, run, proved rejected or accepted, and discarded; the recorded proof is the disposition and the
+condition that produced it, never a summary of it.
 
 ### `P3` — Walk ladder rungs 0 through 4
 

--- a/.gobbi/projects/gobbi/skills/desktop/checklists.md
+++ b/.gobbi/projects/gobbi/skills/desktop/checklists.md
@@ -3,16 +3,755 @@
 Be the unchecked operational gate source with the protected-waiver truth table. Policy lives in
 [`SKILL.md`](SKILL.md); cases live in [`scenarios.md`](scenarios.md). This source adds no policy.
 
+| Field | Value |
+|---|---|
+| **Mode** | operational |
+| **Owner** | `SKILL.md`, which owns every clause an item enforces |
+| **Consumers** | the run working a filled copy; [`evaluation.md`](evaluation.md) selecting applicable items |
+| **Source state** | **unchecked** — every box below is unticked, and it stays that way |
+| **Run state** | each run works a **fresh filled copy** naming this source's version and the run's identity |
+| **Use-style** | declared per pause point below, per run |
+| **Items** | 36, across four pause points |
+| **Provenance** | each item's `Source` names its parent clause; each item's `Seeds` names the cases that reserved it |
+
+**The source is never worked and never ticked.** A run copies it, fills the copy, and records the copy's
+resolutions there. A pre-ticked source, or a run that mutates the source, corrupts every later run.
+
+**No item in this source is advisory.** Every item derives from a mandatory source — a rule, a prohibition, a
+floor, or a scenario obligation — and an obligation-derived item stays gate or required so it remains
+acceptance-bearing. An advisory row here would be a mandatory obligation quietly dropped out of acceptance.
+
 ## Pause points
+
+| Pause point | Work stops | Use-style | Items | Continue only when |
+|---|---|---|---|---|
+| `DESK-PAUSE-1` — stack and outcome lock | before rung 0 begins | `read-do` | `01`–`05` | the outcome, boundary, stack-fit result, ownership statement, and gate-authority map are accepted |
+| `DESK-PAUSE-2` — design acceptance | before `P5` locks the application contract | `do-confirm` | `06`–`17` | the structural-approval decision is confirmed with no visual rung preceding it, the rung register is complete and substantiated, and all four floors are accepted on **both** their member check and their property check |
+| `DESK-PAUSE-3` — implementation completion | before `P9` treats the grown slices as complete | `do-confirm` | `18`–`26` | the privilege boundary, security posture, platform obligations, local data contract, and in-scope paths are accepted |
+| `DESK-PAUSE-4` — release-readiness handoff | before `P10` publishes readiness or any external release is requested | `do-confirm` | `27`–`36` | every applicable release gate per claimed operating system is accepted, the design record is complete, and the trace and verifier proofs have both run |
+
+**The reserved ranges were extended, and this is the single place that records it.** The design reserved
+thirty-four slots; this source authors **thirty-six**. The extension follows the design's own rule — a range
+grows at its own pause point's tail and every later range shifts:
+
+| Pause point | Reserved by the design | Authored here | Why |
+|---|---|---|---|
+| `DESK-PAUSE-1` | `01`–`05` | `01`–`05` | unchanged |
+| `DESK-PAUSE-2` | `06`–`15` | `06`–`17` | the four non-waivable floors each need a **member** check and a **property** check — eight acceptance-bearing items — plus the structural-approval gate, the rung register, the ladder method, and the protected-waiver discipline |
+| `DESK-PAUSE-3` | `16`–`24` | `18`–`26` | shifted by two; the item count is unchanged |
+| `DESK-PAUSE-4` | `25`–`34` | `27`–`36` | shifted by two; the item count is unchanged |
+
+`DESK-CHECK-06` keeps its pinned position at the head of `DESK-PAUSE-2` regardless of the shift, because the
+design pins that one identifier and this source may not move it.
+
+**Item counts per pause point, and the two that exceed the generic guidance.** The generic guidance is
+roughly five to nine gate-or-required items per operational pause point. `DESK-PAUSE-1` carries 5 and
+`DESK-PAUSE-3` carries 9, both inside it. `DESK-PAUSE-4` carries 10 and `DESK-PAUSE-2` carries 12, both
+outside it. The deviation is recorded rather than resolved by trimming, for a structural reason: the pause
+points are fixed by the design and may not be split here, and eight of `DESK-PAUSE-2`'s twelve items are the
+four non-waivable floors' mandatory member-and-property pairs. Dropping one would remove an
+acceptance-bearing item that a floor requires.
 
 ## Terminal value set
 
+Five terminals. This source uses the owning skill's enum rather than defining one of its own.
+
+| Terminal | Meaning | Closes coverage? | Counts toward acceptance? |
+|---|---|---|---|
+| `PASS` | the pass condition is verified true against named, inspected evidence | Yes | **Yes** |
+| `FAIL:<finding-id>` | verified false; the finding is cited | Yes | No |
+| `n/a:<property>` | the applicability predicate is **inspected false**; the property is named | Yes | Not applicable — the item is out of scope for this run |
+| `recorded-open:<owner + resolution method>` | still open, with a named owner and how it resolves | Yes | **No** |
+| `waived/exception-authorized:<authority + rationale>` | a gate bypassed by a named authority whose mandate covers that item's consequence and stop action | Yes | Only under the bounded exception below, and never as a `PASS` |
+
+**Two gates, kept apart.** *Coverage closure* means every applicable item reached a terminal. *Acceptance*
+means every applicable gate and required item resolved `PASS`. A `FAIL`, a `recorded-open`, or an owner
+attached to an unmet item closes coverage and **never** acceptance. That separation is the owning skill's
+rule, and this source states no predicate of its own for it.
+
+**`n/a` needs inspected evidence, not a label.** An `n/a:<property>` cites the inspection that found the
+applicability predicate false. An applicable item can never be relabelled `n/a` to dodge its gate.
+
+**Waiver scope.** The waiver token exists only in operational mode, only on a gate, and only on an item this
+source explicitly designates waiver-eligible. Exactly one item is so designated — **`DESK-CHECK-28`** — and
+the designation is stated in that item's own record.
+
 ## Gate-resolution truth table
+
+The rung-closing rule `SKILL.md` owns has exactly two conditions on its acceptance side. This table is their
+four combinations, replayed without restating the predicate.
+
+| Resolution kind recorded | Resolution substantiated | Rung accepted? | Coverage closed? |
+|---|---|---|---|
+| yes | yes | **yes** | yes |
+| yes | no | **no** | yes — the row exists, so the bookkeeping is closed; acceptance is not |
+| no | yes | **no** — a resolution kind is required, and evidence with no recorded resolution is not a resolution | no |
+| no | no | **no** | no |
+
+**The disjunct exclusion, and why its search is read rather than counted.** No coverage property — an owner,
+a plan, a schedule, a sign-off, or an artifact at a higher rung — may appear as a **disjunct** in that
+predicate, in any item that implements it, or in any evaluation replay of it.
+
+A token count cannot implement that search. Run over this file, it returns hits the exclusion itself
+requires to exist: the words naming the excluded properties appear in the sentence excluding them, in the
+terminal definitions above, and in `DESK-CHECK-07`'s own pass condition. **What is forbidden is a coverage
+property occupying a disjunctive position in the acceptance predicate**, and only a reader can tell that
+position from a mention. An implementation that counted tokens would fail this source for stating the very
+rule it is checking — the shape of a gate that forbids the state its own step requires.
 
 ## Protected-waiver acceptance truth table
 
+**Which items are protected, and the test that selects them.** An item is protected when its own **claim or
+pass condition bears on the accessibility floor's or the safety floor's property**, whether or not the item
+is one of those floors' own checks. That is the parent discipline's item-scope test: non-waivability attaches
+to any applicable item whose claim or pass condition bears on the protected property, not only to the items
+named after a floor.
+
+Applying that test to this source yields **fourteen** protected items:
+
+| Item | Why the test selects it |
+|---|---|
+| `DESK-CHECK-09`, `DESK-CHECK-10` | the accessibility floor's own member and property checks |
+| `DESK-CHECK-11`, `DESK-CHECK-12` | the safety floor's own member and property checks |
+| `DESK-CHECK-13`, `DESK-CHECK-14` | the participant floor's own member and property checks; the floor is non-waivable and fails closed |
+| `DESK-CHECK-15`, `DESK-CHECK-16` | the direct-evidence floor's own member and property checks; that floor is the acceptance evidence |
+| `DESK-CHECK-17` | its claim is that no waiver was accepted on a protected item — waiving it would be circular |
+| `DESK-CHECK-20` | its pass condition bears on the update install ending the process mid-write, a named safety member |
+| `DESK-CHECK-23` | its pass condition bears on positional argument handling, a named safety member |
+| `DESK-CHECK-24` | its pass condition bears on the interrupted write and the migration downgrade path, two named safety members |
+| `DESK-CHECK-30` | its pass condition bears on an update install racing live state, a named safety member |
+| `DESK-CHECK-31` | its pass condition bears on release irreversibility, a named safety member |
+
+**Why this set is wider than the eight floor checks.** Five items — `20`, `23`, `24`, `30`, and `31` — are
+not floor checks and are protected anyway, because each one's pass condition carries a condition the safety
+floor names as a member. Protecting only the items titled after a floor would leave a waiver available on the
+migration downgrade path and on the update-install race, which are exactly the consequences the floor exists
+to make unwaivable.
+
+**Items whose subject is security rather than safety are not selected by this test.**
+`DESK-CHECK-19`, `DESK-CHECK-21`, and `DESK-CHECK-22` bear on trust and harm, which the root treats as a
+concern distinct from the safety floor's foreseeable-refusable-recoverable property. They remain gates; they
+are simply not waiver-immune by this test.
+
+**The table.** Six rows. Each adversarial row holds every other applicable item at `PASS`, so the row
+isolates one attempted resolution. Coverage closure and acceptance are evaluated separately in every row.
+
+| Row | Protected class or control | Attempted resolution | Coverage closed? | Accepted? |
+|---|---|---|---|---|
+| 1 | the accessibility floor, in any applicable item | waiver token | **No** — invalid token | **No** |
+| 2 | the safety floor, in any applicable item | waiver token | **No** — invalid token | **No** |
+| 3 | the participant consent and protection floor | waiver token | **No** — invalid token | **No** |
+| 4 | the direct representative-user evidence floor | waiver token | **No** — invalid token | **No** |
+| 5 | the coverage/acceptance separation control | one applicable item is failed or `recorded-open` | **Yes** | **No** |
+| 6 | the bounded-waiver control | every protected item passes; `DESK-CHECK-28`, a **non-protected** gate, carries one valid authorized waiver whose named authority covers that item's consequence and stop action | **Yes** | **Yes**, only under the bounded exception |
+
+**Rows 1–4 reject the token outright, and note what that means.** The token closes *neither* gate. It is not
+that the item is covered but unaccepted — an invalid token is not a resolution at all, so the item remains
+unresolved and coverage stays open.
+
+**Row 6 is what makes rows 1–4 meaningful.** Without a demonstrated legitimate waiver path the protection is
+untested: the token would be uniformly invalid and the rows would prove nothing about protection
+specifically. This source designates exactly one non-protected waiver-eligible gate, so **row 6 is reachable
+rather than structurally unreachable**, and the designation is recorded in `DESK-CHECK-28`'s own item.
+
 ## Items by pause point
+
+**Legend.** `[GATE]` is a killer: its miss causes the named consequence, and its on-fail route is the stop
+action. `[REQ]` is required: acceptance-bearing, with a stop action of opening a blocking finding.
+`[PROTECTED]` marks an item the test above selects — no waiver token is valid on it. Every item carries one
+atomic binary claim, an explicit pass condition, a named evidence method, an on-fail route, its `Source`
+clauses, its `Seeds` cases, and the obligation conditions its pass condition must own.
+
+### `DESK-PAUSE-1` — stack and outcome lock · `read-do`
+
+- [ ] **`DESK-CHECK-01`** `[GATE]` · *Applicability:* unconditional — the run's outcome record binds one
+  outcome with its actors, entry modes, claimed operating systems, visible and system completion evidence,
+  and non-goals.
+  *Pass:* all six elements are present and mutually consistent, and the claimed-system set in the outcome
+  sentence equals the set the entry modes and non-goals assume.
+  *Evidence:* direct read of the design record's outcome section.
+  *On fail:* halt before rung 0; return to the framing phase.
+  *Consequence:* a run that never bounded its outcome cannot tell completion from partial work.
+  *Source:* `DESK-R01`, `DESK-R02`, `DESK-N01` · *Seeds:* `DESK-SCENARIO-01`, `DESK-SCENARIO-02`
+  *Obligation conditions owned:* actors · entry modes · claimed operating systems · visible completion ·
+  system completion · non-goals · the unchanged-behavior list for a run inside an existing application · the
+  installed-version reversibility constraint.
+
+- [ ] **`DESK-CHECK-02`** `[GATE]` · *Applicability:* unconditional — the six-criterion wrong-choice test ran
+  with an inspected result recorded per criterion.
+  *Pass:* six rows exist, each carrying an inspected result against this outcome's own stated requirements,
+  and every positive row carries the user's recorded stack decision.
+  *Evidence:* direct read of the six-row result table, plus the gate record for any positive row.
+  *On fail:* halt; run the test, or route the positive criterion to the user.
+  *Consequence:* committing to a stack whose own documented limits contradict a stated product requirement.
+  *Source:* `DESK-R03` · *Seeds:* `DESK-SCENARIO-05`, `DESK-SCENARIO-26`
+  *Obligation conditions owned:* an inspected result per criterion rather than a summary verdict · a stated
+  size or footprint requirement read as a positive first criterion · a positive result routed as a user
+  decision rather than absorbed.
+
+- [ ] **`DESK-CHECK-03`** `[REQ]` · *Applicability:* unconditional — the design-ownership boundary is stated.
+  *Pass:* the record states that this skill is the sole design owner and holds the acceptance gate, and names
+  any project convention that conflicts with that.
+  *Evidence:* direct read of the ownership statement.
+  *On fail:* open a blocking finding; the run cannot rely on a second design authority that does not exist.
+  *Source:* `DESK-R04` · *Seeds:* `DESK-SCENARIO-01`
+  *Obligation conditions owned:* sole design ownership · the acceptance gate's location.
+
+- [ ] **`DESK-CHECK-04`** `[GATE]` · *Applicability:* unconditional — every named user gate has an identified
+  holder, and no gate the run has reached is unfired.
+  *Pass:* the authority map names a holder for each of the eight gates, and every gate reached so far carries
+  an explicit recorded decision from that holder.
+  *Evidence:* direct read of the authority map and of each reached gate's record.
+  *On fail:* halt at the unfired gate and obtain the decision.
+  *Consequence:* work proceeding on an authority nobody granted.
+  *Source:* `DESK-R27`, `DESK-N10` · *Seeds:* `DESK-SCENARIO-04`
+  *Obligation conditions owned:* an explicit decision per gate · silence, continued work, an adjacent
+  decision, and enthusiasm each rejected as approval.
+
+- [ ] **`DESK-CHECK-05`** `[REQ]` · *Applicability:* unconditional — every version-dependent statement names
+  the version it depends on, and every load-bearing external claim reaches a named owner document.
+  *Pass:* no version-dependent statement stands without its version named in the same statement; no
+  load-bearing claim is written as fact with an unnamed owner document; and each unknown carries its marking
+  rather than an assertion or a hedge.
+  *Evidence:* direct read of the claim-to-owner register against the run's own statements.
+  *On fail:* open a blocking finding; mark the unknown.
+  *Source:* `DESK-R26` · *Seeds:* `DESK-SCENARIO-23`, `DESK-SCENARIO-25`
+  *Obligation conditions owned:* the version named in the same statement · a named owner document per
+  load-bearing claim · an unknown marked rather than asserted or hedged.
+
+### `DESK-PAUSE-2` — design acceptance · `do-confirm`
+
+- [ ] **`DESK-CHECK-06`** `[GATE]` · *Applicability:* unconditional — the structural-approval decision is
+  recorded, and no visual rung began before it.
+  *Pass:* the rung register's structural row records an explicit **approval decision** rather than an
+  artifact pointer, and the earliest visual artifact's creation timestamp is later than that decision's.
+  *Evidence:* direct read of the register row, plus a timestamp comparison against the earliest visual
+  artifact.
+  *On fail:* halt; return to the structural rung, and no visual rung proceeds.
+  *Consequence:* the person first sees the structure after the visual artifacts exist, inverting what a
+  structure-before-visuals ladder is for.
+  *Source:* `DESK-R27` — its structural-approval leg · *Seeds:* `DESK-SCENARIO-09`
+  *Obligation conditions owned:* an explicit approval-or-reopen decision · the decision recorded rather than
+  the artifact · no visual rung preceding it.
+
+- [ ] **`DESK-CHECK-07`** `[GATE]` · *Applicability:* unconditional — all nine rung rows carry a resolution
+  kind substantiated against that kind's own conditions.
+  *Pass:* nine rows, each with one of the three resolution kinds, and each with inspected evidence satisfying
+  **that kind's** conditions — a produced artifact resolving to substantive content answering the rung's own
+  question; a citation meeting all five citation conditions including its stated remainder; or an
+  inapplicability naming a property with its inspected evidence and its falsifying observation. **No coverage
+  property closes a row**, and none occupies a disjunctive position in the predicate as applied.
+  *Evidence:* direct read of each row, opening every pointer and reading what it contains rather than
+  confirming that it resolves.
+  *On fail:* halt; return to the owning rung.
+  *Consequence:* a register that looks complete while a rung was never answered.
+  *Source:* `DESK-R05`, `DESK-R06`, `DESK-N02` · *Seeds:* `DESK-SCENARIO-07`, `DESK-SCENARIO-48`,
+  `DESK-SCENARIO-49`
+  *Obligation conditions owned:* one of three kinds per rung · substantiation against that kind's own
+  conditions · the citation branch's five conditions including the remainder resolved in its own right · a
+  pointer resolving to substantive content rather than merely to a valid path · no coverage property closing
+  acceptance.
+
+- [ ] **`DESK-CHECK-08`** `[REQ]` · *Applicability:* unconditional — each rung used its own validation method
+  in its own order, and each visual artifact states three independent fidelity positions.
+  *Pass:* the generative method precedes the evaluative one at each rung that has both; the structural rung
+  carries no visual design; iteration ran as several small rounds rather than one large one; each visual
+  artifact records interactivity, visuals, and content-and-navigation separately; and the wireflow default
+  applies or the record states why this product's shape differs.
+  *Evidence:* direct read of each rung's recorded method and order, and of each visual artifact's axis record.
+  *On fail:* open a blocking finding; return to the owning rung.
+  *Source:* `DESK-R07`, `DESK-R08`, `DESK-R09`, `DESK-N03` · *Seeds:* `DESK-SCENARIO-54`
+  *Obligation conditions owned:* generative before evaluative · the structural rung needing no visual design ·
+  several small rounds · three independent axis positions per visual artifact · the wireflow default or a
+  recorded reason for differing.
+
+- [ ] **`DESK-CHECK-09`** `[GATE, PROTECTED]` · *Applicability:* unconditional — every required action, state,
+  and meaning of the outcome is available through every applicable modality.
+  *Pass:* the run's action, state, and meaning inventory is swept against the modality set its surfaces
+  actually require, with a direct behavioral result recorded per pairing, per claimed operating system.
+  *Evidence:* direct behavioral results per system — not a member-by-member roll-up, and not a captured
+  rendering.
+  *On fail:* halt; acceptance is blocked and the run returns to the owning rung.
+  *Consequence:* a person cannot reach a required action at all.
+  *Source:* `DESK-R10` · *Seeds:* `DESK-SCENARIO-37`, `DESK-SCENARIO-38`, `DESK-SCENARIO-39`,
+  `DESK-SCENARIO-40`
+  *Obligation conditions owned:* availability across every applicable modality · each input alternative
+  operable with focus flow and focus visibility preserved · reduced motion honored from the renderer's own
+  media query · the third system's assistive-technology gap stated rather than implied away.
+
+- [ ] **`DESK-CHECK-10`** `[GATE, PROTECTED]` · *Applicability:* **unconditional** — this check is never
+  conditional and never resolves `n/a`, because the property it claims holds of every desktop outcome.
+  *Claim:* every required action, state, and meaning of this outcome is available through every applicable
+  modality — the property itself.
+  *Pass:* an inventory sweep with direct behavioral results. **Explicitly not satisfied by "members 1–16 all
+  passed."**
+  *Evidence:* the recorded sweep of the run's own action, state, and meaning inventory.
+  *On fail:* halt; block acceptance and return to the owning rung or phase.
+  *Consequence:* a modality loss that no member names ships unnoticed.
+  *Source:* the accessibility floor's property check · *Seeds:* `DESK-SCENARIO-39`, `DESK-SCENARIO-41`
+  *Obligation conditions owned:* the property held over the run's own inventory · a member roll-up explicitly
+  rejected as evidence.
+
+- [ ] **`DESK-CHECK-11`** `[GATE, PROTECTED]` · *Applicability:* unconditional — no clause of the run permits
+  an action whose consequence the actor cannot foresee, refuse, or recover from, across the named members.
+  *Pass:* each named safety member is dispositioned with its inspected evidence, including the
+  argument-matching rule, the durable-or-detectably-incomplete write, the migration downgrade path, and the
+  fail-closed at-rest store.
+  *Evidence:* direct read plus a targeted test per member.
+  *On fail:* halt; block acceptance and return to the clause's owning phase.
+  *Consequence:* an ordinary action destroys work the person cannot recover.
+  *Source:* `DESK-R11` · *Seeds:* `DESK-SCENARIO-16`
+  *Obligation conditions owned:* the argument list parsed by matching and never by position · the positional
+  read treated as a safety defect rather than a correctness preference.
+
+- [ ] **`DESK-CHECK-12`** `[GATE, PROTECTED]` · *Applicability:* **unconditional** — never conditional and
+  never `n/a`, because the property holds of every desktop outcome.
+  *Claim:* no clause of this run permits an action whose consequence the actor cannot foresee, refuse, or
+  recover from — the property itself.
+  *Pass:* a sweep of the run's **own clause inventory** — every rule, phase step, channel, native
+  integration, data operation, and release control it actually contains — each dispositioned foreseeable,
+  refusable, recoverable, or handled. **Explicitly not satisfied by "members 1–9 all passed."**
+  *Evidence:* the recorded clause-inventory sweep.
+  *On fail:* halt; block acceptance and return to the clause's owning phase.
+  *Consequence:* an unlisted clause reaches an unrecoverable consequence while every listed member passes.
+  *Source:* the safety floor's property check · *Seeds:* `DESK-SCENARIO-35`
+  *Obligation conditions owned:* the property held over the run's own clause inventory · a member roll-up
+  explicitly rejected as evidence.
+
+- [ ] **`DESK-CHECK-13`** `[GATE, PROTECTED]` · *Applicability:* unconditional — every participant activity
+  was governed before it ran, and the fail-closed trigger set is honored.
+  *Pass:* informed consent, needed accommodations, minimization, and a protection and retention record exist
+  **before** each activity; observation is recorded separately from interpretation; and any one of missing
+  representative access, missing consent, missing accommodations, or missing required evidence produced a
+  missing-context stop rather than a continuation.
+  *Evidence:* direct read of each activity record against that activity's own timestamps.
+  *On fail:* **stop and report missing context**; no design is accepted.
+  *Consequence:* a person participated without consent, or a design was accepted on whoever was available.
+  *Source:* `DESK-R12` · *Seeds:* `DESK-SCENARIO-06`, `DESK-SCENARIO-10`
+  *Obligation conditions owned:* consent preceding the activity it covers · accommodations · minimization ·
+  protection and retention · observation separate from interpretation · the four fail-closed triggers in full.
+
+- [ ] **`DESK-CHECK-14`** `[GATE, PROTECTED]` · *Applicability:* **unconditional** — never conditional and
+  never `n/a`.
+  *Claim:* every activity of this run involving a person, and every observation from a person used as
+  evidence, was governed by the floor at the time it ran — the property itself.
+  *Pass:* a sweep of the run's **own activity inventory** — every round, interview, observation, card sort,
+  tree test, informal walkthrough, recruitment screening, and post-release contact whose output is cited as
+  evidence anywhere — each carrying its consent, accommodation, minimization, protection, and
+  representativeness record. **Explicitly not satisfied by "members 1–7 all passed," and not satisfied by
+  governing only the activities the ladder happens to name.**
+  *Evidence:* the recorded activity-inventory sweep.
+  *On fail:* **stop and report missing context**; no design is accepted.
+  *Consequence:* an ungoverned activity's observations are cited as evidence.
+  *Source:* the participant floor's property check · *Seeds:* `DESK-SCENARIO-11`
+  *Obligation conditions owned:* the governed set is the activity inventory rather than the ladder's named
+  rounds · a named-round roll-up explicitly rejected as evidence.
+
+- [ ] **`DESK-CHECK-15`** `[GATE, PROTECTED]` · *Applicability:* unconditional — acceptance rests on direct
+  representative-user evidence from this run's own artifacts, per claimed operating system.
+  *Pass:* every human-outcome claim resolves to a participant record from this run's own artifacts on the
+  system the claim is about, covering every applicable observation dimension, with prior research, expert
+  review, analytics, standards conformance, stakeholder approval, captured renderings, and static
+  high-fidelity artifacts all recorded as context only.
+  *Evidence:* direct read of the evidence table, per claimed system.
+  *On fail:* halt; acceptance is unavailable and the run returns to the owning rung.
+  *Consequence:* a design accepted on evidence that proves something else.
+  *Source:* `DESK-R13`, `DESK-N04` · *Seeds:* `DESK-SCENARIO-08`
+  *Obligation conditions owned:* this run's own artifacts · per claimed operating system · the full
+  observation-dimension set · every other signal context only.
+
+- [ ] **`DESK-CHECK-16`** `[GATE, PROTECTED]` · *Applicability:* **unconditional** — never conditional and
+  never `n/a`.
+  *Claim:* every human-outcome claim this run makes is supported by direct representative-user evidence from
+  this run's own artifacts, on the operating system the claim is about — the property itself.
+  *Pass:* a sweep of the run's **own claim inventory** — every claim about what a person can perceive,
+  understand, operate, complete, or recover from — each mapped to the participant record and the operating
+  system that supports it, with any unsupported claim removed or restated as context. **Explicitly not
+  satisfied by "members 1–7 all passed."**
+  *Evidence:* the recorded claim-inventory sweep.
+  *On fail:* halt; block acceptance, and rerun the owning rung or report missing context.
+  *Consequence:* a claim about people that no participant record supports ships as a finding of the run.
+  *Source:* the direct-evidence floor's property check · *Seeds:* `DESK-SCENARIO-55`
+  *Obligation conditions owned:* the property held over the run's own claim inventory · the supporting system
+  named per claim · unsupported claims removed or restated as context · a member roll-up explicitly rejected.
+
+- [ ] **`DESK-CHECK-17`** `[GATE, PROTECTED]` · *Applicability:* unconditional — no waiver token was accepted
+  on any protected item, and no coverage property was counted as acceptance.
+  *Pass:* every waiver-token use in the filled copy sits on `DESK-CHECK-28` and nowhere else; every
+  `recorded-open` is counted as coverage-closed and not accepted; and the six-row table above is reproduced
+  by the filled copy's own resolutions.
+  *Evidence:* direct read of every non-`PASS` resolution in the filled copy against the protected-item list.
+  *On fail:* halt; the resolution is invalid and the item returns to unresolved.
+  *Consequence:* a non-waivable floor closed by a token — the exact escape hatch the floors exist to prevent.
+  *Source:* `DESK-N05` · *Seeds:* `DESK-SCENARIO-51`
+  *Obligation conditions owned:* the token invalid on all four floors · closing neither coverage nor
+  acceptance there.
+
+### `DESK-PAUSE-3` — implementation completion · `do-confirm`
+
+- [ ] **`DESK-CHECK-18`** `[GATE]` · *Applicability:* unconditional — the privilege boundary and the three
+  compilation targets are as specified.
+  *Pass:* each unit states its execution context; the three targets exist with their own library, type, and
+  module settings over one type-only shared layer; the renderer target excludes the runtime's ambient types;
+  the bridge contract carries only structured-cloneable values and plain asynchronous functions; and every
+  statement of the three-target split carries its derived marking.
+  *Evidence:* direct read of the three target configurations plus the bridge contract type.
+  *On fail:* halt; return to the contract phase rather than patching a body.
+  *Consequence:* a green type-check certifying code the sandbox rejects at run time.
+  *Source:* `DESK-R14`, `DESK-R16`, `DESK-R17`, `DESK-N07` · *Seeds:* `DESK-SCENARIO-18`,
+  `DESK-SCENARIO-19`, `DESK-SCENARIO-21`, `DESK-SCENARIO-22`
+  *Obligation conditions owned:* each unit's execution context · the renderer target excluding the runtime's
+  ambient types · one source-of-truth contract type · structured-cloneable values and plain asynchronous
+  functions only · no classes, constructors, or symbol-keyed members · the derived marking travelling with
+  the split.
+
+- [ ] **`DESK-CHECK-19`** `[GATE]` · *Applicability:* unconditional — every privileged crossing validates both
+  its payload and its caller.
+  *Pass:* every registered privileged handler runtime-validates its payload into a domain type and verifies
+  the sending frame **in the handler** before any privileged effect, and the handler set enumerated from
+  source equals the channel inventory.
+  *Evidence:* caller trace plus a targeted test that sends from an unintended frame and observes the
+  privileged sink for any effect.
+  *On fail:* halt; open a security finding.
+  *Consequence:* an unexpected frame reaches a privileged effect.
+  *Source:* `DESK-R15`, `DESK-N06` · *Seeds:* `DESK-SCENARIO-18`, `DESK-SCENARIO-21`, `DESK-SCENARIO-32`
+  *Obligation conditions owned:* payload validated into a domain type · sending frame verified · the check in
+  the handler rather than in a bypassable wrapper · context isolation not relied on to prevent the send · the
+  inventory equal to the enumerated handler set.
+
+- [ ] **`DESK-CHECK-20`** `[GATE, PROTECTED]` · *Applicability:* unconditional — every cross-process resource
+  names the lifecycle event that releases it.
+  *Pass:* each privileged resource held on behalf of a renderer names a window or contents lifecycle event as
+  its release point, with the last-resort terminal named and none keyed to scope exit; and the
+  pre-quit-for-update hook is handled so an install does not end the process mid-write.
+  *Evidence:* direct read plus a test under collection pressure confirming delivery survives.
+  *On fail:* halt; return to the contract phase.
+  *Consequence:* a channel that works under test and silently stops in the field, or work lost to an update.
+  *Source:* `DESK-R18` · *Seeds:* `DESK-SCENARIO-20`, `DESK-SCENARIO-30`
+  *Obligation conditions owned:* disposal keyed to a named lifecycle event rather than to scope exit · the
+  last-resort terminal named · the pre-quit-for-update hook handled.
+
+- [ ] **`DESK-CHECK-21`** `[GATE]` · *Applicability:* unconditional — both kinds of security work are
+  complete.
+  *Pass:* a twenty-row inventory where each of the eight defaults is confirmed unchanged, or carries a
+  recorded reason, and each of the twelve applicable positive controls is confirmed **written**, naming the
+  file and line; and no secret is present in the shipped artifact.
+  *Evidence:* direct read of the inventory plus an unpack-and-search of the shipped artifact.
+  *On fail:* halt; open a security finding.
+  *Consequence:* an application that passes every default check while having written none of the controls.
+  *Source:* `DESK-R19`, `DESK-N08` · *Seeds:* `DESK-SCENARIO-31`, `DESK-SCENARIO-34`
+  *Obligation conditions owned:* the eight defaults intact · the twelve positive controls written rather than
+  assumed · packaging, minification, and the archive rejected as security boundaries · no secret in the
+  shipped artifact.
+
+- [ ] **`DESK-CHECK-22`** `[GATE]` · *Applicability:* unconditional — build-time hardening is set, and the
+  build-matrix decision is recorded with both horns.
+  *Pass:* the built artifact's fuse configuration is read and recorded; the two archive fuses are both set,
+  or neither is with a recorded reason; and the hardening-versus-testability decision names both horns, the
+  user's choice, and the resulting stated verification limit.
+  *Evidence:* direct read of the built artifact's fuse configuration, plus the recorded decision.
+  *On fail:* halt; open a finding, and route the undecided matrix to the user.
+  *Consequence:* unvalidated code loadable, or an automated suite silently exercising a different artifact
+  than the one shipping.
+  *Source:* `DESK-R20`, `DESK-R27` — its build-matrix leg, `DESK-N10` · *Seeds:* `DESK-SCENARIO-33`,
+  `DESK-SCENARIO-36`
+  *Obligation conditions owned:* the two archive fuses set as a pair · both horns named with their
+  consequences · the user deciding · the chosen horn's consequence carried as a stated verification limit.
+
+- [ ] **`DESK-CHECK-23`** `[GATE, PROTECTED]` · *Applicability:* unconditional — every per-operating-system
+  behavior obligation the outcome touches is satisfied by its named mechanism.
+  *Pass:* first paint uses the hidden-window-plus-ready-event mechanism **and** a background color; window
+  state restoration validates saved bounds against the currently attached displays with a visible fallback;
+  quit and activation semantics match each claimed system; the second-instance argument list is parsed by
+  matching and never by position; the deep-link route is per system; theming is a three-state machine; one
+  shortcut map exists per platform excluding system-reserved combinations; and no unverified platform
+  convention is asserted.
+  *Evidence:* direct behavioral test per claimed system, including a launch recording and a detached-display
+  relaunch.
+  *On fail:* halt; open a finding against the owning obligation.
+  *Consequence:* a second launch acting on a target the person did not choose, or a window restored where
+  nothing can reach it.
+  *Source:* `DESK-R21`, `DESK-R22`, `DESK-N09` · *Seeds:* `DESK-SCENARIO-12`, `DESK-SCENARIO-14`,
+  `DESK-SCENARIO-16`
+  *Obligation conditions owned:* both first-paint mechanisms rather than either · restored bounds validated
+  against attached displays with a visible fallback · the argument list parsed by matching · no unverified
+  platform convention asserted.
+
+- [ ] **`DESK-CHECK-24`** `[GATE, PROTECTED]` · *Applicability:* unconditional — the local data contract holds
+  in both directions.
+  *Pass:* every local write is durable or detectably incomplete, replacing the target atomically and carrying
+  a marker a reader can reject; every persisted structure carries an explicit version; and the downgrade path
+  preserves, refuses, or copies, never silently rewriting newer data into an older shape.
+  *Evidence:* an interruption test at several offsets including one leaving valid syntax, plus the
+  install-newer / create / install-older / reinstall-newer round trip across the stated support window.
+  *On fail:* halt; open a data-integrity finding.
+  *Consequence:* a person who reinstalls a previous version loses their work.
+  *Source:* `DESK-R11` — its data members · *Seeds:* `DESK-SCENARIO-13`, `DESK-SCENARIO-15`,
+  `DESK-SCENARIO-17`, `DESK-SCENARIO-28`
+  *Obligation conditions owned:* durable or detectably incomplete · atomic replacement · a truncation marker
+  distinguishable from valid syntax · an explicit structure version · the downgrade path proved by round trip
+  rather than only forward.
+
+- [ ] **`DESK-CHECK-25`** `[REQ]` · *Applicability:* unconditional — every entry mode and every designed
+  in-scope path is implemented or explicitly removed from scope.
+  *Pass:* the entry-mode inventory is complete; each mode reaches the outcome or is proved out of scope; and
+  no designed path lacks an implementation without a recorded scope removal.
+  *Evidence:* diff the designed path set against the implemented path set.
+  *On fail:* open a blocking finding; the outcome is not finished.
+  *Source:* `DESK-R01`, `DESK-N01` · *Seeds:* `DESK-SCENARIO-02`, `DESK-SCENARIO-03`
+  *Obligation conditions owned:* the entry modes enumerated · cold-start and warm-start paths distinguished ·
+  no designed path unimplemented without a recorded removal.
+
+- [ ] **`DESK-CHECK-26`** `[REQ]` · *Applicability:* conditional — applies when the run records any
+  performance or footprint measurement. An `n/a:<property>` requires the inspected finding that it records
+  none.
+  *Pass:* every recorded measurement names the platform version it was taken on; no comparison attributes a
+  difference to the run's own work across differing versions; and file and parsing work is kept off the
+  privileged process's own thread.
+  *Evidence:* direct read of each measurement record, plus a multi-window responsiveness observation during a
+  privileged read.
+  *On fail:* open a blocking finding.
+  *Source:* `DESK-R26` — its measurement leg · *Seeds:* `DESK-SCENARIO-23`, `DESK-SCENARIO-24`,
+  `DESK-SCENARIO-25`
+  *Obligation conditions owned:* the version named in the same statement · no cross-version attribution ·
+  blocking work kept off the privileged process's thread.
+
+### `DESK-PAUSE-4` — release-readiness handoff · `do-confirm`
+
+- [ ] **`DESK-CHECK-27`** `[GATE]` · *Applicability:* unconditional — one installer target exists per claimed
+  operating system, and the update path is stated per system.
+  *Pass:* the release matrix carries a row per claimed system with its produced installer, and its update row
+  names that system's own mechanism rather than a uniform claim across all of them.
+  *Evidence:* direct inspection of the produced artifacts plus the release matrix.
+  *On fail:* halt the release; either remove the system from the claim set or produce its installer.
+  *Consequence:* claiming a system the run cannot deliver.
+  *Source:* `DESK-R23` — its packaging gate · *Seeds:* `DESK-SCENARIO-42`, `DESK-SCENARIO-46`
+  *Obligation conditions owned:* an installer per claimed system · the update path stated per system · no
+  built-in automatic updating claimed for the system that has none.
+
+- [ ] **`DESK-CHECK-28`** `[GATE]` · *Applicability:* unconditional — the packaged artifact installs and
+  smoke-tests in a clean environment, per claimed operating system.
+  *Pass:* each claimed system has a recorded install and smoke test on a machine that has not previously
+  hosted this application or its dependencies.
+  *Evidence:* the recorded clean-environment install result per system, naming the environment.
+  *On fail:* halt the release for that system.
+  *Consequence:* an artifact that installs only where the build machine's dependencies already exist.
+  *Source:* `DESK-R23` — its install gate · *Seeds:* `DESK-SCENARIO-42`
+  *Obligation conditions owned:* a clean environment rather than a development machine · one result per
+  claimed system.
+  > **This is the single waiver-eligible gate in this source, and it is not protected.** Its claim bears on
+  > release readiness rather than on the accessibility or safety floor's property. A waiver here is valid
+  > only when the named release authority's mandate covers **this item's** consequence — that first-install
+  > behavior on the named system is unproven for this release — and its stop action, and when the
+  > authorization evidence and the rationale are both recorded. The waiver substitutes for `PASS` on this
+  > item alone, is never counted as a `PASS`, and carries forward as a stated verification limit rather than
+  > disappearing into a green summary.
+
+- [ ] **`DESK-CHECK-29`** `[GATE]` · *Applicability:* conditional — applies per claimed system that has a
+  signing story. An `n/a:<property>` requires the inspected finding that the system has none.
+  *Pass:* signature and, where the system requires it, notarization are verified **on the real packaged
+  artifact**; and any behavior whose precondition is a signature was proved on that signed artifact rather
+  than on a development build.
+  *Evidence:* signature and notarization verification run against the shipped artifact, plus the artifact
+  identity behind each signature-dependent claim.
+  *On fail:* halt the release for that system.
+  *Consequence:* shipping an artifact the operating system treats as unsigned.
+  *Source:* `DESK-R23` — its signing gate · *Seeds:* `DESK-SCENARIO-42`, `DESK-SCENARIO-45`
+  *Obligation conditions owned:* verification on the real artifact · both mandatory steps where the system
+  requires two · signature-dependent evidence taken from the signed artifact.
+
+- [ ] **`DESK-CHECK-30`** `[GATE, PROTECTED]` · *Applicability:* conditional — applies per claimed system with
+  an update path. An `n/a:<property>` requires the inspected finding that the system has none and that
+  updates go through its package manager.
+  *Pass:* an update was rehearsed **from the previously released version** rather than from a fresh install;
+  live work survives the install through the pre-quit hook; and a failure partway leaves the installed
+  version working with the failure surfaced rather than retried silently.
+  *Evidence:* the rehearsal record naming its starting version, plus an interrupted-update test at the
+  download and install stages separately.
+  *On fail:* halt the release.
+  *Consequence:* an update that destroys work the person had open, or leaves a partially replaced
+  application.
+  *Source:* `DESK-R23` — its update gate, `DESK-R24` · *Seeds:* `DESK-SCENARIO-27`, `DESK-SCENARIO-29`,
+  `DESK-SCENARIO-30`, `DESK-SCENARIO-42`, `DESK-SCENARIO-45`, `DESK-SCENARIO-46`, `DESK-SCENARIO-47`
+  *Obligation conditions owned:* the rehearsal starting from the previously released version · work flushed
+  at the pre-quit hook · a failed update leaving the installed version working · the failure surfaced rather
+  than retried silently · unsaved work treated as a stop.
+
+- [ ] **`DESK-CHECK-31`** `[GATE, PROTECTED]` · *Applicability:* unconditional — the release is treated as
+  irreversible, and the supported-old-version window is stated.
+  *Pass:* the record states how far back a version receives a forward fix, what happens to a version outside
+  the window, and that rollback means a forward fix; and both the oldest supported version and one below it
+  were exercised against the stated behavior.
+  *Evidence:* direct read of the stated window plus the edge-and-beyond test result.
+  *On fail:* halt the release.
+  *Consequence:* a person on an old version left with an unhandled failure and no route forward.
+  *Source:* `DESK-R24` · *Seeds:* `DESK-SCENARIO-17`, `DESK-SCENARIO-44`
+  *Obligation conditions owned:* a stated window · a defined out-of-window behavior · rollback as a forward
+  fix · the edge and the case beyond it both proved.
+
+- [ ] **`DESK-CHECK-32`** `[GATE]` · *Applicability:* unconditional — every evidence class is reported as its
+  own claim.
+  *Pass:* the claim ledger carries nine separate rows — design acceptance, implementation correctness,
+  packaged-artifact evidence, signature and notarization evidence, update-rehearsal evidence, per-system
+  evidence, release readiness, release authority, and post-release outcome — each with its evidence class,
+  owner, and per-system scope; and each unrunnable gate is recorded as a limitation blocking its claim.
+  *Evidence:* direct read of the claim ledger.
+  *On fail:* halt the release handoff.
+  *Consequence:* a green summary concealing which of nine distinct claims was never proved.
+  *Source:* `DESK-R25` · *Seeds:* `DESK-SCENARIO-52`
+  *Obligation conditions owned:* nine distinct claims · per-claim scope · an unrunnable gate recorded as a
+  limitation blocking its claim rather than widened into a weaker signal.
+
+- [ ] **`DESK-CHECK-33`** `[REQ]` · *Applicability:* unconditional — the design record carries resolved
+  content in every required element.
+  *Pass:* the rung register, the three-axis statements, the four floor resolutions with their property
+  checks, the participant consent and accommodation records, the locked application contract, the claim-owner
+  verification matrix, and the run's own unknown and gap register are each present **with content**.
+  *Evidence:* direct read of each required element for resolved content rather than for its heading.
+  *On fail:* open a blocking finding.
+  *Source:* `DESK-R29` · *Seeds:* `DESK-SCENARIO-50`
+  *Obligation conditions owned:* each required element present with resolved content · a heading alone
+  rejected as satisfaction.
+
+- [ ] **`DESK-CHECK-34`** `[GATE]` · *Applicability:* unconditional — the trace and the verifier are both
+  proved.
+  *Pass:* the relation test exits zero across all four projections; the verifier is proved at **both** ends,
+  rejecting each planted fixture and accepting the real bundle; and the obligation test's result is recorded
+  **per case**, with the reviewer's identity, across every mapped check for a case with more than one.
+  *Evidence:* the recorded exit statuses and messages for the script-proved legs, and the reviewer's recorded
+  per-case results for the review-proved leg.
+  *On fail:* halt the handoff; the trace is unproved.
+  *Consequence:* a correctly-routed check whose wording dropped a named primitive ships unnoticed behind a
+  green relation test.
+  *Source:* `DESK-R28` · *Seeds:* `DESK-SCENARIO-53`
+  *Obligation conditions owned:* the relation test over four projections · the two-ended verifier proof · the
+  obligation test recorded per case with the reviewer's identity · a green relation test rejected as a
+  complete trace proof.
+
+- [ ] **`DESK-CHECK-35`** `[REQ]` · *Applicability:* conditional — applies when the run names any
+  planned-but-absent capability. An `n/a:<property>` requires the inspected finding that it names none.
+  *Pass:* every forward mention is prose only, carrying no path, no link, and no path-shaped code span, and
+  states that nothing here loads or requires it.
+  *Evidence:* a scan of every forward mention for a path, a link, or a path-shaped span.
+  *On fail:* open a blocking finding.
+  *Source:* `DESK-R31`, `DESK-N12` · *Seeds:* `DESK-SCENARIO-43`
+  *Obligation conditions owned:* prose only · no path, link, or load target · a statement that nothing loads
+  or requires it.
+
+- [ ] **`DESK-CHECK-36`** `[GATE]` · *Applicability:* unconditional — release authority is explicitly granted
+  against a stated readiness position.
+  *Pass:* the release-authority decision is recorded by its named holder, against a presented readiness
+  statement naming what is proved, what is a stated limit, the supported-old-version window, and the stop
+  conditions.
+  *Evidence:* direct read of the recorded decision and of the readiness statement it was made against.
+  *On fail:* halt; no external release action is taken.
+  *Consequence:* an irreversible action taken without the authority for it.
+  *Source:* `DESK-R27` — its release-authority leg · *Seeds:* `DESK-SCENARIO-04`
+  *Obligation conditions owned:* an explicit decision from the named holder · the readiness position it was
+  made against · silence and continued work rejected as approval.
 
 ## Guaranteed coverage map
 
+Every check and the cases that seeded it. This is the second exact projection of the authoritative relation
+in [`scenarios.md`](scenarios.md), verifiable independently of each item's own `Seeds` field above.
+
+| Check | Seeding cases | Pause point |
+|---|---|---|
+| `DESK-CHECK-01` | `DESK-SCENARIO-01`, `DESK-SCENARIO-02` | `DESK-PAUSE-1` |
+| `DESK-CHECK-02` | `DESK-SCENARIO-05`, `DESK-SCENARIO-26` | `DESK-PAUSE-1` |
+| `DESK-CHECK-03` | `DESK-SCENARIO-01` | `DESK-PAUSE-1` |
+| `DESK-CHECK-04` | `DESK-SCENARIO-04` | `DESK-PAUSE-1` |
+| `DESK-CHECK-05` | `DESK-SCENARIO-23`, `DESK-SCENARIO-25` | `DESK-PAUSE-1` |
+| `DESK-CHECK-06` | `DESK-SCENARIO-09` | `DESK-PAUSE-2` |
+| `DESK-CHECK-07` | `DESK-SCENARIO-07`, `DESK-SCENARIO-48`, `DESK-SCENARIO-49` | `DESK-PAUSE-2` |
+| `DESK-CHECK-08` | `DESK-SCENARIO-54` | `DESK-PAUSE-2` |
+| `DESK-CHECK-09` | `DESK-SCENARIO-37`, `DESK-SCENARIO-38`, `DESK-SCENARIO-39`, `DESK-SCENARIO-40` | `DESK-PAUSE-2` |
+| `DESK-CHECK-10` | `DESK-SCENARIO-39`, `DESK-SCENARIO-41` | `DESK-PAUSE-2` |
+| `DESK-CHECK-11` | `DESK-SCENARIO-16` | `DESK-PAUSE-2` |
+| `DESK-CHECK-12` | `DESK-SCENARIO-35` | `DESK-PAUSE-2` |
+| `DESK-CHECK-13` | `DESK-SCENARIO-06`, `DESK-SCENARIO-10` | `DESK-PAUSE-2` |
+| `DESK-CHECK-14` | `DESK-SCENARIO-11` | `DESK-PAUSE-2` |
+| `DESK-CHECK-15` | `DESK-SCENARIO-08` | `DESK-PAUSE-2` |
+| `DESK-CHECK-16` | `DESK-SCENARIO-55` | `DESK-PAUSE-2` |
+| `DESK-CHECK-17` | `DESK-SCENARIO-51` | `DESK-PAUSE-2` |
+| `DESK-CHECK-18` | `DESK-SCENARIO-18`, `DESK-SCENARIO-19`, `DESK-SCENARIO-21`, `DESK-SCENARIO-22` | `DESK-PAUSE-3` |
+| `DESK-CHECK-19` | `DESK-SCENARIO-18`, `DESK-SCENARIO-21`, `DESK-SCENARIO-32` | `DESK-PAUSE-3` |
+| `DESK-CHECK-20` | `DESK-SCENARIO-20`, `DESK-SCENARIO-30` | `DESK-PAUSE-3` |
+| `DESK-CHECK-21` | `DESK-SCENARIO-31`, `DESK-SCENARIO-34` | `DESK-PAUSE-3` |
+| `DESK-CHECK-22` | `DESK-SCENARIO-33`, `DESK-SCENARIO-36` | `DESK-PAUSE-3` |
+| `DESK-CHECK-23` | `DESK-SCENARIO-12`, `DESK-SCENARIO-14`, `DESK-SCENARIO-16` | `DESK-PAUSE-3` |
+| `DESK-CHECK-24` | `DESK-SCENARIO-13`, `DESK-SCENARIO-15`, `DESK-SCENARIO-17`, `DESK-SCENARIO-28` | `DESK-PAUSE-3` |
+| `DESK-CHECK-25` | `DESK-SCENARIO-02`, `DESK-SCENARIO-03` | `DESK-PAUSE-3` |
+| `DESK-CHECK-26` | `DESK-SCENARIO-23`, `DESK-SCENARIO-24`, `DESK-SCENARIO-25` | `DESK-PAUSE-3` |
+| `DESK-CHECK-27` | `DESK-SCENARIO-42`, `DESK-SCENARIO-46` | `DESK-PAUSE-4` |
+| `DESK-CHECK-28` | `DESK-SCENARIO-42` | `DESK-PAUSE-4` |
+| `DESK-CHECK-29` | `DESK-SCENARIO-42`, `DESK-SCENARIO-45` | `DESK-PAUSE-4` |
+| `DESK-CHECK-30` | `DESK-SCENARIO-27`, `DESK-SCENARIO-29`, `DESK-SCENARIO-30`, `DESK-SCENARIO-42`, `DESK-SCENARIO-45`, `DESK-SCENARIO-46`, `DESK-SCENARIO-47` | `DESK-PAUSE-4` |
+| `DESK-CHECK-31` | `DESK-SCENARIO-17`, `DESK-SCENARIO-44` | `DESK-PAUSE-4` |
+| `DESK-CHECK-32` | `DESK-SCENARIO-52` | `DESK-PAUSE-4` |
+| `DESK-CHECK-33` | `DESK-SCENARIO-50` | `DESK-PAUSE-4` |
+| `DESK-CHECK-34` | `DESK-SCENARIO-53` | `DESK-PAUSE-4` |
+| `DESK-CHECK-35` | `DESK-SCENARIO-43` | `DESK-PAUSE-4` |
+| `DESK-CHECK-36` | `DESK-SCENARIO-04` | `DESK-PAUSE-4` |
+
 ## Check-to-obligation union audit
+
+The **reverse** sweep, and the fourth projection of the authoritative relation. The three tables above run
+forward — case to check. This one runs back: for each check, which case obligations it consumes, and whether
+its **actual pass wording** preserves every named condition in them.
+
+**This is the table that catches a check whose routing is correct and whose wording is not.** The relation
+test proves the four projections agree on their edges; it says nothing about whether a check's `Pass:` and
+`Evidence:` wording still owns each named primitive the obligation asserts. A condition-level check that
+confirms the topic survived is not sufficient — a named primitive can be dropped inside a surviving
+condition.
+
+**The result column ships empty, and that is deliberate.** This source is unchecked. The audit is a
+**review-proved** gate rather than a script: no fixed-string comparison can distinguish an asserted
+primitive from a negated one, or a dropped primitive from one carried in an unrelated clause. A named
+reviewer reads each selected case's `Obligation` and **every** mapped check's actual `Pass:` and `Evidence:`
+wording, and records the result **per case** with their own identity. A per-file result, or an unrecorded
+case, is an unrun test.
+
+Matching identifiers, equal counts, and this table's own summary prose close nothing. The `Conditions` column
+is a count for the reviewer's convenience and is **not** evidence — the conditions themselves are enumerated
+in each item's `Obligation conditions owned` field above, and the reviewer reads those against the wording.
+
+| Check | Obligations it consumes | Conditions | Reviewer | Result |
+|---|---|---|---|---|
+| `DESK-CHECK-01` | `DESK-SCENARIO-01`, `DESK-SCENARIO-02` | 8 | | |
+| `DESK-CHECK-02` | `DESK-SCENARIO-05`, `DESK-SCENARIO-26` | 3 | | |
+| `DESK-CHECK-03` | `DESK-SCENARIO-01` | 2 | | |
+| `DESK-CHECK-04` | `DESK-SCENARIO-04` | 2 | | |
+| `DESK-CHECK-05` | `DESK-SCENARIO-23`, `DESK-SCENARIO-25` | 4 | | |
+| `DESK-CHECK-06` | `DESK-SCENARIO-09` | 3 | | |
+| `DESK-CHECK-07` | `DESK-SCENARIO-07`, `DESK-SCENARIO-48`, `DESK-SCENARIO-49` | 5 | | |
+| `DESK-CHECK-08` | `DESK-SCENARIO-54` | 5 | | |
+| `DESK-CHECK-09` | `DESK-SCENARIO-37`, `DESK-SCENARIO-38`, `DESK-SCENARIO-39`, `DESK-SCENARIO-40` | 4 | | |
+| `DESK-CHECK-10` | `DESK-SCENARIO-39`, `DESK-SCENARIO-41` | 2 | | |
+| `DESK-CHECK-11` | `DESK-SCENARIO-16` | 2 | | |
+| `DESK-CHECK-12` | `DESK-SCENARIO-35` | 2 | | |
+| `DESK-CHECK-13` | `DESK-SCENARIO-06`, `DESK-SCENARIO-10` | 6 | | |
+| `DESK-CHECK-14` | `DESK-SCENARIO-11` | 2 | | |
+| `DESK-CHECK-15` | `DESK-SCENARIO-08` | 4 | | |
+| `DESK-CHECK-16` | `DESK-SCENARIO-55` | 4 | | |
+| `DESK-CHECK-17` | `DESK-SCENARIO-51` | 3 | | |
+| `DESK-CHECK-18` | `DESK-SCENARIO-18`, `DESK-SCENARIO-19`, `DESK-SCENARIO-21`, `DESK-SCENARIO-22` | 6 | | |
+| `DESK-CHECK-19` | `DESK-SCENARIO-18`, `DESK-SCENARIO-21`, `DESK-SCENARIO-32` | 5 | | |
+| `DESK-CHECK-20` | `DESK-SCENARIO-20`, `DESK-SCENARIO-30` | 3 | | |
+| `DESK-CHECK-21` | `DESK-SCENARIO-31`, `DESK-SCENARIO-34` | 4 | | |
+| `DESK-CHECK-22` | `DESK-SCENARIO-33`, `DESK-SCENARIO-36` | 4 | | |
+| `DESK-CHECK-23` | `DESK-SCENARIO-12`, `DESK-SCENARIO-14`, `DESK-SCENARIO-16` | 4 | | |
+| `DESK-CHECK-24` | `DESK-SCENARIO-13`, `DESK-SCENARIO-15`, `DESK-SCENARIO-17`, `DESK-SCENARIO-28` | 5 | | |
+| `DESK-CHECK-25` | `DESK-SCENARIO-02`, `DESK-SCENARIO-03` | 3 | | |
+| `DESK-CHECK-26` | `DESK-SCENARIO-23`, `DESK-SCENARIO-24`, `DESK-SCENARIO-25` | 4 | | |
+| `DESK-CHECK-27` | `DESK-SCENARIO-42`, `DESK-SCENARIO-46` | 3 | | |
+| `DESK-CHECK-28` | `DESK-SCENARIO-42` | 2 | | |
+| `DESK-CHECK-29` | `DESK-SCENARIO-42`, `DESK-SCENARIO-45` | 3 | | |
+| `DESK-CHECK-30` | `DESK-SCENARIO-27`, `DESK-SCENARIO-29`, `DESK-SCENARIO-30`, `DESK-SCENARIO-42`, `DESK-SCENARIO-45`, `DESK-SCENARIO-46`, `DESK-SCENARIO-47` | 5 | | |
+| `DESK-CHECK-31` | `DESK-SCENARIO-17`, `DESK-SCENARIO-44` | 4 | | |
+| `DESK-CHECK-32` | `DESK-SCENARIO-52` | 3 | | |
+| `DESK-CHECK-33` | `DESK-SCENARIO-50` | 2 | | |
+| `DESK-CHECK-34` | `DESK-SCENARIO-53` | 4 | | |
+| `DESK-CHECK-35` | `DESK-SCENARIO-43` | 3 | | |
+| `DESK-CHECK-36` | `DESK-SCENARIO-04` | 3 | | |

--- a/.gobbi/projects/gobbi/skills/desktop/checklists.md
+++ b/.gobbi/projects/gobbi/skills/desktop/checklists.md
@@ -11,7 +11,7 @@ Be the unchecked operational gate source with the protected-waiver truth table. 
 | **Source state** | **unchecked** — every box below is unticked, and it stays that way |
 | **Run state** | each run works a **fresh filled copy** naming this source's version and the run's identity |
 | **Use-style** | declared per pause point below, per run |
-| **Items** | 36, across four pause points |
+| **Items** | 43, across four pause points |
 | **Provenance** | each item's `Source` names its parent clause; each item's `Seeds` names the cases that reserved it |
 
 **The source is never worked and never ticked.** A run copies it, fills the copy, and records the copy's
@@ -27,30 +27,36 @@ acceptance-bearing. An advisory row here would be a mandatory obligation quietly
 |---|---|---|---|---|
 | `DESK-PAUSE-1` — stack and outcome lock | before rung 0 begins | `read-do` | `01`–`05` | the outcome, boundary, stack-fit result, ownership statement, and gate-authority map are accepted |
 | `DESK-PAUSE-2` — design acceptance | before `P5` locks the application contract | `do-confirm` | `06`–`17` | the structural-approval decision is confirmed with no visual rung preceding it, the rung register is complete and substantiated, and all four floors are accepted on **both** their member check and their property check |
-| `DESK-PAUSE-3` — implementation completion | before `P9` treats the grown slices as complete | `do-confirm` | `18`–`26` | the privilege boundary, security posture, platform obligations, local data contract, and in-scope paths are accepted |
+| `DESK-PAUSE-3` — implementation completion | before `P9` treats the grown slices as complete | `do-confirm` | `18`–`26`, `37`–`43` | the privilege boundary, security posture, every per-system platform obligation on its own item, local data contract, and in-scope paths are accepted |
 | `DESK-PAUSE-4` — release-readiness handoff | before `P10` publishes readiness or any external release is requested | `do-confirm` | `27`–`36` | every applicable release gate per claimed operating system is accepted, the design record is complete, and the trace and verifier proofs have both run |
 
-**The reserved ranges were extended, and this is the single place that records it.** The design reserved
-thirty-four slots; this source authors **thirty-six**. The extension follows the design's own rule — a range
-grows at its own pause point's tail and every later range shifts:
+**The reserved ranges were extended twice, and this is the single place that records it.** The design reserved
+thirty-four slots; this source authors **forty-three**:
 
 | Pause point | Reserved by the design | Authored here | Why |
 |---|---|---|---|
 | `DESK-PAUSE-1` | `01`–`05` | `01`–`05` | unchanged |
 | `DESK-PAUSE-2` | `06`–`15` | `06`–`17` | the four non-waivable floors each need a **member** check and a **property** check — eight acceptance-bearing items — plus the structural-approval gate, the rung register, the ladder method, and the protected-waiver discipline |
-| `DESK-PAUSE-3` | `16`–`24` | `18`–`26` | shifted by two; the item count is unchanged |
+| `DESK-PAUSE-3` | `16`–`24` | `18`–`26`, `37`–`43` | shifted by two by the first extension; the second extension added seven at the tail of the sequence when `DESK-CHECK-23` was split into one atomic claim per item |
 | `DESK-PAUSE-4` | `25`–`34` | `27`–`36` | shifted by two; the item count is unchanged |
 
-`DESK-CHECK-06` keeps its pinned position at the head of `DESK-PAUSE-2` regardless of the shift, because the
-design pins that one identifier and this source may not move it.
+The first extension followed the design's own rule — a range grows at its own pause point's tail and every
+later range shifts. **The second could not, and the departure is deliberate.** Growing `DESK-PAUSE-3`'s range
+in place would have renumbered every `DESK-PAUSE-4` identifier, which breaks a finding's resolvability across
+revisions; the identifiers are therefore allocated at the tail of the sequence and placed in the pause point
+they belong to. A range here is a set of identifiers, not a contiguous interval.
 
-**Item counts per pause point, and the two that exceed the generic guidance.** The generic guidance is
-roughly five to nine gate-or-required items per operational pause point. `DESK-PAUSE-1` carries 5 and
-`DESK-PAUSE-3` carries 9, both inside it. `DESK-PAUSE-4` carries 10 and `DESK-PAUSE-2` carries 12, both
-outside it. The deviation is recorded rather than resolved by trimming, for a structural reason: the pause
-points are fixed by the design and may not be split here, and eight of `DESK-PAUSE-2`'s twelve items are the
-four non-waivable floors' mandatory member-and-property pairs. Dropping one would remove an
-acceptance-bearing item that a floor requires.
+`DESK-CHECK-06` keeps its pinned position at the head of `DESK-PAUSE-2` regardless of either extension, because
+the design pins that one identifier and this source may not move it.
+
+**Item counts per pause point, and the three that exceed the generic guidance.** The generic guidance is
+roughly five to nine gate-or-required items per operational pause point. `DESK-PAUSE-1` carries 5, inside it.
+`DESK-PAUSE-4` carries 10, `DESK-PAUSE-2` carries 12, and `DESK-PAUSE-3` carries 16, all outside it. The
+deviation is recorded rather than resolved by trimming, for a structural reason: the pause points are fixed by
+the design and may not be split here; eight of `DESK-PAUSE-2`'s twelve items are the four non-waivable floors'
+mandatory member-and-property pairs; and `DESK-PAUSE-3`'s count is what atomicity costs — seven of its items
+are the per-system behavior obligations that one conjoined item used to hide. Dropping one would either remove
+an acceptance-bearing item a floor requires, or put two claims back under one `PASS`.
 
 ## Terminal value set
 
@@ -107,7 +113,7 @@ is one of those floors' own checks. That is the parent discipline's item-scope t
 to any applicable item whose claim or pass condition bears on the protected property, not only to the items
 named after a floor.
 
-Applying that test to this source yields **fourteen** protected items:
+Applying that test to this source yields **fifteen** protected items:
 
 | Item | Why the test selects it |
 |---|---|
@@ -119,19 +125,28 @@ Applying that test to this source yields **fourteen** protected items:
 | `DESK-CHECK-20` | its pass condition bears on the update install ending the process mid-write, a named safety member |
 | `DESK-CHECK-23` | its pass condition bears on positional argument handling, a named safety member |
 | `DESK-CHECK-24` | its pass condition bears on the interrupted write and the migration downgrade path, two named safety members |
+| `DESK-CHECK-38` | its pass condition bears on a window restored where nothing can reach it — a consequence an ordinary relaunch produces and the person cannot foresee, refuse, or recover from. The test selects it through the safety floor's **property and residual clause**, not through a named member, which is what the item-scope test is for |
 | `DESK-CHECK-30` | its pass condition bears on an update install racing live state, a named safety member |
 | `DESK-CHECK-31` | its pass condition bears on release irreversibility, a named safety member |
 
-**Why this set is wider than the eight floor checks.** Five items — `20`, `23`, `24`, `30`, and `31` — are
-not floor checks and are protected anyway, because each one's pass condition carries a condition the safety
-floor names as a member. Protecting only the items titled after a floor would leave a waiver available on the
-migration downgrade path and on the update-install race, which are exactly the consequences the floor exists
-to make unwaivable.
+**Why this set is wider than the eight floor checks.** Six items — `20`, `23`, `24`, `30`, `31`, and `38` — are
+not floor checks and are protected anyway, because each one's pass condition carries a consequence the safety
+floor governs: the first five through a named member, and `38` through the floor's property and residual
+clause. Protecting only the items titled after a floor would leave a waiver available on the migration
+downgrade path, on the update-install race, and on an unreachable restored window, which are exactly the
+consequences the floor exists to make unwaivable.
 
 **Items whose subject is security rather than safety are not selected by this test.**
 `DESK-CHECK-19`, `DESK-CHECK-21`, and `DESK-CHECK-22` bear on trust and harm, which the root treats as a
 concern distinct from the safety floor's foreseeable-refusable-recoverable property. They remain gates; they
 are simply not waiver-immune by this test.
+
+**The other items split out of `DESK-CHECK-23` are not selected either, and the test was applied to each.**
+`DESK-CHECK-37`, `39`, `40`, `41`, `42`, and `43` bear on conformance, discoverability, and honesty: a flash on
+launch, an application that exits where its system's convention persists, a link that never fires, an
+appearance left behind, a dead accelerator, and a conformance claim nobody can check. Each is a defect the
+person can see and the run can correct forward; none reaches a consequence the person cannot foresee, refuse,
+or recover from, and none bears on the accessibility floor's availability property. They remain gates.
 
 **The table.** Six rows. Each adversarial row holds every other applicable item at `PASS`, so the row
 isolates one attempted resolution. Coverage closure and acceptance are evaluated separately in every row.
@@ -461,24 +476,17 @@ clauses, its `Seeds` cases, and the obligation conditions its pass condition mus
   *Obligation conditions owned:* the two archive fuses set as a pair · both horns named with their
   consequences · the user deciding · the chosen horn's consequence carried as a stated verification limit.
 
-- [ ] **`DESK-CHECK-23`** `[GATE, PROTECTED]` · *Applicability:* unconditional — every per-operating-system
-  behavior obligation the outcome touches is satisfied by its named mechanism.
-  *Pass:* first paint uses the hidden-window-plus-ready-event mechanism **and** a background color; window
-  state restoration validates saved bounds against the currently attached displays with a visible fallback;
-  quit and activation semantics match each claimed system; the second-instance argument list is parsed by
-  matching and never by position; the deep-link route is per system; theming is a three-state machine; one
-  shortcut map exists per platform excluding system-reserved combinations; and no unverified platform
-  convention is asserted.
-  *Evidence:* direct behavioral test per claimed system, including a launch recording and a detached-display
-  relaunch.
+- [ ] **`DESK-CHECK-23`** `[GATE, PROTECTED]` · *Applicability:* unconditional — the second-instance argument
+  list is parsed by matching.
+  *Pass:* every read of the second-instance argument list resolves its target by matching what the argument is,
+  and no read indexes a fixed position.
+  *Evidence:* launch a second instance with additional arguments present and in varied order, per claimed
+  system, and confirm the intended target resolves under every ordering.
   *On fail:* halt; open a finding against the owning obligation.
-  *Consequence:* a second launch acting on a target the person did not choose, or a window restored where
-  nothing can reach it.
-  *Source:* `DESK-R21`, `DESK-R22`, `DESK-N09` · *Seeds:* `DESK-SCENARIO-12`, `DESK-SCENARIO-14`,
-  `DESK-SCENARIO-16`
-  *Obligation conditions owned:* both first-paint mechanisms rather than either · restored bounds validated
-  against attached displays with a visible fallback · the argument list parsed by matching · no unverified
-  platform convention asserted.
+  *Consequence:* a second launch acting on a target the person did not choose.
+  *Source:* `DESK-R22` — its argument-handling leg · *Seeds:* `DESK-SCENARIO-16`
+  *Obligation conditions owned:* the argument list parsed by matching · the positional read treated as a safety
+  defect rather than a correctness preference.
 
 - [ ] **`DESK-CHECK-24`** `[GATE, PROTECTED]` · *Applicability:* unconditional — the local data contract holds
   in both directions.
@@ -518,6 +526,105 @@ clauses, its `Seeds` cases, and the obligation conditions its pass condition mus
   `DESK-SCENARIO-25`
   *Obligation conditions owned:* the version named in the same statement · no cross-version attribution ·
   blocking work kept off the privileged process's thread.
+
+**The remaining items of this pause point carry tail identifiers, and this is why.** `DESK-CHECK-23` once
+conjoined eight distinct per-operating-system obligations under one `PASS`, which the legend's atomicity rule
+forbids: a run correct on seven of the eight could not record that, and a `FAIL` localised nothing. Splitting
+it needed seven further slots here. Growing this pause point's range in place would have renumbered every
+identifier at `DESK-PAUSE-4`, breaking a finding's resolvability across revisions, so the seven were allocated
+at the tail of the sequence and placed here, in the pause point they belong to. `DESK-CHECK-23` keeps its own
+identifier and its protected designation because it keeps the claim that earned them — the argument-matching
+claim its protected-item row already cites.
+
+- [ ] **`DESK-CHECK-37`** `[GATE]` · *Applicability:* unconditional — first paint uses both mechanisms.
+  *Pass:* the initial window is created hidden and shown on the ready-to-show event, **and** a background color
+  is set anyway; a run implementing one of the two fails this item.
+  *Evidence:* a launch recording per claimed system, inspected for a flash on show and for a gap between
+  process start and the first visible window.
+  *On fail:* halt; open a finding against the owning obligation.
+  *Consequence:* a white flash on launch, or an application that appears not to have launched at all.
+  *Source:* `DESK-R22` — its first-paint leg · *Seeds:* `DESK-SCENARIO-12`
+  *Obligation conditions owned:* the window created hidden and shown on the ready event · the background color
+  set anyway · both mechanisms rather than either.
+
+- [ ] **`DESK-CHECK-38`** `[GATE, PROTECTED]` · *Applicability:* unconditional — restored window bounds are
+  validated against the displays currently attached.
+  *Pass:* restoration compares the saved bounds against the currently attached displays and falls back to a
+  visible position when they do not intersect one.
+  *Evidence:* set bounds on a second display, detach it, relaunch, and confirm the window is visible and
+  focusable on an attached display.
+  *On fail:* halt; open a finding against the owning obligation.
+  *Consequence:* an ordinary relaunch puts the window where nothing can reach it, recoverable only by editing
+  state by hand.
+  *Source:* `DESK-R22` — its state-restoration leg · *Seeds:* `DESK-SCENARIO-14`
+  *Obligation conditions owned:* restored bounds validated against the currently attached displays · a visible
+  fallback when they intersect none.
+
+- [ ] **`DESK-CHECK-39`** `[GATE]` · *Applicability:* unconditional — quit and activation semantics match each
+  claimed system's own convention.
+  *Pass:* closing the last surface produces that system's documented outcome on every claimed system, and the
+  handler that opens a surface on return is the reactivation event rather than the event that fires on every
+  switch into the application.
+  *Evidence:* close the last surface on each claimed system and observe the process; reactivate and confirm
+  exactly one surface appears; switch away and back repeatedly and confirm none is created.
+  *On fail:* halt; open a finding against the owning obligation.
+  *Consequence:* an application that exits where its system's convention says it persists, or a surface created
+  on every application switch.
+  *Source:* `DESK-R22` — its quit-and-activation leg · *Seeds:* `DESK-SCENARIO-56`
+  *Obligation conditions owned:* each claimed system's own closing-the-last-surface convention · its own
+  activation convention · the reactivation event rather than the every-activation event.
+
+- [ ] **`DESK-CHECK-40`** `[GATE]` · *Applicability:* conditional — applies when the outcome registers a
+  protocol or claims a deep link. An `n/a:<property>` requires the inspected finding that it registers none and
+  claims none.
+  *Pass:* each claimed system's delivery route is the route that system's own documentation names, and any
+  deep-link claim on the system that documents an unpackaged false negative rests on the packaged artifact.
+  *Evidence:* open the link against the packaged, installed artifact per claimed system, and read the
+  implemented route for each against the route that system documents.
+  *On fail:* halt; open a finding against the owning obligation.
+  *Consequence:* a shipped association that never fires, behind a development run that appeared to prove it.
+  *Source:* `DESK-R22` — its deep-link leg · *Seeds:* `DESK-SCENARIO-57`
+  *Obligation conditions owned:* one delivery route per claimed system, each the route that system documents ·
+  the packaged artifact as the evidence wherever the platform documents an unpackaged false negative.
+
+- [ ] **`DESK-CHECK-41`** `[GATE]` · *Applicability:* unconditional — theming is a three-state machine handled
+  live.
+  *Pass:* the person-facing appearance control maps onto all three values of the theme source, and that
+  interface's update event is handled while the application runs rather than read once at startup.
+  *Evidence:* read the mapping between the control and the three values; then change the system appearance
+  while the application is running and observe whether it follows.
+  *On fail:* halt; open a finding against the owning obligation.
+  *Consequence:* an application in the wrong appearance until the person corrects it by hand.
+  *Source:* `DESK-R22` — its theming leg · *Seeds:* `DESK-SCENARIO-58`
+  *Obligation conditions owned:* all three values of the theme source reachable from the person-facing control ·
+  the update event handled live.
+
+- [ ] **`DESK-CHECK-42`** `[GATE]` · *Applicability:* unconditional — one shortcut map exists per claimed
+  platform, and none binds a reserved combination.
+  *Pass:* each claimed platform has its own map, written with the portable modifier rather than one platform's
+  own, and no binding takes a combination that platform's own guidance names as reserved for the system.
+  *Evidence:* exercise each accelerator on each claimed system, and compare the bound set against that system's
+  own reserved list.
+  *On fail:* halt; open a finding against the owning obligation.
+  *Consequence:* a claimed system with no working accelerator at all, or a system combination taken away from
+  every other application the person uses.
+  *Source:* `DESK-R22` — its shortcut-map leg · *Seeds:* `DESK-SCENARIO-59`
+  *Obligation conditions owned:* one map per claimed platform · the portable modifier rather than one
+  platform's own · no system-reserved combination bound.
+
+- [ ] **`DESK-CHECK-43`** `[GATE]` · *Applicability:* unconditional — no unverified platform convention is
+  asserted, and none is hedged.
+  *Pass:* every stated platform convention reaches an owner document a reader can open; a convention with no
+  readable owner appears neither as a fact nor as a hedge about what the vendor probably requires, and instead
+  carries its marking and its closing condition.
+  *Evidence:* take each stated platform convention to the owner document that would establish it, and read
+  every unverifiable one for a marking rather than a softened assertion.
+  *On fail:* halt; open a finding against the owning obligation.
+  *Consequence:* a conformance claim nobody can check, which reads as authority and can be false in exactly the
+  way the assertion would have been.
+  *Source:* `DESK-R21` — its no-unverified-convention leg, `DESK-N09` · *Seeds:* `DESK-SCENARIO-60`
+  *Obligation conditions owned:* no unverified platform convention asserted · none hedged into a claim about
+  what has not been read · the gap marked with its closing condition.
 
 ### `DESK-PAUSE-4` — release-readiness handoff · `do-confirm`
 
@@ -682,7 +789,7 @@ in [`scenarios.md`](scenarios.md), verifiable independently of each item's own `
 | `DESK-CHECK-20` | `DESK-SCENARIO-20`, `DESK-SCENARIO-30` | `DESK-PAUSE-3` |
 | `DESK-CHECK-21` | `DESK-SCENARIO-31`, `DESK-SCENARIO-34` | `DESK-PAUSE-3` |
 | `DESK-CHECK-22` | `DESK-SCENARIO-33`, `DESK-SCENARIO-36` | `DESK-PAUSE-3` |
-| `DESK-CHECK-23` | `DESK-SCENARIO-12`, `DESK-SCENARIO-14`, `DESK-SCENARIO-16` | `DESK-PAUSE-3` |
+| `DESK-CHECK-23` | `DESK-SCENARIO-16` | `DESK-PAUSE-3` |
 | `DESK-CHECK-24` | `DESK-SCENARIO-13`, `DESK-SCENARIO-15`, `DESK-SCENARIO-17`, `DESK-SCENARIO-28` | `DESK-PAUSE-3` |
 | `DESK-CHECK-25` | `DESK-SCENARIO-02`, `DESK-SCENARIO-03` | `DESK-PAUSE-3` |
 | `DESK-CHECK-26` | `DESK-SCENARIO-23`, `DESK-SCENARIO-24`, `DESK-SCENARIO-25` | `DESK-PAUSE-3` |
@@ -696,6 +803,13 @@ in [`scenarios.md`](scenarios.md), verifiable independently of each item's own `
 | `DESK-CHECK-34` | `DESK-SCENARIO-53` | `DESK-PAUSE-4` |
 | `DESK-CHECK-35` | `DESK-SCENARIO-43` | `DESK-PAUSE-4` |
 | `DESK-CHECK-36` | `DESK-SCENARIO-04` | `DESK-PAUSE-4` |
+| `DESK-CHECK-37` | `DESK-SCENARIO-12` | `DESK-PAUSE-3` |
+| `DESK-CHECK-38` | `DESK-SCENARIO-14` | `DESK-PAUSE-3` |
+| `DESK-CHECK-39` | `DESK-SCENARIO-56` | `DESK-PAUSE-3` |
+| `DESK-CHECK-40` | `DESK-SCENARIO-57` | `DESK-PAUSE-3` |
+| `DESK-CHECK-41` | `DESK-SCENARIO-58` | `DESK-PAUSE-3` |
+| `DESK-CHECK-42` | `DESK-SCENARIO-59` | `DESK-PAUSE-3` |
+| `DESK-CHECK-43` | `DESK-SCENARIO-60` | `DESK-PAUSE-3` |
 
 ## Check-to-obligation union audit
 
@@ -744,7 +858,7 @@ in each item's `Obligation conditions owned` field above, and the reviewer reads
 | `DESK-CHECK-20` | `DESK-SCENARIO-20`, `DESK-SCENARIO-30` | 3 | | |
 | `DESK-CHECK-21` | `DESK-SCENARIO-31`, `DESK-SCENARIO-34` | 4 | | |
 | `DESK-CHECK-22` | `DESK-SCENARIO-33`, `DESK-SCENARIO-36` | 4 | | |
-| `DESK-CHECK-23` | `DESK-SCENARIO-12`, `DESK-SCENARIO-14`, `DESK-SCENARIO-16` | 4 | | |
+| `DESK-CHECK-23` | `DESK-SCENARIO-16` | 2 | | |
 | `DESK-CHECK-24` | `DESK-SCENARIO-13`, `DESK-SCENARIO-15`, `DESK-SCENARIO-17`, `DESK-SCENARIO-28` | 5 | | |
 | `DESK-CHECK-25` | `DESK-SCENARIO-02`, `DESK-SCENARIO-03` | 3 | | |
 | `DESK-CHECK-26` | `DESK-SCENARIO-23`, `DESK-SCENARIO-24`, `DESK-SCENARIO-25` | 4 | | |
@@ -758,3 +872,10 @@ in each item's `Obligation conditions owned` field above, and the reviewer reads
 | `DESK-CHECK-34` | `DESK-SCENARIO-53` | 4 | | |
 | `DESK-CHECK-35` | `DESK-SCENARIO-43` | 3 | | |
 | `DESK-CHECK-36` | `DESK-SCENARIO-04` | 3 | | |
+| `DESK-CHECK-37` | `DESK-SCENARIO-12` | 3 | | |
+| `DESK-CHECK-38` | `DESK-SCENARIO-14` | 2 | | |
+| `DESK-CHECK-39` | `DESK-SCENARIO-56` | 3 | | |
+| `DESK-CHECK-40` | `DESK-SCENARIO-57` | 2 | | |
+| `DESK-CHECK-41` | `DESK-SCENARIO-58` | 2 | | |
+| `DESK-CHECK-42` | `DESK-SCENARIO-59` | 3 | | |
+| `DESK-CHECK-43` | `DESK-SCENARIO-60` | 3 | | |

--- a/.gobbi/projects/gobbi/skills/desktop/checklists.md
+++ b/.gobbi/projects/gobbi/skills/desktop/checklists.md
@@ -289,9 +289,15 @@ clauses, its `Seeds` cases, and the obligation conditions its pass condition mus
 - [ ] **`DESK-CHECK-09`** `[GATE, PROTECTED]` · *Applicability:* unconditional — every required action, state,
   and meaning of the outcome is available through every applicable modality.
   *Pass:* the run's action, state, and meaning inventory is swept against the modality set its surfaces
-  actually require, with a direct behavioral result recorded per pairing, per claimed operating system.
-  *Evidence:* direct behavioral results per system — not a member-by-member roll-up, and not a captured
-  rendering.
+  actually require, with a direct behavioral result recorded per pairing, per claimed operating system; each
+  applicable input alternative preserves the intended focus flow and visible focus; the system with no
+  platform assistive-technology guidance states that gap and does not claim or imply parity; and reduced
+  motion is read in the renderer through its own media query, with the record stating that the theme interface
+  exposes no reduced-motion property and that this absence does not make the signal unavailable.
+  *Evidence:* direct behavioral results per system, including focus-order and focus-visibility exercise for
+  each applicable input alternative; the per-system assistive-technology rows inspected for the no-guidance
+  gap and absence of a parity claim; and source plus behavior showing the renderer media-query read and the
+  theme-interface absence statement — not a member-by-member roll-up, and not a captured rendering.
   *On fail:* halt; acceptance is blocked and the run returns to the owning rung.
   *Consequence:* a person cannot reach a required action at all.
   *Source:* `DESK-R10` · *Seeds:* `DESK-SCENARIO-37`, `DESK-SCENARIO-38`, `DESK-SCENARIO-39`,
@@ -305,8 +311,11 @@ clauses, its `Seeds` cases, and the obligation conditions its pass condition mus
   *Claim:* every required action, state, and meaning of this outcome is available through every applicable
   modality — the property itself.
   *Pass:* an inventory sweep with direct behavioral results. **Explicitly not satisfied by "members 1–16 all
-  passed."**
-  *Evidence:* the recorded sweep of the run's own action, state, and meaning inventory.
+  passed."** Its per-system assistive-technology result states the no-guidance gap where platform guidance is
+  absent and makes no parity claim for that system.
+  *Evidence:* the recorded sweep of the run's own action, state, and meaning inventory, including inspection
+  of every per-system assistive-technology row for an explicit no-guidance gap and for the absence of implied
+  parity.
   *On fail:* halt; block acceptance and return to the owning rung or phase.
   *Consequence:* a modality loss that no member names ships unnoticed.
   *Source:* the accessibility floor's property check · *Seeds:* `DESK-SCENARIO-39`, `DESK-SCENARIO-41`
@@ -414,9 +423,15 @@ clauses, its `Seeds` cases, and the obligation conditions its pass condition mus
   compilation targets are as specified.
   *Pass:* each unit states its execution context; the three targets exist with their own library, type, and
   module settings over one type-only shared layer; the renderer target excludes the runtime's ambient types;
-  the bridge contract carries only structured-cloneable values and plain asynchronous functions; and every
-  statement of the three-target split carries its derived marking.
-  *Evidence:* direct read of the three target configurations plus the bridge contract type.
+  the bridge contract carries only structured-cloneable values and plain asynchronous functions and is not
+  typed in terms of classes, constructors, or symbol-keyed members; every statement of the three-target split
+  carries its derived marking; and every channel-inventory entry
+  associates its channel identifier with its payload type, runtime validation, sender rule, and privileged
+  effect.
+  *Evidence:* direct read of the three target configurations and the source-of-truth bridge contract type,
+  inspecting the contract for the absence of classes, constructors, and symbol-keyed members; plus every
+  channel inventory row for all five associated values: channel identifier, payload type, runtime validation,
+  sender rule, and privileged effect.
   *On fail:* halt; return to the contract phase rather than patching a body.
   *Consequence:* a green type-check certifying code the sandbox rejects at run time.
   *Source:* `DESK-R14`, `DESK-R16`, `DESK-R17`, `DESK-N07` · *Seeds:* `DESK-SCENARIO-18`,
@@ -430,9 +445,11 @@ clauses, its `Seeds` cases, and the obligation conditions its pass condition mus
   its payload and its caller.
   *Pass:* every registered privileged handler runtime-validates its payload into a domain type and verifies
   the sending frame **in the handler** before any privileged effect, and the handler set enumerated from
-  source equals the channel inventory.
-  *Evidence:* caller trace plus a targeted test that sends from an unintended frame and observes the
-  privileged sink for any effect.
+  source equals the channel inventory; for every channel, the handler's payload type and validation, sender
+  rule, and privileged effect agree with the associations in that channel's inventory entry.
+  *Evidence:* inspect each channel inventory row against its handler for the channel identifier, payload type,
+  runtime validation, sender rule, and privileged effect; then follow the caller trace and run a targeted test
+  that sends from an unintended frame and observes the privileged sink for any effect.
   *On fail:* halt; open a security finding.
   *Consequence:* an unexpected frame reaches a privileged effect.
   *Source:* `DESK-R15`, `DESK-N06` · *Seeds:* `DESK-SCENARIO-18`, `DESK-SCENARIO-21`, `DESK-SCENARIO-32`
@@ -444,8 +461,11 @@ clauses, its `Seeds` cases, and the obligation conditions its pass condition mus
   names the lifecycle event that releases it.
   *Pass:* each privileged resource held on behalf of a renderer names a window or contents lifecycle event as
   its release point, with the last-resort terminal named and none keyed to scope exit; and the
-  pre-quit-for-update hook is handled so an install does not end the process mid-write.
-  *Evidence:* direct read plus a test under collection pressure confirming delivery survives.
+  pre-quit-for-update hook releases its owned resources before termination and makes unresolved unsaved work
+  an explicit stop to installation and quit, so an install does not end the process mid-write.
+  *Evidence:* direct read plus a test under collection pressure confirming delivery survives, and a
+  pre-quit/update-path test that observes resource release before termination and proves unresolved unsaved
+  work blocks both installation and quit.
   *On fail:* halt; return to the contract phase.
   *Consequence:* a channel that works under test and silently stops in the field, or work lost to an update.
   *Source:* `DESK-R18` · *Seeds:* `DESK-SCENARIO-20`, `DESK-SCENARIO-30`
@@ -456,8 +476,10 @@ clauses, its `Seeds` cases, and the obligation conditions its pass condition mus
   complete.
   *Pass:* a twenty-row inventory where each of the eight defaults is confirmed unchanged, or carries a
   recorded reason, and each of the twelve applicable positive controls is confirmed **written**, naming the
-  file and line; and no secret is present in the shipped artifact.
-  *Evidence:* direct read of the inventory plus an unpack-and-search of the shipped artifact.
+  file and line; no secret is present in the shipped artifact; and the design explicitly rejects packaging,
+  minification, and the ASAR archive as security boundaries.
+  *Evidence:* direct read of the inventory and security-boundary statements to confirm that packaging,
+  minification, and ASAR are each rejected as a boundary, plus an unpack-and-search of the shipped artifact.
   *On fail:* halt; open a security finding.
   *Consequence:* an application that passes every default check while having written none of the controls.
   *Source:* `DESK-R19`, `DESK-N08` · *Seeds:* `DESK-SCENARIO-31`, `DESK-SCENARIO-34`
@@ -619,9 +641,12 @@ claim its protected-item row already cites.
   asserted, and none is hedged.
   *Pass:* every stated platform convention reaches an owner document a reader can open; a convention with no
   readable owner appears neither as a fact nor as a hedge about what the vendor probably requires, and instead
-  carries its marking and its closing condition.
+  carries its marking and its closing condition; every operative rule remains valid regardless of how that
+  unresolved convention is later answered.
   *Evidence:* take each stated platform convention to the owner document that would establish it, and read
-  every unverifiable one for a marking rather than a softened assertion.
+  every unverifiable one for a marking rather than a softened assertion; for every operative rule that refers
+  to the unresolved convention, inspect the rule under each possible later answer and require the same rule to
+  remain valid.
   *On fail:* halt; open a finding against the owning obligation.
   *Consequence:* a conformance claim nobody can check, which reads as authority and can be false in exactly the
   way the assertion would have been.
@@ -721,10 +746,12 @@ claim its protected-item row already cites.
   an update path. An `n/a:<property>` requires the inspected finding that the system has none and that
   updates go through its package manager.
   *Pass:* an update was rehearsed **from the previously released version** rather than from a fresh install;
-  live work survives the install through the pre-quit hook; and a failure partway leaves the installed
-  version working with the failure surfaced rather than retried silently.
+  the pre-quit hook flushes live work and releases every owned resource before updater-driven process
+  termination; unresolved unsaved work explicitly stops installation and quit; and a failure partway leaves
+  the installed version working with the failure surfaced rather than retried silently.
   *Evidence:* the rehearsal record naming its starting version, plus an interrupted-update test at the
-  download and install stages separately.
+  download and install stages separately, and a pre-quit/update-path trace proving resource release precedes
+  updater-driven termination and unresolved unsaved work blocks both installation and quit.
   *On fail:* halt the release.
   *Consequence:* an update that destroys work the person had open, or leaves a partially replaced
   application.
@@ -775,8 +802,9 @@ claim its protected-item row already cites.
   *Pass:* the relation test exits zero across all four projections; the verifier is proved at **both** ends,
   rejecting each planted fixture and accepting the real bundle; and the obligation test's result is recorded
   **per case**, with the reviewer's identity, across every mapped check for a case with more than one.
-  *Evidence:* the recorded exit statuses and messages for the script-proved legs, and the reviewer's recorded
-  per-case results for the review-proved leg.
+  *Evidence:* the recorded exit statuses and messages from
+  [`scripts/check_relation.py`](scripts/check_relation.py) for the script-proved legs, and the reviewer's
+  recorded per-case results for the review-proved leg.
   *On fail:* halt the handoff; the trace is unproved.
   *Consequence:* a correctly-routed check whose wording dropped a named primitive ships unnoticed behind a
   green relation test.

--- a/.gobbi/projects/gobbi/skills/desktop/checklists.md
+++ b/.gobbi/projects/gobbi/skills/desktop/checklists.md
@@ -167,9 +167,12 @@ clauses, its `Seeds` cases, and the obligation conditions its pass condition mus
 - [ ] **`DESK-CHECK-01`** `[GATE]` · *Applicability:* unconditional — the run's outcome record binds one
   outcome with its actors, entry modes, claimed operating systems, visible and system completion evidence,
   and non-goals.
-  *Pass:* all six elements are present and mutually consistent, and the claimed-system set in the outcome
-  sentence equals the set the entry modes and non-goals assume.
-  *Evidence:* direct read of the design record's outcome section.
+  *Pass:* all six elements are present and mutually consistent; the claimed-system set in the outcome
+  sentence equals the set the entry modes and non-goals assume; and for a run inside an existing application
+  the record additionally names the behavior that must not change and the installed versions that constrain
+  reversibility.
+  *Evidence:* direct read of the design record's outcome section, including — for a run inside an existing
+  application — the unchanged-behavior list and the installed-version constraint.
   *On fail:* halt before rung 0; return to the framing phase.
   *Consequence:* a run that never bounded its outcome cannot tell completion from partial work.
   *Source:* `DESK-R01`, `DESK-R02`, `DESK-N01` · *Seeds:* `DESK-SCENARIO-01`, `DESK-SCENARIO-02`

--- a/.gobbi/projects/gobbi/skills/desktop/checklists.md
+++ b/.gobbi/projects/gobbi/skills/desktop/checklists.md
@@ -11,7 +11,7 @@ Be the unchecked operational gate source with the protected-waiver truth table. 
 | **Source state** | **unchecked** — every box below is unticked, and it stays that way |
 | **Run state** | each run works a **fresh filled copy** naming this source's version and the run's identity |
 | **Use-style** | declared per pause point below, per run |
-| **Items** | 43, across four pause points |
+| **Items** | 46, across four pause points |
 | **Provenance** | each item's `Source` names its parent clause; each item's `Seeds` names the cases that reserved it |
 
 **The source is never worked and never ticked.** A run copies it, fills the copy, and records the copy's
@@ -27,17 +27,17 @@ acceptance-bearing. An advisory row here would be a mandatory obligation quietly
 |---|---|---|---|---|
 | `DESK-PAUSE-1` — stack and outcome lock | before rung 0 begins | `read-do` | `01`–`05` | the outcome, boundary, stack-fit result, ownership statement, and gate-authority map are accepted |
 | `DESK-PAUSE-2` — design acceptance | before `P5` locks the application contract | `do-confirm` | `06`–`17` | the structural-approval decision is confirmed with no visual rung preceding it, the rung register is complete and substantiated, and all four floors are accepted on **both** their member check and their property check |
-| `DESK-PAUSE-3` — implementation completion | before `P9` treats the grown slices as complete | `do-confirm` | `18`–`26`, `37`–`43` | the privilege boundary, security posture, every per-system platform obligation on its own item, local data contract, and in-scope paths are accepted |
+| `DESK-PAUSE-3` — implementation completion | before `P9` treats the grown slices as complete | `do-confirm` | `18`–`26`, `37`–`46` | the privilege boundary, security posture, every per-system platform obligation on its own item, local data contract, and in-scope paths are accepted |
 | `DESK-PAUSE-4` — release-readiness handoff | before `P10` publishes readiness or any external release is requested | `do-confirm` | `27`–`36` | every applicable release gate per claimed operating system is accepted, the design record is complete, and the trace and verifier proofs have both run |
 
 **The reserved ranges were extended twice, and this is the single place that records it.** The design reserved
-thirty-four slots; this source authors **forty-three**:
+thirty-four slots; this source authors **forty-six**:
 
 | Pause point | Reserved by the design | Authored here | Why |
 |---|---|---|---|
 | `DESK-PAUSE-1` | `01`–`05` | `01`–`05` | unchanged |
 | `DESK-PAUSE-2` | `06`–`15` | `06`–`17` | the four non-waivable floors each need a **member** check and a **property** check — eight acceptance-bearing items — plus the structural-approval gate, the rung register, the ladder method, and the protected-waiver discipline |
-| `DESK-PAUSE-3` | `16`–`24` | `18`–`26`, `37`–`43` | shifted by two by the first extension; the second extension added seven at the tail of the sequence when `DESK-CHECK-23` was split into one atomic claim per item |
+| `DESK-PAUSE-3` | `16`–`24` | `18`–`26`, `37`–`46` | shifted by two by the first extension; the second extension added ten at the tail of the sequence — seven when `DESK-CHECK-23` was split into one atomic claim per item, and three for taught capabilities that had no check at all |
 | `DESK-PAUSE-4` | `25`–`34` | `27`–`36` | shifted by two; the item count is unchanged |
 
 The first extension followed the design's own rule — a range grows at its own pause point's tail and every
@@ -51,12 +51,13 @@ the design pins that one identifier and this source may not move it.
 
 **Item counts per pause point, and the three that exceed the generic guidance.** The generic guidance is
 roughly five to nine gate-or-required items per operational pause point. `DESK-PAUSE-1` carries 5, inside it.
-`DESK-PAUSE-4` carries 10, `DESK-PAUSE-2` carries 12, and `DESK-PAUSE-3` carries 16, all outside it. The
+`DESK-PAUSE-4` carries 10, `DESK-PAUSE-2` carries 12, and `DESK-PAUSE-3` carries 19, all outside it. The
 deviation is recorded rather than resolved by trimming, for a structural reason: the pause points are fixed by
 the design and may not be split here; eight of `DESK-PAUSE-2`'s twelve items are the four non-waivable floors'
-mandatory member-and-property pairs; and `DESK-PAUSE-3`'s count is what atomicity costs — seven of its items
-are the per-system behavior obligations that one conjoined item used to hide. Dropping one would either remove
-an acceptance-bearing item a floor requires, or put two claims back under one `PASS`.
+mandatory member-and-property pairs; and `DESK-PAUSE-3`'s count is what atomicity and coverage cost — seven of its
+items are the per-system behavior obligations that one conjoined item used to hide, and three are capabilities
+the mechanics children taught with nothing gating them. Dropping one would either remove an acceptance-bearing
+item a floor requires, put two claims back under one `PASS`, or return a taught capability to having no check.
 
 ## Terminal value set
 
@@ -141,11 +142,13 @@ consequences the floor exists to make unwaivable.
 concern distinct from the safety floor's foreseeable-refusable-recoverable property. They remain gates; they
 are simply not waiver-immune by this test.
 
-**The other items split out of `DESK-CHECK-23` are not selected either, and the test was applied to each.**
-`DESK-CHECK-37`, `39`, `40`, `41`, `42`, and `43` bear on conformance, discoverability, and honesty: a flash on
+**The other new items are not selected either, and the test was applied to each.**
+`DESK-CHECK-37`, `39`, `40`, `41`, `42`, `43`, `44`, `45`, and `46` bear on conformance, discoverability, and
+honesty: a flash on
 launch, an application that exits where its system's convention persists, a link that never fires, an
-appearance left behind, a dead accelerator, and a conformance claim nobody can check. Each is a defect the
-person can see and the run can correct forward; none reaches a consequence the person cannot foresee, refuse,
+appearance left behind, a dead accelerator, a conformance claim nobody can check, a stale tray menu, an
+unlocalised menu item, and a drop that does nothing. Each is a defect the person can see and the run can
+correct forward; none reaches a consequence the person cannot foresee, refuse,
 or recover from, and none bears on the accessibility floor's availability property. They remain gates.
 
 **The table.** Six rows. Each adversarial row holds every other applicable item at `PASS`, so the row
@@ -626,6 +629,50 @@ claim its protected-item row already cites.
   *Obligation conditions owned:* no unverified platform convention asserted · none hedged into a claim about
   what has not been read · the gap marked with its closing condition.
 
+- [ ] **`DESK-CHECK-44`** `[GATE]` · *Applicability:* conditional — applies when the outcome is entered from or
+  resident in a status-area icon. An `n/a:<property>` requires the inspected finding that it is entered from
+  none.
+  *Pass:* the icon carries a context menu; every change to a menu item is applied by setting the context menu
+  again rather than by mutating the item in place; the tray entry mode appears in the run's own entry-mode
+  inventory; and nothing written for the person promises an activation gesture on a system whose own
+  specification leaves that gesture to the environment.
+  *Evidence:* change one context-menu item at run time and open the menu on each claimed system; read the
+  entry-mode inventory for its tray row; and read every person-facing instruction naming a gesture against that
+  system's own specification.
+  *On fail:* halt; open a finding against the owning obligation.
+  *Consequence:* a menu that silently stops reflecting the application's own state, or a promise about a
+  gesture nobody can keep on that system.
+  *Source:* `DESK-R22` — its tray leg · *Seeds:* `DESK-SCENARIO-61`
+  *Obligation conditions owned:* the context menu re-set rather than the item mutated · the tray entry mode in
+  the inventory · no activation gesture promised where the specification fixes none.
+
+- [ ] **`DESK-CHECK-45`** `[GATE]` · *Applicability:* unconditional — every menu item matching a standard role
+  specifies that role.
+  *Pass:* the menu items enumerated from source contain no item whose behaviour matches a documented standard
+  role while the item reimplements that behaviour instead of specifying the role.
+  *Evidence:* enumerate the menu items from source and, for each whose behaviour matches a documented role,
+  read whether the role is specified or the behaviour is hand-written.
+  *On fail:* halt; open a finding against the owning obligation.
+  *Consequence:* the platform's own structure, labels, and localisation are lost, leaving an application
+  correct in one language and unlocalised in every other.
+  *Source:* `DESK-R21` — its role leg · *Seeds:* `DESK-SCENARIO-62`
+  *Obligation conditions owned:* the role specified for any item matching a standard role · the behaviour not
+  reimplemented in a click handler.
+
+- [ ] **`DESK-CHECK-46`** `[GATE]` · *Applicability:* conditional — applies when the outcome receives files
+  dropped onto it. An `n/a:<property>` requires the inspected finding that it receives none.
+  *Pass:* every read of a dropped file's path goes through the documented replacement helper, and no code path
+  reads the removed path property.
+  *Evidence:* enumerate every read of a dropped file's path from source; then drop a real file and observe the
+  path the handler actually receives, because the removed property's failure is an empty value rather than an
+  error and source reading alone will not surface a reachable one.
+  *On fail:* halt; open a finding against the owning obligation.
+  *Consequence:* a drop that silently does nothing, in code that compiles and whose handler is reached — the
+  form most published examples still show.
+  *Source:* `DESK-R26` — its verify-the-mechanism-at-its-owner leg · *Seeds:* `DESK-SCENARIO-63`
+  *Obligation conditions owned:* the path taken from the documented replacement helper · the removed property
+  read nowhere · the empty value treated as the failure rather than an error.
+
 ### `DESK-PAUSE-4` — release-readiness handoff · `do-confirm`
 
 - [ ] **`DESK-CHECK-27`** `[GATE]` · *Applicability:* unconditional — one installer target exists per claimed
@@ -810,6 +857,9 @@ in [`scenarios.md`](scenarios.md), verifiable independently of each item's own `
 | `DESK-CHECK-41` | `DESK-SCENARIO-58` | `DESK-PAUSE-3` |
 | `DESK-CHECK-42` | `DESK-SCENARIO-59` | `DESK-PAUSE-3` |
 | `DESK-CHECK-43` | `DESK-SCENARIO-60` | `DESK-PAUSE-3` |
+| `DESK-CHECK-44` | `DESK-SCENARIO-61` | `DESK-PAUSE-3` |
+| `DESK-CHECK-45` | `DESK-SCENARIO-62` | `DESK-PAUSE-3` |
+| `DESK-CHECK-46` | `DESK-SCENARIO-63` | `DESK-PAUSE-3` |
 
 ## Check-to-obligation union audit
 
@@ -879,3 +929,6 @@ in each item's `Obligation conditions owned` field above, and the reviewer reads
 | `DESK-CHECK-41` | `DESK-SCENARIO-58` | 2 | | |
 | `DESK-CHECK-42` | `DESK-SCENARIO-59` | 3 | | |
 | `DESK-CHECK-43` | `DESK-SCENARIO-60` | 3 | | |
+| `DESK-CHECK-44` | `DESK-SCENARIO-61` | 3 | | |
+| `DESK-CHECK-45` | `DESK-SCENARIO-62` | 2 | | |
+| `DESK-CHECK-46` | `DESK-SCENARIO-63` | 3 | | |

--- a/.gobbi/projects/gobbi/skills/desktop/checklists.md
+++ b/.gobbi/projects/gobbi/skills/desktop/checklists.md
@@ -890,7 +890,7 @@ in each item's `Obligation conditions owned` field above, and the reviewer reads
 | `DESK-CHECK-02` | `DESK-SCENARIO-05`, `DESK-SCENARIO-26` | 3 | | |
 | `DESK-CHECK-03` | `DESK-SCENARIO-01` | 2 | | |
 | `DESK-CHECK-04` | `DESK-SCENARIO-04` | 2 | | |
-| `DESK-CHECK-05` | `DESK-SCENARIO-23`, `DESK-SCENARIO-25` | 4 | | |
+| `DESK-CHECK-05` | `DESK-SCENARIO-23`, `DESK-SCENARIO-25` | 3 | | |
 | `DESK-CHECK-06` | `DESK-SCENARIO-09` | 3 | | |
 | `DESK-CHECK-07` | `DESK-SCENARIO-07`, `DESK-SCENARIO-48`, `DESK-SCENARIO-49` | 5 | | |
 | `DESK-CHECK-08` | `DESK-SCENARIO-54` | 5 | | |
@@ -902,7 +902,7 @@ in each item's `Obligation conditions owned` field above, and the reviewer reads
 | `DESK-CHECK-14` | `DESK-SCENARIO-11` | 2 | | |
 | `DESK-CHECK-15` | `DESK-SCENARIO-08` | 4 | | |
 | `DESK-CHECK-16` | `DESK-SCENARIO-55` | 4 | | |
-| `DESK-CHECK-17` | `DESK-SCENARIO-51` | 3 | | |
+| `DESK-CHECK-17` | `DESK-SCENARIO-51` | 2 | | |
 | `DESK-CHECK-18` | `DESK-SCENARIO-18`, `DESK-SCENARIO-19`, `DESK-SCENARIO-21`, `DESK-SCENARIO-22` | 6 | | |
 | `DESK-CHECK-19` | `DESK-SCENARIO-18`, `DESK-SCENARIO-21`, `DESK-SCENARIO-32` | 5 | | |
 | `DESK-CHECK-20` | `DESK-SCENARIO-20`, `DESK-SCENARIO-30` | 3 | | |
@@ -911,7 +911,7 @@ in each item's `Obligation conditions owned` field above, and the reviewer reads
 | `DESK-CHECK-23` | `DESK-SCENARIO-16` | 2 | | |
 | `DESK-CHECK-24` | `DESK-SCENARIO-13`, `DESK-SCENARIO-15`, `DESK-SCENARIO-17`, `DESK-SCENARIO-28` | 5 | | |
 | `DESK-CHECK-25` | `DESK-SCENARIO-02`, `DESK-SCENARIO-03` | 3 | | |
-| `DESK-CHECK-26` | `DESK-SCENARIO-23`, `DESK-SCENARIO-24`, `DESK-SCENARIO-25` | 4 | | |
+| `DESK-CHECK-26` | `DESK-SCENARIO-23`, `DESK-SCENARIO-24`, `DESK-SCENARIO-25` | 3 | | |
 | `DESK-CHECK-27` | `DESK-SCENARIO-42`, `DESK-SCENARIO-46` | 3 | | |
 | `DESK-CHECK-28` | `DESK-SCENARIO-42` | 2 | | |
 | `DESK-CHECK-29` | `DESK-SCENARIO-42`, `DESK-SCENARIO-45` | 3 | | |

--- a/.gobbi/projects/gobbi/skills/desktop/checklists.md
+++ b/.gobbi/projects/gobbi/skills/desktop/checklists.md
@@ -1,0 +1,18 @@
+# Desktop Application Operational Checklist
+
+Be the unchecked operational gate source with the protected-waiver truth table. Policy lives in
+[`SKILL.md`](SKILL.md); cases live in [`scenarios.md`](scenarios.md). This source adds no policy.
+
+## Pause points
+
+## Terminal value set
+
+## Gate-resolution truth table
+
+## Protected-waiver acceptance truth table
+
+## Items by pause point
+
+## Guaranteed coverage map
+
+## Check-to-obligation union audit

--- a/.gobbi/projects/gobbi/skills/desktop/evaluation.md
+++ b/.gobbi/projects/gobbi/skills/desktop/evaluation.md
@@ -4,18 +4,320 @@ Be the evaluator entrypoint that selects the applicable cases and checks and add
 in [`SKILL.md`](SKILL.md); cases live in [`scenarios.md`](scenarios.md) and binary operational gates live in
 [`checklists.md`](checklists.md). It adds no policy and creates no additional evaluation phase or artifact.
 
+**Non-expansion, stated plainly.** This file refines the general evaluation method's lenses and evidence for a
+desktop subject. It does not replace that method, add a perspective, add a verdict value, or produce a second
+result. The **caller** owns the machine shape, the output path, the validation, the aggregation, and the
+storage mechanics; nothing here changes them, and nothing here is a separate deliverable the caller must
+collect.
+
+**Bundle load list.** Three files, all of which exist: [`SKILL.md`](SKILL.md),
+[`scenarios.md`](scenarios.md), and [`checklists.md`](checklists.md). The mechanics children are read as needed
+for a specific claim. There is **no `mistakes.md` in this skill's directory**, so nothing here loads one — a
+skill-owned mistakes home is written by Wrap-up promotion, and naming a path that does not exist would fail
+the load closed.
+
 ## Stage 0 — Frame the evidence
+
+Before judging anything, fix what is being judged and what evidence exists for it.
+
+1. **Bind the subject and its version.** Name the exact artifacts under review and the platform version every
+   version-dependent claim depends on. [`runtime-deltas.md`](runtime-deltas.md) is the sole owner of those
+   literals; a claim whose version is unnamed is unevaluable rather than passing.
+2. **Confirm independence.** The evaluator did not design, author, or implement the subject. Self-review does
+   not supply the independent verdict, and a creator's own PASS is not evidence.
+3. **Freeze the subject.** If the writer can still change it, stop. A report that reviewed different bytes from
+   the declared subject is not a result.
+4. **Record the capability limit.** Several desktop claims need a runtime that can build, install, sign, or
+   launch on a specific operating system. Where this evaluator cannot execute the proving action, the claim
+   stays **unevaluable** and the limit is stated; it is never resolved by close reading. Attribute any executed
+   proof to the system that ran it.
+5. **Inventory the claimed operating systems.** Every per-system claim needs that system's own evidence.
+   Evidence from one system supports no claim about another, so the claim set determines the evidence set.
+
+**Evidence:** a frame record naming the subject and version, the independence statement, the platform-version
+pin, the claimed-system set, and every capability limit that will leave a claim unevaluable.
 
 ## Rule-to-coverage crosswalk
 
+Every live rule and prohibition, the families that exercise it, and the check cluster that gates it. Thirty
+rules and eleven prohibitions are live; two identifiers were withdrawn during design and are never
+reallocated.
+
+| Clauses | Families | Check cluster |
+|---|---|---|
+| `DESK-R01`, `DESK-R02`, `DESK-N01` | `01` | outcome and boundary — `DESK-CHECK-01`, `DESK-CHECK-25` |
+| `DESK-R03` | `01`, `05`, `09` | stack fit — `DESK-CHECK-02` |
+| `DESK-R04` | `01`, `10` | design ownership — `DESK-CHECK-03` |
+| `DESK-R05`, `DESK-R06`, `DESK-N02` | `10`, `02` | rung register and silent skip — `DESK-CHECK-07` |
+| `DESK-R07`, `DESK-R08`, `DESK-R09`, `DESK-N03` | `02`, `08` | ladder method and fidelity — `DESK-CHECK-08` |
+| `DESK-R10` | `08` | accessibility floor, member and property — `DESK-CHECK-09`, `DESK-CHECK-10` |
+| `DESK-R11` | `03`, `06`, `07`, `09` | safety floor, member and property — `DESK-CHECK-11`, `DESK-CHECK-12`, `DESK-CHECK-24` |
+| `DESK-R12` | `02` | participant floor, member and property — `DESK-CHECK-13`, `DESK-CHECK-14` |
+| `DESK-R13`, `DESK-N04` | `02`, `10` | direct-evidence floor, member and property — `DESK-CHECK-15`, `DESK-CHECK-16` |
+| `DESK-N05` | `02`, `08`, `10` | protected-waiver truth table — `DESK-CHECK-17` |
+| `DESK-R14`, `DESK-R16`, `DESK-R17`, `DESK-N07` | `04` | privilege boundary and targets — `DESK-CHECK-18` |
+| `DESK-R15`, `DESK-N06` | `04`, `07` | crossing validation — `DESK-CHECK-19` |
+| `DESK-R18` | `03`, `04`, `06` | lifecycle disposal — `DESK-CHECK-20` |
+| `DESK-R19`, `DESK-R20`, `DESK-N08` | `07` | security posture and hardening — `DESK-CHECK-21`, `DESK-CHECK-22` |
+| `DESK-R21`, `DESK-R22`, `DESK-N09` | `03`, `08` | platform conformance — `DESK-CHECK-23` |
+| `DESK-R23`, `DESK-R24` | `09`, `06` | release gates and irreversibility — `DESK-CHECK-27`, `DESK-CHECK-28`, `DESK-CHECK-29`, `DESK-CHECK-30`, `DESK-CHECK-31` |
+| `DESK-R25` | `10` | claim separation — `DESK-CHECK-32` |
+| `DESK-R26` | `05`, `09`, `10` | version pinning, claim-to-source register, and unknowns — `DESK-CHECK-05`, `DESK-CHECK-26` |
+| `DESK-R27`, `DESK-N10` | `01`, `10` | user-gate authority — `DESK-CHECK-04`, `DESK-CHECK-22`, `DESK-CHECK-36` |
+| `DESK-R27` — the `DESK-G3` structural-approval leg | `02`, `10` | structural-skeleton approval — `DESK-CHECK-06` |
+| `DESK-R28` | `10` | trace and verifier proof — `DESK-CHECK-34` |
+| `DESK-R29` | `10`, `02` | design-record completeness — `DESK-CHECK-33` |
+| `DESK-R31`, `DESK-N12` | `10`, `09` | deferred-capability marking — `DESK-CHECK-35` |
+
+**Closure, in both directions.** Forward: every one of the thirty live rules and eleven live prohibitions
+appears above with at least one family and at least one check. Reverse: every family `01`–`10` and every check
+`01`–`36` appears in at least one row, so no case and no check is orphaned from a live clause. Both sweeps run
+to **zero orphans**. A clause with no family or no check is a coverage gap in the scenario or checklist source
+rather than something a crosswalk row can paper over.
+
+**`Source` is not a fifth projection.** Each check's `Source` field is a *(check, rule)* relation, and it is the
+check side of this crosswalk. The four projections named below are *(case, check)* relations. A relation over
+one pair of sets cannot be an exact projection of a relation over a different pair, so requiring equality
+across all five is a test no correct bundle can pass. `Source` closes its own direction here.
+
 ## Selecting cases and checks
+
+1. **Start from the whole set, then disposition.** All ten families and all thirty-six checks are candidates.
+   Select every case and check whose applicability predicate holds for this subject.
+2. **A non-selection needs an inspected property.** Record `n/a:<property>` with the inspection that found the
+   predicate false. The conditional checks — measurement, signing, update, deferred-capability — are the only
+   places a legitimate `n/a` normally arises, and even there the property is inspected rather than assumed.
+3. **The four `-PROPERTY` checks are never deselected.** `DESK-CHECK-10`, `DESK-CHECK-12`, `DESK-CHECK-14`, and
+   `DESK-CHECK-16` each declare `Applicability: unconditional` exactly once and never resolve `n/a`, because the
+   property each claims holds of every desktop outcome.
+4. **Freeze the selected frame before recording any result**, then treat it as the coverage floor rather than
+   the limit. The perspective investigation below is required to look past it.
+5. **Add what the frame missed.** A material condition with no case or check is added, evaluated, and recorded
+   as a coverage gap in the source — not silently absorbed into an adjacent row.
 
 ## Relation and obligation verification
 
+Two tests, and they prove different things. Running one and reporting the trace as proved is the specific
+failure this section exists to prevent.
+
+**The relation test — mechanical, self-failing.** The four projections of the authoritative *(case, check)*
+relation must have identical normalized edge sets:
+
+1. the case-level `Trace` field in [`scenarios.md`](scenarios.md) — **authoritative**;
+2. each check's `Seeds` field in [`checklists.md`](checklists.md);
+3. the guaranteed coverage map in [`checklists.md`](checklists.md);
+4. the check-to-obligation union audit in [`checklists.md`](checklists.md).
+
+The test compares edge sets and **exits non-zero on any symmetric difference**, naming the offending edge and
+which side holds it. It never prints a count and calls that a result. It fails closed on an empty inventory, a
+missing file, and a missing section, because a gate that cannot see its subject must not pass it.
+
+**The obligation test — review-proved, per case.** A named reviewer reads each selected case's `Obligation` and
+**every** mapped check's actual `Pass:` and `Evidence:` wording, and confirms the check's own wording owns
+every named primitive the obligation asserts, **in the obligation's sense** — asserted, not negated, not named
+as an anti-pattern, and not carried in an unrelated clause.
+
+- Matching identifiers, equal counts, and the audit table's summary prose close nothing.
+- The reviewer reads **every** mapped check for a case with more than one, not the first; a per-case result
+  covers that case's whole mapped set.
+- The result is recorded **per case with the reviewer's identity**. An unrecorded case is an unrun test, and a
+  failed case fails the obligation test.
+
+**Why this leg is review-proved rather than scripted.** No fixed-string comparison can distinguish an asserted
+primitive from a negated one, or a dropped primitive from one carried in an unrelated clause. An earlier design
+tried a substring containment leg and it was unsound: a token was satisfied by a longer token containing it — a
+prefix collision on a real configuration value this very skill teaches. **What is lost is stated rather than
+hidden:** no script fails on a dropped primitive. The relation test still proves mechanically that the
+projections agree, so a mis-routed edge is caught by a command; a correctly-routed check whose wording dropped
+a primitive is caught only by the recorded read.
+
+**The planted-fixture proof — three fixtures, and the verifier proved at both ends.**
+
+| Fixture | Planted defect | Rejected by | Leg |
+|---|---|---|---|
+| **F-A** | a case's `Trace` names a check whose `Seeds` omits that case | the relation test, on a non-empty symmetric difference | **script-proved** |
+| **F-B** | a check's `Seeds` names a case whose `Trace` omits that check | the relation test, on a non-empty symmetric difference | **script-proved** |
+| **F-C** | all four projections agree, and one named primitive the case's `Obligation` asserts is absent from the mapped check's `Pass:` and `Evidence:` wording | the obligation test | **review-proved** |
+
+Plant one defect per disposable copy, run the verifier, record the exact non-zero exit and message for each
+script-proved fixture and the reviewer's recorded rejection for the review-proved one, then discard the copies.
+**The recorded proof is the three rejections themselves, not a statement that they were run.**
+
+**Both ends, every leg.** The verifier exits non-zero on each planted fixture **and** exits zero on the real
+bundle; the reviewer rejects F-C **and** accepts the real bundle. Both results are recorded for both legs. A
+gate proved only on the failing side can forbid the state the work must reach; a gate proved only on the
+passing side can be fail-open.
+
+**The verifier's own output states which legs are script-proved and which is review-proved**, so a reader never
+mistakes a green relation test for a complete obligation proof.
+
 ## Evidence classes and claim boundaries
+
+| Evidence | May support | Does not alone support |
+|---|---|---|
+| Source and static inspection | structure, configured controls, the fuse configuration as written, dependency shape | run-time behavior, per-system behavior, user success |
+| Automated tests | exercised behavior in the test environment, on the build the suite actually ran against | the shipped artifact when the build matrix differs, visual quality, user acceptance |
+| Live application interaction | the operated path and visible state on that system, in that build | hidden semantics, other operating systems, packaged behavior |
+| Accessibility-tree inspection | semantics, name, role, value, exposed state | pixel quality, all assistive-technology behavior, user acceptance |
+| Captured rendering | the captured pixels and visible state at one moment | semantics, keyboard and focus behavior, motion, accessibility conformance — [`vision`](../vision/SKILL.md) owns these limits |
+| Representative-user evidence | observed design fit for the recruited people, on the system it was gathered on | implementation correctness, or any population or system not represented |
+| Local-data and state evidence | authoritative on-disk effects and invariants in that environment | user comprehension, or behavior after a version change |
+| Lab performance | repeatable synthetic behavior under declared conditions, **on the named platform version** | the production population, or any other platform version |
+| Field telemetry | instrumented behavior for the observed installed population | causality, uninstrumented harm, or design acceptance |
+| **Packaged-artifact evidence** *(desktop)* | that an installer exists and installs in a clean environment on that system | that it is signed, that it updates, or that it behaves correctly once installed |
+| **Signature and notarization evidence** *(desktop)* | that the shipped bytes carry a valid identity on that system | that an update works, or that signature-gated behavior was exercised |
+| **Update-rehearsal evidence** *(desktop)* | that a person on the previously released version reaches this one with data intact | anything about a release two versions back, or about a fresh install |
+| **Per-operating-system evidence** *(desktop — an axis rather than a method)* | claims about the system it was gathered on | any claim about any other claimed system |
+
+**The four desktop additions exist because the release chain has four separately provable stages** — packaged,
+installed, signed, updated — and because the operating system is itself an evidence axis here rather than a
+configuration detail. Window behavior, menu structure, notification behavior, shortcut mapping, and
+assistive-technology behavior all differ per system.
+
+**Never merge evidence classes into one tested status.** Nine claims are separate by rule: design acceptance,
+implementation correctness, packaged-artifact evidence, signature and notarization evidence, update-rehearsal
+evidence, per-system evidence, release readiness, release authority, and post-release outcome. Resolve a
+contradiction at the authoritative owner and never let the favorable signal mask it. An unrunnable gate is
+recorded as a limitation that **blocks** the claim it would have proved, never widened into a weaker signal
+that partially supports it.
 
 ## The seven perspectives
 
+Seven lenses plus Overall, in the general method's fixed order. Each entry below is the desktop refinement of
+that lens rather than a replacement for it, and each names the families whose declared primary category routes
+to it.
+
+### Project
+
+*Families `01`, `02`.* Test the trigger, the bounded outcome, the claimed operating systems, the scope
+boundary, the non-goals, and the completion claim. Test the stack-fit result as **six inspected results** rather
+than a verdict, and test whether any positive criterion reached the user as a decision. Test the ownership
+statement. Look for a claimed system with no evidence route, an entry mode named in the outcome and absent from
+every path, and a designed path left unimplemented behind a green build.
+
+### Structure
+
+*Families `03`, `04`.* Test the execution-context assignment per unit, the channel inventory against the
+handlers enumerated from source, the bridge contract's shape, and the three compilation targets. Test that the
+derived marking travels with the three-target split at every site that states it. Test lifetime ownership:
+every cross-process resource keyed to a named lifecycle event rather than to scope exit. Look for a privileged
+handler reachable over a channel absent from the inventory, and for a contract typed in terms of classes.
+
+### Performance
+
+*Family `05`.* Test whether every recorded measurement names the platform version it was taken on, and whether
+any comparison attributes a difference to the run's own work across differing versions. Test that file and
+parsing work is off the privileged process's own thread — a blocking call there freezes every window at once,
+which has no analogue on the web. Look for an unqualified startup number presented as an improvement.
+
+### Aesthetics
+
+*No family declares this as its primary category*, which is worth stating rather than leaving as an apparent
+gap: the subject is a delivery skill, and its aesthetic surface is its own prose and structure. Test
+self-evidence, accurate naming, concision, convention fit, and whether the bundle reads as one coherent
+artifact. Test that no file restates a fact another owns. Look for placeholders, headings with no resolved
+content, and a size figure treated as a pass condition.
+
+### Usage
+
+*Families `02`, `08`.* Test the experience of the person using the application and of the operator running the
+release. Test the accessibility union as a **property** over the run's own action, state, and meaning inventory,
+per claimed system, with direct behavioral results. Test that reduced motion is honored from the renderer's own
+media query, and that the absence of a theme-interface property was not read as the signal being unavailable.
+Test the participant conditions and their fail-closed behavior. Look for a per-system accessibility claim
+resting on documentation that names nothing for that system.
+
+### Consistency
+
+*Families `09`, `10`.* Test agreement across the family: the four projections, the crosswalk in both
+directions, each check's `Source` against the clause it names, every intra-family pointer against content the
+target actually holds, and every version-dependent statement against the single owner. Test the design record
+against the run's own claims. Look for a stale pointer that still resolves, a count stated in one file and
+contradicted by a scan, and an identifier reallocated after withdrawal.
+
+### Risk
+
+*Families `06`, `07`.* Test the two kinds of security work as **written or missing**, per item, naming file and
+line. Test the fuse configuration on the built artifact rather than in source. Test the four floors on both
+their member check and their property check, and test that no waiver token sits on a protected item. Test the
+release chain's irreversibility: the supported-old-version window, the update rehearsal from the previous
+release, and the stop conditions. Require **direct** evidence for every irreversible, trust-boundary, and
+data-loss claim. Look for a secret in the shipped artifact, an unlisted clause reaching an unrecoverable
+consequence, and a build matrix recorded with one horn.
+
 ## Recommended verification
 
+| # | Verification | Method | What it cannot prove |
+|---|---|---|---|
+| 1 | The relation test over the four projections | run it; require exit zero and a named edge count | that any check's wording carries its obligation's primitives |
+| 2 | The obligation test, per selected case | a recorded read of every mapped check's `Pass:` and `Evidence:` wording, with the reviewer's identity | routing correctness, which verification 1 owns |
+| 3 | The three planted fixtures, at both ends | plant, run, record the exit and message or the recorded rejection, discard | anything about a defect class no fixture models |
+| 4 | Clause closure in both directions | enumerate live clauses from `SKILL.md` and compare against the crosswalk; then enumerate families and checks and compare back | that a mapped check actually exercises the clause |
+| 5 | The four `-PROPERTY` declarations | confirm each carries exactly one unconditional-gate declaration; a bare total of four false-passes a two-and-two split | that the property check's evidence was actually gathered |
+| 6 | The unchecked source | confirm no ticked box exists in `checklists.md` | that a filled copy resolved correctly |
+| 7 | Every count the family states | reproduce each by scan — families, cases, cells, items, edges, conditions | that the counted set is the right set |
+| 8 | Every intra-family pointer | open the target and confirm it holds the content the pointer's context expects | that the content is correct, only that it is present |
+| 9 | Version-dependent statements | confirm each names its version and resolves to the single owner | that the owner's own value is current |
+| 10 | Fuse and security state | read the **built artifact**, not the source | behavior on a system the evidence was not gathered on |
+
+**A capability limit is recorded, never resolved by reading.** Where this evaluator cannot build, install, sign,
+launch, or measure on a claimed system, the affected verification stays unrun and the claim stays unevaluable.
+Attribute any executed proof to the system that ran it.
+
 ## Overall anchors and claim ledger
+
+**Overall integrates across lenses; it is not a summary of them.** Six anchors, each a cross-perspective
+effect no single lens owns:
+
+1. **The gap between what was designed and what was built.** The ladder produces a design record; the build
+   produces an artifact. Overall tests whether the artifact realizes the accepted design, and whether any rung
+   was quietly reinterpreted during implementation rather than re-entered.
+2. **The gap between what was tested and what ships.** If the build-matrix decision put automation on a
+   differently fused build, every claim that automation supports is a claim about a different artifact. Overall
+   tests whether that limit is stated where the claims are read, not only where the decision was recorded.
+3. **Evidence-class merging under time pressure.** The nine claims are separate by rule and converge into one
+   green status under deadline. Overall tests whether the ledger still distinguishes them, and whether an
+   unrunnable gate is recorded as blocking rather than as partial support.
+4. **Per-system claims resting on one system's evidence.** The most common cross-lens failure here: a claim
+   proved on one operating system and reported as a property of the outcome. Overall tests whether the claim
+   scope matches the evidence scope, per claim.
+5. **A floor satisfied member-by-member while its property is violated.** Each floor's member check and
+   property check pass separately; Overall tests whether the property checks were resolved by an inventory
+   sweep or by a member roll-up wearing the sweep's name.
+6. **Mechanism standing in for an outcome contract.** A green relation test, a complete matrix, a full
+   register — Overall tests whether the machinery was used to establish the property or to substitute for it.
+
+**Strengths this family's later work must preserve**, recorded because a revision that loses them is a
+regression even if every check still passes: the single-owner discipline for version literals; the property
+checks' explicit rejection of member roll-ups; the item-scope test that protects items bearing on a floor
+rather than only items titled after one; the review-proved obligation test and its honestly stated coverage
+loss; and the marked gaps that were left as gaps rather than filled from a plausible summary.
+
+### The claim ledger
+
+One row per claim the evaluation itself makes. It is the evaluator's own honesty surface, and it is filled in
+the report rather than here.
+
+| Field | What it records |
+|---|---|
+| Claim | the single thing asserted |
+| Evidence class | which row of the table above supports it |
+| Scope | the operating system, build, and version the evidence covers |
+| Method | what was actually run or read, exactly |
+| Limit | what this evidence cannot support |
+| Verdict contribution | which perspective result it feeds |
+
+**Three ledger rules.**
+
+- **A claim with no evidence row is not a finding**; it is an observation, and it is labelled one.
+- **A claim whose scope is narrower than its wording is a defect in the wording**, not a limitation to note in
+  passing. Narrow the claim to its evidence.
+- **An unevaluable claim is recorded as unevaluable and blocks what it would have proved.** It never
+  contributes a weaker signal toward a pass.
+
+**Verdict derivation belongs to the general method**, which owns the three verdict values, the thresholds, and
+the aggregation. This file adds no verdict value and changes no threshold. What it adds is the desktop
+consequence of the general rule that a supported finding stays visible: **the irreversibility of a shipped
+release means a Risk or Consistency finding on the release chain cannot be softened because the correction
+looks cheap.** Once the artifact is on a person's machine, the correction is a new release, and the finding was
+the last point at which it was cheap.

--- a/.gobbi/projects/gobbi/skills/desktop/evaluation.md
+++ b/.gobbi/projects/gobbi/skills/desktop/evaluation.md
@@ -59,10 +59,10 @@ reallocated.
 | `DESK-R15`, `DESK-N06` | `04`, `07` | crossing validation — `DESK-CHECK-19` |
 | `DESK-R18` | `03`, `04`, `06` | lifecycle disposal — `DESK-CHECK-20` |
 | `DESK-R19`, `DESK-R20`, `DESK-N08` | `07` | security posture and hardening — `DESK-CHECK-21`, `DESK-CHECK-22` |
-| `DESK-R21`, `DESK-R22`, `DESK-N09` | `03`, `08` | platform conformance, one claim per item — `DESK-CHECK-23`, `DESK-CHECK-37`, `DESK-CHECK-38`, `DESK-CHECK-39`, `DESK-CHECK-40`, `DESK-CHECK-41`, `DESK-CHECK-42`, `DESK-CHECK-43` |
+| `DESK-R21`, `DESK-R22`, `DESK-N09` | `03`, `08` | platform conformance, one claim per item — `DESK-CHECK-23`, `DESK-CHECK-37`, `DESK-CHECK-38`, `DESK-CHECK-39`, `DESK-CHECK-40`, `DESK-CHECK-41`, `DESK-CHECK-42`, `DESK-CHECK-43`, `DESK-CHECK-44`, `DESK-CHECK-45` |
 | `DESK-R23`, `DESK-R24` | `09`, `06` | release gates and irreversibility — `DESK-CHECK-27`, `DESK-CHECK-28`, `DESK-CHECK-29`, `DESK-CHECK-30`, `DESK-CHECK-31` |
 | `DESK-R25` | `10` | claim separation — `DESK-CHECK-32` |
-| `DESK-R26` | `05`, `09`, `10` | version pinning, claim-to-source register, and unknowns — `DESK-CHECK-05`, `DESK-CHECK-26` |
+| `DESK-R26` | `03`, `05`, `09`, `10` | version pinning, the claim-to-source register, unknowns, and mechanism verification at the owner — `DESK-CHECK-05`, `DESK-CHECK-26`, `DESK-CHECK-46` |
 | `DESK-R27`, `DESK-N10` | `01`, `10` | user-gate authority — `DESK-CHECK-04`, `DESK-CHECK-22`, `DESK-CHECK-36` |
 | `DESK-R27` — the `DESK-G3` structural-approval leg | `02`, `10` | structural-skeleton approval — `DESK-CHECK-06` |
 | `DESK-R28` | `10` | trace and verifier proof — `DESK-CHECK-34` |
@@ -71,7 +71,7 @@ reallocated.
 
 **Closure, in both directions.** Forward: every one of the thirty live rules and eleven live prohibitions
 appears above with at least one family and at least one check. Reverse: every family `01`–`10` and every check
-`01`–`43` appears in at least one row, so no case and no check is orphaned from a live clause. Both sweeps run
+`01`–`46` appears in at least one row, so no case and no check is orphaned from a live clause. Both sweeps run
 to **zero orphans**. A clause with no family or no check is a coverage gap in the scenario or checklist source
 rather than something a crosswalk row can paper over.
 
@@ -82,11 +82,12 @@ across all five is a test no correct bundle can pass. `Source` closes its own di
 
 ## Selecting cases and checks
 
-1. **Start from the whole set, then disposition.** All ten families and all forty-three checks are candidates.
+1. **Start from the whole set, then disposition.** All ten families and all forty-six checks are candidates.
    Select every case and check whose applicability predicate holds for this subject.
 2. **A non-selection needs an inspected property.** Record `n/a:<property>` with the inspection that found the
-   predicate false. The conditional checks — measurement, signing, update, deferred-capability — are the only
-   places a legitimate `n/a` normally arises, and even there the property is inspected rather than assumed.
+   predicate false. The conditional checks — measurement, deep link, tray residency, dropped files, signing,
+   update, deferred capability — are the only places a legitimate `n/a` normally arises, and even there the
+   property is inspected rather than assumed.
 3. **The four `-PROPERTY` checks are never deselected.** `DESK-CHECK-10`, `DESK-CHECK-12`, `DESK-CHECK-14`, and
    `DESK-CHECK-16` each declare `Applicability: unconditional` exactly once and never resolve `n/a`, because the
    property each claims holds of every desktop outcome.

--- a/.gobbi/projects/gobbi/skills/desktop/evaluation.md
+++ b/.gobbi/projects/gobbi/skills/desktop/evaluation.md
@@ -59,7 +59,7 @@ reallocated.
 | `DESK-R15`, `DESK-N06` | `04`, `07` | crossing validation — `DESK-CHECK-19` |
 | `DESK-R18` | `03`, `04`, `06` | lifecycle disposal — `DESK-CHECK-20` |
 | `DESK-R19`, `DESK-R20`, `DESK-N08` | `07` | security posture and hardening — `DESK-CHECK-21`, `DESK-CHECK-22` |
-| `DESK-R21`, `DESK-R22`, `DESK-N09` | `03`, `08` | platform conformance — `DESK-CHECK-23` |
+| `DESK-R21`, `DESK-R22`, `DESK-N09` | `03`, `08` | platform conformance, one claim per item — `DESK-CHECK-23`, `DESK-CHECK-37`, `DESK-CHECK-38`, `DESK-CHECK-39`, `DESK-CHECK-40`, `DESK-CHECK-41`, `DESK-CHECK-42`, `DESK-CHECK-43` |
 | `DESK-R23`, `DESK-R24` | `09`, `06` | release gates and irreversibility — `DESK-CHECK-27`, `DESK-CHECK-28`, `DESK-CHECK-29`, `DESK-CHECK-30`, `DESK-CHECK-31` |
 | `DESK-R25` | `10` | claim separation — `DESK-CHECK-32` |
 | `DESK-R26` | `05`, `09`, `10` | version pinning, claim-to-source register, and unknowns — `DESK-CHECK-05`, `DESK-CHECK-26` |
@@ -71,7 +71,7 @@ reallocated.
 
 **Closure, in both directions.** Forward: every one of the thirty live rules and eleven live prohibitions
 appears above with at least one family and at least one check. Reverse: every family `01`–`10` and every check
-`01`–`36` appears in at least one row, so no case and no check is orphaned from a live clause. Both sweeps run
+`01`–`43` appears in at least one row, so no case and no check is orphaned from a live clause. Both sweeps run
 to **zero orphans**. A clause with no family or no check is a coverage gap in the scenario or checklist source
 rather than something a crosswalk row can paper over.
 
@@ -82,7 +82,7 @@ across all five is a test no correct bundle can pass. `Source` closes its own di
 
 ## Selecting cases and checks
 
-1. **Start from the whole set, then disposition.** All ten families and all thirty-six checks are candidates.
+1. **Start from the whole set, then disposition.** All ten families and all forty-three checks are candidates.
    Select every case and check whose applicability predicate holds for this subject.
 2. **A non-selection needs an inspected property.** Record `n/a:<property>` with the inspection that found the
    predicate false. The conditional checks — measurement, signing, update, deferred-capability — are the only

--- a/.gobbi/projects/gobbi/skills/desktop/evaluation.md
+++ b/.gobbi/projects/gobbi/skills/desktop/evaluation.md
@@ -1,0 +1,21 @@
+# Desktop Application Evaluation Entry
+
+Be the evaluator entrypoint that selects the applicable cases and checks and adds desktop lenses. Policy lives
+in [`SKILL.md`](SKILL.md); cases live in [`scenarios.md`](scenarios.md) and binary operational gates live in
+[`checklists.md`](checklists.md). It adds no policy and creates no additional evaluation phase or artifact.
+
+## Stage 0 — Frame the evidence
+
+## Rule-to-coverage crosswalk
+
+## Selecting cases and checks
+
+## Relation and obligation verification
+
+## Evidence classes and claim boundaries
+
+## The seven perspectives
+
+## Recommended verification
+
+## Overall anchors and claim ledger

--- a/.gobbi/projects/gobbi/skills/desktop/evaluation.md
+++ b/.gobbi/projects/gobbi/skills/desktop/evaluation.md
@@ -113,6 +113,17 @@ The test compares edge sets and **exits non-zero on any symmetric difference**, 
 which side holds it. It never prints a count and calls that a result. It fails closed on an empty inventory, a
 missing file, and a missing section, because a gate that cannot see its subject must not pass it.
 
+Run the checked-in implementation from the repository root:
+
+```bash
+python3 -B .gobbi/projects/gobbi/skills/desktop/scripts/check_relation.py
+python3 -B .gobbi/projects/gobbi/skills/desktop/scripts/check_relation.py --self-test
+```
+
+Use `--scenarios PATH --checklists PATH` together for disposable copies. The success output names the shared
+non-zero edge count and states `relation_leg=script-proved obligation_leg=review-proved`; the count supports
+the result but exact edge-set equality is the acceptance condition.
+
 **The obligation test — review-proved, per case.** A named reviewer reads each selected case's `Obligation` and
 **every** mapped check's actual `Pass:` and `Evidence:` wording, and confirms the check's own wording owns
 every named primitive the obligation asserts, **in the obligation's sense** — asserted, not negated, not named

--- a/.gobbi/projects/gobbi/skills/desktop/fidelity-ladder.md
+++ b/.gobbi/projects/gobbi/skills/desktop/fidelity-ladder.md
@@ -1,0 +1,16 @@
+# The Design Fidelity Ladder
+
+Define the nine generic design rungs, the three fidelity axes, and the validation methods that close each
+rung. Every definition here is product-neutral: no platform, no operating system, and no product class
+appears inside a rung, and no identifier is named except this file's own `DESK-RUNG-N`. Where a rung needs
+the policy that binds it, or the floor that owns its evidence set, it names that owner by role.
+
+## The three fidelity axes
+
+## The nine rungs
+
+## The Build terminus
+
+## Validation methods
+
+## Deliverable definitions

--- a/.gobbi/projects/gobbi/skills/desktop/fidelity-ladder.md
+++ b/.gobbi/projects/gobbi/skills/desktop/fidelity-ladder.md
@@ -1,16 +1,259 @@
 # The Design Fidelity Ladder
 
-Define the nine generic design rungs, the three fidelity axes, and the validation methods that close each
-rung. Every definition here is product-neutral: no platform, no operating system, and no product class
-appears inside a rung, and no identifier is named except this file's own `DESK-RUNG-N`. Where a rung needs
-the policy that binds it, or the floor that owns its evidence set, it names that owner by role.
+Nine ordered design rungs, three independent fidelity axes, and the validation method that closes each rung.
+This is the generic layer: every definition here is product-neutral, and nothing in it names a platform, an
+operating system, or a product class.
+
+**One altitude rule governs the whole file, and it covers identifiers as well as prose.** Every rung is
+written in generic terms and names no identifier except its own `DESK-RUNG-N`. Where a rung needs the policy
+that makes it binding, or the floor that owns its evidence set, or the gate that approves it, it names that
+owner **by role** — "the run's own skill's rule that makes the rungs binding", "the run's own skill's
+direct-evidence floor", "the run's own skill's structural-approval gate". A rung that cited a rule or a floor
+by identifier could not be relocated without editing its body, and relocation unchanged is the property this
+file is written to preserve. For the same reason it carries no path, in its header or its body: there is no
+path here to rewrite.
+
+Where a rung's default artifact or its evidence axis depends on the product's shape, this file states the
+**selection rule** and the run's own skill states the instantiation of it. No rung resolves that choice for a
+particular product class.
+
+**Nine rungs, and Build is not one of them.** The rungs are `DESK-RUNG-0` through `DESK-RUNG-8`. Build is the
+terminus the ladder feeds: it has no design question, no default artifact, and no closing evidence of its own.
+
+**Ordered and re-enterable.** The rungs are walked in order because each one's question depends on the answer
+above it. They are explicitly re-enterable: the progression is iterative scaffolding rather than a recipe, so
+a later rung's answer that invalidates an earlier rung returns to the earliest affected rung. Re-entry is
+normal and is not a failure; an unresolved rung is the failure.
 
 ## The three fidelity axes
 
+Fidelity is never one dial. Every **visual** artifact — rungs 6 through 8 — states its position on all three
+axes independently. The structural rung, 5, is deliberately non-visual, so it carries no position on the
+visuals axis and owes no fidelity statement at all.
+
+| Axis | Low | High |
+|---|---|---|
+| Interactivity | a facilitator simulates the response | the artifact responds automatically |
+| Visuals | schematic layout without visual hierarchy | realistic hierarchy, spacing, and layout |
+| Content and navigation | summarized stand-ins | final content and real navigation |
+
+An artifact may legitimately be high in content and low in visuals at the same time, so a two-step
+low-then-high gate misrepresents the concept.
+
+The axes carry a real selection consequence. High fidelity is better for testing a specific component, a
+workflow, an affordance, and a realistic system response time, and for reducing facilitator error. Low
+fidelity is better for rapid iteration, for changing the design mid-test, for lowering user pressure and
+designer attachment, and for signalling to stakeholders that the work is unfinished. Choose per axis from the
+question being asked, never from a stage number.
+
 ## The nine rungs
+
+Every rung carries the same five fields: its identifier and name, its *Question*, its *Default artifact*, its
+*Done-condition*, and its *Closing evidence*. `Done-condition` is the property that must hold; `Closing
+evidence` is what a reader inspects to confirm it.
+
+### `DESK-RUNG-0` — Research and problem definition
+
+*Question:* Is this the right problem, for whom, in what situation?
+
+*Default artifact:* personas grounded in observed behavior, plus an interview guide.
+
+*Done-condition:* the problem, the affected people, and the situation that triggers the need are stated from
+evidence about real people rather than from assumption.
+
+*Closing evidence:* interview or contextual-inquiry records with participant context, consent, and the
+separation of observation from interpretation.
+
+### `DESK-RUNG-1` — Task analysis
+
+*Question:* What does the user actually do, in what order, at what cognitive cost?
+
+*Default artifact:* a hierarchical task-analysis diagram.
+
+*Done-condition:* the task decomposition reflects observed work, not self-reported work, and names where cost
+concentrates.
+
+*Closing evidence:* observation in the real work context. A self-report alone does not close this rung, which
+is this rung's own stated validator.
+
+### `DESK-RUNG-2` — Information architecture
+
+*Question:* What exists, how is it organized, and what is it called?
+
+*Default artifact:* a content inventory, an audit, and a taxonomy.
+
+*Done-condition:* every object the outcome exposes has a place and a name derived from users' own grouping,
+not from the implementation's structure.
+
+*Closing evidence:* a generative card sort followed by an evaluative tree test, in that order. The two
+methods, and the reason their order is part of the contract, are set out under validation methods below.
+
+### `DESK-RUNG-3` — Navigation design
+
+*Question:* Can users reach it?
+
+*Default artifact:* navigation components derived from the information architecture.
+
+*Done-condition:* every object in the architecture is reachable, and reachable directly enough to be found
+rather than hunted.
+
+*Closing evidence:* tree testing reporting both success rate and directness. Success rate alone does not close
+it, because a found-by-wandering path passes success and fails directness.
+
+### `DESK-RUNG-4` — User flows
+
+*Question:* What is the path through a task, end to end?
+
+*Default artifact:* a user flow or journey map.
+
+*Done-condition:* each task from the task analysis has a complete path including its decision points, waits,
+failures, and recovery routes.
+
+*Closing evidence:* a walkthrough of each flow against the task analysis, naming any task with no flow and any
+flow with no task.
+
+### `DESK-RUNG-5` — Structural skeleton, surface-neutral
+
+*Question:* Does one whole structure hold the outcome together, before any surface, layout, or visual decision
+is made?
+
+*Default artifact:* a surface-neutral structural specification — hierarchy, regions or stages, navigation or
+command structure, action priority, information flow, system status, state relationships, decision points,
+failure zones, recovery routes, handoffs, adaptation, and completion evidence, stated without assuming a
+graphical layout — plus the mapping from each claimed surface onto that one structure.
+
+*Done-condition:* every claimed surface realizes the same structure and serves one outcome, and no local unit
+detail has been designed yet.
+
+*Closing evidence:* the versioned structural specification with its state and path map, its surface mapping,
+and its open-question register, recorded as this rung's resolution in the register **and explicitly approved
+at the run's own skill's structural-approval gate before any later rung begins**. The register row records the
+approval decision, not merely the artifact.
+
+> **This rung carries its own approval point, and it fires before any visual rung.** The rung closes only when
+> the approver has explicitly approved the structure or reopened it. Folding that decision into the later
+> design-acceptance gate would mean the structure is first seen after the visual artifacts already exist,
+> which inverts what a structure-before-visuals ladder is for. The gate is named and numbered by the run's own
+> skill; this rung names it by role only.
+
+### `DESK-RUNG-6` — Low-fidelity structure
+
+*Question:* Does the structure hold when a person tries to use it?
+
+*Default artifact:* selected by the product's shape. Where the product is few surfaces that change dynamically
+in place, the default is a **wireflow**; where it is many discrete largely static pages, the default is page
+wireframes plus a site map. This file states the rule; the run's own skill states which side of it the product
+falls on.
+
+The default is a default, not a mandate: a run may choose page wireframes and a site map, and records why the
+product's shape differs from the stated condition. What it may not do is skip the rung.
+
+*Done-condition:* the structure supports the flows without a dead end, a hidden state, or an unreachable
+required action.
+
+*Closing evidence:* an iteration round with representative users on the structure, with findings recorded and
+the design record revised before the artifact. This round is **iteration evidence, not acceptance evidence**.
+
+### `DESK-RUNG-7` — High-fidelity presentation
+
+*Question:* Do hierarchy and affordance read correctly with real content and every state present?
+
+*Default artifact:* the rung-6 artifact carried to high visual and content fidelity, holding real content and
+all applicable states.
+
+*Done-condition:* hierarchy, affordance, and state distinction are legible with real content, and every state
+named in the design record is present.
+
+*Closing evidence:* heuristic review plus component-level checks. This rung's artifact is a static simulation,
+so it may not be offered as behavioral or accessibility evidence.
+
+### `DESK-RUNG-8` — Interactive prototype
+
+*Question:* Can the task be completed unaided, at a realistic response speed?
+
+*Default artifact:* an interactive prototype plus its prototype specification.
+
+*Done-condition:* representative users complete the task unaided, and the failures they hit are the ones the
+design record already anticipated and handles.
+
+*Closing evidence:* a round with representative users on this run's own post-approval artifact, **per claimed
+surface or delivery target the run declares**, covering every applicable dimension in the observation set,
+with observations separated from interpretation and claims bounded to the evidence. The method, the sample,
+and the claim boundary are derived from the question, the diversity of the affected people, the uncertainty,
+the impact, and the risk — never from a fixed participant count. This is the rung whose evidence the run's own
+skill makes the acceptance evidence, at its direct-evidence floor; that floor is also what states which axis
+the run's claimed targets are.
+
+> **The observation set has one home, and it is not here.** The complete dimension set and its count are
+> stated once, by the run's own skill's direct-evidence floor — the same floor that makes this rung's evidence
+> the acceptance evidence. This rung requires coverage of **every applicable dimension that floor names** and
+> enumerates none of them itself, because a set enumerated twice drifts.
 
 ## The Build terminus
 
+**Build.** No question, no default artifact, no validator, and no position on any fidelity axis. It is entered
+only from a resolved rung register and a passed design-acceptance gate, and it is owned by the construction
+phases of the run's own skill rather than by this ladder. It is named here so the rung count carries no
+ambiguity: Build is the terminus the ladder feeds, not a tenth rung.
+
 ## Validation methods
 
+### Card sorting, then tree testing
+
+The two methods are not interchangeable, and their order is part of the rung contract.
+
+| Method | Kind | What it produces | Participants |
+|---|---|---|---|
+| Card sorting | generative — participants group labeled cards by their own criteria | users' own mental model and grouping vocabulary | about 15 qualitative, or 30–50 quantitative, with 30–50 cards |
+| Tree testing | evaluative — users locate features in a given hierarchy | success rate and directness; needs no visual design or content | about 5 qualitatively |
+
+Order: card sort to **generate** the structure at `DESK-RUNG-2`, then tree test to **validate** it at
+`DESK-RUNG-2` and again at `DESK-RUNG-3`. For validating a structure that already exists, tree testing is the
+recommended choice over a closed card sort. Running only a card sort leaves the structure ungraded; running
+only a tree test grades a structure the users never shaped.
+
+### Round cadence
+
+Zero users give zero insights; one user reveals roughly 31% of problems; five reach roughly 85%; past the
+fifth user in one round the marginal return is spent. The prescription is therefore to divide the budget:
+rather than one fifteen-user study, run three rounds of five, because each round's fixes expose the deeper
+problems the surface defects were masking.
+
+Mapped onto the ladder: a round at `DESK-RUNG-6`, fix, a round at `DESK-RUNG-8`, fix. The tree-test rounds at
+`DESK-RUNG-2` and `DESK-RUNG-3` run at about five participants qualitatively; the card sort at `DESK-RUNG-2`
+needs its own larger sample, above.
+
+**The five-user figure is an iteration heuristic and never an acceptance threshold.** No participant count
+stated here sets an acceptance bar. The run's own skill's direct-evidence floor owns that question, and it
+sets no fixed count.
+
 ## Deliverable definitions
+
+Each name below has its own established definition. That is why these are separate rungs rather than fidelity
+settings on a single artifact.
+
+- **wireframe** — an outline of structure and functionality, produced before visual design.
+- **mockup** — a static high-fidelity simulation including visual design detail.
+- **prototype** — an early version for testing and validating ideas and functionality.
+- **wireflow** — wireframe-style layout combined with a simplified flowchart-like representation of the
+  interactions between those layouts.
+- **user flow** — the typical steps needed to accomplish a common task.
+- **hierarchical task-analysis diagram** — a graphical breakdown of a user process into tasks.
+- **paper prototype** — a low-cost research tool sketching concepts for user testing.
+- **site map** — a visual representation of content organization.
+- **storyboard** — images in sequential panels, chronologically mapping the main events.
+
+### Two senses of `skeleton`, and which one each rung means
+
+Both senses are legitimate, both are in use, and no inflection of the word is prohibited.
+
+- **The structural sense — a design artifact.** The whole surface-neutral hierarchy, state, and path map,
+  produced and approved *before* any local detail. This is `DESK-RUNG-5`.
+- **The code sense — a construction artifact.** Stub modules and empty bodies, produced *after* design
+  acceptance and verified by a compiler. This belongs to the construction phases the Build terminus feeds,
+  not to any rung.
+
+Each rung's own *Default artifact* field says which deliverable it means, so nothing depends on a reader
+disambiguating the word. **What no rung does is call a visual deliverable a skeleton:** a wireflow, a mockup,
+and an interactive prototype are the visual deliverables at rungs 6 through 8, and they are neither sense of
+the word.

--- a/.gobbi/projects/gobbi/skills/desktop/filesystem-data.md
+++ b/.gobbi/projects/gobbi/skills/desktop/filesystem-data.md
@@ -1,0 +1,14 @@
+# Desktop — Filesystem and Local Data
+
+Own user-data locations, durable local writes, schema migration including downgrade, and secret handling at
+rest. Policy lives in [`SKILL.md`](SKILL.md); this child owns the mechanics.
+
+## User-data locations per operating system
+
+## Durable write and corruption behavior
+
+## Schema versioning and migration, including the downgrade path
+
+## `safeStorage` and its failure mode
+
+## What must never be written

--- a/.gobbi/projects/gobbi/skills/desktop/filesystem-data.md
+++ b/.gobbi/projects/gobbi/skills/desktop/filesystem-data.md
@@ -3,12 +3,167 @@
 Own user-data locations, durable local writes, schema migration including downgrade, and secret handling at
 rest. Policy lives in [`SKILL.md`](SKILL.md); this child owns the mechanics.
 
+Local data is where a desktop application differs most sharply from a page. There is no server holding the
+authoritative copy, no session that ends and discards the mess, and no deploy that migrates everyone at once.
+The data sits on a machine this run will never see again, written by a version that may be older than the one
+reading it.
+
+Three of `DESK-FLOOR-02`'s safety members live here — the interrupted write, the schema migration including
+its downgrade path, and the at-rest secret store's failure. Each is a place where a person can reach a
+consequence they cannot foresee, refuse, or recover from, by doing something entirely ordinary.
+
+> **Where this file states an obligation and not a mechanism, that is deliberate.** This skill's evidence
+> register carries no owner document for the platform's own data interfaces — not for the user-data path
+> interface, not for the at-rest secret store. **Those mechanisms are therefore marked as unread rather than
+> described**, each with what would close it. The obligations below do not depend on them and are stated at
+> full strength. `DESK-R26` requires exactly this split: verify a mechanism at its owner, or mark it.
+
 ## User-data locations per operating system
+
+**Resolve the application's data directory through the platform's own interface. Never compose the path by
+hand.** The three operating systems put per-user application data in different places, under different
+conventions, and a hand-composed path is wrong on at least two of them and breaks on the third the moment a
+person's account is configured unusually.
+
+**UNVERIFIED here — the platform's own path interface and the per-system directory conventions were not read
+for this skill.** No owner document for them appears in this skill's claim register, so none is named and no
+directory layout is taught. *Closing condition:* read the platform's own application-path reference, record
+the interface and the per-system result in the run's design record, and treat that record as the run's
+authority.
+
+What holds regardless of the mechanism, and what a run decides at `P5`:
+
+- **One owned directory, and everything the application writes lives under it** — except what the person
+  explicitly chooses a location for. A file the person picked belongs where the person picked it.
+- **Separate the data by what its loss costs.** Configuration a person set by hand, work the person created,
+  a cache that can be rebuilt, and diagnostic logs have different durability requirements and different
+  privacy exposure. Storing them together forces the strictest requirement onto all of them, or — more
+  commonly — the loosest.
+- **A path that came from outside is untrusted input.** A dropped file, a deep link, a second-instance
+  argument, and a configuration value are all reachable by someone other than the person using the
+  application. Validate before the path reaches a file interface, per `DESK-R15`'s standard for any
+  privileged effect.
 
 ## Durable write and corruption behavior
 
+**Every local write is durable or detectably incomplete.** That is `DESK-FLOOR-02` member 3, and both halves
+are permitted outcomes. What is not permitted is a third state: a file that reads as valid and is not.
+
+Interruption is ordinary, not exceptional. A person forces the application to quit; the machine loses power;
+an update installs while a write is in flight; the process is killed for using too much memory. A run that
+treats interruption as an edge case has chosen the state it cannot recover from.
+
+Two properties make the difference:
+
+1. **A reader never observes a partially written file.** Write to a temporary file in the same directory,
+   then replace the target with it. The replacement is the point: a reader sees either the whole old content
+   or the whole new content.
+2. **A reader can tell truncation from completeness.** A length, a checksum, or a terminal marker lets the
+   reader reject a file rather than parse half of one into a plausible-looking value. Detectably incomplete
+   is a fine outcome; silently incomplete is the failure.
+
+**Parse persisted data at the boundary, into a domain type.** A file written by an older version of this
+application is external input in exactly the sense a network payload is, and the compiler cannot check what a
+previous release wrote. [`typescript/typing.md`](../typescript/typing.md) owns the
+declaration-versus-verification distinction that makes a boundary parse work.
+
+> **Never do file work synchronously in the privileged process.** It owns windows, interaction, and the
+> interface thread **across every window at once**, so one synchronous read or one large parse freezes the
+> entire application — every window, simultaneously. This is a documented performance property of the process
+> model and a bug class with no analogue on the web, where a blocked script blocks one tab.
+> [`process-model.md`](process-model.md) owns the context split this follows from.
+
 ## Schema versioning and migration, including the downgrade path
+
+**Every persisted structure carries an explicit version.** Not an implicit one inferred from which fields are
+present — a written version the reader checks first.
+
+Forward migration is the half everyone builds: a newer version reads an older structure and upgrades it.
+
+**The downgrade path is the half that gets skipped, and it is a floor member.** A person who installs an
+older version after a newer one **must not lose or corrupt data**. This is not a hypothetical:
+
+- release is irreversible and old versions persist on machines indefinitely (`DESK-R24`), so there is always
+  an older version available to install;
+- a person who hits a bug in a new release reinstalls the previous one — that is the normal human response,
+  not a misuse;
+- the older version then opens data written by a structure it has never seen.
+
+Three behaviors are acceptable, and the run picks one per structure:
+
+| Behavior | What the older version does | When it fits |
+|---|---|---|
+| Forward-compatible read | reads what it understands and **preserves** what it does not, writing the unknown parts back untouched | additive changes, which is most of them |
+| Explicit refusal | detects the newer version, declines to open it, and says so — leaving the data intact | a structural change too large to read safely |
+| Copy on upgrade | the newer version migrates a **copy** and leaves the older structure in place | a one-way migration that cannot be made reversible |
+
+**What is never acceptable: silently rewriting a newer structure into an older shape.** That is the data-loss
+path, and it is invisible until the person opens the newer version again and finds their work gone.
+
+**Prove it by test, in this order:** install the newer version, create real data, install the older version
+over it, open the data, then reinstall the newer version and confirm the data survived the round trip. A
+migration proved only in the forward direction has proved half the obligation. This test needs packaged
+artifacts, so it belongs with the install gate `DESK-R23` adds rather than with the unit suite.
 
 ## `safeStorage` and its failure mode
 
+The obligation, which is `DESK-FLOOR-02` member 5:
+
+> **An at-rest secret store fails closed. It never silently stores in the clear.**
+
+When the platform cannot provide encryption at rest, the correct outcome is a failed write and a decision
+routed to the run — never a quiet degradation to plaintext that leaves the caller believing the value is
+protected. A caller that cannot tell the difference between an encrypted write and a plaintext one has no
+security property at all, only the belief in one.
+
+**UNVERIFIED here — the named store's own documented failure mode was not read for this skill.** Its owner
+document does not appear in this skill's claim register, so no failure behavior is described and no
+availability claim is made. *Closing condition:* read that interface's own reference, and record what it
+actually does when the backing store is unavailable.
+
+**The rule is written so it does not depend on the answer**, which is what `DESK-R26` requires of an
+unverified mechanism:
+
+1. **Treat availability as per-system and unknown until tested.** Verify on **each claimed operating system**
+   what the store does when its backing service is missing — encrypt, fail, or degrade. Whichever it does is
+   a fact about that system, and `DESK-FLOOR-04` member 6 already says evidence from one system supports no
+   claim about another.
+2. **Wrap it so the caller cannot proceed on an ambiguous result.** If the underlying interface can return
+   something the caller might read as success when it stored plaintext, the wrapper is what turns that into a
+   failure. Do not leave the fail-closed property depending on a behavior nobody has confirmed.
+3. **Decide in advance what happens when it fails**, and make that a `DESK-G7`-class decision rather than a
+   default: hold the secret only in memory for the session, ask the person each time, or decline the feature
+   on that system. Silently continuing is the one option the floor forecloses.
+
+**A secret the application must hold at rest is a design question before it is a storage question.** The
+cheapest secret to protect is the one the application never holds — a short-lived token it can re-obtain
+costs nothing when the store is unavailable, and a long-lived credential costs everything.
+
 ## What must never be written
+
+Six entries. Each is a write that is reachable by ordinary means and hard to reverse once it has shipped.
+
+1. **A secret in the shipped bundle.** Not in the archive, not minified, not encoded, not split across
+   files. [`security.md`](security.md) owns this rule and the reason the packaging format supplies no
+   protection; it is listed here because the temptation appears while writing the data layer, not while
+   writing the security posture.
+2. **A credential in the clear on disk** — including "temporarily," including in a file the application
+   intends to delete, and including as a field inside an otherwise ordinary configuration structure. The
+   fail-closed store above is the alternative, and declining to hold the secret at all is the better one.
+3. **Anything outside the application's own data directory without an explicit user choice.** A person's
+   file system is not the application's scratch space. A file the person picked goes where they picked it;
+   everything else stays under the owned directory.
+4. **Personal data the outcome does not need.** `DESK-FLOOR-03` requires minimization for participant data,
+   and the same discipline applies to what the shipped application collects: data never written cannot leak,
+   cannot be subpoenaed, and needs no retention policy.
+5. **A secret or personal data in a log or a crash report.** Diagnostic output is the most-copied,
+   least-guarded file the application produces — people paste it into issue trackers and support chats. Treat
+   its contents as public by default and redact at the point of writing rather than at the point of sharing.
+6. **A path composed from untrusted input without validation.** A deep link, a second-instance argument, a
+   dropped file, and a value read from a configuration file can all carry a path that escapes the intended
+   directory. Validate before the value reaches a file interface — this is `DESK-R15`'s standard applied to
+   the file system as the privileged sink.
+
+**The test that catches most of these is a read, not a run:** after an ordinary session, list every file the
+application created and open each one. A run that has never looked at its own written output does not know
+what is in it.

--- a/.gobbi/projects/gobbi/skills/desktop/ideation.md
+++ b/.gobbi/projects/gobbi/skills/desktop/ideation.md
@@ -1,0 +1,13 @@
+# Desktop Run Ideation
+
+Run the user-decision tree for one desktop run, including which ladder rungs apply and which are proved
+inapplicable. Policy lives in [`SKILL.md`](SKILL.md); rung definitions live in
+[`fidelity-ladder.md`](fidelity-ladder.md). This companion adds no policy.
+
+## Interview conduct
+
+## Decision record
+
+## The dependency-ordered decision tree
+
+## Completion audit

--- a/.gobbi/projects/gobbi/skills/desktop/ideation.md
+++ b/.gobbi/projects/gobbi/skills/desktop/ideation.md
@@ -264,8 +264,10 @@ a sender rule per channel, and any candidate dependency.
 
 - Which per-operating-system behaviours does this outcome touch, and what is the named mechanism for each?
 - Does window state need to survive a restart, and if so, how?
-- Which native integrations are in scope — menus, shortcuts, notifications, dialogs, drag-and-drop, chrome,
-  theming, file associations?
+- Which native integrations are in scope — menus, the tray and the dock, shortcuts, notifications, dialogs,
+  drag-and-drop, chrome, theming, file associations?
+- If the outcome is tray-resident, which system's activation gesture is being assumed, and does that system's
+  own specification fix one?
 - What is written locally, where, in what format, and what happens when a write is interrupted?
 - Does a schema exist, and what is its migration path in **both** directions?
 

--- a/.gobbi/projects/gobbi/skills/desktop/ideation.md
+++ b/.gobbi/projects/gobbi/skills/desktop/ideation.md
@@ -4,10 +4,449 @@ Run the user-decision tree for one desktop run, including which ladder rungs app
 inapplicable. Policy lives in [`SKILL.md`](SKILL.md); rung definitions live in
 [`fidelity-ladder.md`](fidelity-ladder.md). This companion adds no policy.
 
+Twenty decision axes, `D0` through `D19`, walked in dependency order. Eight of them stop for an explicit user
+decision at a named gate. The gate set and its fire order are fixed by `DESK-R27` and are not this file's to
+change; what this file owns is where in the interview each one fires, what evidence is on the table when it
+does, and what the run records afterward.
+
+Load this file at `P1` and keep it open across `P1` through `P6`. The tree is not one sitting: the early axes
+run before any rung, the middle axes run inside the ladder, and the late axes run once the contract is locked.
+An axis may be re-entered whenever later evidence contradicts it.
+
 ## Interview conduct
+
+1. Walk `D0`–`D19` in dependency order and discuss one axis per turn. An axis that depends on an unanswered
+   earlier axis waits.
+2. Inspect the repository, the running application if one exists, and the platform's own documentation before
+   asking. Show the verified fact and ask the user to confirm or correct it. An interview that opens with a
+   question the evidence already answers spends the user's attention on the wrong thing.
+3. Treat each axis's prompts as a bank, not a questionnaire. Ask only what current evidence does not settle
+   and what can still change this run's outcome, boundary, design, contract, proof, or release controls.
+4. Skipping an axis is governed by [`discussion`](../discussion/SKILL.md), which owns the smart-skip rule. Its
+   local application here: an axis is skipped only when current evidence answers it **and** the user has
+   already locked that answer for this run, and both facts are recorded. Skipping an axis is not the same as
+   proving a rung inapplicable — that is a rung resolution, and `SKILL.md` owns its conditions.
+5. Research current authoritative external evidence before any design-bearing recommendation. Present the
+   material options, recommend one, and name the evidence that would change the recommendation.
+6. Mark every answer `confirmed`, `assumption`, `recorded-open:<owner + method>`, or `contradicted`. Push a
+   vague or contradicted answer twice with a concrete example or counterexample, then record it open.
+7. Reopen the earliest owning axis when later evidence contradicts it. Re-entry is normal. Repairing a wrong
+   scope, design, or trust premise downstream instead of at its owning axis is not.
+8. Keep stakeholder decisions, representative-user observations, platform-documentation facts, and forecasts
+   as separate entries. They are different evidence classes, and `DESK-R25` forbids merging them.
+9. Every question card follows the [`discussion`](../discussion/SKILL.md) shape. That skill owns card
+   semantics, the twice-probe limit, and the prohibition on soft agreement.
 
 ## Decision record
 
+Each axis records six fields, and a gate axis records two more.
+
+| Field | What it holds |
+|---|---|
+| Evidence | what was inspected and what it showed, with the source named |
+| Options | the material alternatives that existed, including the one not taken |
+| Recommendation | the agent's position and the evidence behind it |
+| Decision | the user's answer, in the user's own terms |
+| Effects | what this answer binds downstream — which axes, phases, rungs, or files it constrains |
+| Reopen condition | the observation that would return the run to this axis |
+| **Gate** | the `DESK-G` identifier, for a gate axis only |
+| **Authority** | who holds the decision, for a gate axis only |
+
+The record is part of the design record `DESK-R29` requires; that rule owns its required content, and the
+active project owns its path. A gate axis carrying a recommendation and no decision is an unfired gate, and
+`DESK-R27` makes continuing past one a failure — silence is not approval.
+
 ## The dependency-ordered decision tree
 
+### `D0` — Current reality, trigger, and authority
+
+Inspect what exists: the application if there is one, its process split, its build and release configuration,
+its data locations, its supported platforms, and its test setup.
+
+- What concrete event triggered this work?
+- What runs today, and which claim about it is supported by inspected evidence rather than by report?
+- Who holds product, design, security, data, and release authority?
+- Which shipped versions and installed users make a change expensive to reverse?
+
+**Close with:** the current-reality register, the trigger, the authority map, and the reversibility
+constraints.
+
+*Trace:* `DESK-R01` for the authority map; `DESK-R24`, because installed users are why release is
+irreversible.
+
+### `D1` — One desktop outcome and its completion evidence
+
+- Which actor reaches what observable result, from which trigger and which entry mode?
+- What visible signal and what system signal jointly prove completion?
+- What could look finished while the required state or effect is absent?
+- Which entry modes exist — launcher, file association, deep link, second instance, auto-start, tray?
+
+Lock one sentence: "When `<trigger>` occurs, `<actor>` can `<bounded outcome>` on `<claimed systems>`,
+evidenced by `<visible signal>` and `<system signal>`."
+
+**Close with:** the locked outcome sentence, the completion and false-completion signals, and the entry-mode
+list.
+
+*Trace:* `DESK-R01`; `DESK-N01`, the false-completion prohibition this axis exists to pre-empt.
+
+### `D2` — Claimed operating systems and the scope boundary
+
+Every later axis reads the claim set. A system claimed here needs its own acceptance evidence, its own
+installer, its own signing story, and its own conformance work.
+
+- Which operating systems does this outcome claim? Which are explicitly out of the claim set?
+- Which paths, states, failures, and recovery routes are necessary to the outcome?
+- Which neighbouring outcomes merely share a window, a channel, a data file, or a build?
+- Which existing behaviour must not change?
+
+A system nobody will test on is not a claim; it is a wish. Record it out of the claim set rather than carrying
+it silently.
+
+**Close with:** the claimed-system set, the in-scope list, the explicit non-goals, and the handoffs.
+
+*Trace:* `DESK-R01` for the claimed systems; `DESK-R02` for the boundary.
+
+### `D3` — Stack fit — the six-criterion wrong-choice test
+
+Run the six-criterion test `DESK-R03` owns and record the **inspected result of each criterion**, not a
+summary verdict. Each criterion is answered from this outcome's own stated requirements: a size or footprint
+requirement the product actually states, a Linux claim actually made at `D2`, an engine-upgrade cadence the
+team has actually agreed to sustain, a remote or user-supplied content source actually loaded, a native
+integration actually central to the product, and an architecture actually claimed past its stated end of life.
+
+A positive result on any one criterion is a stack decision for the user. It is not a reason to proceed
+carefully.
+
+> **Gate `DESK-G1` — stack fit.** Fires when any criterion is positive. Present the criterion, the mechanism
+> that makes it decisive, and the alternative that criterion points at. The user decides whether to continue
+> on this stack, change stacks, or stop. Where no criterion fires, record `DESK-G1` as **not triggered** —
+> that is a recorded result, not a skipped gate.
+
+**Close with:** the six-row result table with an inspected result per criterion, and the `DESK-G1` decision or
+its not-triggered record.
+
+*Trace:* `DESK-R03`; `DESK-R27` for the gate authority.
+
+### `D4` — Design ownership and the co-load boundary
+
+- Does the user expect a separate generic interface or experience review to hold acceptance authority here?
+- Which design decisions has the project already made that this run inherits rather than reopens?
+
+This skill is the sole design owner for desktop work and holds the acceptance gate. State that plainly, so a
+user expecting a second design authority learns it now rather than at the design-acceptance gate.
+
+**Close with:** the ownership statement, the inherited design decisions, and any conflict with a project
+convention.
+
+*Trace:* `DESK-R04`.
+
+### `D5` — Participants, consent, and evidence conditions
+
+This axis runs **before any rung**, because six rungs involve people and the participant floor fails closed.
+
+- Can genuinely representative people be reached, per claimed operating system?
+- Are informed consent, needed accommodations, and data minimisation and protection in place?
+- Which prior research is available, and what does it actually cover?
+- Which observations will be recorded, by whom, and separated from interpretation how?
+
+A missing condition — access to representative users, consent, accommodations, or required evidence — stops
+the run and reports missing context. `DESK-FLOOR-03` owns that trigger set and its fail-closed behaviour; this
+axis establishes whether the conditions hold before any work depends on them.
+
+**Close with:** the participant plan per claimed system, the consent and accommodation record, and any
+missing-context stop.
+
+*Trace:* `DESK-R12`; `DESK-FLOOR-03`.
+
+### `D6` — Rung applicability, rung by rung
+
+Walk all nine rungs. For each, ask what its own question asks of this outcome, and decide how it will be
+resolved: by producing the artifact, by citing an existing answer, or by proving it inapplicable.
+
+- Which rungs does existing work already answer, and does that work address the rung's own question?
+- Which rung is proposed inapplicable, and what property of *this* outcome makes it so?
+- What observation would make a rung proposed inapplicable applicable again?
+
+`SKILL.md` owns what makes each resolution kind substantiated, including what a proof of inapplicability must
+name and why a reason is not a property. Read that rule before recording a resolution; do not re-derive it
+here. [`fidelity-ladder.md`](fidelity-ladder.md) owns each rung's question, default artifact, done-condition,
+and closing evidence.
+
+> **Gate `DESK-G2` — ladder-rung applicability.** The user sees all nine rungs with the proposed resolution
+> kind for each, the evidence behind every proposed inapplicability, and the falsifying observation that would
+> reopen it. The user approves the applicability set or reopens a rung. An inapplicability approved here still
+> has to satisfy the acceptance conditions `SKILL.md` states: this gate approves the plan, not the proof.
+
+**Close with:** the nine-row rung register seeded with a proposed resolution kind per rung, and the `DESK-G2`
+decision.
+
+*Trace:* `DESK-R05` and `DESK-R06` for the rung obligation; `DESK-N02` for the silent-skip prohibition;
+`DESK-R27` for the gate authority.
+
+### `D7` — Fidelity per visual rung
+
+- For each visual rung, what is this artifact for, and what question does it have to answer?
+- Where does it sit on interactivity, on visuals, and on content and navigation — each decided separately?
+- Which axis is deliberately low, and what does that cost?
+
+Three independent axes, never one dial. The ladder owns the axis definitions and their selection consequence;
+this axis records the run's position per artifact. The structural rung is non-visual and owes no fidelity
+statement.
+
+**Close with:** the per-artifact three-axis position for each visual rung, each with its reason.
+
+*Trace:* `DESK-R07`; `DESK-N03`.
+
+### `D8` — The structural skeleton, and its approval
+
+The structural rung is resolved first among the later rungs, and the run stops here **before any visual rung
+begins**.
+
+- Does one whole structure hold the outcome together, with no surface, layout, or visual decision made yet?
+- Does every claimed surface map onto that one structure?
+- Which questions about the structure are still open, and who owns each?
+
+> **Gate `DESK-G3` — structural-skeleton approval.** Present the surface-neutral structure, its state and path
+> map, its surface mapping, and its open-question register. The user explicitly approves it or reopens it. A
+> reopening returns to the structural rung and no visual rung starts. Starting a visual rung with this gate
+> unresolved is itself a `DESK-R27` failure. The register row records the **approval decision**, not merely
+> the artifact.
+
+This gate is why the user sees the structure before the visual artifacts exist rather than after.
+
+**Close with:** the approved structural specification, the `DESK-G3` decision, and any reopening condition.
+
+*Trace:* `DESK-R27` for the gate authority; `DESK-R09` for the structure-before-visuals order.
+
+### `D9` — Design acceptance
+
+- Is every one of the nine rungs resolved and substantiated?
+- Does direct representative-user evidence exist, from this run's own artifacts, on each claimed operating
+  system?
+- Does that evidence cover every applicable observation dimension?
+- Do all four floors hold on both their union check and their property check?
+
+Evidence from one operating system does not support a claim about another, and a captured rendering or a
+static high-fidelity artifact is context only. `DESK-FLOOR-04` owns the observation-dimension set and the
+per-system evidence rule.
+
+> **Gate `DESK-G4` — design acceptance.** Present the complete design record: the rung register, the
+> three-axis statements, the four floor resolutions with their property checks, the participant records, and
+> the stated evidence limits. The user accepts the design or returns it to the owning rung. Acceptance is
+> unavailable while the participant floor or the direct-evidence floor is unmet, and no floor is waivable.
+
+**Close with:** the complete design record and the `DESK-G4` decision.
+
+*Trace:* `DESK-R13` for the acceptance evidence; `DESK-R25` and `DESK-N04` for what is context only;
+`DESK-R27` for the gate authority.
+
+### `D10` — The privilege boundary and the channel inventory
+
+The contract axes begin here, after design acceptance.
+
+- Which unit of the outcome runs in which execution context?
+- Which channels cross the privilege boundary, and what does each carry?
+- What validates each payload into a domain type, and what verifies each caller?
+- Which values cross the bridge, and does every one of them survive the crossing?
+
+[`process-model.md`](process-model.md) owns the context split, the pattern table, the validation obligation,
+and the crossable-type boundary. This axis produces the run's own channel inventory against it.
+
+A typed inter-process-communication library, if one is proposed, is a new production dependency. Record it as
+a candidate here and decide it at `D15`.
+
+**Close with:** the context assignment per unit, the channel inventory with a payload type, a validation, and
+a sender rule per channel, and any candidate dependency.
+
+*Trace:* `DESK-R14`, `DESK-R15`, `DESK-R16`, `DESK-R17`, and `DESK-R18`; `DESK-N06` and `DESK-N07`.
+
+### `D11` — Window lifecycle, native integration, and local data
+
+- Which per-operating-system behaviours does this outcome touch, and what is the named mechanism for each?
+- Does window state need to survive a restart, and if so, how?
+- Which native integrations are in scope — menus, shortcuts, notifications, dialogs, drag-and-drop, chrome,
+  theming, file associations?
+- What is written locally, where, in what format, and what happens when a write is interrupted?
+- Does a schema exist, and what is its migration path in **both** directions?
+
+[`windows-lifecycle.md`](windows-lifecycle.md), [`native-integration.md`](native-integration.md), and
+[`filesystem-data.md`](filesystem-data.md) own these mechanics. Window state restoration has no built-in
+mechanism, so satisfying it means either a third-party dependency or an implementation this run owns — record
+the candidate here and decide it at `D15`.
+
+**Close with:** the per-system behaviour obligations with their mechanisms, the native-integration set, the
+data and migration map, and any candidate dependency.
+
+*Trace:* `DESK-R22` for the per-system obligations; `DESK-R18` for lifecycle-keyed disposal.
+
+### `D12` — Security posture as two distinct kinds of work
+
+- Which safe defaults are in place, and is anything in this outcome about to break one?
+- Which positive controls does this outcome need, and which are actually written today?
+- Where does untrusted content enter, and which privileged effect follows it?
+- Which build-time hardening applies, and what does each fuse cost?
+
+The two kinds of work differ: for the default group the correct action is inaction, and for the positive group
+the control does not exist until someone writes it. [`security.md`](security.md) owns the split, the delivery
+mechanisms, and the fuse set.
+
+**Close with:** the default-group audit, the positive-control inventory with a written-or-missing state per
+item, and the untrusted-input map.
+
+*Trace:* `DESK-R19`; `DESK-R20`; `DESK-N08`.
+
+### `D13` — The build matrix: hardening against testability
+
+Two first-party sources conflict here, and this skill does not resolve the conflict on the reader's behalf.
+Disabling the runtime-inspection fuse is documented hardening; the documented end-to-end test framework
+requires that same fuse enabled. No documented reconciliation exists.
+
+- Does this run need automated end-to-end coverage of the artifact that ships?
+- Or does it need the fully hardened release build, with automation exercising a different build?
+
+> **Gate `DESK-G5` — the hardening-versus-testability build matrix.** Present **both horns** with their
+> consequences named. Either the release build is not automatable by that path, or the automated build is not
+> the hardened one. The user decides. Whichever horn is chosen, its consequence is carried forward as a stated
+> verification limit rather than absorbed into a green summary.
+
+**Close with:** the build-matrix decision, both horns as presented, and the resulting stated verification
+limit.
+
+*Trace:* `DESK-R27` for the gate authority; `DESK-N10`, which forbids resolving this on the reader's behalf.
+
+### `D14` — Build-tool selection
+
+- Does the requirement set name differential updates, staged rollout, or a non-default update provider?
+- Which tool does the project already use, and what would changing it cost?
+
+The skill states a selection **criterion**, never a mandate, and
+[`packaging-distribution.md`](packaging-distribution.md) owns it. Apply the criterion to this run's own stated
+requirements and present the result.
+
+> **Gate `DESK-G6` — build-tool selection.** Present the criterion, this run's requirement set, and which side
+> of the criterion it falls on. The user selects the tool. A tool chosen against the criterion is a valid user
+> decision; record the reason.
+
+**Close with:** the requirement set, the criterion applied to it, and the `DESK-G6` decision.
+
+*Trace:* `DESK-R27` for the gate authority; `DESK-N10` for the criterion-not-mandate rule.
+
+### `D15` — New production dependencies
+
+Every candidate collected at `D10`, `D11`, and elsewhere is decided here, as one set, so the user sees the
+whole cost rather than approving each in isolation.
+
+- What does each candidate do that this run would otherwise write itself?
+- Is it maintained, and what happens to this outcome if it stops being maintained?
+- What does it add to the shipped artifact, and what does it reach at run time?
+
+No end-to-end typed inter-process-communication guidance is published and no library in that space is
+canonical, so every such library is a candidate rather than a default. The same holds for window-state
+restoration.
+
+> **Gate `DESK-G7` — production-dependency adoption.** Present the candidate set with a maintenance state, a
+> cost, and a build-it-here alternative per candidate. The user adopts, rejects, or defers each. A dependency
+> is never adopted as a default.
+
+**Close with:** the candidate register with the `DESK-G7` decision per candidate.
+
+*Trace:* `DESK-R27` for the gate authority.
+
+### `D16` — Release controls, channels, and the supported-version window
+
+- Which installer target ships per claimed operating system?
+- What is signed, by what, and what does signing gate on each system?
+- How does an installed copy learn about an update, and on which systems is that automatic?
+- Which channels exist, and what does a staged rollout look like here?
+- How long is a shipped version supported once a newer one exists?
+
+[`signing-updates.md`](signing-updates.md) owns the signing and update mechanics. Release is irreversible: a
+shipped build cannot be recalled and old versions persist on user machines indefinitely, so rollback means a
+forward fix plus a stated supported-old-version window.
+
+**Close with:** the per-system release chain, the channel and rollout plan, the stop conditions, and the
+supported-old-version window.
+
+*Trace:* `DESK-R23`; `DESK-R24`.
+
+### `D17` — Evidence classes and the claim ledger
+
+- Which claim does this run intend to make at the end, and what evidence class owns each one?
+- Which gate is unrunnable in this environment, and which claim does that block?
+- Which version does each version-dependent claim depend on?
+
+Design acceptance, implementation correctness, packaged-artifact evidence, signature and notarisation
+evidence, update-rehearsal evidence, per-system evidence, release readiness, release authority, and
+post-release outcome are nine separate claims. An unrunnable gate is recorded as a limitation and blocks the
+claim it would have proved; it is never widened into a weaker signal.
+[`runtime-deltas.md`](runtime-deltas.md) owns every version literal the ledger points at.
+
+**Close with:** the claim ledger with an evidence class and an owner per claim, and the known verification
+limits.
+
+*Trace:* `DESK-R25`; `DESK-R26`.
+
+### `D18` — Release authority
+
+- Is every applicable gate passed, with its evidence recorded?
+- Does the installable artifact exist, installed and smoke-tested in a clean environment?
+- Was an update rehearsed from the previously released version?
+- Are the stop conditions and the forward-fix route agreed?
+
+> **Gate `DESK-G8` — release authority.** Present the release-readiness state: what is proved, what is a
+> stated limit, the supported-old-version window, and the stop conditions. The user authorises the release or
+> withholds authority. Nothing about this decision is recoverable afterward, which is why it is a gate rather
+> than a step.
+
+**Close with:** the release-readiness statement and the `DESK-G8` decision.
+
+*Trace:* `DESK-R24`; `DESK-R27` for the gate authority.
+
+### `D19` — Final contract checkpoint
+
+Present the accumulated result in this order:
+
+1. current reality, trigger, authority, and reversibility constraints;
+2. the locked outcome, the claimed systems, the scope boundary, and the non-goals;
+3. the stack-fit result and the design-ownership statement;
+4. the rung register, the fidelity positions, and the design-acceptance state with its evidence limits;
+5. the privilege boundary, the channel inventory, the per-system behaviour obligations, the data and
+   migration map, and the security posture;
+6. the build matrix, the build tool, the adopted dependencies, and the release chain;
+7. the claim ledger, the open items with owners and methods, and every reopen condition.
+
+Ask the user to confirm the whole contract or reopen the earliest owning axis. Do not enter implementation
+with an applicable `recorded-open` item that can change scope, design acceptance, trust, data integrity, or
+release safety.
+
+*Trace:* `DESK-R01` for the bound contract; `DESK-R29`, whose design record this checkpoint populates.
+
 ## Completion audit
+
+The tree is complete when all six conditions hold. Each is checked against the record, not against memory of
+the conversation.
+
+1. **Every axis is closed.** `D0` through `D19` is each confirmed, skipped under the conduct rule above with
+   both facts recorded, or recorded open with an owner and a method.
+2. **Every gate is fired and recorded.** All eight — `DESK-G1`, `DESK-G2`, `DESK-G3`, `DESK-G4`, `DESK-G5`,
+   `DESK-G6`, `DESK-G7`, and `DESK-G8` — carries either a recorded user decision or, for `DESK-G1` alone, a
+   recorded not-triggered result. A gate reached but not decided leaves the tree incomplete regardless of how
+   much later work exists.
+3. **The gates fired in order, and each before the work it governs.** `DESK-G3` fired before any visual rung
+   began; `DESK-G4` fired before any contract axis; `DESK-G7` fired before any candidate dependency entered
+   the build; `DESK-G8` fired before anything was published.
+4. **The rung register is complete and its rows are substantiated.** Nine rows, each carrying a resolution
+   kind and the inspected evidence behind it. Whether a row is substantiated is decided by the rung-closing
+   rule in `SKILL.md`, which owns the conditions per resolution kind. This audit confirms the rows exist and
+   were tested against that rule; it does not restate the rule and does not apply a second, looser one.
+5. **No open item can still change a protected property.** An applicable `recorded-open` item that could
+   change scope, design acceptance, trust, data integrity, or release safety blocks implementation. An item
+   that cannot is carried forward with its owner and method.
+6. **The user confirmed `D19`.** The whole contract was presented in one place and confirmed, or the earliest
+   owning axis was reopened.
+
+**What this audit deliberately does not do.** It does not accept a rung, close a floor, or discharge a gate.
+Those belong to `SKILL.md`, which owns the acceptance rule for each. This audit checks that the interview
+produced the decisions the phases need, in the order they need them — nothing more. A run whose tree is
+complete can still fail acceptance, and that is the correct division: a decision recorded is not a property
+proved.

--- a/.gobbi/projects/gobbi/skills/desktop/native-integration.md
+++ b/.gobbi/projects/gobbi/skills/desktop/native-integration.md
@@ -96,8 +96,10 @@ The default directory a file dialog opens in is one of the values that has chang
 [`runtime-deltas.md`](runtime-deltas.md) records it under *Dialog default path resolves to the downloads
 directory*. A run whose flow depends on where the dialog opens names that version.
 
-**Clipboard access has moved out of the renderer.** It was deprecated at one version and became unavailable
-at another, both recorded in [`runtime-deltas.md`](runtime-deltas.md) under the clipboard rows. The
+**Clipboard access is on its way out of the renderer.** It is deprecated from one version and is scheduled for
+removal at a version that has **not** shipped, both recorded in [`runtime-deltas.md`](runtime-deltas.md) under
+the clipboard rows — check that owner for which state applies to the version a run targets, because on every
+currently supported major the access still exists and is merely deprecated. The
 consequence is structural rather than cosmetic: clipboard work belongs to the privileged process, reached
 over a channel, which makes it one more entry in the channel inventory
 [`process-model.md`](process-model.md) governs — payload validated, sender verified, like every other

--- a/.gobbi/projects/gobbi/skills/desktop/native-integration.md
+++ b/.gobbi/projects/gobbi/skills/desktop/native-integration.md
@@ -17,10 +17,11 @@ and every version literal. This file states the mechanism and points there.
 role, specify the role rather than reimplementing the behavior in a click handler. That is the platform's own
 explicit instruction, and it is the whole conformance mechanism this skill prescribes.
 
-The documented roles include the application, file, edit, view, window, help, and services menu roles; the
-recent-documents roles; the share-menu role; the standard edit and window operations; and the macOS extras
-for hiding, fronting, zooming, native tabs, and speech. Role strings are case-insensitive. On macOS, when a
-role is set, `label` and `accelerator` are the only options that affect the item.
+The documented roles include `appMenu`, `fileMenu`, `editMenu`, `viewMenu`, `windowMenu`, `help`, `services`,
+and `window`; `recentDocuments` and `clearRecentDocuments`; `shareMenu`; the standard edit and window
+operations; and the macOS extras `hide`, `hideOthers`, `unhide`, `front`, and `zoom`, plus the native-tab and
+speech roles. Role strings are case-insensitive. On macOS, when a role is set, `label` and `accelerator` are
+the only options that affect the item.
 
 **Why roles rather than a prescribed structure.** A role carries the platform's own structure, its own
 labels, and its own localization for free. Reimplementing the same item by hand gets the label in one
@@ -66,19 +67,19 @@ combination is a common event. Without undo, an accidental trigger is unrecovera
 
 ## Notifications per operating system
 
-Two interfaces exist: the web notification interface in the renderer, and the platform's own notification
+Two interfaces exist: the web `Notification` interface in the renderer, and the platform's own `Notification`
 module in the privileged process. Choose one deliberately — the second reaches the system's own presentation
 and the first does not always.
 
 Each system has its own precondition, and a notification that never appears is usually a missing
 precondition rather than a bug:
 
-- **Windows** needs a start-menu shortcut carrying an application identity and a matching activator
-  identifier. In development it may additionally need the application identity set explicitly at startup.
+- **Windows** needs a Start Menu shortcut carrying an `AppUserModelID` and a matching `ToastActivatorCLSID`.
+  In development it may additionally need `app.setAppUserModelId()` called at startup.
 - **macOS requires code signing.** Applications must be code-signed for notification events to function
-  properly; an unsigned binary emits a failure event instead. The notification body is also capped at **256
+  properly; an unsigned binary emits a `failed` event instead. The notification body is also capped at **256
   bytes**, so a message composed for the other two systems can arrive truncated here.
-- **Linux** goes through the system's own desktop notification service.
+- **Linux** goes through `libnotify`.
 
 The macOS precondition couples this file to the release chain: notifications cannot be proved on macOS
 against an unsigned development build, so the proof needs a signed artifact and

--- a/.gobbi/projects/gobbi/skills/desktop/native-integration.md
+++ b/.gobbi/projects/gobbi/skills/desktop/native-integration.md
@@ -96,10 +96,10 @@ The default directory a file dialog opens in is one of the values that has chang
 [`runtime-deltas.md`](runtime-deltas.md) records it under *Dialog default path resolves to the downloads
 directory*. A run whose flow depends on where the dialog opens names that version.
 
-**Clipboard access is on its way out of the renderer.** It is deprecated from one version and is scheduled for
-removal at a version that has **not** shipped, both recorded in [`runtime-deltas.md`](runtime-deltas.md) under
-the clipboard rows — check that owner for which state applies to the version a run targets, because on every
-currently supported major the access still exists and is merely deprecated. The
+**Clipboard access is on its way out of the renderer.** The deprecation and the removal begin at two different
+versions, both recorded in [`runtime-deltas.md`](runtime-deltas.md) under the clipboard rows — check that owner
+for the version each state begins at and compare it against the version a run targets, because that
+comparison, and not a state restated here, is what tells a run which state it is in. The
 consequence is structural rather than cosmetic: clipboard work belongs to the privileged process, reached
 over a channel, which makes it one more entry in the channel inventory
 [`process-model.md`](process-model.md) governs — payload validated, sender verified, like every other

--- a/.gobbi/projects/gobbi/skills/desktop/native-integration.md
+++ b/.gobbi/projects/gobbi/skills/desktop/native-integration.md
@@ -1,0 +1,20 @@
+# Desktop — Native Integration
+
+Own menus, tray, dock, notifications, dialogs, clipboard, OS drag-and-drop, file associations, window chrome,
+theming, and shortcuts. Policy lives in [`SKILL.md`](SKILL.md); this child owns the mechanics.
+
+## Menus from roles
+
+## Shortcuts and the three scopes
+
+## Notifications per operating system
+
+## Dialogs and clipboard
+
+## Drag and drop, in and out
+
+## Custom window chrome
+
+## Theming state machine
+
+## File associations

--- a/.gobbi/projects/gobbi/skills/desktop/native-integration.md
+++ b/.gobbi/projects/gobbi/skills/desktop/native-integration.md
@@ -3,18 +3,226 @@
 Own menus, tray, dock, notifications, dialogs, clipboard, OS drag-and-drop, file associations, window chrome,
 theming, and shortcuts. Policy lives in [`SKILL.md`](SKILL.md); this child owns the mechanics.
 
+This is the surface where an application either reads as native or reads as a web page in a frame, and it is
+also the surface where the most confidently wrong guidance circulates. Every claim below is either a
+mechanism this skill verified at its owner, or a gap stated as a gap. `DESK-R21` and `DESK-N09` are the rules
+that make that distinction non-negotiable here.
+
+Where one system diverges from another, [`runtime-deltas.md`](runtime-deltas.md) owns the divergence matrix
+and every version literal. This file states the mechanism and points there.
+
 ## Menus from roles
+
+**Build the platform-standard menu from the documented `role` values.** For any item that matches a standard
+role, specify the role rather than reimplementing the behavior in a click handler. That is the platform's own
+explicit instruction, and it is the whole conformance mechanism this skill prescribes.
+
+The documented roles include the application, file, edit, view, window, help, and services menu roles; the
+recent-documents roles; the share-menu role; the standard edit and window operations; and the macOS extras
+for hiding, fronting, zooming, native tabs, and speech. Role strings are case-insensitive. On macOS, when a
+role is set, `label` and `accelerator` are the only options that affect the item.
+
+**Why roles rather than a prescribed structure.** A role carries the platform's own structure, its own
+labels, and its own localization for free. Reimplementing the same item by hand gets the label in one
+language, the behavior approximately right, and the localization not at all.
+
+> **UNVERIFIED — the vendor's prescriptive design guidance could not be read.** Its pages are client-rendered
+> and return no body content to a fetch, reproduced independently this session on the menu-bar page. **This
+> skill therefore states no macOS minimum menu set, no menu ordering, and no Window-menu document-ordering
+> convention as fact**, and neither should anything built from it. `SKILL.md`'s gap register carries the item
+> with its closing condition: a retrieval path that executes the page's own scripts.
+>
+> This is a real limit, and roles are what make it survivable. Building from roles produces the standard
+> structure without anyone asserting an ordering claim nobody here verified. What it does not do is tell you
+> which menus a particular application ought to have — that question stays open, and filling it in from a
+> search summary is the specific failure `DESK-N09` prohibits.
 
 ## Shortcuts and the three scopes
 
+Accelerators join modifiers and key codes with `+` and are case-insensitive. Use `CommandOrControl` (or its
+short form) rather than naming a platform's own modifier: the macOS command modifier **has no effect** on
+Windows and Linux, so a shortcut written with it is silently dead on two of three systems.
+
+**Three mechanisms, three different scopes.** Choosing the wrong one is the common defect, because all three
+"work" in the developer's own foreground window.
+
+| Mechanism | Scope | Use it when |
+|---|---|---|
+| A menu accelerator | the focused window only | the action belongs to a menu item, which is most of them |
+| `globalShortcut.register()` | system-wide, including when the application is not focused | the action must work while the person is in another application |
+| `before-input-event` | the focused window, **before the renderer sees the key** | the key must be intercepted rather than handled |
+
+**A known limitation on the global mechanism:** on macOS it does not work with keyboard layouts other than
+QWERTY. A run that claims a global shortcut on macOS and has tested only on a QWERTY layout has not tested
+the claim.
+
+**Do not take a system-reserved combination.** The GNOME guidance names `Alt+Tab` and `Alt+F4` as reserved
+for the system, and an application that binds one takes it away from every other application the person uses.
+`DESK-R22` requires one shortcut map per platform; the reserved set is part of what makes the maps differ.
+
+**Pair every accelerator with undo.** An accelerator is a one-keystroke path to an action, and a mistyped
+combination is a common event. Without undo, an accidental trigger is unrecoverable — which makes it a
+`DESK-FLOOR-02` safety member rather than an interaction preference.
+
 ## Notifications per operating system
+
+Two interfaces exist: the web notification interface in the renderer, and the platform's own notification
+module in the privileged process. Choose one deliberately — the second reaches the system's own presentation
+and the first does not always.
+
+Each system has its own precondition, and a notification that never appears is usually a missing
+precondition rather than a bug:
+
+- **Windows** needs a start-menu shortcut carrying an application identity and a matching activator
+  identifier. In development it may additionally need the application identity set explicitly at startup.
+- **macOS requires code signing.** Applications must be code-signed for notification events to function
+  properly; an unsigned binary emits a failure event instead. The notification body is also capped at **256
+  bytes**, so a message composed for the other two systems can arrive truncated here.
+- **Linux** goes through the system's own desktop notification service.
+
+The macOS precondition couples this file to the release chain: notifications cannot be proved on macOS
+against an unsigned development build, so the proof needs a signed artifact and
+[`signing-updates.md`](signing-updates.md) owns how one is produced.
 
 ## Dialogs and clipboard
 
+**Dialogs are native, and that has two consequences.** They are presented by the operating system, so they
+look correct without effort; and they are presented by the operating system, so the renderer cannot style,
+position, or intercept them. A design that depends on a custom-looking file picker is a design that has to
+build one out of ordinary content, not configure the native one.
+
+The default directory a file dialog opens in is one of the values that has changed with a platform version;
+[`runtime-deltas.md`](runtime-deltas.md) records it under *Dialog default path resolves to the downloads
+directory*. A run whose flow depends on where the dialog opens names that version.
+
+**Clipboard access has moved out of the renderer.** It was deprecated at one version and became unavailable
+at another, both recorded in [`runtime-deltas.md`](runtime-deltas.md) under the clipboard rows. The
+consequence is structural rather than cosmetic: clipboard work belongs to the privileged process, reached
+over a channel, which makes it one more entry in the channel inventory
+[`process-model.md`](process-model.md) governs — payload validated, sender verified, like every other
+crossing.
+
+Treat pasted content as untrusted input. It arrived from another application.
+
 ## Drag and drop, in and out
+
+The two directions use entirely different mechanisms, and only one of them is the standard web interface.
+
+**Dragging in** uses the standard document drag-and-drop interface. Nothing platform-specific is required to
+receive the drop.
+
+**Dragging out** uses `webContents.startDrag({ file, icon })`, called from the privileged process and
+triggered from the renderer's own drag-start handler over a channel. The renderer cannot start a system drag
+by itself.
+
+> **The path property was removed from dropped files.** Reading `file.path` on a dropped file returns nothing
+> on **every supported version** — [`runtime-deltas.md`](runtime-deltas.md) records the removal version under
+> *File-path property removed from dropped files*. The replacement is `webUtils.getPathForFile(file)`.
+>
+> This is worth checking for explicitly in any existing application, because the old form is what most
+> published examples still show, and the failure is a silently empty value rather than an error.
+
+A dropped file is untrusted input twice over: the path came from outside, and so did the contents.
+[`filesystem-data.md`](filesystem-data.md) owns what happens once the run reads it.
 
 ## Custom window chrome
 
+Custom chrome is a debt, taken deliberately. The mechanism is straightforward; what it costs is the part that
+gets underestimated.
+
+**The mechanism.** `titleBarStyle` takes four values:
+
+| Value | Effect |
+|---|---|
+| `default` | the standard system title bar |
+| `hidden` | removes the title bar. macOS keeps the traffic lights at the upper left; Windows and Linux remove all controls unless an overlay is configured |
+| `hiddenInset` | macOS — shifts the traffic lights' vertical position |
+| `customButtonsOnHover` | macOS — hides the traffic lights until hover |
+
+`titleBarOverlay` accepts `true` or an object carrying `color` (Windows and Linux), `symbolColor` (Windows),
+and `height` (all). It requires a `titleBarStyle` other than `default`. In the renderer, CSS `app-region: drag`
+marks a region draggable, and the safe-area variables `env(titlebar-area-x)`, `env(titlebar-area-width)`, and
+`env(titlebar-area-height)` give the space the system controls do not occupy. macOS additionally offers
+`setWindowButtonVisibility` and a traffic-light position.
+
+**The debts, from the Windows title-bar guidance.** Removing the system title bar transfers its requirements
+to the application:
+
+- height **32px**, or **48px** when the bar carries a search box or a person-picture control;
+- the default background material is Mica, and the guidance recommends the title bar blend with the rest of
+  the window where possible;
+- **all title-bar elements are semi-transparent while the window is inactive**;
+- colors adjust for high-contrast themes and for light and dark;
+- the title text responds to text scaling, which may require the bar to grow in height.
+
+**And three behaviors that are mandatory, not stylistic:**
+
+1. all empty space and space occupied by non-interactive elements is **draggable**;
+2. right-click or press-and-hold on non-interactive title-bar space **shows the system window menu**;
+3. double-click **toggles maximize and restore**.
+
+A custom title bar that omits the third is the one people notice within a minute of use. Budget for all three
+before choosing `hidden`, and reconsider `default` if the visual gain does not justify them.
+
 ## Theming state machine
 
+`nativeTheme.themeSource` takes exactly three values: `'system'`, `'dark'`, and `'light'`. The platform's own
+recommendation is a state machine with **three user-facing options mapping onto those three values**.
+
+**A two-state light/dark toggle is therefore wrong.** Follow-system is a required third state, not a
+convenience — without it, a person whose system switches at sunset has to switch the application by hand, and
+an application that starts in the wrong appearance is the visible result.
+
+**Handle the `updated` event live.** Reading the theme once at startup produces an application that is
+correct until the system changes, which is exactly the case the third state exists to serve.
+
+**The related signals the theme interface exposes:** `shouldUseHighContrastColors`,
+`shouldUseInvertedColorScheme`, `prefersReducedTransparency`, and `shouldDifferentiateWithoutColor`.
+
+> **There is no reduced-motion property on this interface, and inventing one is a defect.** Reduced motion
+> comes from the renderer's own `@media (prefers-reduced-motion)` query. This matters beyond tidiness:
+> `DESK-FLOOR-01` carries reduced motion as a member of the accessibility floor precisely because the obvious
+> place to look for it does not have it, and a run that goes looking on the theme interface, finds nothing,
+> and concludes the signal is unavailable has failed a non-waivable floor by inference.
+
+**On assistive technology.** The application enables accessibility features automatically in the presence of
+assistive technology, and a programmatic setting to expose the accessibility tree exists — but the person's
+own system utilities take priority over it and will override it. The platform names a screen reader for
+Windows and one for macOS and **names none for Linux**;
+[`runtime-deltas.md`](runtime-deltas.md) records that per-system table including the gap. A run claiming
+assistive-technology behavior on the third system states what evidence it actually has rather than implying
+parity across three. The floor obligation itself is `DESK-FLOOR-01`'s, not this file's.
+
 ## File associations
+
+Two different associations are usually meant by one phrase, and they have different mechanisms and different
+evidence behind them.
+
+**A protocol association** — the application answers a custom link scheme — is registered by
+`setAsDefaultProtocolClient()`, and [`windows-lifecycle.md`](windows-lifecycle.md) owns its per-system
+delivery route and the packaged-only caveat that makes development testing misleading.
+
+**A file-type association** — the application opens a document kind from the system's file browser — splits
+into two halves that this skill's evidence covers unevenly:
+
+- **The delivery half is verified.** On macOS the file arrives through the `open-file` event, which must be
+  registered before the ready event; that mechanism and its launch-event trap are
+  [`windows-lifecycle.md`](windows-lifecycle.md)'s.
+- **The registration half belongs to the installer, and this skill states no mechanism for it.** Declaring
+  which document kinds an application claims is per-system installer configuration, and
+  [`packaging-distribution.md`](packaging-distribution.md) owns the installer targets. No primary source for
+  the per-system registration syntax was read for this skill, so none is taught here. Take that question to
+  the build tool's own documentation, and record what you find in the run's own design record rather than
+  assuming a shape.
+
+**What a run should do with that split.** Design the delivery path against the verified mechanism, and treat
+registration as configuration to be proved by test rather than by reading — install the packaged artifact in
+a clean environment, open a document of the claimed kind from the file browser, and observe whether the
+application receives it. That test is already required: `DESK-R23` extends the verification order with an
+install-and-smoke-test gate on the real artifact, and file-type association is exactly the class of behavior
+that is unprovable before it.
+
+**Claim only the kinds you tested, per system.** An association that works on one operating system is no
+evidence at all about another — that is `DESK-FLOOR-04`'s per-system rule applied to this mechanic, and the
+delivery routes above are different code paths on each system, so the usual reason for optimism does not
+apply here either.

--- a/.gobbi/projects/gobbi/skills/desktop/native-integration.md
+++ b/.gobbi/projects/gobbi/skills/desktop/native-integration.md
@@ -38,6 +38,57 @@ language, the behavior approximately right, and the localization not at all.
 > which menus a particular application ought to have — that question stays open, and filling it in from a
 > search summary is the specific failure `DESK-N09` prohibits.
 
+## Tray, menu-bar residency, and the dock
+
+An application whose primary surface is a status-area icon rather than a window is built from the tray
+interface, and on macOS from the dock property as well. This section states those mechanisms.
+[`runtime-deltas.md`](runtime-deltas.md) owns the per-system divergences and records them under *Tray and
+dock*; they are large enough here that a run claiming three systems for a tray-resident product is claiming
+three different behaviors.
+
+**The cross-platform mechanism.** A tray icon is created from an image and given a context menu. **To change an
+individual menu item, call the set-context-menu method again.** Mutating a menu item in place does not apply —
+the field changes and the menu the person opens does not. There is no error to follow; the symptom is a menu
+that never updates.
+
+Three of the divergences decide whether a design is buildable at all, so the mechanism each one applies to is
+named here:
+
+- **The activation gesture cannot be promised on Linux.** The tray goes through `StatusNotifierItem` by
+  default, and falls back to `GtkStatusIcon` where the person's desktop environment does not provide it. The
+  `click` event fires on activation, but **the `StatusNotifierItem` specification leaves which gesture
+  activates to the environment** — single left click in some, double left click in others. A run may state that
+  activation is handled. It may not state which gesture the person will use, and writing "click the icon" into
+  an instruction for that system is a claim about an environment nobody read.
+- **macOS icons are Template Images, and the naming is the mechanism.** The image filename must end in
+  `Template`, and the `@2x` image carries the same filename as the standard image at 144dpi. 16×16 at 72dpi
+  plus 32×32@2x at 144dpi work for most icons. `setTitle()` — text beside the icon, with ANSI colour support —
+  is macOS-only.
+- **Several tray events exist on one system only.** Right-click, double-click, drag-and-drop, and the mouse
+  events (up, down, enter, leave, move) are **macOS-only**, and **`mouse-up` is not emitted at all when a
+  context menu is set on the tray** — so a design that both sets a context menu and handles `mouse-up` has a
+  handler that never runs. Balloon notifications are **Windows-only**: the balloon show, click, and closed
+  events and the display-balloon, remove-balloon, and focus methods exist on Windows alone. Windows also
+  recommends ICO format for the icon.
+
+**The dock, and the limit stated honestly.** `app.dock` is documented as a dock property that is **present on
+macOS and undefined on every other platform**. Hiding the dock icon is the macOS mechanism for an application
+that lives in the menu bar rather than in the dock, and it is macOS-only: on the other two systems there is no
+dock to hide and the property is not there to call.
+
+> **UNVERIFIED — the dock interface's own operations were not read.** The hide, show, and activation-policy
+> operations live on a separate documentation page this skill did not retrieve, so **it states nothing about
+> their behavior** — not what each does, not when it takes effect, and not what an activation policy changes.
+> `SKILL.md`'s gap register carries the item with its closing condition: a read of that page. Design the
+> residency decision against the property that *is* verified — the dock exists on one system only — and take
+> the operations to their own documentation before writing code against them.
+
+**What a stack-fit inspection reads here.** `DESK-R03` criterion 5 asks whether deep native integration or a
+platform-exclusive interface is the point. For a tray-resident product the material to inspect is this section:
+the tray mechanism the platform exposes on all three systems, the divergences it does not paper over, and the
+dock's single-system presence. A product whose value depends on a gesture this skill cannot promise, or on the
+dock operations above, has a positive criterion and a `DESK-G1` decision rather than a careful plan.
+
 ## Shortcuts and the three scopes
 
 Accelerators join modifiers and key codes with `+` and are case-insensitive. Use `CommandOrControl` (or its

--- a/.gobbi/projects/gobbi/skills/desktop/packaging-distribution.md
+++ b/.gobbi/projects/gobbi/skills/desktop/packaging-distribution.md
@@ -3,12 +3,156 @@
 Own per-OS installer targets, ASAR packaging, native module rebuild, and bundled resources. Policy lives in
 [`SKILL.md`](SKILL.md); this child owns the mechanics.
 
+Packaging is where a development build becomes a thing a person installs, and it is the first point at which
+several obligations become provable at all. A development build proves nothing about an installer, an
+installer proves nothing about a signature, and a signature proves nothing about an update — `DESK-R23` adds
+those as four separate gates for exactly that reason.
+
+This file covers producing the artifact. [`signing-updates.md`](signing-updates.md) covers what happens to it
+afterward, and the two form one chain: package, then sign, then update.
+
 ## Per-OS target matrix
+
+**One installer target per claimed operating system, produced by the build, and installed from in a clean
+environment before the outcome is called finished.** A run that claims three systems and produces two
+installers has claimed one system it cannot deliver.
+
+The matrix a run fills in at `P5` names, per claimed system: the target format, what produces it, whether it
+is signed and by what, and how an installed copy receives an update.
+
+**NOT STATED HERE — the per-system installer format names and their trade-offs.** This skill's claim register
+carries no owner document enumerating them, so none is taught. *Closing condition:* read the selected build
+tool's own target documentation and record the chosen format per system in the run's design record. The
+selection is a real decision with real consequences — package-manager integration, update path, and
+permissions all differ by format — and it is made against a document this skill has read rather than against
+a list reproduced from memory.
+
+What holds regardless of format:
+
+- **Linux distribution goes through package formats**, and that fact reaches beyond packaging: it is why the
+  system has no built-in update path, which [`signing-updates.md`](signing-updates.md) owns.
+- **The clean-environment install is the proof.** Installing over a development machine that already carries
+  every dependency proves nothing about the artifact. `DESK-R23`'s install gate means a machine that has not
+  seen this application before.
+- **Each format is per-system evidence.** `DESK-FLOOR-04` member 6 applies here as everywhere: an installer
+  proved on one system supports no claim about another.
 
 ## The build-tool selection criterion
 
+**This skill states a criterion, never a mandate.** `DESK-N10` forbids resolving the choice on the reader's
+behalf, and the evidence genuinely does not pick a winner: both leading tools are maintained and both are
+first-party-adjacent rather than third-party afterthoughts.
+
+**The criterion:**
+
+> Start from the all-in-one tool. Move to the alternative when the requirement set names **differential
+> updates**, **staged rollout**, or a **non-default update provider** — because the platform's own built-in
+> updater documents none of those, and the alternative's updater supplies all three.
+
+Read the criterion against the run's own stated requirements, not against a preference. A run that has no
+staged-rollout requirement gains nothing by adopting the heavier chain for one.
+
+**Three facts that keep the choice honest:**
+
+1. **The all-in-one tool does not claim official status in its own documentation.** The platform's tutorial
+   recommends it and uses its publishing plugins, which is a recommendation and not a designation. Do not
+   write "the official build tool" as a quoted fact — `DESK-R26` requires a claim to be verifiable at its
+   owner, and that one is not.
+2. **Its actual stated advantage is upstream proximity:** it wraps first-party tooling, so new platform
+   capabilities arrive through it immediately rather than after a port. That is a maintenance argument, and
+   it is the strongest one on offer.
+3. **The dev-and-build layer is orthogonal to both.** The tool that compiles and bundles the three targets is
+   not a competitor to the tool that packages and publishes — it composes with either. Presenting all three
+   as one choice is a category error that produces a needless decision.
+
+**This is a `DESK-G6` user decision.** Present the criterion, the run's requirement set, and which side of
+the criterion it falls on. A tool chosen against the criterion is a legitimate answer; record the reason.
+
+**Version-sensitivity, stated rather than pinned here.** The alternative tool's current major is a breaking
+release with its own module-syntax and runtime-floor requirements. Pin the version the run actually uses and
+read that version's own migration notes. This file states no tool version literal, because a literal here
+would be stale before it is useful, and [`runtime-deltas.md`](runtime-deltas.md) owns the platform baseline
+that the tools track.
+
 ## ASAR packaging mechanics
+
+The archive bundles application source into a single file that the platform reads directly, without
+unpacking, at run time. That is the mechanic.
+
+Three properties change how code inside it behaves, and each one surprises somebody:
+
+1. **It is read-only.** Anything the application writes goes elsewhere —
+   [`filesystem-data.md`](filesystem-data.md) owns where.
+2. **File-status calls return guessed values.** Code that branches on file metadata inside the archive is
+   branching on an approximation.
+3. **Some interfaces silently extract to a temporary directory.** A file a reader believes is sealed inside
+   the archive can exist, unpacked, on disk. This matters for path resolution below and it matters for
+   anything the run assumed was inaccessible.
+
+**The archive is not a security boundary**, and its own documentation claims only that it conceals source
+from cursory inspection. [`security.md`](security.md) owns that rule, the paired integrity fuses, and the
+never-bundle-a-secret consequence. What belongs here is the packaging half: **the two archive fuses are set
+at build time**, so whether the shipped artifact validates its own archive is decided by this step and not by
+application code.
+
+Integrity support is not available on every system, and the per-system minimum versions live in
+[`runtime-deltas.md`](runtime-deltas.md).
 
 ## Native module rebuild and its per-OS traps
 
+**A native module built for the standalone runtime does not work here, and must be rebuilt.** The platform's
+application binary interface differs from the standalone runtime's — the documented example is that it uses
+Chromium's **BoringSSL** where the standalone runtime uses **OpenSSL** — so the compiled artifact is
+genuinely incompatible rather than merely untested.
+
+This has consequences a run plans for rather than discovers:
+
+- **The rebuild is per platform and per architecture.** Every claimed system needs its own build of every
+  native dependency, which means a build environment per system or a cross-build setup that produces them.
+- **Windows needs a delay-load hook.** A native module built for this platform requires
+  `'win_delay_load_hook': 'true'` in its `binding.gyp`; without it the module fails at load with
+  **"Module did not self-register"**. That message names a symptom that reads like a corrupted build, so a
+  run that has not seen it before will look in the wrong place.
+- **A native dependency is a `DESK-G7` decision.** It is a production dependency that multiplies the build
+  matrix by every claimed system, and it can block a system entirely if no build exists for it. Surface that
+  cost when the dependency is proposed, not when the third system's build fails.
+
+**Check native dependencies before claiming a system.** A run that claims three systems and depends on a
+module that builds for two has a contradiction in its own contract, and the earliest honest place to find it
+is the stack-fit test at `DESK-R03`.
+
 ## Bundled resources and path resolution
+
+**A path that worked in development is the single most common thing to break on packaging**, because the
+layout changes underneath it. In development the application runs from a directory tree; packaged, part of it
+runs from inside an archive, part sits beside the archive, and part may be silently extracted to a temporary
+directory when something reads it.
+
+Three rules follow:
+
+1. **Never compose a path from the source file's own location and assume it survives packaging.** Resolve
+   resource paths through whatever the packaged layout actually provides, and verify the resolution against
+   the installed artifact rather than against the development tree.
+2. **Decide per resource whether it belongs inside the archive or beside it.** Anything that must be read by
+   a mechanism outside the platform's own file interfaces — another process, a native module, a system
+   service — cannot rely on reading from inside the archive, and the silent-extraction behavior above is not
+   a contract to depend on.
+3. **Bundle resources locally rather than fetching them at run time.** This is one of the platform's own
+   documented performance recommendations, and it has a second benefit the performance framing understates:
+   a locally bundled resource cannot fail because a network is missing, which is a substantial part of what
+   makes an installed application feel different from a page.
+
+**The path proof belongs to the install gate.** `DESK-R23` requires a smoke test of the installed artifact in
+a clean environment, and resource resolution is precisely the class of defect that gate exists to catch —
+invisible in development, immediate on a machine that has only the shipped files.
+
+> **UNVERIFIED — a custom startup-snapshot workflow for application code.** The platform's recent releases
+> changed the startup baseline: the privileged process now boots from an embedded startup snapshot, and
+> framework bundles and preload scripts are cached as compiled bytecode.
+> [`runtime-deltas.md`](runtime-deltas.md) records the versions those behaviors hold from.
+>
+> **Whether a custom snapshot workflow for an application's own code is documented was not confirmed, so no
+> such workflow is taught here.** *Closing condition:* the vendor documents one for application code. The
+> documented startup action available today is upgrading the platform version itself — which means a startup
+> measurement that does not name the version it was taken on measures nothing, and `DESK-R26`'s
+> version-naming rule is what keeps such a measurement honest.

--- a/.gobbi/projects/gobbi/skills/desktop/packaging-distribution.md
+++ b/.gobbi/projects/gobbi/skills/desktop/packaging-distribution.md
@@ -1,0 +1,14 @@
+# Desktop — Packaging and Distribution
+
+Own per-OS installer targets, ASAR packaging, native module rebuild, and bundled resources. Policy lives in
+[`SKILL.md`](SKILL.md); this child owns the mechanics.
+
+## Per-OS target matrix
+
+## The build-tool selection criterion
+
+## ASAR packaging mechanics
+
+## Native module rebuild and its per-OS traps
+
+## Bundled resources and path resolution

--- a/.gobbi/projects/gobbi/skills/desktop/process-model.md
+++ b/.gobbi/projects/gobbi/skills/desktop/process-model.md
@@ -49,10 +49,10 @@ a second `require`.
 **No rationale is written here for the removal of the former remote-access module.** The governing document
 gives none and no primary statement was found — **UNVERIFIED**, and the gap is recorded in `SKILL.md`'s gap
 register rather than filled with a plausible story. Two adjacent verified facts do the teaching work instead:
-passing the whole renderer-side messaging module across the bridge yields an **empty object** on the
-receiving side from the version [`runtime-deltas.md`](runtime-deltas.md) records under *Whole message-port
-module across the bridge yields an empty object*, and direct renderer-to-renderer messaging was removed at the
-version recorded under *Direct renderer-to-renderer messaging removed*.
+passing the whole `ipcRenderer` module across `contextBridge` yields an **empty object** on the receiving
+side from the version [`runtime-deltas.md`](runtime-deltas.md) records under *Whole message-port module across
+the bridge yields an empty object*, and `ipcRenderer.sendTo()` was removed at the version recorded under
+*Direct renderer-to-renderer messaging removed*.
 
 ## The IPC pattern table
 
@@ -66,8 +66,8 @@ version recorded under *Direct renderer-to-renderer messaging removed*.
 `ipcRenderer.sendSync` is cautioned against for performance reasons: it blocks the renderer that calls it.
 Reach for `invoke` instead, and treat a synchronous crossing as a decision that needs a reason.
 
-There is no direct renderer-to-renderer channel. The removed method that once provided one is gone as of the
-version [`runtime-deltas.md`](runtime-deltas.md) records under *Direct renderer-to-renderer messaging
+There is no direct renderer-to-renderer channel. `ipcRenderer.sendTo()`, which once provided one, is gone as
+of the version [`runtime-deltas.md`](runtime-deltas.md) records under *Direct renderer-to-renderer messaging
 removed*, so a design that assumes it is broken on every supported version.
 
 **Enumerate the channels.** The run's channel inventory names, per channel, its payload type, its runtime
@@ -118,11 +118,11 @@ What does **not** survive:
   arrives as data. Its methods do not arrive with it.
 - **`Error` properties may be lost**, because the error is thrown in a different context from the one that
   will catch it.
-- **The whole renderer-side messaging module** yields an empty object on the receiving side from the version
+- **The whole `ipcRenderer` module** yields an empty object on the receiving side from the version
   [`runtime-deltas.md`](runtime-deltas.md) records for it. Expose named methods, never the module.
 
-Isolated worlds are addressed by number, and `999` is the platform's own preload default. A custom world uses
-`1000` or above so it cannot collide with that default.
+`exposeInIsolatedWorld(worldId, …)` addresses isolated worlds by number, and `999` is the platform's own
+preload default. A custom world uses `1000` or above so it cannot collide with that default.
 
 ### Why this is the highest-value teaching point in the skill
 

--- a/.gobbi/projects/gobbi/skills/desktop/process-model.md
+++ b/.gobbi/projects/gobbi/skills/desktop/process-model.md
@@ -50,8 +50,8 @@ a second `require`.
 gives none and no primary statement was found — **UNVERIFIED**, and the gap is recorded in `SKILL.md`'s gap
 register rather than filled with a plausible story. Two adjacent verified facts do the teaching work instead:
 passing the whole `ipcRenderer` module across `contextBridge` yields an **empty object** on the receiving
-side from the version [`runtime-deltas.md`](runtime-deltas.md) records under *Whole message-port module across
-the bridge yields an empty object*, and `ipcRenderer.sendTo()` was removed at the version recorded under
+side from the version [`runtime-deltas.md`](runtime-deltas.md) records under *Whole `ipcRenderer` module sent
+across the bridge yields an empty object*, and `ipcRenderer.sendTo()` was removed at the version recorded under
 *Direct renderer-to-renderer messaging removed*.
 
 ## The IPC pattern table

--- a/.gobbi/projects/gobbi/skills/desktop/process-model.md
+++ b/.gobbi/projects/gobbi/skills/desktop/process-model.md
@@ -3,14 +3,228 @@
 Fix the main / renderer / preload / utility split and the IPC contract as a trust boundary. Policy lives in
 [`SKILL.md`](SKILL.md); this child owns the mechanics.
 
+The boundary between the privileged process and the presentation process is the product's real perimeter, and
+it presents as an ordinary typed function call. Everything in this file exists because a declared type states
+a shape and never validates one.
+
+Every version-dependent statement below names the behaviour whose availability version
+[`runtime-deltas.md`](runtime-deltas.md) owns, and points there instead of restating the literal.
+
 ## The four execution contexts and their privileges
+
+| Context | Privilege | What it owns | What it must not do |
+|---|---|---|---|
+| **Main** | full — a Node.js environment | windows, application lifecycle, and every native operating-system interface | block. It owns the interface thread across every window at once, so one synchronous file read or parse freezes the whole application |
+| **Renderer** | none beyond web standards | one window's document, its rendering, and its own event loop | reach a privileged interface directly. It has no direct access to `require` or other Node.js interfaces, so a package from the registry needs a bundler |
+| **Preload** | narrow and deliberate | the single sanctioned bridge between a renderer and the privileged side | expose a broad surface. It executes in a renderer before that renderer's web content begins loading, which is the whole reason it can install a contract the page cannot tamper with |
+| **Utility** | isolated | work that must not run in main and must not run in a renderer | be treated as a renderer. It is the platform's own equivalent of the runtime's `fork`, built on the browser engine's services layer, and it communicates over `MessagePort` |
+
+State which context each unit of the outcome runs in. A unit whose context is unstated is a unit whose
+privilege is unstated.
+
+### The three defaults, and what they mean
+
+Three security defaults define the shape above. Each has been the default since the version
+[`runtime-deltas.md`](runtime-deltas.md) records for it, under *Renderer runtime integration off by default*,
+*Context isolation on by default*, and *Renderer sandbox on by default*. The renderer sandbox is on unless
+runtime integration is switched on or the sandbox is switched off explicitly.
+
+The platform's own guidance is stronger than it is usually read to be: enable the sandbox in **all**
+renderers, and do not load, read, or process untrusted content in an unsandboxed process — **including the
+privileged process**. The privileged process is not exempt from that instruction.
+
+A sandboxed renderer can freely use processor cycles and memory and nothing else; every privileged operation
+is delegated across the boundary.
+
+### What a sandboxed preload actually gets
+
+A sandboxed preload does not get the runtime. It gets a **polyfill with limited functionality**: a `require`
+restricted to `contextBridge`, `crashReporter`, `ipcRenderer`, `nativeImage`, `webFrame`, and `webUtils`, plus
+`events`, `timers`, `url`, and the `Buffer`, `process`, `setImmediate`, and `clearImmediate` globals.
+
+The direct consequence is a build fact, not a style preference: **preload code cannot be split across
+CommonJS files**, so preload is a bundling target. A preload that grows past one file needs the bundler, not
+a second `require`.
+
+**No rationale is written here for the removal of the former remote-access module.** The governing document
+gives none and no primary statement was found — **UNVERIFIED**, and the gap is recorded in `SKILL.md`'s gap
+register rather than filled with a plausible story. Two adjacent verified facts do the teaching work instead:
+passing the whole renderer-side messaging module across the bridge yields an **empty object** on the
+receiving side from the version [`runtime-deltas.md`](runtime-deltas.md) records under *Whole message-port
+module across the bridge yields an empty object*, and direct renderer-to-renderer messaging was removed at the
+version recorded under *Direct renderer-to-renderer messaging removed*.
 
 ## The IPC pattern table
 
+| Direction | Mechanism | Status |
+|---|---|---|
+| Renderer to main, one-way | `ipcRenderer.send` with `ipcMain.on` | fire-and-forget only; no result reaches the caller |
+| Renderer to main, two-way | `ipcRenderer.invoke` with `ipcMain.handle` | **the documented recommendation** — use it whenever possible |
+| Main to renderer | `webContents.send` | the only direction from the privileged side |
+| Renderer to renderer | none directly | broker through main, or hand over a `MessagePort` |
+
+`ipcRenderer.sendSync` is cautioned against for performance reasons: it blocks the renderer that calls it.
+Reach for `invoke` instead, and treat a synchronous crossing as a decision that needs a reason.
+
+There is no direct renderer-to-renderer channel. The removed method that once provided one is gone as of the
+version [`runtime-deltas.md`](runtime-deltas.md) records under *Direct renderer-to-renderer messaging
+removed*, so a design that assumes it is broken on every supported version.
+
+**Enumerate the channels.** The run's channel inventory names, per channel, its payload type, its runtime
+validation, its sender rule, and the privileged effect it reaches. A channel absent from the inventory is a
+channel nobody has reasoned about.
+
 ## Sender and payload validation
+
+Both validations are mandatory at every privileged crossing, and they defend against different things.
+
+### The caller
+
+**Validate the sender of all inter-process messages by default.** This is the platform's own instruction, not
+a hardening option, and the reason is structural: all web frames can in theory send messages to the
+privileged process, including iframes and child windows in some scenarios. Context isolation does **not**
+prevent it — isolation separates the page's world from the preload's world, and says nothing about which
+frame a message came from.
+
+The documented pattern checks `event.senderFrame` before any privileged effect. Check it in the handler, not
+in a wrapper the handler can be reached around.
+
+### The payload
+
+Runtime-validate every payload into a domain type before the privileged effect. A declared type is erased at
+the boundary: the compiler checks the caller it can see, and the value arriving at the handler came from a
+process the compiler never checked.
+
+This is the shape `DESK-N06` names — trusting a payload or its sender because the declared type says it is
+safe. The two failures pair: a valid payload from an unexpected frame and an invalid payload from the
+expected frame are both reachable, and each needs its own check.
+
+Parsing an untrusted value into a domain type is a language concern, and
+[`typescript/typing.md`](../typescript/typing.md) owns the declaration-versus-verification distinction that
+makes it work. This file states where the parse must happen; that file states how to write one.
 
 ## The `contextBridge` crossable-type boundary
 
+The bridge is a real type boundary, not a transparent channel. What crosses is enumerated:
+
+`string`, `number`, `boolean`, `Object`, `Array`, `Error`, `Promise`, `Function`, cloneable types, `Element`,
+`Blob`, and `VideoFrame`.
+
+What does **not** survive:
+
+- **`Symbol` cannot cross.** A `Symbol`-keyed member is not merely dropped from the copy; the value cannot
+  make the crossing at all.
+- **Prototype modifications are dropped, and sending classes or constructors does not work.** An instance
+  arrives as data. Its methods do not arrive with it.
+- **`Error` properties may be lost**, because the error is thrown in a different context from the one that
+  will catch it.
+- **The whole renderer-side messaging module** yields an empty object on the receiving side from the version
+  [`runtime-deltas.md`](runtime-deltas.md) records for it. Expose named methods, never the module.
+
+Isolated worlds are addressed by number, and `999` is the platform's own preload default. A custom world uses
+`1000` or above so it cannot collide with that default.
+
+### Why this is the highest-value teaching point in the skill
+
+The declared type says `Foo`. The runtime delivers a prototype-stripped object shaped like `Foo` and missing
+everything `Foo`'s prototype carried. The compiler cannot see the difference, because from its side this is
+an ordinary in-process call against a declared interface.
+
+So the boundary presents as a fully typed function call while carrying data an attacker can shape. There is
+no analogue for that in ordinary language use, which is why the language skill does not name it and why this
+skill has to. `DESK-R16` is the rule: one source-of-truth contract type, imported type-only by both sides,
+carrying only structured-cloneable values and plain asynchronous functions.
+
+**Design the contract for what survives.** A contract typed in terms of classes will type-check and fail at
+run time. A contract typed in terms of plain data and asynchronous functions returning plain data will not.
+
 ## `MessagePort` lifetime
 
+Ports come in pairs, and the pair is the unit.
+
+- **The ordinary send and invoke methods cannot transfer a port.** Only the `postMessage` methods can. A
+  design that plans to hand a port over an ordinary channel does not work.
+- **The privileged-side classes are `MessageChannelMain` and `MessagePortMain`,** and they are runtime-style
+  rather than web-style: `.on('message')`, not `.onmessage`. Code copied from a browser example needs this
+  change.
+- **A port can be implicitly closed by being garbage-collected.** That is the trap. A port held only by a
+  local variable in a function that returns will close at a time nothing in the code names.
+
+Therefore lifetime is owned explicitly. `DESK-R18` states the rule: every privileged resource held on behalf
+of a renderer names the window or `webContents` lifecycle event that releases it, with `will-quit` as the
+last-resort terminal. Key disposal to the lifecycle event, never to scope exit.
+[`typescript/async-resources.md`](../typescript/async-resources.md) owns the disposal idiom itself.
+
+A utility process communicates over these ports, so a utility process's lifetime is a port lifetime question
+and inherits everything above.
+
 ## The three compilation targets
+
+**INFERRED — the three-target split is derived, not documented.** No primary source states it. It follows
+from the verified sentence that the preload context has the document interfaces plus a limited subset of the
+runtime's and the platform's own interfaces, and following-from is not documented-as. `DESK-R17` carries this
+marking, and the marking travels with the rule wherever it is restated, taught, or exercised — including
+`P7`, which materialises these three projects. Teach the split; teach it as derived.
+
+| Target | Ambient types | Document interfaces | Why |
+|---|---|---|---|
+| Main | the runtime's own types | none | it is a runtime environment with no document |
+| Renderer | **none from the runtime** | yes | it is a web-standards context, and the sandbox rejects what runtime types would promise |
+| Preload | the narrowest set of the three | yes | it has the document interfaces and only a limited subset of the rest |
+
+Wire the three as separate projects with their own library, type, and module settings, joined by project
+references over **one type-only shared layer**. [`typescript/modules-tooling.md`](../typescript/modules-tooling.md)
+owns the flag set and the import-extension fork; this file states only which targets exist and why they
+differ.
+
+### Excluding the runtime's types from the renderer is a defect fix, not a preference
+
+With renderer runtime integration off — the default recorded in [`runtime-deltas.md`](runtime-deltas.md) —
+including the runtime's types in the renderer target makes `require`, `process`, and file-system calls
+**type-check green over code that throws at run time**.
+
+A green type-check over code the sandbox rejects is a correctness and security inversion: the one tool that
+was supposed to catch the mistake now certifies it. `DESK-N07` prohibits it outright, and it is prohibited
+because the failure is silent until a user hits the path.
+
+### Sharing the contract without leaking the runtime's types
+
+Two pieces, and the shape of each matters:
+
+1. **A shared contract module holding only erasable type declarations, with no runtime import of the
+   platform's own module.** Importing a type *from* the platform module inside a renderer file drags the
+   runtime's ambient types into the browser target and reintroduces the defect above through the back door.
+2. **A renderer-side declaration file** that augments the global window object with the contract type, so the
+   renderer sees the bridge surface and nothing else.
+
+Both sides import the contract type-only. That is what makes it one source of truth rather than two
+declarations that agree today.
+
+### Module-syntax asymmetry across the three targets
+
+Module syntax arrived at the version [`runtime-deltas.md`](runtime-deltas.md) records under *Module syntax
+support in the main process*, and it behaves differently in each of the three contexts. This is the single
+largest source of surprise in the three-target build.
+
+- **Main** uses the runtime's own module loader and needs either the module file extension or the module type
+  declared in the manifest. Its imports load **asynchronously**, so only side effects from the entry point's
+  own imports run before the ready event. Any registration that must happen before that event is subject to
+  this, and [`windows-lifecycle.md`](windows-lifecycle.md) names the launch-event trap it produces.
+- **Preload** is the constrained one. A **sandboxed preload cannot use module-syntax imports at all**. An
+  unsandboxed preload requires the module file extension and **ignores** the module type declared in the
+  manifest. An unsandboxed module-syntax preload runs after page load on pages with no content, and a dynamic
+  runtime-module import in a preload requires context isolation.
+- **Renderer** uses the browser engine's loader. It has no access to the runtime's built-in modules and
+  cannot load packages from the installed dependency tree, so **a bundler is mandatory** — this is the same
+  fact the context table states, reached from the module side.
+
+### The entry-point question that stays open
+
+**UNKNOWN — whether the privileged process can run a TypeScript entry directly through the runtime's own type
+stripping.** This skill's rule is written so it does not depend on the answer: **require a compile or bundle
+step**, which every current template assumes. The rule does not claim the alternative is impossible, because
+that would be a claim about the world that nobody here has checked.
+
+One test settles it: run a TypeScript main entry under the pinned runtime version and record the result.
+`SKILL.md`'s gap register carries it with that closing condition. Neither assert nor hedge it in the
+meantime — a hedge is a positive claim and fails the same way.

--- a/.gobbi/projects/gobbi/skills/desktop/process-model.md
+++ b/.gobbi/projects/gobbi/skills/desktop/process-model.md
@@ -1,0 +1,16 @@
+# Desktop — Process Model and the Privilege Boundary
+
+Fix the main / renderer / preload / utility split and the IPC contract as a trust boundary. Policy lives in
+[`SKILL.md`](SKILL.md); this child owns the mechanics.
+
+## The four execution contexts and their privileges
+
+## The IPC pattern table
+
+## Sender and payload validation
+
+## The `contextBridge` crossable-type boundary
+
+## `MessagePort` lifetime
+
+## The three compilation targets

--- a/.gobbi/projects/gobbi/skills/desktop/runtime-deltas.md
+++ b/.gobbi/projects/gobbi/skills/desktop/runtime-deltas.md
@@ -17,10 +17,11 @@ than copying the literal.
 
 **Verified against the platform's own release feed and release-timeline documentation on 2026-07-25**, and the
 per-feature availability rows below against its published breaking-changes record on 2026-07-26. The tray, dock
-and login-item rows — the login-item service-type row above and the *Tray and dock* block below — were verified
-against the platform's own tray, dock and login-item API documentation on 2026-07-26; the cells that block
-marks **Not read** or **None recorded** were not retrieved and are stated as such rather than filled in. The
-claim-to-source register with retrieval identifiers is kept with the design record, not reproduced here.
+and login-item rows — the login-item service-type row in the table below, the login-item registration row in
+the interaction matrix, and the *Tray and dock* block — were verified against the platform's own tray, dock and
+login-item API documentation on 2026-07-26; the cells that block marks **Not read** or **None recorded** were
+not retrieved and are stated as such rather than filled in. The claim-to-source register with retrieval
+identifiers is kept with the design record, not reproduced here.
 
 **Three rows in this document were wrong on first authoring and were corrected against that primary source.**
 The whole-module-across-the-bridge row named the wrong module; the dialog default-path row was two majors

--- a/.gobbi/projects/gobbi/skills/desktop/runtime-deltas.md
+++ b/.gobbi/projects/gobbi/skills/desktop/runtime-deltas.md
@@ -15,8 +15,17 @@ Read this before writing any statement whose truth can expire.
 Every value here is owned here. A sibling needing one states the property and points at this section rather
 than copying the literal.
 
-**Verified against the platform's own release feed and release-timeline documentation on 2026-07-25.** The
+**Verified against the platform's own release feed and release-timeline documentation on 2026-07-25**, and the
+per-feature availability rows below against its published breaking-changes record on 2026-07-26. The
 claim-to-source register with retrieval identifiers is kept with the design record, not reproduced here.
+
+**Three rows in this document were wrong on first authoring and were corrected against that primary source.**
+The whole-module-across-the-bridge row named the wrong module; the dialog default-path row was two majors
+early; and the clipboard-removal row was one major early and stated as shipped when it has not shipped. All
+three had been written from recollection rather than from the evidence register, and none was traceable to it
+— which is how they were caught. The lesson is recorded here because this document is the family's sole owner
+of version literals: a wrong value here is wrong everywhere that points at it, and pointing is exactly what
+every sibling is required to do.
 
 | Value class | Current value |
 |---|---|
@@ -93,13 +102,18 @@ sentence, so a statement that goes stale identifies itself rather than failing s
 | Renderer sandbox on by default | 20.0.0 |
 | Module syntax support in the main process | 28.0.0 |
 | Direct renderer-to-renderer messaging removed | 28.0.0 |
-| Whole message-port module across the bridge yields an empty object | 29.0.0 |
+| Whole `ipcRenderer` module sent across the bridge yields an empty object | 29.0.0 |
 | File-path property removed from dropped files | 32.0.0 |
 | Clipboard access from the renderer deprecated | 40.0.0 |
-| Dialog default path resolves to the downloads directory | 41.0.0 |
-| Clipboard access from the renderer unavailable | 43.0.0 |
+| Dialog default path resolves to the downloads directory | 43.0.0 |
 | Main process boots from an embedded startup snapshot | 43.0.0 |
 | Framework bundles and preload scripts cached as compiled bytecode | 43.0.0 |
+| Clipboard module no longer exposed to renderers | **44.0 — announced, not yet shipped** |
+
+**The last row is the only forward-looking one.** The current platform version is 43.2.0, so that removal has
+not landed. A run on a supported major still has renderer clipboard access, deprecated. Treat it as a
+migration deadline rather than as current behaviour, and re-check it at the next major — it is the clearest
+case of a statement that is true now and will be wrong without warning.
 
 **A startup measurement is meaningless without its platform version.** The 43.0.0 rows changed the startup
 baseline, so any performance number a run records names the version it was measured on.

--- a/.gobbi/projects/gobbi/skills/desktop/runtime-deltas.md
+++ b/.gobbi/projects/gobbi/skills/desktop/runtime-deltas.md
@@ -16,7 +16,10 @@ Every value here is owned here. A sibling needing one states the property and po
 than copying the literal.
 
 **Verified against the platform's own release feed and release-timeline documentation on 2026-07-25**, and the
-per-feature availability rows below against its published breaking-changes record on 2026-07-26. The
+per-feature availability rows below against its published breaking-changes record on 2026-07-26. The tray, dock
+and login-item rows — the login-item service-type row above and the *Tray and dock* block below — were verified
+against the platform's own tray, dock and login-item API documentation on 2026-07-26; the cells that block
+marks **Not read** or **None recorded** were not retrieved and are stated as such rather than filled in. The
 claim-to-source register with retrieval identifiers is kept with the design record, not reproduced here.
 
 **Three rows in this document were wrong on first authoring and were corrected against that primary source.**
@@ -37,6 +40,7 @@ every sibling is required to do.
 | 32-bit and older-ARM end of life | The **43.x** series is the last shipping prebuilt binaries for 32-bit Windows and older 32-bit ARM Linux. Support ends **January 2027** |
 | Platform-certificate policy date | The platform **states that** Microsoft has required extended-validation signing for Windows software **since June 2023** |
 | Archive-integrity minimums | macOS from **16.0.0**; Windows from **30.0.0**; **no Linux support** |
+| Login-item service types | The login-item registration takes a service type from **macOS 13** onward |
 
 **On the certificate-policy row.** It is written as what the platform *states*, not as a vendor fact, because
 the evidence on hand is the platform's report of another vendor's policy rather than that vendor's own
@@ -69,6 +73,26 @@ something the platform does not provide, and the direct-evidence floor's per-tar
 | Deep links before packaging | **Do not work** — testing unpackaged gives a false negative | Work | Work |
 | Global accelerators | Known failure on non-QWERTY keyboard layouts | No equivalent limitation recorded | No equivalent limitation recorded |
 | Notification prerequisites | Signing required; body text truncated beyond a documented byte limit | A start-menu shortcut carrying an application identity and its activator identifier | A desktop notification service |
+| Login-item registration | **Present** | **Present** | **No platform interface** — automatic start at login is the run's own mechanism and its own evidence |
+
+### Tray and dock
+
+A menu-bar-resident design reads this block before it claims a system.
+[`native-integration.md`](native-integration.md) names the mechanism each row applies to.
+
+| Concern | macOS | Windows | Linux |
+|---|---|---|---|
+| Tray activation gesture | **Not read** — no gesture statement was retrieved for this system | **Not read** — no gesture statement was retrieved for this system | **Unspecified by the underlying specification** — the activation event fires, but which gesture activates is left to the desktop environment |
+| Underlying tray interface | The system's own status area | The system's own notification area | A status-notifier interface by default, falling back to an older status-icon interface where the desktop environment lacks it |
+| Icon format expectation | A template image, named by the documented filename suffix, with a matching higher-density image | An icon-format file is recommended | **None recorded** |
+| Right-click, double-click, drag-and-drop, and tray mouse events | **Present** | Not present | Not present |
+| Title text beside the tray icon | **Present** | Not present | Not present |
+| Balloon notifications and their focus control | Not present | **Present** | Not present |
+| Dock property | **Present** | **Undefined** | **Undefined** |
+
+The activation-gesture row is the one that changes a design rather than a detail. A run cannot promise the
+person a specific gesture on a system whose specification does not fix one; it states that activation is
+handled and leaves the gesture unstated.
 
 ### Assistive technology
 

--- a/.gobbi/projects/gobbi/skills/desktop/runtime-deltas.md
+++ b/.gobbi/projects/gobbi/skills/desktop/runtime-deltas.md
@@ -1,0 +1,12 @@
+# Desktop — Runtime Deltas
+
+Own the per-OS delta matrix and be the single home for every version-sensitive value in this family. Policy
+lives in [`SKILL.md`](SKILL.md); this child owns the mechanics.
+
+## The version baseline block
+
+## Per-OS delta matrix
+
+## Per-feature availability
+
+## The re-verify trigger

--- a/.gobbi/projects/gobbi/skills/desktop/runtime-deltas.md
+++ b/.gobbi/projects/gobbi/skills/desktop/runtime-deltas.md
@@ -3,10 +3,133 @@
 Own the per-OS delta matrix and be the single home for every version-sensitive value in this family. Policy
 lives in [`SKILL.md`](SKILL.md); this child owns the mechanics.
 
+Two jobs, kept separate. The **version baseline** is the sole owner of every version literal in this family:
+no sibling restates one, and every sibling stating a version-dependent property points here. The **delta
+matrices** record where one operating system behaves differently from another, so a sibling can state an
+obligation once and name the platform that changes it.
+
+Read this before writing any statement whose truth can expire.
+
 ## The version baseline block
+
+Every value here is owned here. A sibling needing one states the property and points at this section rather
+than copying the literal.
+
+**Verified against the platform's own release feed and release-timeline documentation on 2026-07-25.** The
+claim-to-source register with retrieval identifiers is kept with the design record, not reproduced here.
+
+| Value class | Current value |
+|---|---|
+| Platform version | Electron **43.2.0**, released 2026-07-22 |
+| Bundled browser engine | Chromium **150.0.7871.129** |
+| Bundled runtime | Node **24.18.0** |
+| Supported major set | **41, 42, 43** — the latest three stable majors |
+| Release cadence | **Eight weeks**, measured major to major, four weeks alpha and four weeks beta |
+| 32-bit and older-ARM end of life | The **43.x** series is the last shipping prebuilt binaries for 32-bit Windows and older 32-bit ARM Linux. Support ends **January 2027** |
+| Platform-certificate policy date | The platform **states that** Microsoft has required extended-validation signing for Windows software **since June 2023** |
+| Archive-integrity minimums | macOS from **16.0.0**; Windows from **30.0.0**; **no Linux support** |
+
+**On the certificate-policy row.** It is written as what the platform *states*, not as a vendor fact, because
+the evidence on hand is the platform's report of another vendor's policy rather than that vendor's own
+document. Any sibling restating it keeps that attribution. Upgrading it to a direct claim requires reading the
+vendor's own source first.
 
 ## Per-OS delta matrix
 
+A sibling states its obligation once and points here for the divergence. Each row is a place where an
+obligation written for one system is wrong on another.
+
+### Release and update
+
+| Concern | macOS | Windows | Linux |
+|---|---|---|---|
+| Built-in update mechanism | Yes | Yes | **None.** Updates go through the system package manager |
+| Signing required for updates | **Yes** — updates do not function unsigned | Yes | Not applicable |
+| Archive-integrity validation | From 16.0.0 | From 30.0.0 | **Unsupported** |
+| Signing model | Developer-program identity, then notarization — **two steps, both required** | Extended-validation certificate on hardware meeting the stated security level | No platform signing story |
+
+The Linux column is the one that surprises teams. A run claiming three-platform automatic updating is claiming
+something the platform does not provide, and the direct-evidence floor's per-target requirement will expose it.
+
+### Interaction and lifecycle
+
+| Concern | macOS | Windows | Linux |
+|---|---|---|---|
+| Closing every surface | Application keeps running | Application exits | Application exits |
+| Deep-link delivery | A dedicated open-URL event | Through the single-instance lock and its second-instance event | As Windows |
+| Deep links before packaging | **Do not work** — testing unpackaged gives a false negative | Work | Work |
+| Global accelerators | Known failure on non-QWERTY keyboard layouts | No equivalent limitation recorded | No equivalent limitation recorded |
+| Notification prerequisites | Signing required; body text truncated beyond a documented byte limit | A start-menu shortcut carrying an application identity and its activator identifier | A desktop notification service |
+
+### Assistive technology
+
+| System | Screen reader named in the platform's own documentation |
+|---|---|
+| Windows | JAWS |
+| macOS | VoiceOver |
+| Linux | **None named — a documented gap, not an omission here** |
+
+The Linux row is stated rather than quietly dropped. A run claiming Linux accessibility support cannot lean on
+platform documentation for it and must say what evidence it has instead. The accessibility floor is
+non-waivable and does not soften because the platform's guidance is thin.
+
+### Surface-state restoration
+
+The platform provides **no built-in mechanism** for saving and restoring surface position and size. This is a
+conformance gap rather than a convenience gap: the design guidance for at least two systems assumes a surface
+reopens where the person left it. Closing it means either a third-party dependency — a user decision, never a
+default — or an implementation the run owns. The run states which, because a surface that forgets its position
+reads as broken regardless of what the platform supplies.
+
 ## Per-feature availability
 
+Each row gives the version from which the behaviour holds. A rule depending on one names it in the same
+sentence, so a statement that goes stale identifies itself rather than failing silently.
+
+| Behaviour | Holds from |
+|---|---|
+| Renderer runtime integration off by default | 5.0.0 |
+| Context isolation on by default | 12.0.0 |
+| Renderer sandbox on by default | 20.0.0 |
+| Module syntax support in the main process | 28.0.0 |
+| Direct renderer-to-renderer messaging removed | 28.0.0 |
+| Whole message-port module across the bridge yields an empty object | 29.0.0 |
+| File-path property removed from dropped files | 32.0.0 |
+| Clipboard access from the renderer deprecated | 40.0.0 |
+| Dialog default path resolves to the downloads directory | 41.0.0 |
+| Clipboard access from the renderer unavailable | 43.0.0 |
+| Main process boots from an embedded startup snapshot | 43.0.0 |
+| Framework bundles and preload scripts cached as compiled bytecode | 43.0.0 |
+
+**A startup measurement is meaningless without its platform version.** The 43.0.0 rows changed the startup
+baseline, so any performance number a run records names the version it was measured on.
+
 ## The re-verify trigger
+
+**The trigger is an event: the next platform major release.** It is deliberately not a date.
+
+The cadence measures major-to-major intervals, and the newest release recorded here is a **patch**. A patch
+date plus a major-to-major interval does not yield the next major's date, so no such date is derivable from
+the evidence on hand and none is stated. A predicted date would read as a fact and would be wrong in a way a
+reader could not detect.
+
+When the next major ships, re-verify in this order:
+
+1. The platform, browser-engine and runtime versions in the baseline table.
+2. The supported-major set — its oldest member changes on every release.
+3. Every per-feature availability row, since a behaviour can change in the same release.
+4. The end-of-life row, which fixes a date and so expires by calendar rather than by release.
+5. Every sibling statement naming a version — the naming rule is what makes them findable.
+
+**Falling outside the supported-major set is a security failure, not a maintenance preference.** Three majors
+are supported at a time and browser-engine vulnerabilities reach this platform through its engine updates
+continuously. A run that cannot sustain that cadence should have taken the stack-fit decision differently, and
+the wrong-choice criteria in [`SKILL.md`](SKILL.md) say so.
+
+## What this document does not own
+
+The obligations that *use* these values live with their subjects: the privilege boundary and its message
+contract, the security posture and its build-time hardening, surface lifecycle and native integration, local
+data and migration, packaging, and the release chain. Each states its obligation and points here for the value.
+
+This document states values and divergences. It states no rule.

--- a/.gobbi/projects/gobbi/skills/desktop/scenarios.md
+++ b/.gobbi/projects/gobbi/skills/desktop/scenarios.md
@@ -4,13 +4,13 @@ Be the authoritative scenario source and the authoritative case-to-check relatio
 outcome. Policy lives in [`SKILL.md`](SKILL.md). Its consumers are [`checklists.md`](checklists.md) and
 [`evaluation.md`](evaluation.md). It exercises the parent contract and adds no policy.
 
-**Purpose:** ten coverage families and **sixty cases** that a desktop run must handle, each with an
+**Purpose:** ten coverage families and **sixty-three cases** that a desktop run must handle, each with an
 observable outcome a wrong run would produce differently, and each converted into the design obligation it
 proves. **Target:** one bounded desktop application outcome as `SKILL.md` defines it. **Consumer:** the run
 itself while designing, and an evaluator afterward. **Lifecycle mode:** design obligations, consumed in
 evaluation.
 
-**Scale, and the thresholds this set records.** Ten families, sixty cases, and **51 populated cells**,
+**Scale, and the thresholds this set records.** Ten families, sixty-three cases, and **51 populated cells**,
 where a cell is one distinct `(category, triggered case type)` pair. Every figure here is reproduced by
 scanning this file rather than carried from a plan. The cell figure did not move when the case count did: every
 case added after the first authoring landed in a cell that was already populated, and a second case in a
@@ -63,7 +63,7 @@ Abbreviations: **Pos** positive · **Alt** alternative-valid · **Neg** negative
 |---|---|---|---|---|---|---|---|---|
 | `01` Purpose | 01 | 02 | 03 | `n/a: the outcome contract has no quantity, ordering, or time-window property to sit at a limit of` | `n/a: a scope contract is a written agreement, not a runtime component that can fail partway` | 04 | `n/a: this family fixes the contract before any version of it exists to change` | 05 |
 | `02` Actors | 06, 54 | 07 | 08 | 09 | 10 | 11 | `n/a: participant conditions are re-established per activity, so there is no before/after version of them to compare` | `n/a: the participant floor's premise is fail-closed by construction, leaving no load-bearing premise to invert` |
-| `03` Behavior | 12, 56 | `n/a: the state machine's valid entry paths are enumerated by DESK-FAMILY-01's entry-mode inventory, so a second valid class here would duplicate that family's coverage` | 13, 58 | 14, 57 | 15 | 16, 59, 60 | 17 | `n/a: this family asserts no premise beyond the platform mechanisms its siblings verify at their owners` |
+| `03` Behavior | 12, 56, 61 | `n/a: the state machine's valid entry paths are enumerated by DESK-FAMILY-01's entry-mode inventory, so a second valid class here would duplicate that family's coverage` | 13, 58, 62 | 14, 57 | 15 | 16, 59, 60 | 17, 63 | `n/a: this family asserts no premise beyond the platform mechanisms its siblings verify at their owners` |
 | `04` Interfaces | 18 | `n/a: the four execution contexts are one enumerated set, not alternative valid routes through one contract` | 19 | `n/a: the crossable-type set is a membership question, not a limit with an adjacent value` | 20 | 21 | 22 | `n/a: the boundary's premise — that a declared type does not validate — is exercised directly by case 21 rather than inverted` |
 | `05` Quality | 23 | `n/a: a measurement has one valid method here; a second would vary the subject, not the class` | `n/a: an invalid measurement is an unsourced claim, which DESK-FAMILY-10 owns as an evidence defect` | 24 | `n/a: a resource bound that is exceeded is this family's boundary case, not a separate injected failure` | 25 | `n/a: a cross-version comparison of a measurement is exactly what case 24's version-naming obligation exists to make possible, and is covered there` | 26 |
 | `06` Failure | 27 | `n/a: recovery has one correct path per failure here; a second valid route would be a different failure` | `n/a: rejecting an invalid input is DESK-FAMILY-04's crossing validation, not a recovery concern` | 28 | 29 | 30 | `n/a: a failed update's version change is exercised by DESK-FAMILY-09, which owns the version axis` | `n/a: this family's premise — that interruption is ordinary — is asserted by the safety floor and not inverted here` |
@@ -79,10 +79,11 @@ prohibition, a `DESK-FLOOR` floor with its property check, a `DESK-G` gate, or a
 children supply the concrete mechanism each case exercises. No case derives from a source outside the
 family, and no case introduces a mechanism its owning child does not state.
 
-**Stable-ID policy.** `DESK-FAMILY-01`–`10` and `DESK-SCENARIO-01`–`60` are permanent — sixty cases,
-numbered without gaps, reproduced by scan. The last seven identifiers were allocated after later coverage
-sweeps — two after a sweep found two reserved checks with no seeding case, and five after the per-system
-behavior check was split into one claim per item and five of its claims proved to have no case of their own —
+**Stable-ID policy.** `DESK-FAMILY-01`–`10` and `DESK-SCENARIO-01`–`63` are permanent — sixty-three cases,
+numbered without gaps, reproduced by scan. The last ten identifiers were allocated after later coverage
+sweeps — two after a sweep found two reserved checks with no seeding case, five after the per-system behavior
+check was split into one claim per item and five of its claims proved to have no case of their own, and three
+for capabilities the mechanics children taught with no case behind them —
 so they sit at the end of the sequence rather than inside their families' runs; identifiers are
 allocation-ordered and never renumbered. Renaming a title never changes an identifier. A case whose *discrimination* changes — it now tests something different — gets
 a new identifier rather than reusing the old one, so a finding stays resolvable across revisions. A retired
@@ -529,6 +530,61 @@ with no readable owner fails whether it was asserted or hedged.
 claim about what has not been read; it MUST mark the gap, name its closing condition, and write the rule so it
 does not depend on the answer.
 *Trace:* `DESK-CHECK-43`
+
+#### `DESK-SCENARIO-61` — A tray-resident outcome, and the gesture it must not promise
+
+*Primary type:* **Positive** — the ordinary valid path of an outcome entered from a status-area icon.
+*Coverage-role:* `positive` (exercises tray residency end to end, including the state change its mechanism
+requires).
+*Given* an outcome whose primary entry mode is a status-area icon on every claimed system. *When* the run
+builds it, and later changes one item of its context menu. *Then* the icon carries a context menu; the changed
+item is applied by setting the context menu again rather than by mutating the item in place; the entry mode
+appears in the run's own entry-mode inventory; and nothing written for the person promises a specific
+activation gesture on a system whose own specification leaves the gesture to the environment.
+*Failure oracle:* a menu item whose field was changed and whose menu never updates, with no error anywhere; a
+tray entry mode absent from the inventory while the outcome is entered through it; or an instruction naming a
+gesture on the system that fixes none.
+*Evidence:* change one context-menu item at run time and open the menu on each claimed system; read the
+entry-mode inventory for the tray row; and read every person-facing instruction naming a gesture against that
+system's own specification.
+*Obligation:* the design MUST build a tray-resident entry mode from an icon and a context menu re-set rather
+than mutated in place, MUST carry that entry mode in its inventory, and MUST NOT promise an activation gesture
+on a system whose specification leaves it to the environment.
+*Trace:* `DESK-CHECK-44`
+
+#### `DESK-SCENARIO-62` — A standard menu item reimplemented in a click handler
+
+*Primary type:* **Negative** — an invalid menu construction expecting rejection.
+*Coverage-role:* `negative` (exercises rejection of a hand-built standard item).
+*Given* a menu whose items include ones matching documented standard roles. *When* the run implements them by
+hand, giving each a literal label and a click handler that approximates the behaviour. *Then* the construction
+is rejected: an item matching a standard role specifies that role, because the role carries the platform's own
+structure, its own labels, and its own localisation, while the hand-built item carries the label in one
+language and the localisation not at all.
+*Failure oracle:* a menu item whose behaviour matches a documented role while the item specifies no role; or a
+menu correct in its author's own language and unlocalised in every other.
+*Evidence:* enumerate the menu items from source and, for each whose behaviour matches a documented role,
+confirm the role is specified rather than reimplemented.
+*Obligation:* the design MUST specify the documented role for any menu item matching a standard role, rather
+than reimplementing that behaviour in a click handler.
+*Trace:* `DESK-CHECK-45`
+
+#### `DESK-SCENARIO-63` — A dropped file's path read through a property that was removed
+
+*Primary type:* **Change / regression** — it compares behaviour across the platform change that removed the
+property. *Coverage-role:* `change/regression` (exercises the removal against code written before it).
+*Given* an application that reads a dropped file's path from the file object's own path property — the form
+most published examples still show — and a target version at or after the removal the version baseline
+records. *When* a person drops a file on it. *Then* the property yields nothing. Not an error: an empty value,
+so the drop silently does nothing and the defect surfaces as a feature that does not work rather than as a
+failure with a stack trace. The path is obtained from the documented replacement helper instead.
+*Failure oracle:* any read of a dropped file's path from the removed property; or a drop path whose only
+evidence is that the code compiles and the handler is reached.
+*Evidence:* enumerate every read of a dropped file's path from source and confirm each goes through the
+replacement helper; then drop a real file and observe the path the handler actually receives.
+*Obligation:* the design MUST obtain a dropped file's path from the documented replacement helper and MUST NOT
+read the removed path property, whose failure is a silently empty value rather than an error.
+*Trace:* `DESK-CHECK-46`
 
 ### `DESK-FAMILY-04` — The privilege boundary, the channel inventory, and the three targets
 
@@ -1172,27 +1228,28 @@ Every case's obligation and the check identifier it reserves. This table is the 
 trace — policy and case to check — and it is generated from the `Trace:` fields above rather than maintained
 beside them, so the two cannot drift apart.
 
-**No case in this set is exploratory**, so all sixty carry an obligation and appear here. An exploratory
+**No case in this set is exploratory**, so all sixty-three carry an obligation and appear here. An exploratory
 case would be exempt from the obligation trace only while explicitly marked as one, and the exemption would
 end the moment it became an approved constraint.
 
 **The reserved ranges, and the two extensions this set required.** The design fixes four pause points and
-reserves thirty-four check slots across them. This set reserves **forty-three**. The first extension took it to
+reserves thirty-four check slots across them. This set reserves **forty-six**. The first extension took it to
 thirty-six, because the four protected floors each need a member check *and* a property check — eight slots
 where the original allocation left room for fewer — and the protected-waiver table needs its own; it followed
 the rule the design states, growing a range at its own pause point's tail and shifting every later range. The
-second extension took it to forty-three and could not follow that rule: splitting the per-system behavior check
-into one atomic claim per item needed seven further slots at `DESK-PAUSE-3`, and growing that range in place
-would have renumbered every later identifier, which the stable-ID policy above forbids. Those seven are
-therefore **allocated at the tail of the sequence and placed in their pause point's own list**, exactly as
-`DESK-SCENARIO-54` and `DESK-SCENARIO-55` sit inside their families with tail numbers.
+second extension took it to forty-six and could not follow that rule: splitting the per-system behavior check
+into one atomic claim per item needed seven further slots at `DESK-PAUSE-3`, and three taught capabilities with
+no check at all — tray residency, menus from roles, and the dropped-file path — needed three more. Growing that
+range in place would have renumbered every later identifier, which the stable-ID policy above forbids. Those
+ten are therefore **allocated at the tail of the sequence and placed in their pause point's own list**, exactly
+as `DESK-SCENARIO-54` and `DESK-SCENARIO-55` sit inside their families with tail numbers.
 [`checklists.md`](checklists.md) records the final ranges once, as their owner.
 
 | Pause point | Reserved range | Confirms |
 |---|---|---|
 | `DESK-PAUSE-1` — stack and outcome lock | `01`–`05` | outcome, boundary, stack-fit result, ownership statement, gate-authority map |
 | `DESK-PAUSE-2` — design acceptance | `06`–`17`, with **`06` reserved for the structural-approval check** | the structural-approval decision, the rung register, and all four floors on both their member and property checks |
-| `DESK-PAUSE-3` — implementation completion | `18`–`26` and `37`–`43` | the privilege boundary, security posture, platform obligations one claim at a time, local data, and in-scope paths |
+| `DESK-PAUSE-3` — implementation completion | `18`–`26` and `37`–`46` | the privilege boundary, security posture, platform obligations one claim at a time, local data, and in-scope paths |
 | `DESK-PAUSE-4` — release-readiness handoff | `27`–`36` | every applicable release gate per claimed system, the design record, and the trace and verifier proofs |
 
 `DESK-CHECK-06` is pinned by the design rather than chosen here: the restored structural-approval gate
@@ -1263,3 +1320,6 @@ one check cluster.
 | `DESK-SCENARIO-58` | A two-state light and dark toggle offered as the theme contract | `DESK-CHECK-41` | `DESK-PAUSE-3` |
 | `DESK-SCENARIO-59` | A shortcut map that works in its author's own window | `DESK-CHECK-42` | `DESK-PAUSE-3` |
 | `DESK-SCENARIO-60` | A platform convention filled in from a plausible summary | `DESK-CHECK-43` | `DESK-PAUSE-3` |
+| `DESK-SCENARIO-61` | A tray-resident outcome, and the gesture it must not promise | `DESK-CHECK-44` | `DESK-PAUSE-3` |
+| `DESK-SCENARIO-62` | A standard menu item reimplemented in a click handler | `DESK-CHECK-45` | `DESK-PAUSE-3` |
+| `DESK-SCENARIO-63` | A dropped file's path read through a property that was removed | `DESK-CHECK-46` | `DESK-PAUSE-3` |

--- a/.gobbi/projects/gobbi/skills/desktop/scenarios.md
+++ b/.gobbi/projects/gobbi/skills/desktop/scenarios.md
@@ -1,0 +1,17 @@
+# Desktop Application Scenario Set
+
+Be the authoritative scenario source and the authoritative case-to-check relation for one desktop application
+outcome. Policy lives in [`SKILL.md`](SKILL.md). Its consumers are [`checklists.md`](checklists.md) and
+[`evaluation.md`](evaluation.md). It exercises the parent contract and adds no policy.
+
+## Coverage register
+
+## Category × case-type matrix
+
+## Sources and IDs
+
+## The authoritative relation
+
+## The ten families
+
+## Obligation-to-check reservation

--- a/.gobbi/projects/gobbi/skills/desktop/scenarios.md
+++ b/.gobbi/projects/gobbi/skills/desktop/scenarios.md
@@ -4,14 +4,1158 @@ Be the authoritative scenario source and the authoritative case-to-check relatio
 outcome. Policy lives in [`SKILL.md`](SKILL.md). Its consumers are [`checklists.md`](checklists.md) and
 [`evaluation.md`](evaluation.md). It exercises the parent contract and adds no policy.
 
+**Purpose:** ten coverage families and **fifty-five cases** that a desktop run must handle, each with an
+observable outcome a wrong run would produce differently, and each converted into the design obligation it
+proves. **Target:** one bounded desktop application outcome as `SKILL.md` defines it. **Consumer:** the run
+itself while designing, and an evaluator afterward. **Lifecycle mode:** design obligations, consumed in
+evaluation.
+
+**Scale, and the thresholds this set records.** Ten families, fifty-five cases, and **51 populated cells**,
+where a cell is one distinct `(category, triggered case type)` pair. Every figure here is reproduced by
+scanning this file rather than carried from a plan.
+
+The generic defaults are roughly twelve families and forty cells, and this set **records its own cell
+threshold as 55**. Two reasons, and the first is the load-bearing one. The family count is not this author's
+to tune: `SKILL.md`'s design fixes exactly ten families, one per coverage category, so splitting the set
+under a parent index would contradict the parent rather than bound this file — the split remedy the generic
+threshold prescribes is unavailable here. And fifty-one cells across ten locked families is close to the
+floor for this target, because each family owes a positive case and an adversarial face before any
+risk-triggered minimum is discharged, which is twenty cells before the first stress case exists.
+
+**Non-goals.** This set constructs no verification checks and reads none. It reserves check IDs and states
+obligations; [`checklists.md`](checklists.md) authors the checks themselves. It states no policy — every
+obligation traces to a clause `SKILL.md` already carries, and a case with no such clause is a parent-policy
+finding rather than a licence to write one here.
+
 ## Coverage register
+
+All ten categories are `selected`. None is `covered-elsewhere` and none is `n/a`: a desktop application
+outcome touches every one of them, which is why the family set is exactly ten.
+
+| # | Category | Disposition | Carrier | The desktop discrimination it carries |
+|---|---|---|---|---|
+| 1 | Purpose / outcomes / scope | `selected` | `DESK-FAMILY-01` | one bounded desktop outcome, the stack-fit decision, the ownership boundary |
+| 2 | Actors / stakeholders / use-context | `selected` | `DESK-FAMILY-02` | the ladder's participant activities, consent, per-system representativeness |
+| 3 | Behavior / state / data | `selected` | `DESK-FAMILY-03` | window and application lifecycle state, local data, migration including downgrade |
+| 4 | Interfaces / dependencies / structure | `selected` | `DESK-FAMILY-04` | the privilege boundary, the channel inventory, the three compilation targets |
+| 5 | Quality attributes / resource economics | `selected` | `DESK-FAMILY-05` | startup and responsiveness against a named platform version, privileged-process blocking, footprint |
+| 6 | Failure / recovery / operations | `selected` | `DESK-FAMILY-06` | crash and reload, interrupted write, failed update, corrupt-state recovery |
+| 7 | Trust / harm / governance | `selected` | `DESK-FAMILY-07` | the two kinds of security work, build-time hardening, secrets, untrusted content |
+| 8 | Inclusion / locale | `selected` | `DESK-FAMILY-08` | the accessibility union, per-system assistive technology, locale and language |
+| 9 | Change / compatibility / reversibility | `selected` | `DESK-FAMILY-09` | release irreversibility, the supported-old-version window, signing and update |
+| 10 | Evidence / traceability / clarity | `selected` | `DESK-FAMILY-10` | the rung register, the claim ledger, evidence-class separation, the trace and verifier proof |
+
+**No `covered-elsewhere` disposition appears**, so no condition-to-clause ledger is required. Two adjacent
+skills own material this set points at rather than covering — the language skill owns general idiom and the
+generic evaluation skill owns perspectives — but neither owns a *coverage category* of this set.
 
 ## Category × case-type matrix
 
+Every cell is dispositioned. A populated cell names the cases; an unpopulated cell names the **property**
+that makes that case type inapplicable to that family. No cell is a bare `n/a`.
+
+Abbreviations: **Pos** positive · **Alt** alternative-valid · **Neg** negative · **Bnd** boundary ·
+**F/R** failure/recovery · **Adv** adversarial · **Chg** change/regression · **Ctf** counterfactual.
+
+| Family | Pos | Alt | Neg | Bnd | F/R | Adv | Chg | Ctf |
+|---|---|---|---|---|---|---|---|---|
+| `01` Purpose | 01 | 02 | 03 | `n/a: the outcome contract has no quantity, ordering, or time-window property to sit at a limit of` | `n/a: a scope contract is a written agreement, not a runtime component that can fail partway` | 04 | `n/a: this family fixes the contract before any version of it exists to change` | 05 |
+| `02` Actors | 06, 54 | 07 | 08 | 09 | 10 | 11 | `n/a: participant conditions are re-established per activity, so there is no before/after version of them to compare` | `n/a: the participant floor's premise is fail-closed by construction, leaving no load-bearing premise to invert` |
+| `03` Behavior | 12 | `n/a: the state machine's valid entry paths are enumerated by DESK-FAMILY-01's entry-mode inventory, so a second valid class here would duplicate that family's coverage` | 13 | 14 | 15 | 16 | 17 | `n/a: this family asserts no premise beyond the platform mechanisms its siblings verify at their owners` |
+| `04` Interfaces | 18 | `n/a: the four execution contexts are one enumerated set, not alternative valid routes through one contract` | 19 | `n/a: the crossable-type set is a membership question, not a limit with an adjacent value` | 20 | 21 | 22 | `n/a: the boundary's premise — that a declared type does not validate — is exercised directly by case 21 rather than inverted` |
+| `05` Quality | 23 | `n/a: a measurement has one valid method here; a second would vary the subject, not the class` | `n/a: an invalid measurement is an unsourced claim, which DESK-FAMILY-10 owns as an evidence defect` | 24 | `n/a: a resource bound that is exceeded is this family's boundary case, not a separate injected failure` | 25 | `n/a: a cross-version comparison of a measurement is exactly what case 24's version-naming obligation exists to make possible, and is covered there` | 26 |
+| `06` Failure | 27 | `n/a: recovery has one correct path per failure here; a second valid route would be a different failure` | `n/a: rejecting an invalid input is DESK-FAMILY-04's crossing validation, not a recovery concern` | 28 | 29 | 30 | `n/a: a failed update's version change is exercised by DESK-FAMILY-09, which owns the version axis` | `n/a: this family's premise — that interruption is ordinary — is asserted by the safety floor and not inverted here` |
+| `07` Trust | 31 | `n/a: a control is written or it is not; there is no materially different valid way to leave a default intact` | 32 | 33 | `n/a: a security control that fails open is an adversarial case here, and case 34 carries it` | 34, 35 | 36 | `n/a: the premise that packaging is not a boundary is stated by its own documentation and needs no inversion` |
+| `08` Inclusion | 37 | 38 | 39 | 40 | `n/a: assistive technology failing is an availability loss, which this family's positive and boundary cases already observe directly` | 41 | `n/a: a locale or modality change is a re-run of case 37's own union, not a version event` | `n/a: the union is a stated minimum with a residual clause, so its premise is open by construction` |
+| `09` Change | 42 | `n/a: each claimed system's release chain is its own required path, covered per system inside case 42 rather than as an alternative` | 43 | 44 | 45 | 46 | 47 | `n/a: irreversibility is a property of the world here, not a premise this set could invert` |
+| `10` Evidence | 48 | `n/a: a resolution kind is one of three enumerated values, and all three are exercised inside case 48` | 49 | 50 | `n/a: a missing record is an evidence defect this family observes directly, not an injected runtime failure` | 51, 52, 55 | `n/a: the record's own version history is the run's concern, not this skill's` | 53 |
+
 ## Sources and IDs
+
+**Sources.** Every case derives from a clause `SKILL.md` already carries — a `DESK-R` rule, a `DESK-N`
+prohibition, a `DESK-FLOOR` floor with its property check, a `DESK-G` gate, or a named phase. The mechanics
+children supply the concrete mechanism each case exercises. No case derives from a source outside the
+family, and no case introduces a mechanism its owning child does not state.
+
+**Stable-ID policy.** `DESK-FAMILY-01`–`10` and `DESK-SCENARIO-01`–`55` are permanent — fifty-five cases,
+numbered without gaps, reproduced by scan. The last two identifiers were allocated after a coverage sweep
+found two reserved checks with no seeding case, so they sit at the end of the sequence rather than inside
+their families' runs; identifiers are allocation-ordered and never renumbered. Renaming a title
+never changes an identifier. A case whose *discrimination* changes — it now tests something different — gets
+a new identifier rather than reusing the old one, so a finding stays resolvable across revisions. A retired
+identifier is never reallocated.
+
+**Sensitive evidence is referenced, never inlined.** Participant records, consent records, and any captured
+personal data are named by pointer to the run's own design record, with the run's retention policy governing
+them. No case reproduces a participant's own words or data here.
 
 ## The authoritative relation
 
+**Each case's `Trace:` field is the authoritative case-to-check relation for this family.** Three other
+projections must be exact projections of it — each check's `Seeds` field and the guaranteed coverage map in
+[`checklists.md`](checklists.md), and the check-to-obligation union audit in the same file. No forward-only,
+reverse-only, grouped, or inferred edge is valid.
+
+There are **four** projections, not five. A check's `Source` field is a *(check, rule)* relation while these
+four are *(case, check)* relations; a relation over one pair of sets cannot be an exact projection of a
+relation over a different pair, so requiring equality across all five is a test no correct bundle can pass.
+`Source` closes its own direction through the crosswalk [`evaluation.md`](evaluation.md) owns.
+
+**Every case carries six fields**: primary type with its coverage-role set, Given/When/Then, a failure
+oracle, an evidence tuple, an obligation, and the trace. **A case's primary category and primary type are
+author-declared with a one-line justification, never derived from the matched set** — no mechanical rule is
+correct for every family, and four design iterations proved it by counterexample before the declared form
+was settled. The primary label carries stable IDs, grouping, and perspective routing only; it never
+discharges coverage.
+
 ## The ten families
 
+### `DESK-FAMILY-01` — One bounded outcome, the stack decision, and the ownership boundary
+
+*Declared primary category:* **1 Purpose / outcomes / scope** — the family's defining discrimination is
+whether the right outcome and the right in-or-out-of-scope boundary are served. *Secondary tags:* 2 Actors,
+10 Evidence. *Applicability:* unconditional. *Priority:* first — every later family reads this one's claim
+set.
+
+*Actor:* the run's decision-holder. *Outcome:* a bounded desktop outcome with its claimed systems, its entry
+modes, its completion signals, and its stack decision recorded. *Invariant:* nothing downstream may widen
+the claim set without returning here.
+
+#### `DESK-SCENARIO-01` — The outcome, the boundary, and the ownership statement are locked together
+
+*Primary type:* **Positive** — it exercises the ordinary valid path of framing a run. *Coverage-role:*
+`positive` (exercises the intended framing outcome end to end).
+*Given* a trigger and an application that may or may not exist yet. *When* the run frames the outcome per
+`DESK-R01`, states the claimed systems, and states the design-ownership boundary per `DESK-R04`. *Then* one
+outcome sentence, the claimed-system set, the entry modes, the visible and system completion signals, the
+non-goals, and the ownership statement are all recorded and mutually consistent.
+*Failure oracle:* any claimed system with no named evidence route, or an entry mode named in the outcome
+that appears in no path, or an ownership statement absent while a second design authority is assumed.
+*Evidence:* read the run's own design record; confirm each field is present and that the claimed-system set
+in the outcome sentence equals the set the entry modes and non-goals assume.
+*Obligation:* the design MUST bind one outcome with its actors, entry modes, claimed operating systems,
+visible and system completion evidence, non-goals, and the statement that this skill is the sole design
+owner holding the acceptance gate.
+*Trace:* `DESK-CHECK-01`, `DESK-CHECK-03`
+
+#### `DESK-SCENARIO-02` — An alternative-valid framing: an existing application rather than a new one
+
+*Primary type:* **Alternative-valid** — a materially different valid starting state, not a second happy
+path. *Coverage-role:* `alternative-valid` (exercises the inherited-constraint route the greenfield case
+cannot).
+*Given* a shipped application with installed users and a live release chain. *When* the run frames a bounded
+outcome inside it. *Then* the frame additionally records what must not change, which compatibility promises
+bind, and which installed versions make the change expensive to reverse.
+*Failure oracle:* a frame that reads identically to a greenfield frame — no unchanged-behavior list and no
+installed-version constraint — while a shipped version exists.
+*Evidence:* read the frame against the release history; confirm the unchanged-behavior list is non-empty and
+names real current behavior.
+*Obligation:* the design MUST record, for a run inside an existing application, the behavior that must not
+change and the installed versions that constrain reversibility.
+*Trace:* `DESK-CHECK-01`, `DESK-CHECK-25`
+
+#### `DESK-SCENARIO-03` — A packaged artifact offered as a finished outcome
+
+*Primary type:* **Negative** — it supplies an invalid completion claim and expects rejection.
+*Coverage-role:* `negative` (exercises safe rejection of a false completion).
+*Given* a run whose designed paths include a cancelled-operation recovery route that was never implemented.
+*When* the run offers a packaged, installing artifact as the finished outcome. *Then* the claim is rejected
+and the run returns to close the missing path, with no release authority sought.
+*Failure oracle:* release readiness reported while a path named in the run's own flow set has no
+implementation; or a green build presented as outcome completion.
+*Evidence:* diff the run's designed path set against its implemented path set; any designed path with no
+implementation and no recorded scope removal fails.
+*Obligation:* the design MUST NOT treat a window, a handler, a passing development build, or a packaged
+artifact as a finished outcome while any in-scope designed path is unimplemented.
+*Trace:* `DESK-CHECK-25`
+
+#### `DESK-SCENARIO-04` — Continued work offered as gate approval
+
+*Primary type:* **Adversarial** — a cosmetically compliant run attempts to pass an authority gate without
+the decision. *Coverage-role:* `adversarial` (attacks the gate-authority invariant).
+*Given* a run that reached a named gate, presented its material, received no answer, and continued.
+*When* the run later cites the completed downstream work as evidence the gate was approved. *Then* the gate
+is treated as unfired, the downstream work does not substitute for the decision, and the run stops for the
+explicit answer.
+*Failure oracle:* a gate row carrying a recommendation and downstream artifacts but no recorded decision,
+accepted as approved. Silence, continued work, an earlier decision on a different axis, or a stakeholder's
+enthusiasm each read as approval.
+*Evidence:* read the gate record; a gate without an explicit recorded decision from the named authority is
+unfired regardless of what followed it.
+*Obligation:* the design MUST stop at each named gate for an explicit decision, and MUST NOT accept silence,
+continued work, an adjacent decision, or enthusiasm in its place.
+*Trace:* `DESK-CHECK-04`, `DESK-CHECK-36`
+
+#### `DESK-SCENARIO-05` — The stack-fit premise is inverted: a criterion fires
+
+*Primary type:* **Counterfactual** — it inverts the load-bearing premise that this stack suits the outcome.
+*Coverage-role:* `counterfactual` (inverts the stack premise and requires a named disconfirmation response).
+*Given* an outcome whose stated requirements make one of the six wrong-choice criteria positive on
+inspection. *When* the run reaches the stack decision. *Then* the positive criterion, the mechanism that
+makes it decisive, and the alternative it points at are presented to the user as a stack decision, and the
+run does not proceed on the strength of a plan to be careful.
+*Failure oracle:* a positive criterion recorded and the run continuing on this stack with no user decision;
+or six criteria answered as a summary verdict rather than as six inspected results.
+*Evidence:* read the six-row result table; each row carries an inspected result against this outcome's own
+stated requirements, and any positive row carries the user's decision.
+*Obligation:* the design MUST run the six-criterion test with a recorded inspected result per criterion, and
+MUST route any positive result to the user as a stack decision rather than absorbing it.
+*Trace:* `DESK-CHECK-02`
+
+### `DESK-FAMILY-02` — Participants, consent, representativeness, and the design gates
+
+*Declared primary category:* **2 Actors / stakeholders / use-context** — the defining discrimination is who
+participates, under what conditions, and whether they genuinely represent the claimed population. *Secondary
+tags:* 7 Trust (consent and data protection), 10 Evidence. *Applicability:* unconditional — six ladder rungs
+involve people. *Priority:* high; a failure here fails closed and stops the run.
+
+*Actor:* participants and the run's researcher. *Outcome:* every participant activity governed, and the
+design accepted only on direct evidence from representative people per claimed system. *Invariant:* a
+missing participant condition stops the run and reports missing context.
+
+#### `DESK-SCENARIO-06` — Participant conditions in place before the first activity
+
+*Primary type:* **Positive** — the ordinary valid path of running a participant activity.
+*Coverage-role:* `positive` (exercises the governed-activity path end to end).
+*Given* a run about to hold contextual interviews at the research rung. *When* the activity is prepared.
+*Then* informed consent, needed accommodations, data minimization, and a retention and protection record
+exist **before** the first session, and observation is recorded separately from interpretation.
+*Failure oracle:* a consent record dated after the session it governs; or interpretation and observation
+recorded as one field.
+*Evidence:* read the activity record against the session timestamps; consent must precede the activity it
+covers.
+*Obligation:* the design MUST establish informed consent, accommodations, minimization, and protection
+before any activity involving a person, and MUST keep observation separate from interpretation.
+*Trace:* `DESK-CHECK-13`
+
+#### `DESK-SCENARIO-07` — An alternative-valid participant route: cited prior research
+
+*Primary type:* **Alternative-valid** — a materially different valid way to satisfy a rung's evidence.
+*Coverage-role:* `alternative-valid` (exercises the citation route rather than the fresh-activity route).
+*Given* an existing study whose participants match this outcome's claimed population. *When* the run closes
+a rung by citing it. *Then* the citation addresses that rung's own question, resolves to an inspectable and
+substantive artifact, states why it is still valid, states what it does not cover, and does not point
+forward — and the uncovered remainder is answered or proved inapplicable in its own right.
+*Failure oracle:* a citation that closes a whole rung while answering part of its question, with no recorded
+remainder.
+*Evidence:* open the cited artifact and read it against the rung's question text; confirm the remainder
+statement exists and that the remainder itself carries a resolution.
+*Obligation:* the design MUST let an existing answer close only the part of a rung's question it actually
+addresses, with the remainder resolved in its own right.
+*Trace:* `DESK-CHECK-07`
+
+#### `DESK-SCENARIO-08` — Acceptance sought without direct evidence from representative people
+
+*Primary type:* **Negative** — an invalid acceptance precondition, expecting refusal.
+*Coverage-role:* `negative` (exercises refusal of acceptance on context-only evidence).
+*Given* a design record whose human-outcome claims rest on expert review, heuristic review, analytics, and
+stakeholder approval. *When* acceptance is sought. *Then* acceptance is unavailable, because every one of
+those is context only, and the run returns to obtain direct evidence from representative people using this
+run's own artifacts.
+*Failure oracle:* acceptance granted with no participant record from this run's own artifacts; or a
+stakeholder's approval presented as user evidence.
+*Evidence:* read the design record's evidence table; each human-outcome claim resolves to a participant
+record from this run, or acceptance fails.
+*Obligation:* the design MUST make direct representative-user evidence from this run's own artifacts the
+acceptance evidence, and MUST treat prior research, expert review, analytics, and approval as context only.
+*Trace:* `DESK-CHECK-15`
+
+#### `DESK-SCENARIO-09` — The structural skeleton is approved before any visual rung begins
+
+*Primary type:* **Boundary** — it sits at the exact transition between the structural rung and the first
+visual rung. *Coverage-role:* `boundary` (exercises the exact gate transition).
+*Given* a completed surface-neutral structural specification with its state and path map, its surface
+mapping, and its open-question register. *When* the run reaches the point where a visual rung would begin.
+*Then* the run stops, the user explicitly approves the structure or reopens it, the register row records the
+**approval decision** rather than merely the artifact, and no visual rung starts until that decision exists.
+*Failure oracle:* a wireflow, mockup, or interactive prototype whose creation timestamp precedes the
+recorded structural-approval decision; or a register row citing the specification artifact with no decision.
+*Evidence:* compare the recorded approval decision's timestamp against the earliest visual artifact's; and
+read the register row for a decision, not an artifact pointer.
+*Obligation:* the design MUST obtain an explicit structural-approval decision before any visual rung begins,
+and MUST record the decision itself in the rung register.
+*Trace:* `DESK-CHECK-06`
+
+#### `DESK-SCENARIO-10` — A required participant condition is missing
+
+*Primary type:* **Failure / recovery** — a required precondition is absent and the run must fail closed.
+*Coverage-role:* `failure/recovery` (exercises the fail-closed stop and its recovery route).
+*Given* a run that cannot reach genuinely representative users for one claimed operating system. *When* the
+run reaches an activity that needs them. *Then* the run stops and reports missing context; it may record an
+assumptions register and a test plan, and it may not accept a design.
+*Failure oracle:* the run proceeding with whoever was available and describing them as representative; or a
+missing accommodation absorbed as a limitation while acceptance proceeds.
+*Evidence:* read the participant record per claimed system; a system with no representative-participant
+record and an accepted design fails.
+*Obligation:* the design MUST fail closed on any one of missing access to representative users, missing
+consent, missing accommodations, or missing required evidence, and MUST report missing context rather than
+proceeding.
+*Trace:* `DESK-CHECK-13`
+
+#### `DESK-SCENARIO-11` — An unlisted participant activity whose observations are cited
+
+*Primary type:* **Adversarial** — a cosmetically compliant run whose named activities all pass while an
+unnamed one is ungoverned. *Coverage-role:* `adversarial` (attacks the floor through the gap between the
+named list and the actual inventory).
+*Given* a run where every ladder round carries a complete consent and accommodation record. *When* the
+design record additionally cites observations from a recruitment screening call that no round names, and
+that call ran with no consent record. *Then* the floor fails, because the governed set is the run's own
+**activity inventory** and not the ladder's named rounds.
+*Failure oracle:* a floor passing on the strength of its named rounds while an activity whose output is
+cited as evidence anywhere carries no consent record.
+*Evidence:* sweep every activity whose output is cited as evidence anywhere in the design record — rounds,
+interviews, screenings, informal walkthroughs, post-release contact — and require a consent, accommodation,
+minimization, protection, and representativeness record for each.
+*Obligation:* the design MUST govern every activity involving a person whose output is cited as evidence,
+whether or not the activity type appears in the ladder, and MUST NOT accept a named-round roll-up as the
+property check's evidence.
+*Trace:* `DESK-CHECK-14`
+
+#### `DESK-SCENARIO-54` — The ladder's own method order, and three axes stated per visual artifact
+
+*Primary type:* **Positive** — the ordinary valid path of running the ladder's methods in their own order.
+*Coverage-role:* `positive` (exercises the method order and the three-axis statement together).
+*Given* a run at the information-architecture and visual rungs. *When* each rung is resolved. *Then* the
+generative method runs before the evaluative one — a card sort producing the users' own grouping, then a
+tree test grading it — the structural rung needs no visual design, iteration budget goes to several small
+rounds rather than one large one, and **each visual artifact states its position on all three fidelity axes
+independently**. The shape-conditioned default applies: a desktop application is few windows with heavy
+in-place state change, so the wireflow is the default primary artifact rather than page wireframes plus a
+site map.
+*Failure oracle:* a tree test run on a structure no card sort shaped, or a card sort with no tree test
+grading it; a single low-to-high fidelity dial in place of three independent axis positions; or a
+page-oriented site map produced as the default deliverable for this product shape with no recorded reason.
+*Evidence:* read each rung's recorded method and its order against the rung's own stated validator; and read
+each visual artifact's record for three separately stated axis positions.
+*Obligation:* the design MUST use each rung's own validation method in its own generative-then-evaluative
+order, MUST state interactivity, visuals, and content-and-navigation as three independent positions per
+visual artifact, and MUST apply the wireflow default for this product shape or record why the shape differs.
+*Trace:* `DESK-CHECK-08`
+
+### `DESK-FAMILY-03` — Window lifecycle, local data, and migration
+
+*Declared primary category:* **3 Behavior / state / data** — the defining discrimination is a pre/post state,
+a transition, or a data-lifecycle step. *Secondary tags:* 6 Failure/recovery, 9 Change, 7 Trust. *Note on
+the declared primary:* the order-default for a family matching {3, 6, 7, 9} would be 7, but this family's
+cases turn on the state and the data rather than on a harm surface or a version event; the harm and version
+faces are carried by families 07 and 09, which declare those categories. *Applicability:* unconditional.
+*Priority:* high.
+
+*Actor:* the person using the installed application. *Outcome:* windows and data behave correctly across
+launch, quit, interruption, and version change. *Invariant:* no ordinary action reaches a state the person
+cannot foresee, refuse, or recover from.
+
+#### `DESK-SCENARIO-12` — First paint uses both mechanisms
+
+*Primary type:* **Positive** — the ordinary valid launch path. *Coverage-role:* `positive` (exercises a
+correct first paint).
+*Given* an application configured with a hidden initial window, a ready-to-show handler, **and** a background
+color. *When* it launches. *Then* the window appears with neither a white flash nor a period in which the
+application appears not to have launched.
+*Failure oracle:* a visible flash on show, or a measurable gap between launch and any visible window; either
+one indicates only one of the two mechanisms is in place.
+*Evidence:* record the launch on each claimed system and inspect the frames between process start and first
+paint.
+*Obligation:* the design MUST create the window hidden and show it on the ready-to-show event **and** set a
+background color, because each mechanism alone leaves one bad case.
+*Trace:* `DESK-CHECK-23`
+
+#### `DESK-SCENARIO-13` — A downgrade rewrites newer data into an older shape
+
+*Primary type:* **Negative** — an invalid migration behavior expecting refusal or preservation.
+*Coverage-role:* `negative` (exercises rejection of the destructive downgrade path).
+*Given* data written by a newer version, carrying an explicit structure version. *When* an older version
+opens it. *Then* the older version either reads what it understands while preserving what it does not,
+refuses explicitly and leaves the data intact, or works on a copy — and it never silently rewrites the newer
+structure into the older shape.
+*Failure oracle:* open with the newer version after the round trip; any field written by the newer version
+that is absent, and any structure-version downgrade written back, is data loss.
+*Evidence:* install newer, create real data, install older, open it, reinstall newer, and diff the data
+against the pre-downgrade state.
+*Obligation:* the design MUST carry an explicit structure version and a downgrade path that preserves,
+refuses, or copies — and MUST NOT silently rewrite newer data into an older shape.
+*Trace:* `DESK-CHECK-24`
+
+#### `DESK-SCENARIO-14` — A monitor disappears between sessions
+
+*Primary type:* **Boundary** — it sits at the exact transition where saved bounds stop intersecting an
+attached display. *Coverage-role:* `boundary` (exercises the exact display-attachment transition).
+*Given* saved window bounds on a secondary display. *When* the application is relaunched with that display
+detached. *Then* the restore validates the saved bounds against the currently attached displays and falls
+back to a visible default rather than placing the window where nothing can reach it.
+*Failure oracle:* a window restored to coordinates outside every attached display's area — invisible, and
+unreachable without editing state by hand.
+*Evidence:* set bounds on a second display, detach it, relaunch, and confirm the window is visible and
+focusable on an attached display.
+*Obligation:* the design MUST validate restored window bounds against the currently attached displays and
+fall back to a visible position when they do not intersect one.
+*Trace:* `DESK-CHECK-23`
+
+#### `DESK-SCENARIO-15` — A local write is interrupted
+
+*Primary type:* **Failure / recovery** — an interruption is injected and detection plus containment is
+expected. *Coverage-role:* `failure/recovery` (exercises interruption detection and recovery).
+*Given* an application writing a data file. *When* the process is killed mid-write. *Then* the next read
+observes either the whole previous content or the whole new content, or detects the file as incomplete and
+refuses it — and never parses a truncated file into a plausible-looking value.
+*Failure oracle:* a post-interruption read that succeeds and returns a structurally valid value whose
+content is half of each version.
+*Evidence:* interrupt a write repeatedly under load, then read; classify each result as old, new, or
+detected-incomplete, and fail on any fourth outcome.
+*Obligation:* the design MUST make every local write durable or detectably incomplete, replacing the target
+atomically and carrying a marker that lets a reader reject a truncated file.
+*Trace:* `DESK-CHECK-24`
+
+#### `DESK-SCENARIO-16` — A second instance's arguments are read by position
+
+*Primary type:* **Adversarial** — an ordinary launch produces an argument list whose order the run assumed.
+*Coverage-role:* `adversarial` (attacks the argument-handling invariant with a legitimate but unexpected
+launch).
+*Given* an application that reads the deep link from a fixed index of the second-instance argument list.
+*When* the operating system delivers that list with a changed order or an appended argument. *Then* the run
+acts on the wrong target — which is why the argument must be found by matching what it is rather than by
+where it sits.
+*Failure oracle:* a second launch that opens a document or navigates to a target the person did not choose;
+the platform documents that the list's order can change and that arguments can be appended.
+*Evidence:* launch a second instance with additional arguments present and in varied order; confirm the run
+resolves the intended target in every ordering.
+*Obligation:* the design MUST parse the second-instance argument list by matching, never by position, and
+MUST treat a positional read as a safety defect rather than a correctness preference.
+*Trace:* `DESK-CHECK-23`, `DESK-CHECK-11`
+
+#### `DESK-SCENARIO-17` — A schema change ships and the previous version is still installed
+
+*Primary type:* **Change / regression** — it compares behavior across a version change.
+*Coverage-role:* `change/regression` (exercises the mixed-version data state).
+*Given* two installed versions in the field and one shared data location. *When* the newer version writes
+and the older version subsequently reads. *Then* both directions are exercised and recorded, and the
+supported-old-version window states which older versions this obligation covers.
+*Failure oracle:* a migration proved only forward, with the reverse direction untested and undocumented.
+*Evidence:* the round-trip test from case 13 run against every version inside the stated support window.
+*Obligation:* the design MUST state which older versions its data contract supports, and MUST prove the data
+round trip across that stated window rather than only forward.
+*Trace:* `DESK-CHECK-24`, `DESK-CHECK-31`
+
+### `DESK-FAMILY-04` — The privilege boundary, the channel inventory, and the three targets
+
+*Declared primary category:* **4 Interfaces / dependencies / structure** — the defining discrimination is a
+contract between components across a boundary. *Secondary tags:* 7 Trust, 3 Behavior. *Applicability:*
+unconditional. *Priority:* high — this is the product's real perimeter.
+
+*Actor:* the code on either side of the boundary, and an attacker shaping what crosses it. *Outcome:* every
+crossing validated on both payload and caller, and every unit's execution context stated. *Invariant:* a
+declared type states a shape and never validates one.
+
+#### `DESK-SCENARIO-18` — Every channel carries its type, its validation, and its sender rule
+
+*Primary type:* **Positive** — the ordinary valid path of a complete channel inventory.
+*Coverage-role:* `positive` (exercises a correctly specified privileged crossing).
+*Given* an outcome whose privileged effects are reached over named channels. *When* the contract is locked.
+*Then* every channel in the inventory names its payload type, the runtime validation that parses it into a
+domain type, the sender rule that verifies the calling frame, and the privileged effect it reaches — and
+every unit of the outcome states which execution context it runs in.
+*Failure oracle:* a privileged handler reachable over a channel absent from the inventory; or an inventory
+row with a payload type and no runtime validation.
+*Evidence:* enumerate the registered handlers from the source and compare against the inventory; the two
+sets must be equal.
+*Obligation:* the design MUST enumerate every channel with its payload type, runtime validation, sender
+rule, and privileged effect, and MUST state each unit's execution context.
+*Trace:* `DESK-CHECK-19`, `DESK-CHECK-18`
+
+#### `DESK-SCENARIO-19` — The renderer target includes the runtime's ambient types
+
+*Primary type:* **Negative** — an invalid configuration expecting rejection.
+*Coverage-role:* `negative` (exercises rejection of the type-check inversion).
+*Given* a renderer target configured with the runtime's ambient types while renderer runtime integration is
+off. *When* renderer code calls a file-system or process interface. *Then* the type-check passes and the
+call throws at run time — which is why the configuration is a defect rather than a preference.
+*Failure oracle:* a green type-check over a renderer call that the sandbox rejects when executed.
+*Evidence:* read the renderer target's type configuration; and run the renderer path that the ambient types
+would permit, observing the runtime failure.
+*Obligation:* the design MUST exclude the runtime's ambient types from the renderer target, because a green
+type-check over code the sandbox rejects is a correctness and security inversion.
+*Trace:* `DESK-CHECK-18`
+
+#### `DESK-SCENARIO-20` — A port closes when nothing named its lifetime
+
+*Primary type:* **Failure / recovery** — an async resource is lost and the failure must be detected and
+contained. *Coverage-role:* `failure/recovery` (exercises lifetime loss and its recovery route).
+*Given* a message port held only by a local variable in a function that returns. *When* collection runs.
+*Then* the port closes at a time nothing in the code names, and the channel silently stops delivering —
+which is why every privileged resource held for a renderer names the lifecycle event that releases it.
+*Failure oracle:* a channel that works under test and stops under memory pressure or after idle time, with
+no error at the point of closure.
+*Evidence:* hold the port, force collection pressure, and observe delivery; then repeat with the lifetime
+keyed to a named window or contents lifecycle event.
+*Obligation:* the design MUST key every cross-process resource's disposal to a named lifecycle event rather
+than to scope exit, with the last-resort terminal named.
+*Trace:* `DESK-CHECK-20`
+
+#### `DESK-SCENARIO-21` — A class instance is sent across the bridge
+
+*Primary type:* **Adversarial** — a fully typed call delivers a value the type system cannot describe.
+*Coverage-role:* `adversarial` (attacks the assumption that a declared type describes what arrives).
+*Given* a bridge contract whose declared type names a class. *When* an instance is sent across. *Then* the
+receiving side gets a prototype-stripped object: the data arrives, the methods do not, and the compiler
+reports nothing — and a symbol-keyed member does not cross at all.
+*Failure oracle:* a call that type-checks and fails at run time on a missing method; or a contract typed in
+terms of classes rather than plain data and asynchronous functions.
+*Evidence:* send an instance across and inspect the received value's prototype and own keys on the receiving
+side.
+*Obligation:* the design MUST give the bridge one source-of-truth contract type carrying only
+structured-cloneable values and plain asynchronous functions, and MUST NOT type it in terms of classes,
+constructors, or symbol-keyed members.
+*Trace:* `DESK-CHECK-18`, `DESK-CHECK-19`
+
+#### `DESK-SCENARIO-22` — The three-target split is taught as documented fact
+
+*Primary type:* **Change / regression** — it compares the claim's status before and after someone checks
+its source. *Coverage-role:* `change/regression` (exercises the marking's survival across restatement).
+*Given* the three-target compilation split, which no primary source states and which follows from the
+verified preload-context sentence. *When* the split is restated in a rule, a phase, a case, or a mechanics
+child. *Then* the derived marking travels with it at every one of those sites, and the split is never
+presented as documented.
+*Failure oracle:* any site stating the three-target split without its derived marking.
+*Evidence:* enumerate every site that states the split and confirm the marking is present at each; the
+design names the rule, the build phase, this family, and the mechanics child as those sites.
+*Obligation:* the design MUST carry the derived marking with the three-target split wherever the split is
+restated, taught, or exercised.
+*Trace:* `DESK-CHECK-18`
+
+### `DESK-FAMILY-05` — Startup, responsiveness, and resource economics
+
+*Declared primary category:* **5 Quality attributes / resource economics** — the defining discrimination is
+a latency, capacity, or footprint bound. *Secondary tags:* 10 Evidence, 1 Purpose. *Applicability:*
+conditional on the outcome stating a performance or footprint property; unconditional for the
+version-naming obligation, which binds any measurement the run records. *Priority:* medium.
+
+*Actor:* the person waiting for the application. *Outcome:* measurements that mean something a version
+later. *Invariant:* a measurement without its platform version measures nothing.
+
+#### `DESK-SCENARIO-23` — A startup measurement names its platform version
+
+*Primary type:* **Positive** — the ordinary valid path of recording a measurement.
+*Coverage-role:* `positive` (exercises a correctly qualified measurement).
+*Given* a startup measurement taken on a specific platform version. *When* it is recorded. *Then* the record
+names that version in the same statement, so a later reader can tell whether the number still applies.
+*Failure oracle:* a startup number in the record with no version beside it; the platform's own startup
+baseline changed with a recent release, so an unqualified number cannot be compared to anything.
+*Evidence:* read each recorded measurement; every one carries the platform version it was taken on.
+*Obligation:* the design MUST name the platform version any version-dependent statement depends on, in the
+same statement, so a stale statement identifies itself.
+*Trace:* `DESK-CHECK-26`, `DESK-CHECK-05`
+
+#### `DESK-SCENARIO-24` — A synchronous read runs in the privileged process
+
+*Primary type:* **Boundary** — it sits at the exact transition where one blocking call stops every window.
+*Coverage-role:* `boundary` (exercises the exact blocking threshold across all windows at once).
+*Given* an application with several windows open. *When* the privileged process performs one synchronous
+file read or one large parse. *Then* every window stops responding simultaneously, because that process owns
+the interface thread across all of them.
+*Failure oracle:* interaction stalling in a window that is doing no work of its own, at the moment another
+window triggers a privileged read.
+*Evidence:* open several windows, trigger the synchronous path, and record responsiveness in a window not
+involved in the operation.
+*Obligation:* the design MUST keep file and parsing work off the privileged process's own thread, because a
+blocking call there freezes every window at once rather than one.
+*Trace:* `DESK-CHECK-26`
+
+#### `DESK-SCENARIO-25` — An unqualified number is offered as an improvement
+
+*Primary type:* **Adversarial** — a cosmetically valid measurement is used to support a claim it cannot
+carry. *Coverage-role:* `adversarial` (attacks the measurement's claim boundary).
+*Given* two startup numbers taken on different platform versions. *When* their difference is presented as
+the run's own improvement. *Then* the claim is rejected, because a platform upgrade is itself a
+startup-performance action and the comparison does not isolate the run's work.
+*Failure oracle:* a before/after performance claim whose two measurements name different platform versions,
+or name none.
+*Evidence:* read both measurements' recorded versions; equal versions are required before the difference is
+attributed to the run.
+*Obligation:* the design MUST NOT attribute a measured difference to its own work when the platform version
+differs between the two measurements.
+*Trace:* `DESK-CHECK-26`, `DESK-CHECK-05`
+
+#### `DESK-SCENARIO-26` — The footprint premise is inverted
+
+*Primary type:* **Counterfactual** — it inverts the premise that this stack's footprint suits the outcome.
+*Coverage-role:* `counterfactual` (inverts the footprint premise and requires the named response).
+*Given* a product requirement that states a distribution-size or memory bound. *When* the stack-fit test
+runs. *Then* the first wrong-choice criterion is positive, and the run routes a stack decision to the user
+rather than planning to optimize the bundled engine away.
+*Failure oracle:* a stated size or memory requirement recorded, the first criterion answered negative, and
+the run continuing on this stack with an optimization plan.
+*Evidence:* read the product requirements for a stated size or footprint bound, then read the criterion's
+inspected result against it.
+*Obligation:* the design MUST treat a stated distribution-size or footprint requirement as a positive
+wrong-choice criterion, because the bundled engine baseline is structural rather than tunable.
+*Trace:* `DESK-CHECK-02`
+
+### `DESK-FAMILY-06` — Crash, interruption, failed update, and recovery
+
+*Declared primary category:* **6 Failure / recovery / operations** — the defining discrimination is a partial
+or full failure and its detection, containment, and recovery. *Secondary tags:* 3 Behavior, 9 Change.
+*Applicability:* unconditional. *Priority:* high.
+
+*Actor:* the person mid-task when something fails. *Outcome:* every failure detected, contained, and
+recoverable. *Invariant:* interruption is ordinary, not exceptional.
+
+#### `DESK-SCENARIO-27` — An update install flushes live work first
+
+*Primary type:* **Positive** — the ordinary valid path of a correct update install. Note that for this
+family the positive discrimination is the handled path succeeding, not a happy path with no failure in it.
+*Coverage-role:* `positive` (exercises correct containment of the install race).
+*Given* an application with unsaved work and an update ready to install. *When* the install begins. *Then*
+the pre-quit-for-update hook fires, work is flushed durably, resources are released, the person's position
+is recorded, and the restart resumes where they were.
+*Failure oracle:* work present before the update and absent after it; or a restart that lands the person at
+a default state with no record of where they were.
+*Evidence:* create unsaved work, trigger the install, and compare the post-restart state against the
+pre-install state.
+*Obligation:* the design MUST handle the pre-quit-for-update event to flush work and release resources
+before the updater ends the process.
+*Trace:* `DESK-CHECK-30`
+
+#### `DESK-SCENARIO-28` — A corrupt data file is opened
+
+*Primary type:* **Boundary** — it sits at the exact transition between a parseable file and a rejected one.
+*Coverage-role:* `boundary` (exercises the exact truncation boundary).
+*Given* a data file truncated at a point where the remaining content still parses as valid.
+*When* the application opens it. *Then* the marker or length check rejects it and the run reports a
+detectable failure, rather than proceeding on a value that is structurally valid and semantically half.
+*Failure oracle:* a truncated file that opens successfully and yields a value the application acts on.
+*Evidence:* truncate a real file at several offsets, including one that leaves valid syntax, and confirm
+each is rejected.
+*Obligation:* the design MUST let a reader distinguish a complete file from a truncated one by a length,
+checksum, or terminal marker rather than by whether the content parses.
+*Trace:* `DESK-CHECK-24`
+
+#### `DESK-SCENARIO-29` — An update fails partway
+
+*Primary type:* **Failure / recovery** — an injected failure during the update, expecting containment.
+*Coverage-role:* `failure/recovery` (exercises detection plus recovery of a failed update).
+*Given* an update download or install that fails partway. *When* the failure occurs. *Then* the installed
+version continues to work, the failure is surfaced rather than silent, and the person is not left with a
+partially replaced application.
+*Failure oracle:* an application that will not start after a failed update; or a failure that leaves no
+record and simply retries forever.
+*Evidence:* interrupt the update at the download and install stages separately, and confirm the previous
+version launches and functions after each.
+*Obligation:* the design MUST leave the installed version working after a failed update, and MUST surface
+the failure rather than retrying silently.
+*Trace:* `DESK-CHECK-30`
+
+#### `DESK-SCENARIO-30` — The install races a live write with no pre-quit handling
+
+*Primary type:* **Adversarial** — an ordinary update sequence reaches an unrecoverable state.
+*Coverage-role:* `adversarial` (attacks the safety invariant through a mechanism the person did not
+initiate).
+*Given* an application writing data and an updater that calls quit-and-install. *When* the two coincide.
+*Then* the process ends mid-write — a consequence the person could not foresee, refuse, or recover from,
+because the updater chose the moment and not them.
+*Failure oracle:* data loss after an update, reproducible by triggering the install during a write.
+*Evidence:* trigger the install during an active write and inspect the data afterward; then repeat with the
+pre-quit hook handled and confirm the loss disappears.
+*Obligation:* the design MUST treat an update install racing live state as a safety member, handling the
+pre-quit event and treating unsaved work as a stop rather than an acceptable hazard.
+*Trace:* `DESK-CHECK-30`, `DESK-CHECK-20`
+
+### `DESK-FAMILY-07` — The two kinds of security work, hardening, and untrusted content
+
+*Declared primary category:* **7 Trust / harm / governance** — the defining discrimination is an abuse or
+harm surface. *Secondary tags:* 4 Interfaces, 3 Behavior. *Applicability:* unconditional. *Priority:*
+highest.
+
+*Actor:* an attacker shaping content, and the run deciding what to write. *Outcome:* every default intact
+and every applicable positive control written. *Invariant:* the defaults are not the work.
+
+#### `DESK-SCENARIO-31` — Both kinds of security work are complete
+
+*Primary type:* **Positive** — the ordinary valid path of a complete posture. The positive discrimination
+here is the defence holding, not a feature working.
+*Coverage-role:* `positive` (exercises both kinds of security work succeeding together).
+*Given* an application with the eight defaults intact. *When* the posture is audited. *Then* each of the
+eight is confirmed unchanged with a recorded reason for any exception, and each of the twelve applicable
+positive controls is confirmed **written**, with the file and line naming it.
+*Failure oracle:* an audit that reports the posture complete while any of the twelve resolves to "the
+default covers it" — the twelve do not exist until written.
+*Evidence:* a twenty-row inventory, each row naming either the untouched default or the written control's
+location.
+*Obligation:* the design MUST leave the eight safe defaults intact and write every applicable one of the
+twelve positive controls, treating the two as distinct kinds of work.
+*Trace:* `DESK-CHECK-21`
+
+#### `DESK-SCENARIO-32` — An unexpected frame sends a privileged message
+
+*Primary type:* **Negative** — an invalid caller expecting safe rejection.
+*Coverage-role:* `negative` (exercises rejection of an unauthorized sender with no privileged side effect).
+*Given* a privileged handler reachable from any web frame, including an iframe or a child window.
+*When* an unexpected frame sends a well-formed message. *Then* the handler verifies the sending frame and
+refuses before any privileged effect, and no state changes.
+*Failure oracle:* a privileged effect observable after a message from a frame the run did not intend to
+authorize; context isolation does not prevent the send.
+*Evidence:* send the message from an unintended frame and observe the privileged sink for any effect; the
+sink, not the handler's return value, is the oracle.
+*Obligation:* the design MUST verify the sending frame before any privileged effect, in the handler itself,
+and MUST NOT rely on context isolation to prevent an unexpected sender.
+*Trace:* `DESK-CHECK-19`
+
+#### `DESK-SCENARIO-33` — The archive-integrity fuses are enabled singly
+
+*Primary type:* **Boundary** — it sits at the exact configuration transition where one fuse of a pair is
+set. *Coverage-role:* `boundary` (exercises the exact paired-fuse boundary).
+*Given* a build with archive integrity validation enabled and the archive-only load path left disabled.
+*When* the artifact runs. *Then* validated code is verified and unvalidated code can still load from outside
+the archive — the path the pairing exists to close.
+*Failure oracle:* a build whose fuse configuration sets one of the two without the other.
+*Evidence:* read the built artifact's fuse configuration and confirm both are set, or that neither is and
+the reason is recorded.
+*Obligation:* the design MUST set the two archive fuses as a pair, because integrity validation without an
+archive-only load path leaves unvalidated code loadable.
+*Trace:* `DESK-CHECK-22`
+
+#### `DESK-SCENARIO-34` — A secret in the bundle defended as protected
+
+*Primary type:* **Adversarial** — a cosmetically compliant artifact claims a property it does not have.
+*Coverage-role:* `adversarial` (attacks the packaging-as-boundary assumption).
+*Given* a credential placed inside the packaged archive. *When* the run defends it as protected because the
+archive conceals source and the build is minified. *Then* the claim fails: the archive is read-only,
+conceals source from cursory inspection only, and some interfaces extract silently to a temporary directory.
+*Failure oracle:* any credential recoverable from the shipped artifact by unpacking it; effort is not a
+security property.
+*Evidence:* unpack the shipped artifact and search it for the credential; recovery of the value is the
+failure.
+*Obligation:* the design MUST NOT treat packaging, minification, or the archive as a security boundary, and
+MUST NOT place a secret in the shipped artifact.
+*Trace:* `DESK-CHECK-21`
+
+#### `DESK-SCENARIO-35` — An unlisted clause reaches an unrecoverable consequence
+
+*Primary type:* **Adversarial** — every listed member passes while the property is violated elsewhere.
+*Coverage-role:* `adversarial` (attacks the floor through the gap between the member list and the run's own
+clause inventory).
+*Given* a run where all nine listed safety members pass. *When* a tray-menu action empties the capture cache
+with no confirmation and no recovery route — a tenth clause the list does not name. *Then* the floor fails,
+because that clause is a member **by the property**, and a longer list would not have caught it either.
+*Failure oracle:* a floor reported as passing on a member-by-member roll-up while any clause of the run
+permits an unforeseeable, unrefusable, or unrecoverable consequence.
+*Evidence:* sweep the run's own clause inventory — every rule, phase step, channel, native integration, data
+operation, and release control it actually contains — and disposition each as foreseeable, refusable,
+recoverable, or handled.
+*Obligation:* the design MUST hold each floor as a property over the run's own clause inventory, and MUST
+NOT accept a member roll-up as the property check's evidence.
+*Trace:* `DESK-CHECK-12`
+
+#### `DESK-SCENARIO-36` — The hardening-versus-testability decision is recorded with one horn
+
+*Primary type:* **Change / regression** — it compares the build's properties before and after the decision.
+*Coverage-role:* `change/regression` (exercises the decision's effect on what the shipped artifact is).
+*Given* two first-party sources in direct conflict over one runtime-inspection fuse, with no documented
+reconciliation. *When* the run records its build-matrix decision. *Then* both horns are stated with their
+consequences, the user decides, and the chosen horn's consequence is carried forward as a stated
+verification limit.
+*Failure oracle:* a build matrix recorded with one option and no statement of what the other would have
+bought; or an automated suite reported as covering the shipped artifact when it exercises a differently
+fused build.
+*Evidence:* read the recorded decision for both horns and for the named verification limit; then compare the
+fuse configuration of the tested build against the shipped one.
+*Obligation:* the design MUST present the hardening-versus-testability conflict as a user decision with both
+horns named, and MUST carry the chosen horn's consequence as a stated verification limit.
+*Trace:* `DESK-CHECK-22`
+
+### `DESK-FAMILY-08` — The accessibility union, assistive technology, and locale
+
+*Declared primary category:* **8 Inclusion / locale** — the defining discrimination is an access need, input
+method, language, or locale. *Secondary tags:* 2 Actors, 10 Evidence. *Applicability:* unconditional and
+non-waivable. *Priority:* highest.
+
+*Actor:* a person using any applicable modality. *Outcome:* every required action, state, and meaning
+available through every applicable modality. *Invariant:* no identity choice, platform convention, aesthetic
+decision, or component library reduces that availability.
+
+#### `DESK-SCENARIO-37` — Every required action, state, and meaning is available
+
+*Primary type:* **Positive** — the ordinary valid path of a run holding the floor.
+*Coverage-role:* `positive` (exercises the floor's property holding across the modality set).
+*Given* the run's own inventory of required actions, states, and meanings. *When* the floor is resolved.
+*Then* each one is available through every modality the outcome's surfaces actually require, with direct
+behavioral results per claimed system rather than a member-by-member roll-up.
+*Failure oracle:* a required action reachable through only one modality; or a state whose meaning is carried
+by color alone.
+*Evidence:* sweep the action, state, and meaning inventory against the required modality set, recording a
+direct behavioral result for each pairing.
+*Obligation:* the design MUST hold the accessibility floor as a property across at least the complete named
+union, evidenced by a sweep of the run's own inventory rather than by a member roll-up.
+*Trace:* `DESK-CHECK-09`
+
+#### `DESK-SCENARIO-38` — An alternative-valid modality: keyboard-only operation
+
+*Primary type:* **Alternative-valid** — a materially different valid input method, not a second happy path.
+*Coverage-role:* `alternative-valid` (exercises a distinct valid input modality end to end).
+*Given* the same required actions. *When* they are performed with the keyboard alone. *Then* every one is
+reachable, focus order follows the reading order, the focused element is visibly identifiable at all times,
+and no action requires a pointer.
+*Failure oracle:* an action reachable only by pointer; or a focus position that becomes invisible during a
+transition.
+*Evidence:* perform each required action keyboard-only on each claimed system, recording focus visibility
+throughout.
+*Obligation:* the design MUST make every required action operable through each applicable input alternative,
+with focus flow and focus visibility preserved.
+*Trace:* `DESK-CHECK-09`
+
+#### `DESK-SCENARIO-39` — Assistive-technology parity claimed across three systems
+
+*Primary type:* **Negative** — an unsupported claim expecting refusal.
+*Coverage-role:* `negative` (exercises rejection of an unevidenced per-system claim).
+*Given* platform documentation that names a screen reader for two systems and none for the third. *When* the
+run claims assistive-technology support on all three. *Then* the claim on the third is refused, because it
+rests on documentation that does not exist, and the run states what evidence it actually has instead.
+*Failure oracle:* a support claim covering a system for which neither platform guidance nor the run's own
+testing supplies evidence.
+*Evidence:* read the per-system evidence record; a claimed system with no named screen reader and no
+recorded direct testing cannot carry the claim.
+*Obligation:* the design MUST state the assistive-technology gap for the system with no platform guidance
+rather than implying parity, and MUST support any per-system claim with that system's own evidence.
+*Trace:* `DESK-CHECK-09`, `DESK-CHECK-10`
+
+#### `DESK-SCENARIO-40` — Reduced motion is read from the theme interface
+
+*Primary type:* **Boundary** — it sits at the exact boundary of what the theme interface exposes.
+*Coverage-role:* `boundary` (exercises the exact edge of the interface's signal set).
+*Given* a theme interface exposing high-contrast, inverted-scheme, reduced-transparency, and
+differentiate-without-color signals, and **no** reduced-motion signal. *When* the run looks there for
+reduced motion. *Then* it finds nothing — and the correct source is the renderer's own reduced-motion media
+query, not an invented theme property and not the conclusion that the signal is unavailable.
+*Failure oracle:* animation continuing at full motion for a person who has set the system preference; or a
+run that concludes reduced motion cannot be honored because the theme interface lacks it.
+*Evidence:* set the system reduced-motion preference and observe the rendered motion; and read the source
+for where the signal is obtained.
+*Obligation:* the design MUST honor reduced motion from the renderer's own media query, because the theme
+interface exposes no such property, and MUST NOT treat that absence as the signal being unavailable.
+*Trace:* `DESK-CHECK-09`
+
+#### `DESK-SCENARIO-41` — A member roll-up offered as the property check's evidence
+
+*Primary type:* **Adversarial** — a cosmetically complete floor resolution attempts to close the property
+check. *Coverage-role:* `adversarial` (attacks the property check's own pass condition).
+*Given* a floor whose every listed member passes. *When* the run offers "all members passed" as the property
+check's evidence. *Then* the property check is not satisfied, because its claim is the property itself and
+its evidence is the inventory sweep — which is what would catch a modality loss no member names.
+*Failure oracle:* a property check resolved with a member-count roll-up and no inventory sweep recorded.
+*Evidence:* read the property check's recorded evidence; it must be the sweep of the run's own inventory,
+not a summary of the member results.
+*Obligation:* the design MUST make each floor's property check explicitly unsatisfiable by a member
+roll-up, requiring the inventory sweep as its evidence.
+*Trace:* `DESK-CHECK-10`
+
+### `DESK-FAMILY-09` — Release irreversibility, signing, and the update chain
+
+*Declared primary category:* **9 Change / compatibility / reversibility** — the defining discrimination is a
+version or lifecycle change event. *Secondary tags:* 6 Failure/recovery, 7 Trust. *Applicability:*
+unconditional. *Priority:* high — this family's failures are the ones that cannot be undone.
+
+*Actor:* the person with an installed copy. *Outcome:* a signed, installable, update-rehearsed release per
+claimed system. *Invariant:* a shipped version cannot be recalled.
+
+#### `DESK-SCENARIO-42` — The four release gates each pass per claimed system
+
+*Primary type:* **Positive** — the ordinary valid path of a complete release chain.
+*Coverage-role:* `positive` (exercises the whole chain succeeding per system).
+*Given* a run claiming more than one operating system. *When* release readiness is assessed. *Then* each
+claimed system has its own installer produced, its own clean-environment install and smoke test, its own
+signature and notarization verification on the real artifact, and its own rehearsed update — four results
+per system, not four results total.
+*Failure oracle:* a release-readiness table with fewer rows than claimed systems; or one system's result
+presented as covering another.
+*Evidence:* read the release matrix; every claimed system carries all four results, each naming the artifact
+it was run against.
+*Obligation:* the design MUST prove the packaged, installed, signed, and updated gates per claimed operating
+system, and MUST NOT let one system's result support another's claim.
+*Trace:* `DESK-CHECK-27`, `DESK-CHECK-28`, `DESK-CHECK-29`, `DESK-CHECK-30`
+
+#### `DESK-SCENARIO-43` — A deferred capability named with a path
+
+*Primary type:* **Negative** — an invalid forward reference expecting rejection.
+*Coverage-role:* `negative` (exercises rejection of a dangling-but-resolving pointer).
+*Given* a capability that is planned and absent today. *When* it is mentioned. *Then* the mention is prose
+only — no path, no link, no path-shaped code span — and states that nothing here loads or requires it.
+*Failure oracle:* a link or path naming a capability that does not exist; a pointer that resolves to
+something is worse than one that visibly breaks, because nothing flags it.
+*Evidence:* scan every forward mention for a path, link, or path-shaped span; any occurrence fails.
+*Obligation:* the design MUST state a planned-but-absent capability as prose only, with no path, link, or
+load target.
+*Trace:* `DESK-CHECK-35`
+
+#### `DESK-SCENARIO-44` — A version at the edge of the supported-old-version window
+
+*Primary type:* **Boundary** — it sits at the exact edge of the stated support window.
+*Coverage-role:* `boundary` (exercises the exact oldest-supported version and the one below it).
+*Given* a stated supported-old-version window. *When* an installed copy at the oldest supported version, and
+another one release older, each attempt to update and to read current data. *Then* the version at the edge
+is supported as stated, and the one below it receives the stated out-of-window behavior — told, blocked, or
+left alone — rather than an unhandled failure.
+*Failure oracle:* an out-of-window version that fails in an unstated way; or a window stated without a
+defined behavior for what falls outside it.
+*Evidence:* run the update and data-read paths from the oldest supported version and from one below it, and
+compare each against the stated behavior.
+*Obligation:* the design MUST state a supported-old-version window and the behavior for versions outside it,
+and MUST prove both the edge and the case beyond it.
+*Trace:* `DESK-CHECK-31`
+
+#### `DESK-SCENARIO-45` — Signing is deferred and dependent behavior is proved on an unsigned build
+
+*Primary type:* **Failure / recovery** — a missing precondition surfaces late, and the recovery is a re-run.
+*Coverage-role:* `failure/recovery` (exercises detection of an invalid proof and its correction).
+*Given* a run that proves notification behavior and update behavior against an unsigned development build.
+*When* signing is applied at the end. *Then* both proofs are invalid on the system that requires signing for
+each, and both must be re-run against the signed artifact.
+*Failure oracle:* a notification or update claim whose evidence names a development build on a system where
+signing is a precondition for that behavior.
+*Evidence:* read each claim's evidence for the artifact it was obtained from; a development build cannot
+support a claim whose precondition is a signature.
+*Obligation:* the design MUST obtain evidence for signature-dependent behavior from the signed artifact, and
+MUST NOT carry forward a proof taken on a build that could not exhibit the behavior.
+*Trace:* `DESK-CHECK-29`, `DESK-CHECK-30`
+
+#### `DESK-SCENARIO-46` — Three-platform automatic updating claimed through the built-in updater
+
+*Primary type:* **Adversarial** — a plausible release claim that the platform does not support.
+*Coverage-role:* `adversarial` (attacks the release claim with the platform's own asymmetry).
+*Given* three claimed operating systems. *When* the run states that all three update automatically through
+the built-in updater. *Then* the claim is false: one of the three has no built-in updater at all, and its
+updates go through the system's own package manager.
+*Failure oracle:* a release plan whose update row is identical across three systems; the per-system update
+mechanism is not uniform.
+*Evidence:* read the update row per claimed system against the platform's documented per-system mechanism;
+a uniform claim across all three is the failure.
+*Obligation:* the design MUST state the update path per claimed operating system, and MUST NOT claim
+built-in automatic updating for the system that has none.
+*Trace:* `DESK-CHECK-27`, `DESK-CHECK-30`
+
+#### `DESK-SCENARIO-47` — A rehearsed update from a fresh install rather than the previous release
+
+*Primary type:* **Change / regression** — it compares the two candidate baselines for the same gate.
+*Coverage-role:* `change/regression` (exercises the version-transition the fresh path never crosses).
+*Given* an update-rehearsal gate. *When* the rehearsal is run from a fresh install of the new version rather
+than from the previously released one. *Then* the gate has proved first-time installation and not the update
+path — a different claim, and the one nearly every user will not take.
+*Failure oracle:* an update-rehearsal record whose starting state is a clean machine rather than the
+previous release; migration defects live in the transition the fresh path skips.
+*Evidence:* read the rehearsal record's starting version; it must name the previously released version.
+*Obligation:* the design MUST rehearse the update from the previously released version, because a fresh
+install proves a different claim and never crosses the data transition.
+*Trace:* `DESK-CHECK-30`
+
+### `DESK-FAMILY-10` — The rung register, the claim ledger, and the trace proof
+
+*Declared primary category:* **10 Evidence / traceability / clarity** — the defining discrimination is
+whether a source, proof, or trace is followable by a cold reader. *Secondary tags:* 1 Purpose, 2 Actors.
+*Applicability:* unconditional. *Priority:* high — this family is what makes every other family's result
+readable.
+
+*Actor:* a cold reader, and an evaluator. *Outcome:* a record another operator can act on with no hidden
+session context. *Invariant:* a decision recorded is not a property proved.
+
+#### `DESK-SCENARIO-48` — Nine rung rows, each substantiated by its own kind's conditions
+
+*Primary type:* **Positive** — the ordinary valid path of a complete rung register. All three resolution
+kinds are exercised within this one case, which is why no alternative-valid case is separately required.
+*Coverage-role:* `positive` (exercises a complete and substantiated register).
+*Given* a run that has walked all nine rungs. *When* the register is read. *Then* every row carries one of
+the three resolution kinds and evidence that satisfies **that kind's** own conditions — a produced artifact
+resolving to substantive content answering the rung's own question, a citation meeting all five citation
+conditions, or a proved inapplicability naming a property with its inspected evidence and its falsifying
+observation.
+*Failure oracle:* a row whose kind is recorded and whose evidence satisfies a different kind's conditions;
+or a row closed on a coverage property such as an owner, a plan, or a sign-off.
+*Evidence:* read each of the nine rows against the conditions its own recorded kind imposes.
+*Obligation:* the design MUST record one of three resolution kinds per rung and MUST substantiate it against
+that kind's own conditions, with no coverage property closing acceptance.
+*Trace:* `DESK-CHECK-07`
+
+#### `DESK-SCENARIO-49` — A hollow pointer in an otherwise complete register
+
+*Primary type:* **Negative** — an invalid resolution presented in valid form.
+*Coverage-role:* `negative` (exercises rejection of a structurally complete but substantively empty row).
+*Given* all nine rows present with a resolution kind recorded on each. *When* one row's pointer resolves to
+an empty file, a heading-only outline, or a placeholder. *Then* that row fails: the condition is what the
+inspection **found**, so a valid path to an empty artifact is not a resolution.
+*Failure oracle:* a register that passes a completeness count while one pointer opens to nothing; a valid
+file can still be the wrong content.
+*Evidence:* open every pointer in the register and read what it contains, rather than confirming it
+resolves.
+*Obligation:* the design MUST require a resolution's named evidence to resolve to substantive content
+answering the rung's own question, not merely to a valid path.
+*Trace:* `DESK-CHECK-07`
+
+#### `DESK-SCENARIO-50` — A design record with headings and no resolved content
+
+*Primary type:* **Boundary** — it sits at the exact transition between an outlined record and a resolved
+one. *Coverage-role:* `boundary` (exercises the exact completeness edge of the record).
+*Given* a design record containing every required section heading. *When* completeness is assessed. *Then* a
+heading with no resolved content does not satisfy the record obligation, and each required element — the
+rung register, the three-axis statements, the four floor resolutions with their property checks, the
+participant records, the locked contract, the claim-owner matrix, and the run's own gap register — is
+present with content.
+*Failure oracle:* a record whose section count is complete and whose sections are empty.
+*Evidence:* read each required section for resolved content rather than for its heading.
+*Obligation:* the design MUST require the design record's each required element to carry resolved content,
+because a heading alone does not satisfy the obligation.
+*Trace:* `DESK-CHECK-33`
+
+#### `DESK-SCENARIO-51` — A waiver token on a protected floor
+
+*Primary type:* **Adversarial** — a legitimate mechanism is applied where it is invalid.
+*Coverage-role:* `adversarial` (attacks the non-waivability of the four floors).
+*Given* a run with an authorized waiver mechanism available for operational gates. *When* the token is
+applied to an item bearing on one of the four floors. *Then* the token is invalid there: it closes neither
+coverage nor acceptance, and the item resolves through a permitted terminal or fails.
+*Failure oracle:* a floor-bearing item resolved by a waiver token and counted toward either coverage or
+acceptance.
+*Evidence:* read every waiver-token use against the item's protected status; any token on a floor-bearing
+item fails both gates.
+*Obligation:* the design MUST make a waiver token invalid on all four protected floors, closing neither
+coverage nor acceptance there.
+*Trace:* `DESK-CHECK-17`
+
+#### `DESK-SCENARIO-52` — Nine claims merged into one release status
+
+*Primary type:* **Adversarial** — a green summary is offered in place of separate claims.
+*Coverage-role:* `adversarial` (attacks the claim-separation invariant with a plausible aggregate).
+*Given* design acceptance, implementation correctness, packaged-artifact evidence, signature and
+notarization evidence, update-rehearsal evidence, per-system evidence, release readiness, release authority,
+and post-release outcome. *When* they are reported as one tested status. *Then* the report fails, because
+each proves a different thing and the merge hides which one is missing.
+*Failure oracle:* a release report with one overall status and no per-claim rows; or an unrunnable gate
+widened into a weaker signal supporting the claim it could not prove.
+*Evidence:* read the claim ledger for nine separate rows, each with its own evidence class, owner, and
+per-system scope, and each unrunnable gate recorded as a limitation that blocks its claim.
+*Obligation:* the design MUST report each evidence class as a distinct claim with its own scope, and MUST
+record an unrunnable gate as a limitation blocking its claim rather than as a weaker signal.
+*Trace:* `DESK-CHECK-32`
+
+#### `DESK-SCENARIO-53` — A green relation test offered as a complete trace proof
+
+*Primary type:* **Counterfactual** — it inverts the premise that a passing mechanical gate proves the whole
+trace. *Coverage-role:* `counterfactual` (inverts the verifier-completeness premise and requires the named
+disconfirmation).
+*Given* four projections whose edge sets agree exactly, so the relation test exits zero. *When* that result
+is offered as proof the trace is sound. *Then* it is not: the relation test proves routing, and a
+correctly-routed check whose pass wording dropped a named primitive from the obligation it carries passes it
+unchanged. The obligation test is a separate, review-proved gate, and an unrecorded case is an unrun test.
+*Failure oracle:* a trace proof citing only the relation test's exit code; or an obligation-test result
+recorded per file rather than per case, or with no reviewer identity.
+*Evidence:* read the recorded obligation-test result per selected case, with the reviewer's identity, across
+every mapped check for a case with more than one; and confirm the verifier's own output states which legs
+are script-proved and which is review-proved.
+*Obligation:* the design MUST prove the trace with both the mechanical relation test and the review-proved
+obligation test, recording the second per case with the reviewer's identity, and MUST NOT present a green
+relation test as a complete trace proof.
+*Trace:* `DESK-CHECK-34`
+
+#### `DESK-SCENARIO-55` — A human-outcome claim with no participant record behind it
+
+*Primary type:* **Adversarial** — a complete-looking claim set conceals one claim nothing supports.
+*Coverage-role:* `adversarial` (attacks the direct-evidence floor through the run's own claim inventory).
+*Given* a run whose participant records cover the claimed systems and whose floor members all pass.
+*When* the design record additionally asserts that people can recover from a particular error state — a
+claim no participant record covers, on any system. *Then* the property check fails, because its evidence is
+a sweep of the run's **own claim inventory** mapping every claim about what a person can perceive,
+understand, operate, complete, or recover from to the participant record and the operating system that
+supports it.
+*Failure oracle:* a human-outcome claim in the record with no participant record behind it; or a claim
+supported by evidence gathered on a different operating system than the claim is about.
+*Evidence:* enumerate every claim about human capability in the design record and map each to its
+supporting participant record and system; an unmapped claim is removed or restated as context, and a
+member-by-member roll-up does not satisfy this check.
+*Obligation:* the design MUST support every human-outcome claim with direct representative-user evidence
+from this run's own artifacts on the operating system the claim is about, removing or restating any
+unsupported claim as context.
+*Trace:* `DESK-CHECK-16`
+
 ## Obligation-to-check reservation
+
+Every case's obligation and the check identifier it reserves. This table is the **forward** direction of the
+trace — policy and case to check — and it is generated from the `Trace:` fields above rather than maintained
+beside them, so the two cannot drift apart.
+
+**No case in this set is exploratory**, so all fifty-five carry an obligation and appear here. An exploratory
+case would be exempt from the obligation trace only while explicitly marked as one, and the exemption would
+end the moment it became an approved constraint.
+
+**The reserved ranges, and the extension this set required.** The design fixes four pause points and reserves
+thirty-four check slots across them. This set reserves **thirty-six**, because the four protected floors each
+need a member check *and* a property check — eight slots where the original allocation left room for fewer —
+and the protected-waiver table needs its own. The extension follows the rule the design states: the range
+grows at its own pause point's tail and every later range shifts. [`checklists.md`](checklists.md) records
+the final ranges once, as their owner.
+
+| Pause point | Reserved range | Confirms |
+|---|---|---|
+| `DESK-PAUSE-1` — stack and outcome lock | `01`–`05` | outcome, boundary, stack-fit result, ownership statement, gate-authority map |
+| `DESK-PAUSE-2` — design acceptance | `06`–`17`, with **`06` reserved for the structural-approval check** | the structural-approval decision, the rung register, and all four floors on both their member and property checks |
+| `DESK-PAUSE-3` — implementation completion | `18`–`26` | the privilege boundary, security posture, platform obligations, local data, and in-scope paths |
+| `DESK-PAUSE-4` — release-readiness handoff | `27`–`36` | every applicable release gate per claimed system, the design record, and the trace and verifier proofs |
+
+`DESK-CHECK-06` is pinned by the design rather than chosen here: the restored structural-approval gate
+requires a reserved check, and it sits at the head of its pause point's range because it is the earliest item
+that pause point confirms. Every other number is this author's allocation. What binds is not a range width
+but the crosswalk [`evaluation.md`](evaluation.md) owns — every live rule and prohibition reaching at least
+one check cluster.
+
+| Case | The obligation it proves | Reserves | Confirmed at |
+|---|---|---|---|
+| `DESK-SCENARIO-01` | The outcome, the boundary, and the ownership statement are locked together | `DESK-CHECK-01`, `DESK-CHECK-03` | `DESK-PAUSE-1` |
+| `DESK-SCENARIO-02` | An alternative-valid framing: an existing application rather than a new one | `DESK-CHECK-01`, `DESK-CHECK-25` | `DESK-PAUSE-1`, `DESK-PAUSE-3` |
+| `DESK-SCENARIO-03` | A packaged artifact offered as a finished outcome | `DESK-CHECK-25` | `DESK-PAUSE-3` |
+| `DESK-SCENARIO-04` | Continued work offered as gate approval | `DESK-CHECK-04`, `DESK-CHECK-36` | `DESK-PAUSE-1`, `DESK-PAUSE-4` |
+| `DESK-SCENARIO-05` | The stack-fit premise is inverted: a criterion fires | `DESK-CHECK-02` | `DESK-PAUSE-1` |
+| `DESK-SCENARIO-06` | Participant conditions in place before the first activity | `DESK-CHECK-13` | `DESK-PAUSE-2` |
+| `DESK-SCENARIO-07` | An alternative-valid participant route: cited prior research | `DESK-CHECK-07` | `DESK-PAUSE-2` |
+| `DESK-SCENARIO-08` | Acceptance sought without direct evidence from representative people | `DESK-CHECK-15` | `DESK-PAUSE-2` |
+| `DESK-SCENARIO-09` | The structural skeleton is approved before any visual rung begins | `DESK-CHECK-06` | `DESK-PAUSE-2` |
+| `DESK-SCENARIO-10` | A required participant condition is missing | `DESK-CHECK-13` | `DESK-PAUSE-2` |
+| `DESK-SCENARIO-11` | An unlisted participant activity whose observations are cited | `DESK-CHECK-14` | `DESK-PAUSE-2` |
+| `DESK-SCENARIO-54` | The ladder's own method order, and three axes stated per visual artifact | `DESK-CHECK-08` | `DESK-PAUSE-2` |
+| `DESK-SCENARIO-12` | First paint uses both mechanisms | `DESK-CHECK-23` | `DESK-PAUSE-3` |
+| `DESK-SCENARIO-13` | A downgrade rewrites newer data into an older shape | `DESK-CHECK-24` | `DESK-PAUSE-3` |
+| `DESK-SCENARIO-14` | A monitor disappears between sessions | `DESK-CHECK-23` | `DESK-PAUSE-3` |
+| `DESK-SCENARIO-15` | A local write is interrupted | `DESK-CHECK-24` | `DESK-PAUSE-3` |
+| `DESK-SCENARIO-16` | A second instance's arguments are read by position | `DESK-CHECK-23`, `DESK-CHECK-11` | `DESK-PAUSE-2`, `DESK-PAUSE-3` |
+| `DESK-SCENARIO-17` | A schema change ships and the previous version is still installed | `DESK-CHECK-24`, `DESK-CHECK-31` | `DESK-PAUSE-3`, `DESK-PAUSE-4` |
+| `DESK-SCENARIO-18` | Every channel carries its type, its validation, and its sender rule | `DESK-CHECK-19`, `DESK-CHECK-18` | `DESK-PAUSE-3` |
+| `DESK-SCENARIO-19` | The renderer target includes the runtime's ambient types | `DESK-CHECK-18` | `DESK-PAUSE-3` |
+| `DESK-SCENARIO-20` | A port closes when nothing named its lifetime | `DESK-CHECK-20` | `DESK-PAUSE-3` |
+| `DESK-SCENARIO-21` | A class instance is sent across the bridge | `DESK-CHECK-18`, `DESK-CHECK-19` | `DESK-PAUSE-3` |
+| `DESK-SCENARIO-22` | The three-target split is taught as documented fact | `DESK-CHECK-18` | `DESK-PAUSE-3` |
+| `DESK-SCENARIO-23` | A startup measurement names its platform version | `DESK-CHECK-26`, `DESK-CHECK-05` | `DESK-PAUSE-1`, `DESK-PAUSE-3` |
+| `DESK-SCENARIO-24` | A synchronous read runs in the privileged process | `DESK-CHECK-26` | `DESK-PAUSE-3` |
+| `DESK-SCENARIO-25` | An unqualified number is offered as an improvement | `DESK-CHECK-26`, `DESK-CHECK-05` | `DESK-PAUSE-1`, `DESK-PAUSE-3` |
+| `DESK-SCENARIO-26` | The footprint premise is inverted | `DESK-CHECK-02` | `DESK-PAUSE-1` |
+| `DESK-SCENARIO-27` | An update install flushes live work first | `DESK-CHECK-30` | `DESK-PAUSE-4` |
+| `DESK-SCENARIO-28` | A corrupt data file is opened | `DESK-CHECK-24` | `DESK-PAUSE-3` |
+| `DESK-SCENARIO-29` | An update fails partway | `DESK-CHECK-30` | `DESK-PAUSE-4` |
+| `DESK-SCENARIO-30` | The install races a live write with no pre-quit handling | `DESK-CHECK-30`, `DESK-CHECK-20` | `DESK-PAUSE-3`, `DESK-PAUSE-4` |
+| `DESK-SCENARIO-31` | Both kinds of security work are complete | `DESK-CHECK-21` | `DESK-PAUSE-3` |
+| `DESK-SCENARIO-32` | An unexpected frame sends a privileged message | `DESK-CHECK-19` | `DESK-PAUSE-3` |
+| `DESK-SCENARIO-33` | The archive-integrity fuses are enabled singly | `DESK-CHECK-22` | `DESK-PAUSE-3` |
+| `DESK-SCENARIO-34` | A secret in the bundle defended as protected | `DESK-CHECK-21` | `DESK-PAUSE-3` |
+| `DESK-SCENARIO-35` | An unlisted clause reaches an unrecoverable consequence | `DESK-CHECK-12` | `DESK-PAUSE-2` |
+| `DESK-SCENARIO-36` | The hardening-versus-testability decision is recorded with one horn | `DESK-CHECK-22` | `DESK-PAUSE-3` |
+| `DESK-SCENARIO-37` | Every required action, state, and meaning is available | `DESK-CHECK-09` | `DESK-PAUSE-2` |
+| `DESK-SCENARIO-38` | An alternative-valid modality: keyboard-only operation | `DESK-CHECK-09` | `DESK-PAUSE-2` |
+| `DESK-SCENARIO-39` | Assistive-technology parity claimed across three systems | `DESK-CHECK-09`, `DESK-CHECK-10` | `DESK-PAUSE-2` |
+| `DESK-SCENARIO-40` | Reduced motion is read from the theme interface | `DESK-CHECK-09` | `DESK-PAUSE-2` |
+| `DESK-SCENARIO-41` | A member roll-up offered as the property check's evidence | `DESK-CHECK-10` | `DESK-PAUSE-2` |
+| `DESK-SCENARIO-42` | The four release gates each pass per claimed system | `DESK-CHECK-27`, `DESK-CHECK-28`, `DESK-CHECK-29`, `DESK-CHECK-30` | `DESK-PAUSE-4` |
+| `DESK-SCENARIO-43` | A deferred capability named with a path | `DESK-CHECK-35` | `DESK-PAUSE-4` |
+| `DESK-SCENARIO-44` | A version at the edge of the supported-old-version window | `DESK-CHECK-31` | `DESK-PAUSE-4` |
+| `DESK-SCENARIO-45` | Signing is deferred and dependent behavior is proved on an unsigned build | `DESK-CHECK-29`, `DESK-CHECK-30` | `DESK-PAUSE-4` |
+| `DESK-SCENARIO-46` | Three-platform automatic updating claimed through the built-in updater | `DESK-CHECK-27`, `DESK-CHECK-30` | `DESK-PAUSE-4` |
+| `DESK-SCENARIO-47` | A rehearsed update from a fresh install rather than the previous release | `DESK-CHECK-30` | `DESK-PAUSE-4` |
+| `DESK-SCENARIO-48` | Nine rung rows, each substantiated by its own kind's conditions | `DESK-CHECK-07` | `DESK-PAUSE-2` |
+| `DESK-SCENARIO-49` | A hollow pointer in an otherwise complete register | `DESK-CHECK-07` | `DESK-PAUSE-2` |
+| `DESK-SCENARIO-50` | A design record with headings and no resolved content | `DESK-CHECK-33` | `DESK-PAUSE-4` |
+| `DESK-SCENARIO-51` | A waiver token on a protected floor | `DESK-CHECK-17` | `DESK-PAUSE-2` |
+| `DESK-SCENARIO-52` | Nine claims merged into one release status | `DESK-CHECK-32` | `DESK-PAUSE-4` |
+| `DESK-SCENARIO-53` | A green relation test offered as a complete trace proof | `DESK-CHECK-34` | `DESK-PAUSE-4` |
+| `DESK-SCENARIO-55` | A human-outcome claim with no participant record behind it | `DESK-CHECK-16` | `DESK-PAUSE-2` |

--- a/.gobbi/projects/gobbi/skills/desktop/scenarios.md
+++ b/.gobbi/projects/gobbi/skills/desktop/scenarios.md
@@ -4,15 +4,17 @@ Be the authoritative scenario source and the authoritative case-to-check relatio
 outcome. Policy lives in [`SKILL.md`](SKILL.md). Its consumers are [`checklists.md`](checklists.md) and
 [`evaluation.md`](evaluation.md). It exercises the parent contract and adds no policy.
 
-**Purpose:** ten coverage families and **fifty-five cases** that a desktop run must handle, each with an
+**Purpose:** ten coverage families and **sixty cases** that a desktop run must handle, each with an
 observable outcome a wrong run would produce differently, and each converted into the design obligation it
 proves. **Target:** one bounded desktop application outcome as `SKILL.md` defines it. **Consumer:** the run
 itself while designing, and an evaluator afterward. **Lifecycle mode:** design obligations, consumed in
 evaluation.
 
-**Scale, and the thresholds this set records.** Ten families, fifty-five cases, and **51 populated cells**,
+**Scale, and the thresholds this set records.** Ten families, sixty cases, and **51 populated cells**,
 where a cell is one distinct `(category, triggered case type)` pair. Every figure here is reproduced by
-scanning this file rather than carried from a plan.
+scanning this file rather than carried from a plan. The cell figure did not move when the case count did: every
+case added after the first authoring landed in a cell that was already populated, and a second case in a
+populated cell is not a new cell.
 
 The generic defaults are roughly twelve families and forty cells, and this set **records its own cell
 threshold as 55**. Two reasons, and the first is the load-bearing one. The family count is not this author's
@@ -61,7 +63,7 @@ Abbreviations: **Pos** positive · **Alt** alternative-valid · **Neg** negative
 |---|---|---|---|---|---|---|---|---|
 | `01` Purpose | 01 | 02 | 03 | `n/a: the outcome contract has no quantity, ordering, or time-window property to sit at a limit of` | `n/a: a scope contract is a written agreement, not a runtime component that can fail partway` | 04 | `n/a: this family fixes the contract before any version of it exists to change` | 05 |
 | `02` Actors | 06, 54 | 07 | 08 | 09 | 10 | 11 | `n/a: participant conditions are re-established per activity, so there is no before/after version of them to compare` | `n/a: the participant floor's premise is fail-closed by construction, leaving no load-bearing premise to invert` |
-| `03` Behavior | 12 | `n/a: the state machine's valid entry paths are enumerated by DESK-FAMILY-01's entry-mode inventory, so a second valid class here would duplicate that family's coverage` | 13 | 14 | 15 | 16 | 17 | `n/a: this family asserts no premise beyond the platform mechanisms its siblings verify at their owners` |
+| `03` Behavior | 12, 56 | `n/a: the state machine's valid entry paths are enumerated by DESK-FAMILY-01's entry-mode inventory, so a second valid class here would duplicate that family's coverage` | 13, 58 | 14, 57 | 15 | 16, 59, 60 | 17 | `n/a: this family asserts no premise beyond the platform mechanisms its siblings verify at their owners` |
 | `04` Interfaces | 18 | `n/a: the four execution contexts are one enumerated set, not alternative valid routes through one contract` | 19 | `n/a: the crossable-type set is a membership question, not a limit with an adjacent value` | 20 | 21 | 22 | `n/a: the boundary's premise — that a declared type does not validate — is exercised directly by case 21 rather than inverted` |
 | `05` Quality | 23 | `n/a: a measurement has one valid method here; a second would vary the subject, not the class` | `n/a: an invalid measurement is an unsourced claim, which DESK-FAMILY-10 owns as an evidence defect` | 24 | `n/a: a resource bound that is exceeded is this family's boundary case, not a separate injected failure` | 25 | `n/a: a cross-version comparison of a measurement is exactly what case 24's version-naming obligation exists to make possible, and is covered there` | 26 |
 | `06` Failure | 27 | `n/a: recovery has one correct path per failure here; a second valid route would be a different failure` | `n/a: rejecting an invalid input is DESK-FAMILY-04's crossing validation, not a recovery concern` | 28 | 29 | 30 | `n/a: a failed update's version change is exercised by DESK-FAMILY-09, which owns the version axis` | `n/a: this family's premise — that interruption is ordinary — is asserted by the safety floor and not inverted here` |
@@ -77,11 +79,12 @@ prohibition, a `DESK-FLOOR` floor with its property check, a `DESK-G` gate, or a
 children supply the concrete mechanism each case exercises. No case derives from a source outside the
 family, and no case introduces a mechanism its owning child does not state.
 
-**Stable-ID policy.** `DESK-FAMILY-01`–`10` and `DESK-SCENARIO-01`–`55` are permanent — fifty-five cases,
-numbered without gaps, reproduced by scan. The last two identifiers were allocated after a coverage sweep
-found two reserved checks with no seeding case, so they sit at the end of the sequence rather than inside
-their families' runs; identifiers are allocation-ordered and never renumbered. Renaming a title
-never changes an identifier. A case whose *discrimination* changes — it now tests something different — gets
+**Stable-ID policy.** `DESK-FAMILY-01`–`10` and `DESK-SCENARIO-01`–`60` are permanent — sixty cases,
+numbered without gaps, reproduced by scan. The last seven identifiers were allocated after later coverage
+sweeps — two after a sweep found two reserved checks with no seeding case, and five after the per-system
+behavior check was split into one claim per item and five of its claims proved to have no case of their own —
+so they sit at the end of the sequence rather than inside their families' runs; identifiers are
+allocation-ordered and never renumbered. Renaming a title never changes an identifier. A case whose *discrimination* changes — it now tests something different — gets
 a new identifier rather than reusing the old one, so a finding stays resolvable across revisions. A retired
 identifier is never reallocated.
 
@@ -358,7 +361,7 @@ one indicates only one of the two mechanisms is in place.
 paint.
 *Obligation:* the design MUST create the window hidden and show it on the ready-to-show event **and** set a
 background color, because each mechanism alone leaves one bad case.
-*Trace:* `DESK-CHECK-23`
+*Trace:* `DESK-CHECK-37`
 
 #### `DESK-SCENARIO-13` — A downgrade rewrites newer data into an older shape
 
@@ -389,7 +392,7 @@ unreachable without editing state by hand.
 focusable on an attached display.
 *Obligation:* the design MUST validate restored window bounds against the currently attached displays and
 fall back to a visible position when they do not intersect one.
-*Trace:* `DESK-CHECK-23`
+*Trace:* `DESK-CHECK-38`
 
 #### `DESK-SCENARIO-15` — A local write is interrupted
 
@@ -435,6 +438,97 @@ supported-old-version window states which older versions this obligation covers.
 *Obligation:* the design MUST state which older versions its data contract supports, and MUST prove the data
 round trip across that stated window rather than only forward.
 *Trace:* `DESK-CHECK-24`, `DESK-CHECK-31`
+
+#### `DESK-SCENARIO-56` — Closing the last surface, and coming back to one
+
+*Primary type:* **Positive** — the ordinary valid path of leaving the application with no surface open and
+returning to it. *Coverage-role:* `positive` (exercises the no-surface state and the return from it).
+*Given* an application whose last surface is closed on each claimed system. *When* the person closes it and
+later reactivates the application. *Then* the system whose convention keeps an application alive with no
+surface open keeps running and opens one on its own activation event, the systems whose convention exits do
+exit, and the handler used is the one that fires on reactivation rather than the one that fires on every switch
+into the application.
+*Failure oracle:* identical behaviour on every claimed system — an application that exits where the convention
+says it persists, or persists where the convention says it exits; or a new surface appearing on every switch
+into the application, which is the wrong activation event.
+*Evidence:* close the last surface on each claimed system and observe the process; reactivate and confirm
+exactly one surface appears; then switch away and back repeatedly and confirm none is created.
+*Obligation:* the design MUST satisfy each claimed system's own closing-the-last-surface and activation
+convention with its named mechanism, and MUST NOT use the every-activation event where the reactivation event
+is meant.
+*Trace:* `DESK-CHECK-39`
+
+#### `DESK-SCENARIO-57` — A deep link proved in a development run
+
+*Primary type:* **Boundary** — it sits at the exact packaging transition where the feature starts working on
+one system. *Coverage-role:* `boundary` (exercises the unpackaged-to-packaged transition).
+*Given* a protocol registration and a link that opens correctly when the application is launched from the
+development command. *When* the run cites that result as evidence the deep link works. *Then* the citation is
+refused on the system whose own documentation states the feature does not work unpackaged, the claim is
+re-proved against the packaged artifact, and each claimed system's delivery route is the one that system
+documents rather than one route assumed for all of them.
+*Failure oracle:* a deep-link claim whose only evidence is an unpackaged run on the system that documents a
+false negative there; or one delivery route implemented and several systems claimed.
+*Evidence:* open the link against the packaged, installed artifact on each claimed system, and read the
+implemented delivery route for each against the route that system documents.
+*Obligation:* the design MUST implement each claimed system's own deep-link delivery route, and MUST prove a
+deep-link claim on the packaged artifact wherever the platform states the unpackaged result is a false
+negative.
+*Trace:* `DESK-CHECK-40`
+
+#### `DESK-SCENARIO-58` — A two-state light and dark toggle offered as the theme contract
+
+*Primary type:* **Negative** — an invalid theming contract expecting rejection.
+*Coverage-role:* `negative` (exercises rejection of the missing third state).
+*Given* a theme source that takes exactly three values and an application offering the person two of them.
+*When* the person's system changes appearance on its own schedule. *Then* the application is in the wrong
+appearance until the person corrects it by hand — which is why follow-the-system is a required third state
+rather than a convenience — and the theme interface's own update event is handled live rather than read once
+at startup.
+*Failure oracle:* a two-option appearance control; or a three-option control whose follow-the-system value is
+read at startup and never updated, so a mid-session change leaves the application behind.
+*Evidence:* read the mapping between the person-facing control and the theme source's three values; then
+change the system appearance while the application is running and observe whether it follows.
+*Obligation:* the design MUST map the person-facing appearance control onto all three values of the theme
+source and MUST handle that interface's update event live.
+*Trace:* `DESK-CHECK-41`
+
+#### `DESK-SCENARIO-59` — A shortcut map that works in its author's own window
+
+*Primary type:* **Adversarial** — a configuration that behaves correctly where it was written and is dead or
+hostile everywhere else. *Coverage-role:* `adversarial` (attacks the shortcut contract through the author's own
+environment).
+*Given* accelerators written with one platform's own modifier, and one binding that takes a combination the
+platform's desktop guidance names as reserved for the system. *When* the application runs on the other claimed
+systems, and beside other applications on the same one. *Then* the modifier-specific accelerators are silently
+dead on the systems that do not have that modifier, and the reserved binding takes a system combination away
+from every other application the person uses — so one shortcut map exists per claimed platform, written with
+the portable modifier and excluding the reserved set.
+*Failure oracle:* every accelerator behaving correctly in the author's own foreground window while a claimed
+system has no working accelerator at all; or a binding on a combination the platform's own guidance names as
+reserved.
+*Evidence:* exercise each accelerator on each claimed system, and compare the bound set against that system's
+own reserved list.
+*Obligation:* the design MUST carry one shortcut map per claimed platform, written with the portable modifier
+rather than one platform's own, and MUST NOT bind a system-reserved combination.
+*Trace:* `DESK-CHECK-42`
+
+#### `DESK-SCENARIO-60` — A platform convention filled in from a plausible summary
+
+*Primary type:* **Adversarial** — a confident, well-formed conformance claim with no readable authority behind
+it. *Coverage-role:* `adversarial` (attacks the honesty rule exactly where the answer is unavailable).
+*Given* a vendor design-guidance surface this skill records as unreadable, and a run that needs a menu ordering
+from it. *When* the run takes the ordering from a search summary, or softens it into a hedge about what the
+vendor probably requires. *Then* both are rejected: an unverifiable convention is neither asserted nor hedged,
+the gap is marked, what would close it is named, and the design is written so it does not depend on the answer.
+*Failure oracle:* a menu ordering, a minimum menu set, or a document-ordering convention stated as fact or as a
+hedge, with no readable owner document behind it.
+*Evidence:* take each stated platform convention to the owner document that would establish it; a convention
+with no readable owner fails whether it was asserted or hedged.
+*Obligation:* the design MUST NOT state an unverified platform convention as fact and MUST NOT hedge it into a
+claim about what has not been read; it MUST mark the gap, name its closing condition, and write the rule so it
+does not depend on the answer.
+*Trace:* `DESK-CHECK-43`
 
 ### `DESK-FAMILY-04` — The privilege boundary, the channel inventory, and the three targets
 
@@ -1078,22 +1172,27 @@ Every case's obligation and the check identifier it reserves. This table is the 
 trace — policy and case to check — and it is generated from the `Trace:` fields above rather than maintained
 beside them, so the two cannot drift apart.
 
-**No case in this set is exploratory**, so all fifty-five carry an obligation and appear here. An exploratory
+**No case in this set is exploratory**, so all sixty carry an obligation and appear here. An exploratory
 case would be exempt from the obligation trace only while explicitly marked as one, and the exemption would
 end the moment it became an approved constraint.
 
-**The reserved ranges, and the extension this set required.** The design fixes four pause points and reserves
-thirty-four check slots across them. This set reserves **thirty-six**, because the four protected floors each
-need a member check *and* a property check — eight slots where the original allocation left room for fewer —
-and the protected-waiver table needs its own. The extension follows the rule the design states: the range
-grows at its own pause point's tail and every later range shifts. [`checklists.md`](checklists.md) records
-the final ranges once, as their owner.
+**The reserved ranges, and the two extensions this set required.** The design fixes four pause points and
+reserves thirty-four check slots across them. This set reserves **forty-three**. The first extension took it to
+thirty-six, because the four protected floors each need a member check *and* a property check — eight slots
+where the original allocation left room for fewer — and the protected-waiver table needs its own; it followed
+the rule the design states, growing a range at its own pause point's tail and shifting every later range. The
+second extension took it to forty-three and could not follow that rule: splitting the per-system behavior check
+into one atomic claim per item needed seven further slots at `DESK-PAUSE-3`, and growing that range in place
+would have renumbered every later identifier, which the stable-ID policy above forbids. Those seven are
+therefore **allocated at the tail of the sequence and placed in their pause point's own list**, exactly as
+`DESK-SCENARIO-54` and `DESK-SCENARIO-55` sit inside their families with tail numbers.
+[`checklists.md`](checklists.md) records the final ranges once, as their owner.
 
 | Pause point | Reserved range | Confirms |
 |---|---|---|
 | `DESK-PAUSE-1` — stack and outcome lock | `01`–`05` | outcome, boundary, stack-fit result, ownership statement, gate-authority map |
 | `DESK-PAUSE-2` — design acceptance | `06`–`17`, with **`06` reserved for the structural-approval check** | the structural-approval decision, the rung register, and all four floors on both their member and property checks |
-| `DESK-PAUSE-3` — implementation completion | `18`–`26` | the privilege boundary, security posture, platform obligations, local data, and in-scope paths |
+| `DESK-PAUSE-3` — implementation completion | `18`–`26` and `37`–`43` | the privilege boundary, security posture, platform obligations one claim at a time, local data, and in-scope paths |
 | `DESK-PAUSE-4` — release-readiness handoff | `27`–`36` | every applicable release gate per claimed system, the design record, and the trace and verifier proofs |
 
 `DESK-CHECK-06` is pinned by the design rather than chosen here: the restored structural-approval gate
@@ -1116,9 +1215,9 @@ one check cluster.
 | `DESK-SCENARIO-10` | A required participant condition is missing | `DESK-CHECK-13` | `DESK-PAUSE-2` |
 | `DESK-SCENARIO-11` | An unlisted participant activity whose observations are cited | `DESK-CHECK-14` | `DESK-PAUSE-2` |
 | `DESK-SCENARIO-54` | The ladder's own method order, and three axes stated per visual artifact | `DESK-CHECK-08` | `DESK-PAUSE-2` |
-| `DESK-SCENARIO-12` | First paint uses both mechanisms | `DESK-CHECK-23` | `DESK-PAUSE-3` |
+| `DESK-SCENARIO-12` | First paint uses both mechanisms | `DESK-CHECK-37` | `DESK-PAUSE-3` |
 | `DESK-SCENARIO-13` | A downgrade rewrites newer data into an older shape | `DESK-CHECK-24` | `DESK-PAUSE-3` |
-| `DESK-SCENARIO-14` | A monitor disappears between sessions | `DESK-CHECK-23` | `DESK-PAUSE-3` |
+| `DESK-SCENARIO-14` | A monitor disappears between sessions | `DESK-CHECK-38` | `DESK-PAUSE-3` |
 | `DESK-SCENARIO-15` | A local write is interrupted | `DESK-CHECK-24` | `DESK-PAUSE-3` |
 | `DESK-SCENARIO-16` | A second instance's arguments are read by position | `DESK-CHECK-23`, `DESK-CHECK-11` | `DESK-PAUSE-2`, `DESK-PAUSE-3` |
 | `DESK-SCENARIO-17` | A schema change ships and the previous version is still installed | `DESK-CHECK-24`, `DESK-CHECK-31` | `DESK-PAUSE-3`, `DESK-PAUSE-4` |
@@ -1159,3 +1258,8 @@ one check cluster.
 | `DESK-SCENARIO-52` | Nine claims merged into one release status | `DESK-CHECK-32` | `DESK-PAUSE-4` |
 | `DESK-SCENARIO-53` | A green relation test offered as a complete trace proof | `DESK-CHECK-34` | `DESK-PAUSE-4` |
 | `DESK-SCENARIO-55` | A human-outcome claim with no participant record behind it | `DESK-CHECK-16` | `DESK-PAUSE-2` |
+| `DESK-SCENARIO-56` | Closing the last surface, and coming back to one | `DESK-CHECK-39` | `DESK-PAUSE-3` |
+| `DESK-SCENARIO-57` | A deep link proved in a development run | `DESK-CHECK-40` | `DESK-PAUSE-3` |
+| `DESK-SCENARIO-58` | A two-state light and dark toggle offered as the theme contract | `DESK-CHECK-41` | `DESK-PAUSE-3` |
+| `DESK-SCENARIO-59` | A shortcut map that works in its author's own window | `DESK-CHECK-42` | `DESK-PAUSE-3` |
+| `DESK-SCENARIO-60` | A platform convention filled in from a plausible summary | `DESK-CHECK-43` | `DESK-PAUSE-3` |

--- a/.gobbi/projects/gobbi/skills/desktop/scripts/check_relation.py
+++ b/.gobbi/projects/gobbi/skills/desktop/scripts/check_relation.py
@@ -1,0 +1,573 @@
+#!/usr/bin/env python3
+"""Check the four Desktop case-to-check relation projections."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+
+SCENARIO_PATTERN = r"DESK-SCENARIO-[0-9]{2}"
+CHECK_PATTERN = r"DESK-CHECK-[0-9]{2}"
+PAUSE_PATTERN = r"DESK-PAUSE-[1-4]"
+
+SCENARIO_HEADING = re.compile(
+    rf"^#### `(?P<identifier>{SCENARIO_PATTERN})` — (?P<subject>\S.*)$"
+)
+CHECK_HEADING = re.compile(
+    rf"^- \[ \] \*\*`(?P<identifier>{CHECK_PATTERN})`\*\* (?P<subject>\S.*)$"
+)
+FIELD_MARKER = re.compile(r"\*(?P<name>[A-Za-z][A-Za-z -]*):\*")
+SCENARIO_TOKEN = re.compile(rf"`(?P<identifier>{SCENARIO_PATTERN})`")
+CHECK_TOKEN = re.compile(rf"`(?P<identifier>{CHECK_PATTERN})`")
+SECTION_HEADING = re.compile(r"^## .+$")
+SUBJECT_BOUNDARY = re.compile(r"^#{1,3} .+$")
+
+TRACE_PROJECTION = "trace"
+SEEDS_PROJECTION = "seeds"
+COVERAGE_PROJECTION = "guaranteed-coverage-map"
+AUDIT_PROJECTION = "check-to-obligation-union-audit"
+PROJECTION_ORDER = (
+    TRACE_PROJECTION,
+    SEEDS_PROJECTION,
+    COVERAGE_PROJECTION,
+    AUDIT_PROJECTION,
+)
+
+Edge = tuple[str, str]
+
+
+class RelationError(Exception):
+    """A fail-closed relation-checking error."""
+
+
+class SelfTestError(RelationError):
+    """A self-test setup or expectation failure."""
+
+
+def read_source(path: Path, projection: str) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as error:
+        raise RelationError(
+            f"projection={projection} error=unreadable-file path={path}: {error}"
+        ) from error
+
+
+def add_edge(edges: set[Edge], edge: Edge, projection: str) -> None:
+    if edge in edges:
+        scenario, check = edge
+        raise RelationError(
+            f"projection={projection} error=duplicate-edge "
+            f"edge={scenario}->{check}"
+        )
+    edges.add(edge)
+
+
+def parse_identifier_list(
+    value: str,
+    token_pattern: re.Pattern[str],
+    projection: str,
+    subject: str,
+) -> list[str]:
+    normalized = " ".join(value.split())
+    if not normalized:
+        raise RelationError(
+            f"projection={projection} error=empty-subject subject={subject}"
+        )
+
+    identifiers = [
+        match.group("identifier") for match in token_pattern.finditer(normalized)
+    ]
+    expected = ", ".join(f"`{identifier}`" for identifier in identifiers)
+    if not identifiers or normalized != expected:
+        raise RelationError(
+            f"projection={projection} error=malformed-identifiers "
+            f"subject={subject} value={normalized!r}"
+        )
+    return identifiers
+
+
+def field_value(block: list[str], field: str, projection: str, subject: str) -> str:
+    joined = "\n".join(block)
+    marker = f"*{field}:*"
+    occurrences = joined.count(marker)
+    if occurrences != 1:
+        diagnosis = "missing-field" if occurrences == 0 else "repeated-field"
+        raise RelationError(
+            f"projection={projection} error={diagnosis} "
+            f"field={field} subject={subject}"
+        )
+
+    start = joined.index(marker) + len(marker)
+    following = joined[start:]
+    next_marker = FIELD_MARKER.search(following)
+    if next_marker:
+        following = following[: next_marker.start()]
+    return following.strip()
+
+
+def subject_blocks(
+    text: str,
+    heading_pattern: re.Pattern[str],
+    heading_prefix: str,
+    projection: str,
+) -> list[tuple[str, list[str]]]:
+    lines = text.splitlines()
+    starts: list[tuple[int, str]] = []
+    seen: set[str] = set()
+
+    for index, line in enumerate(lines):
+        match = heading_pattern.match(line)
+        if match:
+            identifier = match.group("identifier")
+            if identifier in seen:
+                raise RelationError(
+                    f"projection={projection} error=duplicate-heading "
+                    f"subject={identifier}"
+                )
+            seen.add(identifier)
+            starts.append((index, identifier))
+        elif line.startswith(heading_prefix):
+            raise RelationError(
+                f"projection={projection} error=malformed-heading "
+                f"line={index + 1}"
+            )
+
+    if not starts:
+        raise RelationError(f"projection={projection} error=empty-projection")
+
+    blocks: list[tuple[str, list[str]]] = []
+    for position, (start, identifier) in enumerate(starts):
+        end = starts[position + 1][0] if position + 1 < len(starts) else len(lines)
+        for index in range(start + 1, end):
+            if SUBJECT_BOUNDARY.match(lines[index]):
+                end = index
+                break
+        blocks.append((identifier, lines[start + 1 : end]))
+    return blocks
+
+
+def parse_trace(text: str) -> set[Edge]:
+    edges: set[Edge] = set()
+    for scenario, block in subject_blocks(
+        text, SCENARIO_HEADING, "#### `DESK-SCENARIO-", TRACE_PROJECTION
+    ):
+        value = field_value(block, "Trace", TRACE_PROJECTION, scenario)
+        for check in parse_identifier_list(
+            value, CHECK_TOKEN, TRACE_PROJECTION, scenario
+        ):
+            add_edge(edges, (scenario, check), TRACE_PROJECTION)
+    if not edges:
+        raise RelationError(f"projection={TRACE_PROJECTION} error=empty-projection")
+    return edges
+
+
+def parse_seeds(text: str) -> set[Edge]:
+    edges: set[Edge] = set()
+    for check, block in subject_blocks(
+        text, CHECK_HEADING, "- [ ] **`DESK-CHECK-", SEEDS_PROJECTION
+    ):
+        value = field_value(block, "Seeds", SEEDS_PROJECTION, check)
+        for scenario in parse_identifier_list(
+            value, SCENARIO_TOKEN, SEEDS_PROJECTION, check
+        ):
+            add_edge(edges, (scenario, check), SEEDS_PROJECTION)
+    if not edges:
+        raise RelationError(f"projection={SEEDS_PROJECTION} error=empty-projection")
+    return edges
+
+
+def required_section(text: str, heading: str, projection: str) -> list[str]:
+    lines = text.splitlines()
+    locations = [index for index, line in enumerate(lines) if line == heading]
+    if len(locations) != 1:
+        diagnosis = "missing-section" if not locations else "repeated-section"
+        raise RelationError(
+            f"projection={projection} error={diagnosis} section={heading!r}"
+        )
+    start = locations[0] + 1
+    end = len(lines)
+    for index in range(start, len(lines)):
+        if SECTION_HEADING.match(lines[index]):
+            end = index
+            break
+    return lines[start:end]
+
+
+def split_table_row(line: str, projection: str, row_number: int) -> list[str]:
+    if not line.startswith("|") or not line.endswith("|"):
+        raise RelationError(
+            f"projection={projection} error=malformed-row row={row_number}"
+        )
+    return [cell.strip() for cell in line[1:-1].split("|")]
+
+
+def table_rows(
+    section: list[str],
+    header: str,
+    separator: str,
+    projection: str,
+) -> list[tuple[int, list[str]]]:
+    header_locations = [index for index, line in enumerate(section) if line == header]
+    if len(header_locations) != 1:
+        diagnosis = "missing-table" if not header_locations else "repeated-table"
+        raise RelationError(f"projection={projection} error={diagnosis}")
+
+    header_index = header_locations[0]
+    if (
+        header_index + 1 >= len(section)
+        or section[header_index + 1] != separator
+    ):
+        raise RelationError(
+            f"projection={projection} error=malformed-table-separator"
+        )
+
+    rows: list[tuple[int, list[str]]] = []
+    for index in range(header_index + 2, len(section)):
+        line = section[index]
+        if not line:
+            break
+        if not line.startswith("|"):
+            raise RelationError(
+                f"projection={projection} error=malformed-row row={index + 1}"
+            )
+        rows.append((index + 1, split_table_row(line, projection, index + 1)))
+    if not rows:
+        raise RelationError(f"projection={projection} error=empty-projection")
+    return rows
+
+
+def single_identifier(
+    cell: str,
+    pattern: str,
+    projection: str,
+    row_number: int,
+    label: str,
+) -> str:
+    match = re.fullmatch(rf"`(?P<identifier>{pattern})`", cell)
+    if not match:
+        raise RelationError(
+            f"projection={projection} error=malformed-row "
+            f"row={row_number} cell={label}"
+        )
+    return match.group("identifier")
+
+
+def parse_coverage_map(text: str) -> set[Edge]:
+    section = required_section(
+        text, "## Guaranteed coverage map", COVERAGE_PROJECTION
+    )
+    rows = table_rows(
+        section,
+        "| Check | Seeding cases | Pause point |",
+        "|---|---|---|",
+        COVERAGE_PROJECTION,
+    )
+    edges: set[Edge] = set()
+    checks: set[str] = set()
+    for row_number, cells in rows:
+        if len(cells) != 3:
+            raise RelationError(
+                f"projection={COVERAGE_PROJECTION} error=malformed-row "
+                f"row={row_number} columns={len(cells)}"
+            )
+        check = single_identifier(
+            cells[0], CHECK_PATTERN, COVERAGE_PROJECTION, row_number, "Check"
+        )
+        if check in checks:
+            raise RelationError(
+                f"projection={COVERAGE_PROJECTION} error=duplicate-heading "
+                f"subject={check}"
+            )
+        checks.add(check)
+        single_identifier(
+            cells[2], PAUSE_PATTERN, COVERAGE_PROJECTION, row_number, "Pause point"
+        )
+        for scenario in parse_identifier_list(
+            cells[1], SCENARIO_TOKEN, COVERAGE_PROJECTION, check
+        ):
+            add_edge(edges, (scenario, check), COVERAGE_PROJECTION)
+    if not edges:
+        raise RelationError(
+            f"projection={COVERAGE_PROJECTION} error=empty-projection"
+        )
+    return edges
+
+
+def parse_union_audit(text: str) -> set[Edge]:
+    section = required_section(
+        text, "## Check-to-obligation union audit", AUDIT_PROJECTION
+    )
+    rows = table_rows(
+        section,
+        "| Check | Obligations it consumes | Conditions | Reviewer | Result |",
+        "|---|---|---|---|---|",
+        AUDIT_PROJECTION,
+    )
+    edges: set[Edge] = set()
+    checks: set[str] = set()
+    for row_number, cells in rows:
+        if len(cells) != 5:
+            raise RelationError(
+                f"projection={AUDIT_PROJECTION} error=malformed-row "
+                f"row={row_number} columns={len(cells)}"
+            )
+        check = single_identifier(
+            cells[0], CHECK_PATTERN, AUDIT_PROJECTION, row_number, "Check"
+        )
+        if check in checks:
+            raise RelationError(
+                f"projection={AUDIT_PROJECTION} error=duplicate-heading "
+                f"subject={check}"
+            )
+        checks.add(check)
+        if not re.fullmatch(r"[1-9][0-9]*", cells[2]):
+            raise RelationError(
+                f"projection={AUDIT_PROJECTION} error=malformed-row "
+                f"row={row_number} cell=Conditions"
+            )
+        for scenario in parse_identifier_list(
+            cells[1], SCENARIO_TOKEN, AUDIT_PROJECTION, check
+        ):
+            add_edge(edges, (scenario, check), AUDIT_PROJECTION)
+    if not edges:
+        raise RelationError(
+            f"projection={AUDIT_PROJECTION} error=empty-projection"
+        )
+    return edges
+
+
+def parse_projections(
+    scenarios_path: Path, checklists_path: Path
+) -> dict[str, set[Edge]]:
+    scenarios_text = read_source(scenarios_path, TRACE_PROJECTION)
+    checklists_text = read_source(checklists_path, SEEDS_PROJECTION)
+    return {
+        TRACE_PROJECTION: parse_trace(scenarios_text),
+        SEEDS_PROJECTION: parse_seeds(checklists_text),
+        COVERAGE_PROJECTION: parse_coverage_map(checklists_text),
+        AUDIT_PROJECTION: parse_union_audit(checklists_text),
+    }
+
+
+def compare_projections(projections: dict[str, set[Edge]]) -> list[str]:
+    authoritative = projections[TRACE_PROJECTION]
+    diagnostics: list[str] = []
+    for projection in PROJECTION_ORDER[1:]:
+        candidate = projections[projection]
+        for scenario, check in sorted(authoritative - candidate):
+            diagnostics.append(
+                f"projection={projection} edge={scenario}->{check} "
+                "side=authoritative-only"
+            )
+        for scenario, check in sorted(candidate - authoritative):
+            diagnostics.append(
+                f"projection={projection} edge={scenario}->{check} "
+                "side=projection-only"
+            )
+    return diagnostics
+
+
+def success_message(edge_count: int) -> str:
+    projections = ",".join(PROJECTION_ORDER)
+    return (
+        f"relation-check: PASS projections={projections} edge_count={edge_count} "
+        "relation_leg=script-proved obligation_leg=review-proved"
+    )
+
+
+def remove_field_token(
+    text: str,
+    heading_pattern: re.Pattern[str],
+    subject: str,
+    field: str,
+    token: str,
+) -> str:
+    lines = text.splitlines(keepends=True)
+    starts = [
+        index
+        for index, line in enumerate(lines)
+        if (match := heading_pattern.match(line.rstrip("\n")))
+        and match.group("identifier") == subject
+    ]
+    if len(starts) != 1:
+        raise SelfTestError(f"self-test fixture-heading-count subject={subject}")
+
+    start = starts[0] + 1
+    end = len(lines)
+    for index in range(start, len(lines)):
+        stripped = lines[index].rstrip("\n")
+        if heading_pattern.match(stripped) or SUBJECT_BOUNDARY.match(stripped):
+            end = index
+            break
+    block = "".join(lines[start:end])
+    marker = f"*{field}:*"
+    if block.count(marker) != 1:
+        raise SelfTestError(
+            f"self-test fixture-field-count field={field} subject={subject}"
+        )
+    marker_start = block.index(marker) + len(marker)
+    next_marker = FIELD_MARKER.search(block, marker_start)
+    value_end = next_marker.start() if next_marker else len(block)
+    value = block[marker_start:value_end]
+    if value.count(token) != 1:
+        raise SelfTestError(
+            f"self-test fixture-token-count token={token} subject={subject}"
+        )
+
+    following = re.compile(re.escape(token) + r",\s*")
+    preceding = re.compile(r",\s*" + re.escape(token))
+    if following.search(value):
+        changed_value = following.sub("", value, count=1)
+    elif preceding.search(value):
+        changed_value = preceding.sub("", value, count=1)
+    else:
+        raise SelfTestError(
+            f"self-test fixture-would-empty-field field={field} subject={subject}"
+        )
+    changed_block = block[:marker_start] + changed_value + block[value_end:]
+    return "".join(lines[:start]) + changed_block + "".join(lines[end:])
+
+
+def require_real_pass(
+    scenarios_path: Path, checklists_path: Path, phase: str
+) -> dict[str, set[Edge]]:
+    projections = parse_projections(scenarios_path, checklists_path)
+    diagnostics = compare_projections(projections)
+    if diagnostics:
+        raise SelfTestError(
+            f"self-test {phase}=FAIL diagnostics={'|'.join(diagnostics)}"
+        )
+    return projections
+
+
+def run_self_test(scenarios_path: Path, checklists_path: Path) -> int:
+    pristine = require_real_pass(scenarios_path, checklists_path, "real-pass-before")
+    authoritative = pristine[TRACE_PROJECTION]
+    scenario_degree = {
+        scenario: sum(edge[0] == scenario for edge in authoritative)
+        for scenario, _ in authoritative
+    }
+    check_degree = {
+        check: sum(edge[1] == check for edge in authoritative)
+        for _, check in authoritative
+    }
+    eligible = sorted(
+        edge
+        for edge in authoritative
+        if scenario_degree[edge[0]] > 1 and check_degree[edge[1]] > 1
+    )
+    if not eligible:
+        raise SelfTestError("self-test no-removable-real-edge")
+    scenario, check = eligible[0]
+
+    with tempfile.TemporaryDirectory(prefix="desktop-relation-self-test-") as temp:
+        fixture = Path(temp)
+        fixture_scenarios = fixture / "scenarios.md"
+        fixture_checklists = fixture / "checklists.md"
+        shutil.copyfile(scenarios_path, fixture_scenarios)
+        shutil.copyfile(checklists_path, fixture_checklists)
+
+        fixture_checklists.write_text(
+            remove_field_token(
+                fixture_checklists.read_text(encoding="utf-8"),
+                CHECK_HEADING,
+                check,
+                "Seeds",
+                f"`{scenario}`",
+            ),
+            encoding="utf-8",
+        )
+        f_a = compare_projections(
+            parse_projections(fixture_scenarios, fixture_checklists)
+        )
+        expected_f_a = [
+            f"projection={SEEDS_PROJECTION} edge={scenario}->{check} "
+            "side=authoritative-only"
+        ]
+        if f_a != expected_f_a:
+            raise SelfTestError(
+                f"self-test F-A=FAIL diagnostics={'|'.join(f_a) or '<none>'}"
+            )
+
+        shutil.copyfile(checklists_path, fixture_checklists)
+        fixture_scenarios.write_text(
+            remove_field_token(
+                fixture_scenarios.read_text(encoding="utf-8"),
+                SCENARIO_HEADING,
+                scenario,
+                "Trace",
+                f"`{check}`",
+            ),
+            encoding="utf-8",
+        )
+        f_b = compare_projections(
+            parse_projections(fixture_scenarios, fixture_checklists)
+        )
+        expected_f_b = [
+            f"projection={projection} edge={scenario}->{check} "
+            "side=projection-only"
+            for projection in PROJECTION_ORDER[1:]
+        ]
+        if f_b != expected_f_b:
+            raise SelfTestError(
+                f"self-test F-B=FAIL diagnostics={'|'.join(f_b) or '<none>'}"
+            )
+
+        shutil.copyfile(scenarios_path, fixture_scenarios)
+        final = require_real_pass(
+            fixture_scenarios, fixture_checklists, "real-pass-after"
+        )
+
+    edge_count = len(final[TRACE_PROJECTION])
+    print(f"self-test real-pass-before=PASS edge_count={edge_count}")
+    print(f"self-test F-A=PASS diagnostic={expected_f_a[0]}")
+    print(f"self-test F-B=PASS diagnostics={' | '.join(expected_f_b)}")
+    print(f"self-test real-pass-after=PASS edge_count={edge_count}")
+    print("relation_leg=script-proved obligation_leg=review-proved")
+    return 0
+
+
+def argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Check the Desktop case-to-check relation projections."
+    )
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--scenarios", type=Path)
+    parser.add_argument("--checklists", type=Path)
+    return parser
+
+
+def main() -> int:
+    parser = argument_parser()
+    args = parser.parse_args()
+    if args.self_test and (args.scenarios is not None or args.checklists is not None):
+        parser.error("--self-test cannot be combined with explicit input paths")
+    if (args.scenarios is None) != (args.checklists is None):
+        parser.error("--scenarios and --checklists must be supplied together")
+
+    desktop = Path(__file__).resolve().parent.parent
+    scenarios_path = args.scenarios or desktop / "scenarios.md"
+    checklists_path = args.checklists or desktop / "checklists.md"
+    try:
+        if args.self_test:
+            return run_self_test(scenarios_path, checklists_path)
+        projections = parse_projections(scenarios_path, checklists_path)
+        diagnostics = compare_projections(projections)
+        if diagnostics:
+            print("\n".join(diagnostics), file=sys.stderr)
+            return 1
+        print(success_message(len(projections[TRACE_PROJECTION])))
+        return 0
+    except RelationError as error:
+        print(f"relation-check: ERROR {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.gobbi/projects/gobbi/skills/desktop/security.md
+++ b/.gobbi/projects/gobbi/skills/desktop/security.md
@@ -3,14 +3,183 @@
 Carry the security posture as two distinct kinds of work: defaults to leave alone, and controls to write.
 Policy lives in [`SKILL.md`](SKILL.md); this child owns the mechanics.
 
+The platform's own security checklist has **twenty** numbered items, and they split cleanly into two groups
+that demand opposite kinds of effort. **Eight** are defaults already in place, where the correct action is
+**inaction**. **Twelve** are positive controls that **do not exist until someone writes them**. Eight plus
+twelve is twenty.
+
+That split is the single most useful thing to hold in mind here, because real applications rarely fail on the
+defaults. They fail by never writing the twelve.
+
+Every version-dependent statement below names the behaviour whose availability version
+[`runtime-deltas.md`](runtime-deltas.md) owns, and points there instead of restating the literal.
+
 ## Group A — defaults to leave intact
+
+Eight items. Each is already correct in a current application. The work is an audit that confirms nothing in
+this outcome has switched one off, and a recorded reason wherever one has been.
+
+| # | Default | What breaking it costs |
+|---|---|---|
+| 2 | No runtime integration for remote content | remote content gains the privileged runtime's interfaces |
+| 3 | Context isolation on | the page's world and the preload's world merge, and the page can rewrite the bridge |
+| 4 | Renderer sandbox on | the renderer stops being a renderer and becomes another privileged process |
+| 6 | Web security left enabled | the origin model that separates content sources stops applying |
+| 8 | Insecure content not allowed to run | a secure page silently loads insecure subresources |
+| 9 | Experimental features off | unshipped engine behaviour reaches production users |
+| 10 | Engine feature flags not enabled | the same, at finer granularity |
+| 11 | Embedded-view popups not allowed | an embedded view opens a window outside the window-creation policy |
+
+The audit question is never "did we enable this?" — it is "did anything in this outcome disable it, and is
+there a recorded reason?" A default switched off without a recorded reason is a finding.
 
 ## Group B — positive controls to write
 
+Twelve items. Each is a control that does not exist until it is written, and an application that has written
+none of them still passes every Group A check.
+
+| # | Control | Where it lives |
+|---|---|---|
+| 1 | Load secure content only | the window's own loading path |
+| 5 | A session permission-request handler | the session, before any permission prompt can reach the user |
+| 7 | A Content Security Policy | delivered per the section below |
+| 12 | Verify embedded-view options as they attach | the attach event for embedded views |
+| 13 | Limit navigation | the navigation event, which fires on every attempt |
+| 14 | Limit window creation | the window-open handler, which decides rather than reacts |
+| 15 | Never hand untrusted content to the external-open interface | wherever a link becomes a shell action |
+| 16 | Stay on a supported platform version | the dependency manifest, checked against the supported-major set |
+| 17 | Validate the inter-process sender | every privileged handler — [`process-model.md`](process-model.md) owns the mechanics |
+| 18 | Avoid the local-file protocol for application content | the loading path, again |
+| 19 | Check the fuses | the build, per the fuse section below |
+| 20 | Never expose platform interfaces to untrusted content | the bridge surface |
+
+Item 16 is a version-dependent control: falling outside the supported-major set is a security failure rather
+than a maintenance preference, and [`runtime-deltas.md`](runtime-deltas.md) owns both the current supported
+set and the cadence that moves it.
+
+**Inventory each of the twelve with a written-or-missing state.** "We follow the security checklist" is not an
+inventory. Twelve rows, each naming the file and the line, is.
+
 ## Content Security Policy delivery
+
+**The preferred delivery mechanism is an HTTP header**, set through the session's response-header hook. That
+is the platform's own stated preference, and it applies to every application serving its own content over a
+protocol that carries headers.
+
+A document-level policy tag is the **fallback**, and it exists for the local-file protocol, where there are no
+headers to set. Reaching for the tag first is the common mistake, and it is a weaker mechanism.
+
+Note the interaction with Group B item 18: the fallback exists for exactly the protocol the checklist asks
+applications to avoid for their own content. An application that avoids the local-file protocol can use the
+header, which is the stronger path.
 
 ## Fuses and the paired ASAR fuses
 
+Fuses are the **build-time** hardening mechanism. They are flipped when the artifact is built, and they are
+validated by the operating system **after** code signing — [`signing-updates.md`](signing-updates.md) owns
+what that ordering means for the release chain.
+
+| Fuse | Default | Hardening action |
+|---|---|---|
+| `runAsNode` | enabled | disable if the application does not use it |
+| `enableCookieEncryption` | disabled | **enable in production** |
+| `enableNodeOptionsEnvironmentVariable` | enabled | disable |
+| `enableNodeCliInspectArguments` | enabled | disable — **but see the build-matrix decision below** |
+| `enableEmbeddedAsarIntegrityValidation` | disabled | **enable, paired with the next row** |
+| `onlyLoadAppFromAsar` | disabled | **enable, paired with the previous row** |
+| `loadBrowserProcessSpecificV8Snapshot` | disabled | enable — it improves isolation |
+| `grantFileProtocolExtraPrivileges` | enabled | disable unless the application serves local files |
+
+### The two archive fuses are one control
+
+`enableEmbeddedAsarIntegrityValidation` and `onlyLoadAppFromAsar` are paired deliberately, and the platform
+states why: together they make it impossible to load non-validated code. Enabling integrity validation while
+still permitting loading from outside the archive leaves the path the validation was meant to close.
+
+Enable both or understand precisely why you are enabling one. On a hash mismatch the platform **terminates
+forcefully** — that is the intended behaviour, not a crash to diagnose.
+
+Archive-integrity support is not available on every operating system, and the per-system minimum versions are
+recorded in [`runtime-deltas.md`](runtime-deltas.md) under *Archive-integrity minimums*. On the system with no
+support, this control is simply absent, and a run claiming load-time integrity across three systems is
+claiming something the platform does not provide.
+
+### The build-matrix decision this table forces — `DESK-G5`
+
+Two first-party sources are in direct operational conflict, and no documented reconciliation exists.
+
+- The platform's own fuse guidance lists **disabling** `enableNodeCliInspectArguments` as hardening.
+- The documented end-to-end test framework **requires that same fuse not be disabled**.
+
+Both horns, stated as consequences rather than as preferences:
+
+| Horn | What it buys | What it costs |
+|---|---|---|
+| Harden the release build | the shipped artifact carries the full fuse set | that artifact is not automatable by that test path, so the automated suite exercises a different build |
+| Keep the fuse enabled for automation | end-to-end automation runs against the artifact that ships | the shipped artifact is not fully hardened |
+
+**This is a user decision at `DESK-G5`, and `DESK-N10` forbids resolving it on the reader's behalf.** Present
+both horns with their consequences. Whichever the user picks, the consequence is carried forward as a stated
+verification limit rather than absorbed into a green summary — if the automated suite exercises a build that
+is not the one shipping, every claim that suite supports is a claim about a different artifact.
+
 ## What ASAR is not
 
+The archive format is a packaging convenience. It is **not a security boundary**, and treating it as one is
+what `DESK-N08` prohibits.
+
+Its own documentation justifies it as concealing source **from cursory inspection**. That is the whole claim.
+Beyond it:
+
+- it is **read-only**;
+- it returns **guessed** file-status values rather than real ones;
+- **some interfaces silently extract to a temporary directory**, so a file a reader believes is sealed inside
+  the archive can exist unpacked on disk.
+
+Therefore: **never place a secret in the bundle.** Not in the archive, not minified, not encoded, not split
+across files. Anything shipped to a user's machine is in that user's possession, and packaging changes how
+much effort reading it takes and nothing else. The at-rest secret handling that *does* work is
+[`filesystem-data.md`](filesystem-data.md)'s subject.
+
+Integrity validation and the archive-only load path, from the fuse table above, are what the archive
+contributes to security: **load-time integrity**, on the systems that support it. That is a different
+property from confidentiality, and it is the only one on offer here.
+
 ## Supply chain and the scanner gap
+
+Two facts about this stack's supply chain change how a run plans its maintenance, and both are uncomfortable.
+
+### The engine roll is continuous; the supported window is not
+
+Only the latest three stable majors are supported at a time — [`runtime-deltas.md`](runtime-deltas.md) owns
+the current set and the cadence that moves it. Meanwhile, remote-code-execution vulnerabilities in the bundled
+browser engine reach this platform continuously, through the engine roll.
+
+Those two facts together are why "stay on this major for two years" is not available, and why upgrading is a
+security activity rather than a maintenance chore. A team that cannot sustain the cadence has a stack-fit
+problem, and `DESK-R03`'s third criterion is where that gets decided — before the stack is committed, not
+after the first unpatchable release.
+
+### The static scanner gap, stated rather than papered over
+
+The standard free static scanner for misconfiguration in this stack is **unmaintained**. Its own maintainers
+state they are no longer actively maintaining the project, and they point users at a commercial successor.
+
+**NOT FOUND — a maintained free replacement.** A bounded search this session found none. Two things follow,
+and the second matters as much as the first:
+
+1. **Do not present a scanner as covering the twenty checklist items.** The audit is manual until a
+   maintained tool exists. Budget for that rather than discovering it at review time.
+2. **Do not imply the commercial successor is the only option.** That is a claim about the market, and no
+   evidence on hand supports it. What is supported is narrower: the standard free tool is unmaintained, and a
+   bounded search found no maintained free replacement.
+
+`SKILL.md`'s gap register carries this with its closing condition — a maintained free scanner appears, or the
+gap is accepted permanently.
+
+### What the manual audit has to cover
+
+Absent a scanner, the audit is the two groups above plus the fuse table, run against the built artifact
+rather than against the source. The distinction matters: Group A defaults live in window configuration,
+Group B controls live in application code, and the fuses live in the **build**. A source review that never
+inspects the built artifact cannot see the third of those.

--- a/.gobbi/projects/gobbi/skills/desktop/security.md
+++ b/.gobbi/projects/gobbi/skills/desktop/security.md
@@ -1,0 +1,16 @@
+# Desktop — Security Posture
+
+Carry the security posture as two distinct kinds of work: defaults to leave alone, and controls to write.
+Policy lives in [`SKILL.md`](SKILL.md); this child owns the mechanics.
+
+## Group A — defaults to leave intact
+
+## Group B — positive controls to write
+
+## Content Security Policy delivery
+
+## Fuses and the paired ASAR fuses
+
+## What ASAR is not
+
+## Supply chain and the scanner gap

--- a/.gobbi/projects/gobbi/skills/desktop/security.md
+++ b/.gobbi/projects/gobbi/skills/desktop/security.md
@@ -19,16 +19,20 @@ Every version-dependent statement below names the behaviour whose availability v
 Eight items. Each is already correct in a current application. The work is an audit that confirms nothing in
 this outcome has switched one off, and a recorded reason wherever one has been.
 
-| # | Default | What breaking it costs |
-|---|---|---|
-| 2 | No runtime integration for remote content | remote content gains the privileged runtime's interfaces |
-| 3 | Context isolation on | the page's world and the preload's world merge, and the page can rewrite the bridge |
-| 4 | Renderer sandbox on | the renderer stops being a renderer and becomes another privileged process |
-| 6 | Web security left enabled | the origin model that separates content sources stops applying |
-| 8 | Insecure content not allowed to run | a secure page silently loads insecure subresources |
-| 9 | Experimental features off | unshipped engine behaviour reaches production users |
-| 10 | Engine feature flags not enabled | the same, at finer granularity |
-| 11 | Embedded-view popups not allowed | an embedded view opens a window outside the window-creation policy |
+| # | Default | Named setting | What breaking it costs |
+|---|---|---|---|
+| 2 | No Node integration for remote content | `nodeIntegration: false` | remote content gains the privileged runtime's interfaces |
+| 3 | Context isolation on | `contextIsolation: true` | the page's world and the preload's world merge, and the page can rewrite the bridge |
+| 4 | Renderer sandbox on | `sandbox: true` | the renderer stops being a renderer and becomes another privileged process |
+| 6 | Web security left enabled | `webSecurity` (do not disable) | the origin model that separates content sources stops applying |
+| 8 | Insecure content not allowed to run | `allowRunningInsecureContent` (leave off) | a secure page silently loads insecure subresources |
+| 9 | Experimental features off | `experimentalFeatures` (leave off) | unshipped engine behaviour reaches production users |
+| 10 | Engine feature flags not enabled | `enableBlinkFeatures` (leave unset) | the same, at finer granularity |
+| 11 | Embedded-view popups not allowed | `allowpopups` on `<webview>` (leave unset) | an embedded view opens a window outside the window-creation policy |
+
+The three defaults in rows 2, 3, and 4 are the ones whose values changed over time;
+[`runtime-deltas.md`](runtime-deltas.md) records the version each became the default, and
+[`process-model.md`](process-model.md) owns what they mean for the context split.
 
 The audit question is never "did we enable this?" — it is "did anything in this outcome disable it, and is
 there a recorded reason?" A default switched off without a recorded reason is a finding.
@@ -38,20 +42,20 @@ there a recorded reason?" A default switched off without a recorded reason is a 
 Twelve items. Each is a control that does not exist until it is written, and an application that has written
 none of them still passes every Group A check.
 
-| # | Control | Where it lives |
+| # | Control | Named mechanism |
 |---|---|---|
-| 1 | Load secure content only | the window's own loading path |
-| 5 | A session permission-request handler | the session, before any permission prompt can reach the user |
-| 7 | A Content Security Policy | delivered per the section below |
-| 12 | Verify embedded-view options as they attach | the attach event for embedded views |
-| 13 | Limit navigation | the navigation event, which fires on every attempt |
-| 14 | Limit window creation | the window-open handler, which decides rather than reacts |
-| 15 | Never hand untrusted content to the external-open interface | wherever a link becomes a shell action |
+| 1 | Load secure content only | the window's own loading path — no plain-HTTP resource in a shipped build |
+| 5 | A session permission-request handler | `session.setPermissionRequestHandler()`, set before any prompt can reach the person |
+| 7 | A Content Security Policy | `session.webRequest.onHeadersReceived`, per the section below |
+| 12 | Verify embedded-view options as they attach | the `will-attach-webview` event |
+| 13 | Limit navigation | the `will-navigate` event, which fires on every attempt |
+| 14 | Limit window creation | `setWindowOpenHandler`, which decides rather than reacts |
+| 15 | Never hand untrusted content to `shell.openExternal` | wherever a link becomes a shell action |
 | 16 | Stay on a supported platform version | the dependency manifest, checked against the supported-major set |
-| 17 | Validate the inter-process sender | every privileged handler — [`process-model.md`](process-model.md) owns the mechanics |
-| 18 | Avoid the local-file protocol for application content | the loading path, again |
+| 17 | Validate the inter-process sender | `event.senderFrame` in every privileged handler — [`process-model.md`](process-model.md) owns it |
+| 18 | Avoid `file://` for application content | the loading path, again |
 | 19 | Check the fuses | the build, per the fuse section below |
-| 20 | Never expose platform interfaces to untrusted content | the bridge surface |
+| 20 | Never expose platform interfaces to untrusted content | the `contextBridge` surface |
 
 Item 16 is a version-dependent control: falling outside the supported-major set is a security failure rather
 than a maintenance preference, and [`runtime-deltas.md`](runtime-deltas.md) owns both the current supported
@@ -62,16 +66,16 @@ inventory. Twelve rows, each naming the file and the line, is.
 
 ## Content Security Policy delivery
 
-**The preferred delivery mechanism is an HTTP header**, set through the session's response-header hook. That
-is the platform's own stated preference, and it applies to every application serving its own content over a
-protocol that carries headers.
+**The preferred delivery mechanism is an HTTP header**, set through
+`session.webRequest.onHeadersReceived`. That is the platform's own stated preference, and it applies to every
+application serving its own content over a protocol that carries headers.
 
-A document-level policy tag is the **fallback**, and it exists for the local-file protocol, where there are no
-headers to set. Reaching for the tag first is the common mistake, and it is a weaker mechanism.
+A `<meta>` tag is the **fallback**, and it exists for `file://`, where there are no headers to set. Reaching
+for the tag first is the common mistake, and it is a weaker mechanism.
 
 Note the interaction with Group B item 18: the fallback exists for exactly the protocol the checklist asks
-applications to avoid for their own content. An application that avoids the local-file protocol can use the
-header, which is the stronger path.
+applications to avoid for their own content. An application that avoids `file://` can use the header, which
+is the stronger path.
 
 ## Fuses and the paired ASAR fuses
 
@@ -132,7 +136,7 @@ Its own documentation justifies it as concealing source **from cursory inspectio
 Beyond it:
 
 - it is **read-only**;
-- it returns **guessed** file-status values rather than real ones;
+- it returns **guessed** `fs.stat` values rather than real ones;
 - **some interfaces silently extract to a temporary directory**, so a file a reader believes is sealed inside
   the archive can exist unpacked on disk.
 

--- a/.gobbi/projects/gobbi/skills/desktop/signing-updates.md
+++ b/.gobbi/projects/gobbi/skills/desktop/signing-updates.md
@@ -3,16 +3,208 @@
 Own code signing, notarization, update feeds, channels, staged rollout, and the irreversibility rule. Policy
 lives in [`SKILL.md`](SKILL.md); this child owns the mechanics.
 
+This is the end of the chain [`packaging-distribution.md`](packaging-distribution.md) begins: package, then
+sign, then update. It is also the part of a desktop outcome with the least in common with shipping a web
+page. There is no rollback here. A version that reaches a person's machine stays there until that person
+installs a different one, and some of them never will.
+
+**The three systems diverge more here than anywhere else in this skill**, and the divergence is not a matter
+of degree — one of them has no built-in update mechanism at all.
+[`runtime-deltas.md`](runtime-deltas.md) owns the per-system matrix and every version literal.
+
 ## macOS — sign, then notarize
+
+**Two mandatory steps, in order.** Signing is not sufficient on its own.
+
+1. **Enrol in the vendor's developer program.** The identity comes from there; nothing downstream works
+   without it.
+2. **Sign the artifact**, then **submit it for notarization**. Dedicated first-party tooling exists for each
+   of the two steps: `@electron/osx-sign` and `@electron/notarize`.
+
+A run that signs and stops has completed half the requirement, and the failure surfaces on someone else's
+machine rather than on the build machine — which is the general shape of every defect in this file.
+
+**Signing here is also a precondition for two things that are not obviously about signing:**
+
+- **Updates do not function on unsigned macOS builds.** It is a requirement of `Squirrel.Mac`, the framework
+  behind the built-in updater on that system, so an unsigned build has no update path at all.
+- **Notifications require a code-signed application.** An unsigned binary emits a failure event instead of
+  presenting the notification — [`native-integration.md`](native-integration.md) owns that mechanic. It is
+  named here because a run that defers signing to the end will find its notification work unprovable.
+
+> **UNVERIFIED — hardened runtime and entitlements.** The governing code-signing document **does not cover
+> them**, and no other owner document for them appears in this skill's claim register. **No entitlement is
+> taught here, and none should be copied from a summary of that document either**, because the document does
+> not contain them. *Closing condition:* that document, or another authoritative source, covers hardened
+> runtime and entitlements. `SKILL.md`'s gap register carries this item.
+>
+> A run that needs entitlements takes the question to a source it has actually read and records the result in
+> its own design record. What it does not do is infer them — `DESK-N09` prohibits filling an unverified
+> platform requirement from a plausible reconstruction.
 
 ## Windows — the certificate requirement
 
+**The attribution here is deliberate and load-bearing. Read it as written.**
+
+**The platform states that** Microsoft has required software to be signed with an **extended-validation**
+certificate since the date [`runtime-deltas.md`](runtime-deltas.md) records under *Platform-certificate policy
+date*. **The platform further states that** organization-validation and plain code-signing certificates no
+longer provide benefits, and that the operating system treats such an application as completely unsigned.
+
+**Why this is attributed rather than asserted.** The evidence on hand is the platform's own report of another
+vendor's policy — not that vendor's own document. Nobody on this skill's evidence trail has read the policy
+at its owner. `DESK-R26` requires a claim to be verified at its owner before it is stated as fact, so this
+one is stated as a report, and every restatement of it keeps the attribution. Upgrading it to a direct claim
+requires reading the vendor's own source first. This is the single claim in the whole skill that did not
+close to its proper owner, and it is recorded that way on purpose.
+
+**What the platform states about the certificate's storage:** an extended-validation certificate must reside
+on a hardware storage module compliant with **FIPS 140 Level 2**. That is a procurement fact with a lead
+time, and it belongs in the release plan rather than in the release week.
+
+**On the cheapest route:** the platform's own documentation names **Azure Artifact Signing** as the cheapest
+option for Windows code signing and states that it gets rid of SmartScreen warnings. That is the platform's
+characterization, repeated here as such — this skill makes no independent cost comparison and has no evidence
+for one.
+
+> **UNVERIFIED — the update signature-verification mechanism on Windows.** The governing updater
+> documentation **provides no details**, so **no mechanism is taught here**. What is verified is that the
+> document is silent, which is a different and more useful thing to know than a guess would be.
+> *Closing condition:* the vendor documents the mechanism. `SKILL.md`'s gap register carries it.
+>
+> The practical consequence: a run cannot state what its update pipeline verifies on this system, so it
+> states what it verified by **test** instead — rehearse an update on the real signed artifact and record the
+> observed result. `DESK-R25` keeps that a separate claim from the mechanism claim nobody can make.
+
 ## Linux — no signing story
+
+**The governing document describes no signing story for this system**, and distribution goes through package
+formats instead.
+
+This is not an omission to work around; it is a different distribution model. The package format and its
+repository carry the integrity and provenance role that a signature carries elsewhere, and the person's own
+system already trusts that path.
+
+Two consequences a run states rather than discovers:
+
+- **The archive-integrity control is unavailable here.** [`runtime-deltas.md`](runtime-deltas.md) records
+  which systems support it. A run claiming load-time integrity checking across three systems is claiming
+  something the platform does not provide on one of them, and [`security.md`](security.md) owns that control.
+- **The update path is the system's own package manager**, which is the next section's subject.
 
 ## The update platform asymmetry
 
+**There is no built-in auto-updater on Linux.** The platform's own recommendation is to use the
+distribution's package manager to update the application. This single fact invalidates the most common
+release-plan assumption in this stack:
+
+> **Any claim of three-platform automatic updating through the built-in updater is false.** Not optimistic —
+> false. Two systems have a built-in path; the third does not.
+
+Per-system, with the mechanism named:
+
+| System | Built-in update path | Precondition |
+|---|---|---|
+| macOS | yes, through `Squirrel.Mac` | **signing is mandatory** — a requirement of that framework, not a recommendation |
+| Windows | yes, auto-selecting between an MSIX updater and `Squirrel.Windows` | signed artifacts, per the certificate section above |
+| Linux | **none** | the distribution's package manager carries the update |
+
+**The hosted feed's constraints, which decide whether it is available to a run at all:** the free hosted feed
+`update.electronjs.org` requires a **public** repository, covers **macOS and Windows only**, and requires
+macOS builds to be code-signed. A private-repository project, or one that needs the third system, needs a
+different provider — and needing a non-default provider is one of the three conditions in the build-tool
+criterion [`packaging-distribution.md`](packaging-distribution.md) owns.
+
+**State the per-system update path in the release plan, explicitly.** A run that writes "auto-update" without
+naming the system has written something that is true of two thirds of its claim set.
+
 ## Download and install timing
+
+Two timing behaviors change the design, and both are easy to miss because they work fine on a fast connection
+with a small application.
+
+**The update downloads when the `update-available` event fires.** Not when the person consents, and not when
+the application decides it is convenient — at that point. For a metered connection or a large delta, that is
+a cost the person did not agree to.
+
+The consequence: **gate `checkForUpdates` by policy rather than running it on an interval timer.** An
+interval timer means the download happens whenever it happens. A policy-gated check means the run decides
+when it is acceptable to spend someone's bandwidth, and can ask.
+
+**Installing races live application state.** `quitAndInstall()` ends the application, and the application may
+be mid-write when it does — which is exactly `DESK-FLOOR-02` member 7, an update install racing live state.
+The `before-quit-for-update` event exists precisely because of this race, and it is the hook for flushing
+work, releasing resources, and recording where the person was.
+
+**Use it, and treat an unsaved change as a stop rather than a hazard to accept.** The person did not choose
+this moment to quit; the updater did. Losing their work to an update is a consequence they could not foresee,
+refuse, or recover from, and [`filesystem-data.md`](filesystem-data.md) owns the durable-write property that
+makes the flush trustworthy.
 
 ## Channels and staged rollout
 
+**A channel is a separate audience receiving a separate artifact.** It is what makes a release recoverable in
+the only sense available here — by finding the defect on a small population before it reaches everyone.
+
+**Staged rollout releases to a growing fraction of that audience**, with a stop condition that halts the
+progression when a signal turns bad.
+
+**These are not built-in capabilities.** Differential updates, staged rollouts, and multiple update providers
+come from the alternative build chain's own updater; the platform's built-in updater documents none of the
+three. That is precisely why the build-tool criterion in
+[`packaging-distribution.md`](packaging-distribution.md) turns on this requirement set, and why a run that
+needs staged rollout has effectively already made its `DESK-G6` decision.
+
+**Two things a run defines before the first staged release, not during it:**
+
+1. **The stop condition, as an observable.** "It looks bad" is not a stop condition. A crash rate, an error
+   rate, or a named failure signal, each with a threshold and an owner, is one.
+2. **What stopping actually does.** Halting the rollout stops *new* installations of the bad version. It does
+   nothing about the copies already installed, which is the next section's subject and the reason a stop
+   condition is a mitigation rather than a fix.
+
 ## The irreversibility rule and the supported-version window
+
+**A shipped version cannot be recalled.** `DESK-R24` states the rule; this is what it means operationally.
+
+Once an artifact is installed on a person's machine it is theirs. Withdrawing the download, halting the
+rollout, and deleting the release all change what *new* people receive and change nothing at all for the
+people who already have it. Some of those installations will still be running years from now, on machines
+that never see a network the run controls.
+
+**Therefore rollback means a forward fix.** There is no other mechanism. The defect is corrected in a new
+version, that version is released through the same chain, and the people who install it are fixed. The people
+who do not install it are not.
+
+**Which forces a stated supported-old-version window.** A run decides, in advance and in writing, how far
+back it supports:
+
+- **How old a version still receives a forward fix?** Not "the latest" — an answer that names a bound.
+- **How old a version can still talk to whatever the application talks to?** A protocol or data-format change
+  that assumes everyone upgraded is a break for everyone who did not.
+- **What happens to a version outside the window?** Told, blocked, or left alone are three different
+  answers with three different consequences for a person who cannot upgrade.
+
+**The window is a claim about the past that binds the future**, and it is why `DESK-R24` puts release behind
+its own authority gate at `DESK-G8` rather than treating it as the last step of a build.
+
+### What the release gate actually proves
+
+`DESK-R23` adds four gates after the ordinary build, and the last two live in this file:
+
+| Gate | What it proves | What it does not |
+|---|---|---|
+| Package per system | an installer exists for each claimed system | that it installs |
+| Install and smoke-test in a clean environment | it installs and runs where nothing was prepared for it | that it is signed correctly |
+| **Verify signature and notarization on the real artifact** | the shipped bytes carry a valid identity | that an update works |
+| **Rehearse an update from the previously released version** | a person on the last release reaches this one | anything about a release two versions back |
+
+**Rehearse from the previously released version, not from a fresh install.** A fresh install proves a
+different claim — it proves first-time installation, which is a path most of the audience will never take
+again. The update path is the one nearly everyone uses, and it is the one that can destroy data the fresh
+path never touches.
+
+**Keep the claims separate.** `DESK-R25` requires it, and this is where merging them is most tempting: a
+green pipeline reads as "released successfully" when what it proved was that four distinct things each held
+on the systems it ran on. A run states which system each claim covers, and treats an unrunnable gate as a
+limitation that blocks its claim rather than as a weaker signal that partially supports it.

--- a/.gobbi/projects/gobbi/skills/desktop/signing-updates.md
+++ b/.gobbi/projects/gobbi/skills/desktop/signing-updates.md
@@ -1,0 +1,18 @@
+# Desktop — Signing and Updates
+
+Own code signing, notarization, update feeds, channels, staged rollout, and the irreversibility rule. Policy
+lives in [`SKILL.md`](SKILL.md); this child owns the mechanics.
+
+## macOS — sign, then notarize
+
+## Windows — the certificate requirement
+
+## Linux — no signing story
+
+## The update platform asymmetry
+
+## Download and install timing
+
+## Channels and staged rollout
+
+## The irreversibility rule and the supported-version window

--- a/.gobbi/projects/gobbi/skills/desktop/windows-lifecycle.md
+++ b/.gobbi/projects/gobbi/skills/desktop/windows-lifecycle.md
@@ -127,10 +127,10 @@ bound outcome; this inventory is where a run enumerates them against real mechan
 | A status-area icon | a tray icon and its context menu — [`native-integration.md`](native-integration.md) owns the mechanism and the per-system divergences | a live process that may hold no window at all, and whose activation gesture is not promisable on every claimed system |
 | Automatic start at login | the platform's own login-item registration, on **macOS and Windows only** | a cold start with no person watching it happen |
 
-**Two rows carry a per-system limit that does not fit in a cell.** The login-item mechanism exists on two of
-the three systems, not three: the third has no platform login-item interface, so automatic start at login there
-is the run's own mechanism carrying its own evidence, and a three-system auto-start claim made from one
-interface is wrong on one of them. And from the macOS version [`runtime-deltas.md`](runtime-deltas.md) records
+**The login-item row carries two per-system limits that do not fit in its cell.** The mechanism exists on two
+of the three systems, not three: the third has no platform login-item interface, so automatic start at login
+there is the run's own mechanism carrying its own evidence, and a three-system auto-start claim made from that
+one interface is wrong on one of them. And from the macOS version [`runtime-deltas.md`](runtime-deltas.md) records
 under *Login-item service types*, the registration additionally takes a service type — the main application, an
 agent, a daemon, or a login item — so a run that registers one names which it registers. That file owns both
 divergences and the version.

--- a/.gobbi/projects/gobbi/skills/desktop/windows-lifecycle.md
+++ b/.gobbi/projects/gobbi/skills/desktop/windows-lifecycle.md
@@ -3,14 +3,142 @@
 Own window creation, state restoration, per-OS quit semantics, single-instance behavior, deep links, and
 entry modes. Policy lives in [`SKILL.md`](SKILL.md); this child owns the mechanics.
 
+Every obligation here is a **behavior** contract rather than a visual one. Matching an operating system's
+appearance while breaking one of the behaviors below reads as a broken application, and no amount of visual
+polish repairs it. `DESK-R22` is the rule; this file names the mechanism for each obligation it covers.
+
+Where one system diverges from another, [`runtime-deltas.md`](runtime-deltas.md) owns the divergence matrix
+and every version literal. This file states the obligation once and points there.
+
 ## Creation and first paint
+
+**The first-paint pair is both mechanisms, not either one.**
+
+1. Create the window with `show: false` and show it on `ready-to-show`. Showing after that event has no
+   visual flash.
+2. Set `backgroundColor` **anyway**, even though the application uses `ready-to-show`. The platform's own
+   guidance recommends both together.
+
+Each alone leaves one bad case. Waiting for the event without a background color gives a blank stare while
+the window is invisible and the application appears not to have launched. Showing early without waiting gives
+the white flash the event exists to remove. A run that implements one of the two has implemented half of the
+obligation, and the half it is missing is the half its own test environment is least likely to expose.
+
+The window's own content-loading limits — which navigations are permitted and which window-open requests are
+allowed — are security controls, and [`security.md`](security.md) owns them. Creation is this file's subject;
+what the created window is allowed to load is not.
 
 ## State restoration as a conformance obligation
 
+**There is no built-in mechanism for saving and restoring window position and size.** The platform states
+this directly, and it is tracked as an open request rather than an oversight.
+
+It is a **conformance** gap, not a convenience gap. Both the Windows and the GNOME design guidance assume a
+window that reopens where the person left it, so a window that forgets its position does not read as a
+missing nicety — it reads as broken.
+
+Two routes close it, and the choice between them is the user's:
+
+- **A third-party library.** That is a new production dependency, so it is a `DESK-G7` decision and **never a
+  default**. Present it with its maintenance state and its cost, like any other candidate.
+- **An implementation the run owns.** Smaller surface, no dependency, and the per-system traps below become
+  the run's own problem.
+
+**The trap either route has to handle: a monitor that disappears.** A naive restore writes back the saved
+bounds and puts the window on a display that no longer exists, where it is invisible and unreachable.
+Restoration therefore validates the saved bounds against the currently attached displays before applying
+them, and falls back to a visible default when they do not intersect one.
+
+This is the shape `DESK-FLOOR-02` protects: a state the person cannot foresee, refuse, or recover from,
+reached by an ordinary relaunch.
+
 ## Per-OS quit and activation
+
+Three behaviors diverge, and the divergence is the point.
+
+**Closing the last window.** The `window-all-closed` event's default is to quit the application. Subscribing
+to it takes that decision over. That subscription is the hook for the macOS convention of an application that
+survives with no window open, and it is why the same code quits on one system and persists on another.
+[`runtime-deltas.md`](runtime-deltas.md) records which system does which.
+
+**Activation.** The macOS `activate` event fires on relaunch or a dock click, and is where an application
+with no window opens one. `did-become-active` is a **different** event that fires every time the application
+becomes active, which is not the same question. Using the second where the first is meant produces a window
+on every application switch.
+
+**Handling a file the system hands you.** On macOS the `open-file` event must be registered **very early in
+startup — even before the ready event is emitted**.
+
+> **The launch-event trap this creates.** Module-syntax imports in the privileged process load
+> **asynchronously**, so only side effects from the entry point's own imports run before the ready event —
+> [`process-model.md`](process-model.md) owns that fact. An entry point that registers `open-file` after an
+> `await` therefore misses the launch event, and a file opened from the system file browser silently does
+> nothing. The two facts are individually documented and their combination is where the failure lives.
+> Register the handler synchronously, at the top of the entry point, before any awaited work.
 
 ## Single instance and argument handling
 
+`requestSingleInstanceLock()` claims the lock; the `second-instance` event delivers what the second launch
+was asked to do. That pair is the mechanism.
+
+**Parse the argument list by matching, never by position.** The platform documents that the argument list a
+second instance receives *will not be exactly the same list*: its order might change, and additional
+arguments might be appended.
+
+Positional indexing therefore acts on whatever happens to sit at that index. For a deep link or a file-open
+request that means acting on a target the person did not choose — which is why this is a
+**`DESK-FLOOR-02` safety member** and not merely a correctness note. Find the argument by matching what it
+is, and ignore where it sits.
+
 ## Deep links per operating system
 
+Registration is `setAsDefaultProtocolClient()`. Delivery is not the same on every system.
+
+| System | How the link arrives |
+|---|---|
+| macOS | the dedicated `open-url` event |
+| Windows | the single-instance lock and its `second-instance` event |
+| Linux | the same route as Windows |
+
+**Where the link sits, and why that is not an index.** On Windows and Linux the link is documented as the
+**last** element of the delivered command line. That is a description of where it appears, and it is not a
+contract to index against — the same documented warning about order and appended arguments from the previous
+section applies to exactly this list. Match the protocol scheme. The documented position tells you where to
+look first; the match is what makes the handler correct.
+
+**Testing this unpackaged gives a false negative.** The platform states the feature works on macOS only when
+the application is packaged and does not work when launched in development. A deep link that fails in a
+development run has proved nothing about the shipped artifact, and a run that concludes otherwise will ship a
+broken association or waste a day chasing a working one.
+
 ## Entry-mode inventory
+
+An application is entered in more ways than its own team usually lists, and each entry mode reaches the
+outcome from a different starting state. `DESK-R01` requires the entry modes to be named as part of the
+bound outcome; this inventory is where a run enumerates them against real mechanisms.
+
+| Entry mode | Mechanism | The state it starts from |
+|---|---|---|
+| First launch | ordinary startup | nothing running, no window, no restored state |
+| Relaunch while running | the single-instance lock and its `second-instance` event | a live process that must surface an existing window rather than build a second one |
+| Activation with no window | the macOS `activate` event | a live process with no window, on the system whose convention permits that state |
+| A file handed over by the system | `open-file` on macOS, registered before the ready event | possibly no window yet, and possibly no ready event yet |
+| A deep link | `open-url` on macOS; `second-instance` elsewhere | either a cold start or a live process, and the handler cannot assume which |
+| Automatic start at login | the operating system's own login mechanism | a cold start with no person watching it happen |
+
+**Every mode in the inventory reaches the outcome or is proved out of scope.** A mode that reaches a broken
+state is a `DESK-N01` failure — the outcome is not finished — and a mode nobody enumerated is a mode nobody
+tested.
+
+Three properties are worth checking against the table rather than assumed:
+
+1. **Cold-start and warm-start paths differ.** A deep link arriving at a cold start has to wait for the
+   window that a warm start already has. A handler written for one path and reused for the other is the
+   ordinary way this breaks.
+2. **Some modes arrive before the ready event.** The file-handover row is the documented case, and the
+   registration timing above is what makes it work.
+3. **Registration of the association itself is separate work.** The protocol registration call is named
+   above; file-type association registration belongs to the installer, and
+   [`packaging-distribution.md`](packaging-distribution.md) owns the per-system installer targets that
+   perform it. [`native-integration.md`](native-integration.md) states what this skill's evidence does and
+   does not cover for that registration.

--- a/.gobbi/projects/gobbi/skills/desktop/windows-lifecycle.md
+++ b/.gobbi/projects/gobbi/skills/desktop/windows-lifecycle.md
@@ -124,7 +124,16 @@ bound outcome; this inventory is where a run enumerates them against real mechan
 | Activation with no window | the macOS `activate` event | a live process with no window, on the system whose convention permits that state |
 | A file handed over by the system | `open-file` on macOS, registered before the ready event | possibly no window yet, and possibly no ready event yet |
 | A deep link | `open-url` on macOS; `second-instance` elsewhere | either a cold start or a live process, and the handler cannot assume which |
-| Automatic start at login | the operating system's own login mechanism | a cold start with no person watching it happen |
+| A status-area icon | a tray icon and its context menu — [`native-integration.md`](native-integration.md) owns the mechanism and the per-system divergences | a live process that may hold no window at all, and whose activation gesture is not promisable on every claimed system |
+| Automatic start at login | the platform's own login-item registration, on **macOS and Windows only** | a cold start with no person watching it happen |
+
+**Two rows carry a per-system limit that does not fit in a cell.** The login-item mechanism exists on two of
+the three systems, not three: the third has no platform login-item interface, so automatic start at login there
+is the run's own mechanism carrying its own evidence, and a three-system auto-start claim made from one
+interface is wrong on one of them. And from the macOS version [`runtime-deltas.md`](runtime-deltas.md) records
+under *Login-item service types*, the registration additionally takes a service type — the main application, an
+agent, a daemon, or a login item — so a run that registers one names which it registers. That file owns both
+divergences and the version.
 
 **Every mode in the inventory reaches the outcome or is proved out of scope.** A mode that reaches a broken
 state is a `DESK-N01` failure — the outcome is not finished — and a mode nobody enumerated is a mode nobody

--- a/.gobbi/projects/gobbi/skills/desktop/windows-lifecycle.md
+++ b/.gobbi/projects/gobbi/skills/desktop/windows-lifecycle.md
@@ -1,0 +1,16 @@
+# Desktop — Windows and Application Lifecycle
+
+Own window creation, state restoration, per-OS quit semantics, single-instance behavior, deep links, and
+entry modes. Policy lives in [`SKILL.md`](SKILL.md); this child owns the mechanics.
+
+## Creation and first paint
+
+## State restoration as a conformance obligation
+
+## Per-OS quit and activation
+
+## Single instance and argument handling
+
+## Deep links per operating system
+
+## Entry-mode inventory

--- a/.gobbi/projects/gobbi/skills/evaluation/checklist/mistakes.md
+++ b/.gobbi/projects/gobbi/skills/evaluation/checklist/mistakes.md
@@ -1,0 +1,19 @@
+---
+type: mistakes
+skill: checklist
+description: "Recorded traps for checklist — load before doing checklist work"
+updated: 2026-07-26
+---
+
+# Checklist — Mistakes
+
+> Load before any checklist work. Each `## ` section is one active trap; `## Archived` holds superseded ones.
+
+## Evidence Is Not A Pass Condition
+
+`priority: high` · `domain: evaluation` · `added: 2026-07-26` · `status: active` · `tags: [evaluation, verification]`
+
+**What happened** — A planted fixture removed a required obligation primitive from a checklist item's `Pass:` meaning. The `Evidence:` method could still have noticed the defect, so reading Evidence as part of acceptance made the item look covered.
+**Why it happens** — Evidence explains how to inspect a predicate; it does not itself forbid or require any state. Treating `Pass:` and `Evidence:` as one combined predicate gives detection prose acceptance force it does not own.
+**How to detect** — A required or forbidden primitive appears only in `Evidence:` and is absent from `Pass:`, or a reviewer says an item passes because its evidence method could notice the violation.
+**Correct approach** — Put every required or forbidden obligation primitive in `Pass:`. Use `Evidence:` only to state how the reviewer proves that predicate. Test the distinction with a fixture that preserves Evidence while removing the primitive from Pass.

--- a/.gobbi/projects/gobbi/skills/gobbi/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/gobbi/SKILL.md
@@ -70,6 +70,7 @@ Every skill outside the floor is indexed here once — a name, a one-line descri
 | [`execution`](../execution/SKILL.md) | The Execution-step method: one locked task through study, bounded change, verification, and a focused commit. | Dispatched by `workflow` at the Execution step. |
 | [`wrap-up`](../wrap-up/SKILL.md) | The Wrap-up method: promotion, evaluated handoff, and Git finalization. | Dispatched by `workflow` at the Wrap-up step. |
 | [`coding`](../coding/SKILL.md) | Language-agnostic construction quality. | Relevant whenever the task writes or changes code. |
+| [`desktop`](../desktop/SKILL.md) | Desktop application delivery as an Electron and TypeScript vertical slice: the design fidelity ladder, the privilege boundary, and a signed, update-rehearsed per-OS release. | Relevant when the work targets an installed windowed application; not for a browser page, a command-line tool, a library, or a service. |
 | [`python`](../python/SKILL.md) / [`typescript`](../typescript/SKILL.md) | Language method skills. | Relevant when the task enters that language. |
 | [`codex`](../codex/SKILL.md) | Native Codex and Codex-peer invocation surfaces. | Relevant when the active runtime is Codex or an operation uses a Codex peer. |
 

--- a/.gobbi/projects/gobbi/skills/memory/rules.md
+++ b/.gobbi/projects/gobbi/skills/memory/rules.md
@@ -121,7 +121,7 @@ This carve-out is a direct consequence of the **Scope boundary** at the top of t
 - **Bare-slug types** (§1.2): `{type}/{area}/{slug}.md`
 - **Date-prefixed types** (§1.2): `{type}/{area}/{YYYY-MM-DD}-{slug}.md` — the date stays inside the area, after it.
 
-Examples: `mistakes/verification/grep-absence-claim-needs-exact-pattern.md`, `decisions/memory/2026-06-21-{slug}.md`, `notes/workflow/2026-06-21-{slug}.md`.
+Examples: `archive/mistakes/verification/2026-07-26-grep-absence-claim-needs-exact-pattern.md`, `decisions/memory/2026-06-21-{slug}.md`, `notes/workflow/2026-06-21-{slug}.md`.
 
 **Eager + both-tiers-symmetric.** Every by-area record is namespaced from file 1 — there is no "flat until N files, then split" threshold. The feature tier uses the identical shape: `features/{f}/{type}/{area}/{slug}.md`. One rule, two tiers.
 

--- a/.gobbi/projects/gobbi/skills/workflow/mistakes.md
+++ b/.gobbi/projects/gobbi/skills/workflow/mistakes.md
@@ -2,7 +2,7 @@
 type: mistakes
 skill: workflow
 description: "Recorded traps for Gobbi delegation dispatch — load before manager dispatch work"
-updated: 2026-07-20
+updated: 2026-07-26
 ---
 
 # Workflow Delegation — Mistakes
@@ -93,3 +93,12 @@ updated: 2026-07-20
 
 ### Related
 - [[template-embeds-unnamed-exception]] — the general pattern this is one instance of: a deviation from a stated default/invariant needs an explicit, named justification at the point of deviation, or a reader (here, some executors) won't recognize it as authoritative
+
+## Freeze Must Be A Separate Round Trip From Work
+
+`priority: high` · `domain: process` · `added: 2026-07-26` · `status: active` · `tags: [process, verification]`
+
+**What happened** — A manager bundled a correction, a consistency check, and "then freeze" in one instruction. The producer reported after the correction, the manager treated that report as the freeze, and an evaluator was dispatched while the producer was still completing the check. The evaluated subject moved after dispatch.
+**Why it happens** — A multi-part instruction can span turns. The manager may treat the first report as the end state while the producer treats freeze as the end of the whole instruction.
+**How to detect** — One brief both asks for more work and says the artifact will be frozen afterward, but no separate stable fingerprint or explicit "nothing outstanding" acknowledgement exists before independent dispatch.
+**Correct approach** — Make freeze its own round trip: receive the completed work report, reread and fingerprint the artifact, ask for or record an explicit freeze with nothing outstanding, then dispatch the independent reader. If the fingerprint changes, discard the dispatch and start a new frozen subject.

--- a/plugins/gobbi/.claude-plugin/plugin.json
+++ b/plugins/gobbi/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gobbi",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Gobbi workflow skills and agents for Configuration, Ideation, Planning, Execution, and Wrap-up in Claude Code",
   "author": {
     "name": "HahyeonJeon"

--- a/plugins/gobbi/.codex-plugin/plugin.json
+++ b/plugins/gobbi/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gobbi",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Gobbi workflow skills for Codex.",
   "author": {
     "name": "HahyeonJeon",


### PR DESCRIPTION
## Summary

Add the canonical Desktop application delivery skill and wire it into both repository discovery surfaces and the shared Gobbi plugin package.

## Changes

- Add the Desktop skill family under `.gobbi/projects/gobbi/skills/desktop/`.
- Add its runnable 79-edge relation checker and self-tests.
- Reconcile both plugin manifest versions to `0.5.4`.
- Generate the Codex and Claude repository discovery mirrors.
- Promote the session’s approved durable mistake records, archives, and skill-specific traps.
- Add the evaluated durable handoff for this session.

## Verification

- `scripts/sync-plugin-package.sh --check`
- `scripts/test-sync-plugin-package.sh` — 13/13 fixture coverage during Execution
- `desktop/scripts/check_relation.py` — 79 edges
- `desktop/scripts/check_relation.py --self-test`
- Full Gobbi session-record verification
- Wrap-up iteration 3: Codex PASS under the exact user-approved missing-Claude waiver

## Gobbi session

- Session: `bb2794ce-bc3d-422a-b011-f8b4750c6eed`
- Evaluated head: `d75214bc30c188908c7e85afefc0bc971d3761ee`
- Base branch: `develop`
- Publication policy: ready pull request; no issue configured

## Explicit exclusions

- Installed-cache behavior was not tested or accepted.
- Codex runtime cold use and P7 were not tested or accepted.
- Claude Code runtime cold use and P7 were not tested or accepted.
- P6, whole-skill acceptance, and release readiness were not accepted.
