### PR TITLE
docs(memory): promote v1.0.1 release closure

### DIFF
--- a/.gobbi/projects/gobbi/memory/history/2026-08-03-v1-0-1-release-and-codex-guidance-hotfix.md
+++ b/.gobbi/projects/gobbi/memory/history/2026-08-03-v1-0-1-release-and-codex-guidance-hotfix.md
@@ -1,0 +1,23 @@
+# Gobbi v1.0.1 released and Codex guidance corrected
+
+**Completed at:** 2026-08-03T06:18:53Z
+
+## Changes
+
+- Released the approved accumulated development line as Gobbi plugin v1.0.1. PR #373 integrated the
+  239-file candidate into `develop`; PR #374 promoted it to `main`; annotated tag object
+  `9790927ebdcb227a3132abd1276c9bb538bcaefa` peels to release commit
+  `7e44b5831eb59eaf8d7cf8e19a1d73f19efcbf0d`. The user accepted version 1.0.1 and the disclosed inclusion
+  of 17 canonical skill files. Semantic review of the accumulated skill and agent behavior was excluded.
+- Examined legacy PR #370, found it incomplete, conflicting, and superseded, then closed it without merge.
+- An independent Codex evaluation returned `REVISE`. The user fixed only blocking finding `REL-CONS-001`
+  and accepted `REL-PLAN-002` and `REL-GIT-003` without correction. The frozen findings, waiver, and limits
+  are preserved in the
+  [v1.0.1 release evaluation](../reports/review/2026-08-03-v1-0-1-release-evaluation.md).
+- Corrected the stale Codex install guidance and strengthened the installed-cache smoke. The verified fix
+  was published from a clean branch through PR #376 into `develop` and PR #377 into `main`; the current
+  default-branch tree is `7f02c3dd1e25eeb4d26cda3efc963034029c7ac5` and all version owners remain
+  1.0.1. The immutable v1.0.1 tag intentionally remains on the original pre-hotfix release commit.
+- Retained the Cowork and hotfix branches and worktrees, created no GitHub Release page, and performed no
+  cleanup. No fresh independent evaluation covers the post-evaluation hotfix; Cowork requires another
+  explicit `evaluate` call to obtain one.

--- a/.gobbi/projects/gobbi/memory/history/README.md
+++ b/.gobbi/projects/gobbi/memory/history/README.md
@@ -2,6 +2,7 @@
 
 Link-only index of every history record, newest first.
 
+- [2026-08-03 — Gobbi v1.0.1 released and Codex guidance corrected](2026-08-03-v1-0-1-release-and-codex-guidance-hotfix.md)
 - [2026-08-02 — Agent Teams reduced to a compact tool skill](2026-08-02-agent-teams-tool-skill.md)
 - [2026-08-02 — Locator, partner, and Agent Teams shipped](2026-08-02-locator-partner-agentteams.md)
 - [2026-08-01 — Consumer project bootstrap defined and shipped](2026-08-01-consumer-project-bootstrap.md)

--- a/.gobbi/projects/gobbi/memory/learnings/git/mistakes.md
+++ b/.gobbi/projects/gobbi/memory/learnings/git/mistakes.md
@@ -1,0 +1,15 @@
+# Git Mistakes
+
+## Reusing a squash-merged branch can reopen old history
+
+**Context:** Publishing a focused follow-up from a retained branch after that branch's earlier work was
+squash-merged.
+
+**Mistake:** Assuming a new pull request from the retained branch will contain only its latest tree delta. A
+squash merge creates a new base-branch commit without making the source tip an ancestor, so the server may
+choose the old merge base and display the previously squashed commits and files again.
+
+**Correction:** Inspect the server-side pull-request commit and file diff before merge. When it includes old
+work, leave the retained session branch unchanged. Create a clean non-session branch at the current base,
+apply the focused correction there, verify the exact delta, and publish that branch. Do not force-rewrite the
+retained session branch to make the comparison look smaller.

--- a/.gobbi/projects/gobbi/memory/reports/README.md
+++ b/.gobbi/projects/gobbi/memory/reports/README.md
@@ -4,6 +4,7 @@ Link-only navigation grouped by report category, newest first within each catego
 
 ## Review
 
+- [Gobbi v1.0.1 release evaluation](review/2026-08-03-v1-0-1-release-evaluation.md)
 - [Agent Teams compact tool skill review](review/2026-08-02-agent-teams-tool-skill-review.md)
 - [Locator, partner, and Agent Teams — dual-system review](review/2026-08-02-locator-partner-agentteams-review.md)
 

--- a/.gobbi/projects/gobbi/memory/reports/review/2026-08-03-v1-0-1-release-evaluation.md
+++ b/.gobbi/projects/gobbi/memory/reports/review/2026-08-03-v1-0-1-release-evaluation.md
@@ -1,0 +1,57 @@
+# Gobbi v1.0.1 release evaluation
+
+Independent Codex evaluation of the frozen Cowork release branch through candidate
+`890bf7fedfd4bec810349095b8c067d5626a7b27`. The user explicitly called `evaluate` and explicitly waived
+Claude Code for this named round.
+
+## Subject and limits
+
+The review covered the whole frozen release branch and its mechanical release and package behavior. The
+accepted release scope was the accumulated development line, disclosed by PR #373 as 239 files including 17
+canonical skill files. Semantic review of the accumulated skill and agent behavior was excluded. Version
+1.0.1 was an explicit user decision despite a documented minor-version concern.
+
+## Verdict
+
+`REVISE`
+
+| Finding | Judgment | Evidence | User disposition |
+|---|---|---|---|
+| `REL-CONS-001` | High; confidence 100; blocking | `.codex/AGENTS.md` and the canonical and packaged Codex skill described the obsolete symlink/manifests-only install, contradicting the materialized package and passing installed-cache smoke. The materialization change had not propagated to every authoritative document, and topology checks proved equality without checking cross-document truth. | Correct only this finding while retaining version 1.0.1. |
+| `REL-PLAN-002` | Medium; confidence 100; non-blocking | Frozen `tasks.md` and `plan.md` omitted the legacy-PR inspection and 17-skill disclosure gates, although GitHub evidence proved both occurred. | Accepted without correction; not backlogged. |
+| `REL-GIT-003` | Low; confidence 100; non-blocking | PR #374 recorded `Branch: develop` instead of the Cowork session branch in its Gobbi provenance block. | Accepted without correction; not backlogged. |
+
+## REL-CONS-001 correction and release state
+
+- Cowork commit `3788211c471225e01609f7065f4c93171f9ba5e2` corrected `.codex/AGENTS.md`, the
+  canonical and generated Codex skill, and the installed-cache smoke. The smoke now rejects the obsolete
+  manifests-only guidance and asserts the complete nested skill-tree contract.
+- Reusing the retained Cowork branch for PR #375 exposed the old merge base after the branch's earlier work
+  was squash-merged. GitHub displayed 239 files and 42 commits although the local delta from current
+  `develop` was four files. Pre-merge inspection caught the mismatch, and #375 was closed unmerged as
+  superseded.
+- Clean publication branch `hotfix/codex-install-guidance` started at current `develop` and received the
+  verified correction as `ab4480dfe1e037cd71d46d9287e304388eeaf469`. PR #376 squash-merged its exact
+  one-commit, four-file diff to `develop` as `b61a46ccec638b3c869d119451b87b58aceda918`. PR #377
+  normal-merged that state to `main` as `71889484dc4fa12ca529eb6cf28ecc05ce7cf467`, preserving
+  `develop` ancestry.
+- The current `develop` and `main` tree is `7f02c3dd1e25eeb4d26cda3efc963034029c7ac5`. Both plugin
+  manifests and the Claude marketplace remain at 1.0.1. The existing annotated v1.0.1 tag was intentionally
+  not moved, so it still peels to original release commit `7e44b5831eb59eaf8d7cf8e19a1d73f19efcbf0d` and does
+  not contain the same-version hotfix now present on the default branch.
+
+## Verification
+
+The exact hotfix tree passed canonical/package sync, all 20 sync fixtures, the installed-cache smoke with
+the new guidance assertion, strict Claude plugin validation, focused Markdown link checks, diff checks,
+canonical/package byte equality, public version and guidance checks, branch/tag/PR reference checks, and
+clean-worktree checks. PRs #375, #376, and #377 are respectively closed as superseded, merged, and merged;
+no pull request remains open.
+
+## Evaluation freshness
+
+This verdict covers only the original frozen subject through candidate `890bf7fedfd4bec810349095b8c067d5626a7b27`.
+The accepted REL-CONS-001 hotfix changed that subject, so the verdict became stale after the correction. No
+fresh independent verdict covers Cowork commit `3788211c471225e01609f7065f4c93171f9ba5e2` or released
+`main` commit `71889484dc4fa12ca529eb6cf28ecc05ce7cf467`. Cowork requires another explicit user `evaluate`
+call for that coverage.


### PR DESCRIPTION
## Summary

Promote the verified Gobbi v1.0.1 release and REL-CONS-001 hotfix closure from develop to main.

## Changes

- Add the durable release and hotfix history record.
- Add the independent release evaluation and accepted finding dispositions.
- Add the reusable Git learning from the squash-merge ancestry trap.
- Update the history and report indexes.

## Verification

- Upstream closure PR #378 is merged into develop at 53456945754a12b940040129f8b69f2aa427ecb0.
- PR #378 passed package sync, all 20 reconciliation fixtures, Codex installed-cache smoke, strict Claude validation, Markdown link integrity, and diff checks.
- This promotion must contain only the same five memory files and no runtime, skill, manifest, marketplace, or version changes.

## Gobbi session

- Session: bc4876c0-4812-4ab1-ad2a-2b70ad53f040
- Session branch: codex-2026-08-03-bc4876c0-4812-4ab1-ad2a-2b70ad53f040
- Handoff: merge the verified closure to main, then remove the session worktree.