### PR TITLE
fix(codex): correct installed package guidance

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -79,8 +79,8 @@ exact load directives because specialists do not inherit manager context.
 
 ## Plugin topology
 
-The bounded package at `plugins/gobbi/` distributes canonical `skills` and `agents` through symlinks and
-carries both runtime manifests. `.agents/plugins/marketplace.json` and
+The bounded package at `plugins/gobbi/` distributes one generated, byte-equal real-file copy of the canonical
+`skills` and `agents` and carries both runtime manifests. `.agents/plugins/marketplace.json` and
 `.claude-plugin/marketplace.json` point to `./plugins/gobbi`. Native Codex custom-agent wrappers remain
 repo-local and are not installed as plugin components.
 
@@ -88,14 +88,15 @@ Run `scripts/sync-plugin-package.sh --check` for read-only source-topology valid
 `scripts/test-sync-plugin-package.sh` for fixtures, and `scripts/check-codex-plugin-smoke.sh` for isolated
 installed-cache behavior. The package has no lifecycle-hook component.
 
-A Codex plugin install of Gobbi receives both manifests and no skills, because the Codex plugin installer
-copies a plugin into its cache without following symlinks. This is an open Codex defect —
+The Codex plugin installer copies a plugin into its cache without following symlinks. Gobbi therefore
+materializes the canonical `skills` and `agents` into the package as real files, so an installed plugin
+receives both manifests, the complete nested skill tree, and the agent contracts.
 [openai/codex#24770](https://github.com/openai/codex/issues/24770), "Plugin install: support symlinks per the
-cross-agent marketplace contract" — not a packaging error here, and `check-codex-plugin-smoke.sh` reports it
-as a warning. Keep the single canonical source, and materialize it into the package only as the one generated
-copy a guard proves byte-equal to that source. Any further duplication, and any hand edit of a generated file,
-stays forbidden. Codex skill discovery does follow symlinks, so in this repository `.agents/skills/` resolves
-and needs no install.
+cross-agent marketplace contract", still affects symlink-only packages but no longer leaves a current Gobbi
+install incomplete. `check-codex-plugin-smoke.sh` fails when the isolated installed cache lacks expected
+components. Keep the single canonical source and only the one generated package copy that the guard proves
+byte-equal; any further duplication or hand edit of a generated file stays forbidden. Codex skill discovery
+does follow symlinks, so in this repository `.agents/skills/` resolves and needs no install.
 
 ## Principles
 

--- a/.gobbi/projects/gobbi/skills/codex/SKILL.md
+++ b/.gobbi/projects/gobbi/skills/codex/SKILL.md
@@ -182,12 +182,13 @@ policy; an invocation that must follow that policy passes those values itself.
 | `codex plugin add <plugin>@<marketplace>` | Installs a plugin into the local cache |
 | `codex plugin remove <plugin>@<marketplace>` | Removes an installed plugin from local config and cache |
 
-The Codex plugin installer copies a plugin directory without following symbolic links. Installing the current
-`plugins/gobbi/` package delivers exactly two files — `.claude-plugin/plugin.json` and
-`.codex-plugin/plugin.json` — with no skills, no agents, and no error. That silence is
-[openai/codex#24770](https://github.com/openai/codex/issues/24770), not a fault in the package. Codex skill
-*discovery* does follow symbolic links, so `.agents/skills/` resolves inside this repository and needs no
-install.
+The Codex plugin installer copies a plugin directory without following symbolic links. The current
+`plugins/gobbi/` package therefore materializes `skills/` and `agents/` as real files generated from their
+canonical owners. Installing it delivers both manifests, the complete nested skill tree, and the agent
+contracts; `scripts/check-codex-plugin-smoke.sh` proves those files in an isolated installed cache.
+[openai/codex#24770](https://github.com/openai/codex/issues/24770) still affects symlink-only packages but no
+longer leaves a current Gobbi install incomplete. Codex skill *discovery* does follow symbolic links, so
+`.agents/skills/` resolves inside this repository and needs no install.
 
 ### Diagnose a failure
 
@@ -196,7 +197,7 @@ install.
 | A flag is rejected | `codex exec --help`; an argument error exits `2` and prints the accepted values |
 | Authentication, configuration, or runtime health is unclear | `codex doctor`, `codex doctor --summary`, or `codex doctor --json` for a redacted machine-readable report |
 | A configuration key may be misspelled or retired | Rerun with `--strict-config`, which fails on an unrecognized field |
-| An installed plugin exposes no skill | List the installed cache; a symbolic-linked component installs silently empty |
+| An installed plugin exposes no skill | List the installed cache; current Gobbi installs contain real `skills/` and `agents/` files, while a symlinked package can install silently incomplete |
 | A run must not persist but a session appears | Confirm `--ephemeral` was passed; `resume` and `--ephemeral` cannot both hold |
 
 Report the command, its exact exit status, and its immediate diagnostic. Do not author replacement output for

--- a/plugins/gobbi/skills/codex/SKILL.md
+++ b/plugins/gobbi/skills/codex/SKILL.md
@@ -182,12 +182,13 @@ policy; an invocation that must follow that policy passes those values itself.
 | `codex plugin add <plugin>@<marketplace>` | Installs a plugin into the local cache |
 | `codex plugin remove <plugin>@<marketplace>` | Removes an installed plugin from local config and cache |
 
-The Codex plugin installer copies a plugin directory without following symbolic links. Installing the current
-`plugins/gobbi/` package delivers exactly two files — `.claude-plugin/plugin.json` and
-`.codex-plugin/plugin.json` — with no skills, no agents, and no error. That silence is
-[openai/codex#24770](https://github.com/openai/codex/issues/24770), not a fault in the package. Codex skill
-*discovery* does follow symbolic links, so `.agents/skills/` resolves inside this repository and needs no
-install.
+The Codex plugin installer copies a plugin directory without following symbolic links. The current
+`plugins/gobbi/` package therefore materializes `skills/` and `agents/` as real files generated from their
+canonical owners. Installing it delivers both manifests, the complete nested skill tree, and the agent
+contracts; `scripts/check-codex-plugin-smoke.sh` proves those files in an isolated installed cache.
+[openai/codex#24770](https://github.com/openai/codex/issues/24770) still affects symlink-only packages but no
+longer leaves a current Gobbi install incomplete. Codex skill *discovery* does follow symbolic links, so
+`.agents/skills/` resolves inside this repository and needs no install.
 
 ### Diagnose a failure
 
@@ -196,7 +197,7 @@ install.
 | A flag is rejected | `codex exec --help`; an argument error exits `2` and prints the accepted values |
 | Authentication, configuration, or runtime health is unclear | `codex doctor`, `codex doctor --summary`, or `codex doctor --json` for a redacted machine-readable report |
 | A configuration key may be misspelled or retired | Rerun with `--strict-config`, which fails on an unrecognized field |
-| An installed plugin exposes no skill | List the installed cache; a symbolic-linked component installs silently empty |
+| An installed plugin exposes no skill | List the installed cache; current Gobbi installs contain real `skills/` and `agents/` files, while a symlinked package can install silently incomplete |
 | A run must not persist but a session appears | Confirm `--ephemeral` was passed; `resume` and `--ephemeral` cannot both hold |
 
 Report the command, its exact exit status, and its immediate diagnostic. Do not author replacement output for

--- a/scripts/check-codex-plugin-smoke.sh
+++ b/scripts/check-codex-plugin-smoke.sh
@@ -97,6 +97,28 @@ test_materialization_guard() {
   pass 'materialization guard rejects a symlinked or absent component directory'
 }
 
+require_materialized_install_guidance() {
+  local doc
+  local legacy_pattern='through symlinks|receives both manifests and no skills|delivers exactly two files|with no skills, no agents'
+  local -a docs=(
+    "$repo_root/.codex/AGENTS.md"
+    "$repo_root/.gobbi/projects/gobbi/skills/codex/SKILL.md"
+    "$package_root/skills/codex/SKILL.md"
+  )
+
+  for doc in "${docs[@]}"; do
+    [[ -f "$doc" ]] || fail "Codex materialized-install guidance is missing: ${doc#"$repo_root"/}"
+    if grep -Eq "$legacy_pattern" "$doc"; then
+      fail "Codex materialized-install guidance repeats the obsolete manifests-only package state: ${doc#"$repo_root"/}"
+    fi
+    if ! grep -Fq 'complete nested skill tree' "$doc"; then
+      fail "Codex materialized-install guidance does not state the complete nested skill tree reaches installation: ${doc#"$repo_root"/}"
+    fi
+  done
+
+  pass 'Codex runtime guidance matches the materialized installed-cache contract'
+}
+
 check_installed_allow_set() {
   local root="$1" entry name
   local allowed=' .codex-plugin .claude-plugin skills agents '
@@ -126,6 +148,7 @@ fi
 for component in skills agents; do
   require_materialized_component "$component"
 done
+require_materialized_install_guidance
 
 mkdir -p "$codex_home" "$codex_sqlite_home"
 


### PR DESCRIPTION
## Summary

- Correct the repository Codex entry contract and canonical Codex tool skill so they describe the materialized v1.0.1 package and complete installed cache.
- Regenerate the packaged Codex skill from its canonical owner.
- Make the Codex installed-cache smoke fail if the obsolete manifests-only guidance returns.
- Keep all version metadata at 1.0.1 and leave the existing v1.0.1 tag unchanged.

## Scope

- Resolves evaluation finding REL-CONS-001 only.
- Leaves REL-PLAN-002 and REL-GIT-003 unchanged by user decision.
- Publishes from `hotfix/codex-install-guidance`, created directly from current `develop`, so the server-side diff is exactly this four-file hotfix.
- Retains the Cowork branch as the session evidence source.

## Verification

- [x] `bash scripts/sync-plugin-package.sh --check`
- [x] `bash scripts/test-sync-plugin-package.sh` — 20 fixtures
- [x] `bash scripts/check-codex-plugin-smoke.sh`
- [x] `claude plugin validate --strict plugins/gobbi`
- [x] `bash scripts/check-markdown-links.sh README.md CHANGELOG.md .codex/AGENTS.md .gobbi/projects/gobbi/skills/codex/SKILL.md plugins/gobbi/skills/codex/SKILL.md`
- [x] `git show --check ab4480df`

## Gobbi session

- Mode: `Cowork`
- Session: `bc4876c0-4812-4ab1-ad2a-2b70ad53f040`
- Branch: `codex-2026-08-03-bc4876c0-4812-4ab1-ad2a-2b70ad53f040`
- Handoff: `conversation-only`
